### PR TITLE
AX: Allow strict replacements via AXTextOperation

### DIFF
--- a/LayoutTests/accessibility/mac/text-operation/text-operation-capitalize-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-capitalize-expected.txt
@@ -1,0 +1,23 @@
+Tests that a Capitalize text operation transforms text to capitalized as expected.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'Brown Fo'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick Brown Fox jumps over the lazy dog.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'Er The La'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick Brown Fox jumps ov Er The La zy dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'Lazy'
+PASS: operationResult[1] === 'Ps Over'
+PASS: operationResult[2] === 'E Quick Bro'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: ThE Quick Brown fox jumPs Over the Lazy dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'Lazy'
+FAIL: operationResult[1] !== 'Ps Over', was
+FAIL: operationResult[2] !== 'E Quick Bro', was
+FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT3: Th E Quick Bro wn fox jum Ps Over the Lazy dog.', was AXValue: TEXT3: The quick brown fox jumps over the Lazy dog.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-capitalize.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-capitalize.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick <span id="target1">brown fo</span>x jumps ov<span id="target2">er the la</span>zy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: The quick brown fox jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text3">TEXT3: The quick brown fox jumps over the lazy dog.</p>
+</div>
+
+<script>
+var output = "Tests that a Capitalize text operation transforms text to capitalized as expected.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that text is transformed to capitalized as expected (without smart replacement).
+        text = accessibilityController.accessibleElementById("text");
+        var markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Capitalize", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'Brown Fo'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick Brown Fox jumps over the lazy dog.'");
+
+        // Validate that text is transformed to capitalized as expected (with smart replacement).
+        markers = [await selectElementTextById("target2")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Capitalize", markers, null, /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'Er The La'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick Brown Fox jumps ov Er The La zy dog.'");
+
+        // Validate that multiple ranges of text are transformed to capitalized as expected (without smart replacement).
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectPartialElementTextById("text2", 42, 46), await selectPartialElementTextById("text2", 30, 37), await selectPartialElementTextById("text2", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Capitalize", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'Lazy'");
+        output += expect("operationResult[1]", "'Ps Over'");
+        output += expect("operationResult[2]", "'E Quick Bro'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: ThE Quick Brown fox jumPs Over the Lazy dog.'");
+
+        // Validate that multiple ranges of text are transformed to capitalized as expected (with smart replacement).
+        // The following test is EXPECTED TO FAIL. See https://bugs.webkit.org/show_bug.cgi?id=278928
+        text = accessibilityController.accessibleElementById("text3");
+        markers = [await selectPartialElementTextById("text3", 42, 46), await selectPartialElementTextById("text3", 30, 37), await selectPartialElementTextById("text3", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Capitalize", markers, null, /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'Lazy'");
+        output += expect("operationResult[1]", "'Ps Over'");
+        output += expect("operationResult[2]", "'E Quick Bro'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: Th E Quick Bro wn fox jum Ps Over the Lazy dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-lowercase-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-lowercase-expected.txt
@@ -1,0 +1,23 @@
+Tests that a Lowercase text operation transforms text to lowercase as expected.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'brown fo'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: THE QUICK brown foX JUMPS OVER THE LAZY DOG.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'er the la'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: THE QUICK brown foX JUMPS OV er the la ZY DOG.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'lazy'
+PASS: operationResult[1] === 'ps over'
+PASS: operationResult[2] === 'e quick bro'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: THe quick broWN FOX JUMps over THE lazy DOG.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'lazy'
+FAIL: operationResult[1] !== 'ps over', was
+FAIL: operationResult[2] !== 'e quick bro', was
+FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT3: TH e quick bro WN FOX JUM ps over THE lazy DOG.', was AXValue: TEXT3: THE QUICK BROWN FOX JUMPS OVER THE lazy DOG.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-lowercase.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-lowercase.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">THE QUICK <span id="target1">BROWN FO</span>X JUMPS OV<span id="target2">ER THE LA</span>ZY DOG.</p>
+    <p contenteditable="true" id="text2">TEXT2: THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG.</p>
+    <p contenteditable="true" id="text3">TEXT3: THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG.</p>
+</div>
+
+<script>
+var output = "Tests that a Lowercase text operation transforms text to lowercase as expected.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that text is transformed to lowercase as expected (without smart replacement).
+        text = accessibilityController.accessibleElementById("text");
+        var markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Lowercase", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'brown fo'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: THE QUICK brown foX JUMPS OVER THE LAZY DOG.'");
+
+        // Validate that text is transformed to lowercase as expected (with smart replacement).
+        markers = [await selectElementTextById("target2")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Lowercase", markers, null, /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'er the la'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: THE QUICK brown foX JUMPS OV er the la ZY DOG.'");
+
+        // Validate that multiple ranges of text are transformed to lowercase as expected (without smart replacement).
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectPartialElementTextById("text2", 42, 46), await selectPartialElementTextById("text2", 30, 37), await selectPartialElementTextById("text2", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Lowercase", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'lazy'");
+        output += expect("operationResult[1]", "'ps over'");
+        output += expect("operationResult[2]", "'e quick bro'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: THe quick broWN FOX JUMps over THE lazy DOG.'");
+
+        // Validate that multiple ranges of text are transformed to lowercase as expected (with smart replacement).
+        // The following test is EXPECTED TO FAIL. See https://bugs.webkit.org/show_bug.cgi?id=278928
+        text = accessibilityController.accessibleElementById("text3");
+        markers = [await selectPartialElementTextById("text3", 42, 46), await selectPartialElementTextById("text3", 30, 37), await selectPartialElementTextById("text3", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Lowercase", markers, null, /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'lazy'");
+        output += expect("operationResult[1]", "'ps over'");
+        output += expect("operationResult[2]", "'e quick bro'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: TH e quick bro WN FOX JUM ps over THE lazy DOG.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-expected.txt
@@ -1,0 +1,21 @@
+Tests that a Replace text operation replaces text and attempts to match the case of the replaced string.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'fox named finn'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick brown fox named finn jumps over the lazy dog.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'Capitalized Prefix: The'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: Capitalized Prefix: The quick brown fox jumps over the lazy dog.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'LAZY'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: The quick brown fox jumps over the LAZY dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === '[replaced string]'
+PASS: operationResult[1] === '[replaced string]'
+PASS: operationResult[2] === '[Replaced String]'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT4: [Replaced String] quick brown [replaced string] jumps over the [replaced string] dog.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case-expected.txt
@@ -1,0 +1,18 @@
+Tests that a ReplacePreserveCase text operation replaces text and preserves the case of the replacement string.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'fox named Finn'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick brown fox named Finn jumps over the lazy dog.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'lower case prefix: The'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: lower case prefix: The quick brown fox jumps over the lazy dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === '[Replaced string]'
+PASS: operationResult[1] === '[Replaced string]'
+PASS: operationResult[2] === '[Replaced string]'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: [Replaced string] quick brown [Replaced string] jumps over the [Replaced string] dog.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick brown <span id="target1">fox</span> jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: <span id="target2">The</span> quick brown fox jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text3">TEXT3: <span id="target3">The</span> quick brown <span id="target4">fox</span> jumps over the <span id="target5">lazy</span> dog.</p>
+</div>
+
+<script>
+var output = "Tests that a ReplacePreserveCase text operation replaces text and preserves the case of the replacement string.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that the case of the replacement string is preserved when replacing a lowercase string.
+        text = accessibilityController.accessibleElementById("text");
+        var markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplacePreserveCase", markers, "fox named Finn", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'fox named Finn'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick brown fox named Finn jumps over the lazy dog.'");
+
+        // Validate that the case of the replacement string is preserved when replacing a capitalized string.
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectElementTextById("target2")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplacePreserveCase", markers, "lower case prefix: The", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'lower case prefix: The'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: lower case prefix: The quick brown fox jumps over the lazy dog.'");
+
+        // Validate that the case of the replacement string is preserved across multiple replacements.
+        text = accessibilityController.accessibleElementById("text3");
+        markers = [await selectElementTextById("target5"), await selectElementTextById("target4"), await selectElementTextById("target3")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplacePreserveCase", markers, "[Replaced string]", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'[Replaced string]'");
+        output += expect("operationResult[1]", "'[Replaced string]'");
+        output += expect("operationResult[2]", "'[Replaced string]'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: [Replaced string] quick brown [Replaced string] jumps over the [Replaced string] dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick brown <span id="target1">fox</span> jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: <span id="target2">The</span> quick brown fox jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text3">TEXT3: The quick brown fox jumps over the <span id="target3">lazy</span> dog.</p>
+    <p contenteditable="true" id="text4">TEXT4: <span id="target4">The</span> quick brown  <span id="target5">fox</span> jumps over the <span id="target6">lazy</span> dog.</p>
+</div>
+
+<script>
+var output = "Tests that a Replace text operation replaces text and attempts to match the case of the replaced string.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that replacement string is converted to lowercase when replacing a lowercase string.
+        text = accessibilityController.accessibleElementById("text");
+        markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "fox named Finn", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'fox named finn'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick brown fox named finn jumps over the lazy dog.'");
+
+        // Validate that replacement string is capitalized when replacing a capitalized string.
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectElementTextById("target2")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "capitalized prefix: The", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'Capitalized Prefix: The'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: Capitalized Prefix: The quick brown fox jumps over the lazy dog.'");
+
+        // Validate that an uppercase replacement string stays uppercase. This helps preserve the case of acronyms.
+        text = accessibilityController.accessibleElementById("text3");
+        markers = [await selectElementTextById("target3")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "LAZY", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'LAZY'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: The quick brown fox jumps over the LAZY dog.'");
+
+        // Validate that the case of the replacement string is preserved across multiple replacements.
+        text = accessibilityController.accessibleElementById("text4");
+        markers = [await selectElementTextById("target6"), await selectElementTextById("target5"), await selectElementTextById("target4")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "[Replaced string]", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'[replaced string]'");
+        output += expect("operationResult[1]", "'[replaced string]'");
+        output += expect("operationResult[2]", "'[Replaced String]'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT4: [Replaced String] quick brown [replaced string] jumps over the [replaced string] dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-select-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-select-expected.txt
@@ -1,0 +1,15 @@
+Tests that a Select text operation returns the text for the provided marker ranges.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'fox'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick brown fox jumps over the lazy dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'lazy'
+PASS: operationResult[1] === 'fox'
+PASS: operationResult[2] === 'The'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: The quick brown fox jumps over the lazy dog.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-select.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-select.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick brown <span id="target1">fox</span> jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: <span id="target2">The</span> quick brown  <span id="target3">fox</span> jumps over the <span id="target4">lazy</span> dog.</p>
+</div>
+
+<script>
+var output = "Tests that a Select text operation returns the text for the provided marker ranges.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that the expected string is returned for a single range.
+        text = accessibilityController.accessibleElementById("text");
+        var markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXSelectedTextChanged", () => {
+            operationResult = text.performTextOperation("TextOperationSelect", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'fox'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick brown fox jumps over the lazy dog.'"); // Stays unmodified
+
+        // Validate that the expected strings are returned for multiple ranges.
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectElementTextById("target4"), await selectElementTextById("target3"), await selectElementTextById("target2")];
+        await waitForNotification(text, "AXSelectedTextChanged", () => {
+            operationResult = text.performTextOperation("TextOperationSelect", markers, "[Replaced string]", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'lazy'");
+        output += expect("operationResult[1]", "'fox'");
+        output += expect("operationResult[2]", "'The'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: The quick brown fox jumps over the lazy dog.'"); // Stays unmodified
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace-expected.txt
@@ -1,0 +1,23 @@
+Tests that a text operation replacement produces the expected result with and without smart-replacement.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'lyn'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick lynx jumps over the lazy dog.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'lyn'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: The quick lyn x jumps over the lazy dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === '[replaced string]'
+PASS: operationResult[1] === '[replaced string]'
+PASS: operationResult[2] === '[replaced string]'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: Th[replaced string]wn fox jum[replaced string] the [replaced string] dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === '[replaced string]'
+FAIL: operationResult[1] !== '[replaced string]', was [Replaced string]
+FAIL: operationResult[2] !== '[replaced string]', was [Replaced string]
+FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT4: Th [replaced string] wn fox jum [replaced string] the [replaced string] dog.', was AXValue: TEXT4: The quick brown fox jumps over the [replaced string] dog.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace.html
@@ -1,0 +1,85 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick <span id="target1">brown fo</span>x jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: The quick <span id="target2">brown fo</span>x jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text3">TEXT3: The quick brown fox jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text4">TEXT4: The quick brown fox jumps over the lazy dog.</p>
+</div>
+
+<script>
+var output = "Tests that a text operation replacement produces the expected result with and without smart-replacement.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that non-smart replacements do not add a spaces around the replaced text.
+        text = accessibilityController.accessibleElementById("text");
+        var markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "lyn", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'lyn'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick lynx jumps over the lazy dog.'");
+
+        // Validate that smart replacements add a spaces around the replaced text.
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectElementTextById("target2")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "lyn", /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'lyn'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: The quick lyn x jumps over the lazy dog.'");
+
+        // Validate that multiple non-smart replacements are performed as expected i.e. no additional
+        // spaced added around the replaced string.
+        // NOTE: The replacement string is lowercased due to TextOperationReplace. Use
+        // TextOperationReplacePreserveCase to preserve the case.
+        text = accessibilityController.accessibleElementById("text3");
+        markers = [await selectPartialElementTextById("text3", 42, 46), await selectPartialElementTextById("text3", 30, 37), await selectPartialElementTextById("text3", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "[Replaced string]", /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'[replaced string]'");
+        output += expect("operationResult[1]", "'[replaced string]'");
+        output += expect("operationResult[2]", "'[replaced string]'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: Th[replaced string]wn fox jum[replaced string] the [replaced string] dog.'");
+
+        // Validate that multiple smart replacements are performed as expected i.e. spaces are added
+        // around the replaced string when replacing in the middle of a word, and no spaces are added
+        // when replacing at word boundaries.
+        //
+        // NOTE: The replacement string is lowercased due to TextOperationReplace. Use
+        // TextOperationReplacePreserveCase to preserve the case.
+        //
+        // The following test is EXPECTED TO FAIL. See https://bugs.webkit.org/show_bug.cgi?id=278928
+        text = accessibilityController.accessibleElementById("text4");
+        markers = [await selectPartialElementTextById("text4", 42, 46), await selectPartialElementTextById("text4", 30, 37), await selectPartialElementTextById("text4", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, "[Replaced string]", /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'[replaced string]'");
+        output += expect("operationResult[1]", "'[replaced string]'");
+        output += expect("operationResult[2]", "'[replaced string]'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT4: Th [replaced string] wn fox jum [replaced string] the [replaced string] dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-uppercase-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-uppercase-expected.txt
@@ -1,0 +1,23 @@
+Tests that an Uppercase text operation transforms text to uppercase as expected.
+
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'BROWN FO'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick BROWN FOx jumps over the lazy dog.'
+PASS: operationResult.length === 1
+PASS: operationResult[0] === 'ER THE LA'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick BROWN FOx jumps ov ER THE LA zy dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'LAZY'
+PASS: operationResult[1] === 'PS OVER'
+PASS: operationResult[2] === 'E QUICK BRO'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: ThE QUICK BROwn fox jumPS OVER the LAZY dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'LAZY'
+FAIL: operationResult[1] !== 'PS OVER', was
+FAIL: operationResult[2] !== 'E QUICK BRO', was
+FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT3: Th E QUICK BRO wn fox jum PS OVER the LAZY dog.', was AXValue: TEXT3: The quick brown fox jumps over the LAZY dog.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-uppercase.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-uppercase.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick <span id="target1">brown fo</span>x jumps ov<span id="target2">er the la</span>zy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: The quick brown fox jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text3">TEXT3: The quick brown fox jumps over the lazy dog.</p>
+</div>
+
+<script>
+var output = "Tests that an Uppercase text operation transforms text to uppercase as expected.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text, operationResult;
+    setTimeout(async function() {
+        // Validate that text is transformed to uppercase as expected (without smart replacement).
+        text = accessibilityController.accessibleElementById("text");
+        var markers = [await selectElementTextById("target1")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Uppercase", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'BROWN FO'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick BROWN FOx jumps over the lazy dog.'");
+
+        // Validate that text is transformed to uppercase as expected (with smart replacement).
+        markers = [await selectElementTextById("target2")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Uppercase", markers, null, /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "1");
+        output += expect("operationResult[0]", "'ER THE LA'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick BROWN FOx jumps ov ER THE LA zy dog.'");
+
+        // Validate that multiple ranges of text are transformed to uppercase as expected (without smart replacement).
+        text = accessibilityController.accessibleElementById("text2");
+        markers = [await selectPartialElementTextById("text2", 42, 46), await selectPartialElementTextById("text2", 30, 37), await selectPartialElementTextById("text2", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Uppercase", markers, null, /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'LAZY'");
+        output += expect("operationResult[1]", "'PS OVER'");
+        output += expect("operationResult[2]", "'E QUICK BRO'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: ThE QUICK BROwn fox jumPS OVER the LAZY dog.'");
+
+        // Validate that multiple ranges of text are transformed to uppercase as expected (with smart replacement).
+        // The following test is EXPECTED TO FAIL. See https://bugs.webkit.org/show_bug.cgi?id=278928
+        text = accessibilityController.accessibleElementById("text3");
+        markers = [await selectPartialElementTextById("text3", 42, 46), await selectPartialElementTextById("text3", 30, 37), await selectPartialElementTextById("text3", 9, 20)];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("Uppercase", markers, null, /* smart replace */ true);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'LAZY'");
+        output += expect("operationResult[1]", "'PS OVER'");
+        output += expect("operationResult[2]", "'E QUICK BRO'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: Th E QUICK BRO wn fox jum PS OVER the LAZY dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1124,6 +1124,15 @@ imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.
 # View Transitions API is disabled in WK1.
 imported/w3c/web-platform-tests/css/css-view-transitions [ Skip ]
 
+# AXTextOperation layout tests are not available for WK1.
+accessibility/mac/text-operation/text-operation-capitalize.html [ Skip ]
+accessibility/mac/text-operation/text-operation-lowercase.html [ Skip ]
+accessibility/mac/text-operation/text-operation-replace-preserve-case.html [ Skip ]
+accessibility/mac/text-operation/text-operation-replace.html [ Skip ]
+accessibility/mac/text-operation/text-operation-select.html [ Skip ]
+accessibility/mac/text-operation/text-operation-smart-replace.html [ Skip ]
+accessibility/mac/text-operation/text-operation-uppercase.html [ Skip ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End features not supported in WebKit1
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -577,6 +577,12 @@ imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Fa
 
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
+# webkit.org/b/278928 AX: AXTextOperation over multiple ranges is entirely broken
+[ Debug ] accessibility/mac/text-operation/text-operation-capitalize.html [ Crash ]
+[ Debug ] accessibility/mac/text-operation/text-operation-lowercase.html [ Crash ]
+[ Debug ] accessibility/mac/text-operation/text-operation-smart-replace.html [ Crash ]
+[ Debug ] accessibility/mac/text-operation/text-operation-uppercase.html [ Crash ]
+
 ### END OF (1) Classified failures with bug reports
 ########################################
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -640,17 +640,17 @@ enum class AccessibilityTextOperationType {
     Replace,
     Capitalize,
     Lowercase,
-    Uppercase
+    Uppercase,
+    ReplacePreserveCase
 };
+
+enum class AccessibilityTextOperationSmartReplace : bool { No, Yes };
 
 struct AccessibilityTextOperation {
     Vector<SimpleRange> textRanges; // text on which perform the operation.
-    AccessibilityTextOperationType type;
-    String replacementText; // For type = replace.
-
-    AccessibilityTextOperation()
-        : type(AccessibilityTextOperationType::Select)
-    { }
+    AccessibilityTextOperationType type { AccessibilityTextOperationType::Select };
+    String replacementText; // For type = Replace, ReplacePreserveCase.
+    AccessibilityTextOperationSmartReplace smartReplace { AccessibilityTextOperationSmartReplace::Yes };
 };
 
 enum class AccessibilityOrientation {

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1063,6 +1063,9 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
             }
             break;
         }
+        case AccessibilityTextOperationType::ReplacePreserveCase:
+            replaceSelection = true;
+            break;
         case AccessibilityTextOperationType::Select:
             break;
         }
@@ -1070,7 +1073,7 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
         // A bit obvious, but worth noting the API contract for this method is that we should
         // return the replacement string when replacing, but the selected string if not.
         if (replaceSelection) {
-            frame->editor().replaceSelectionWithText(replacementString, Editor::SelectReplacement::Yes, Editor::SmartReplace::Yes);
+            frame->editor().replaceSelectionWithText(replacementString, Editor::SelectReplacement::Yes, operation.smartReplace == AccessibilityTextOperationSmartReplace::No ? Editor::SmartReplace::No : Editor::SmartReplace::Yes);
             result.append(replacementString);
         } else
             result.append(text);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -392,6 +392,11 @@ static id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>&, NSS
 #define NSAccessibilityTextOperationReplace @"TextOperationReplace"
 #endif
 
+#ifndef NSAccessibilityTextOperationReplacePreserveCase
+// Value for TextOperationType.
+#define NSAccessibilityTextOperationReplacePreserveCase @"TextOperationReplacePreserveCase"
+#endif
+
 #ifndef NSAccessibilityTextOperationCapitalize
 // Value for TextOperationType.
 #define NSAccessibilityTextOperationCapitalize @"Capitalize"
@@ -410,6 +415,11 @@ static id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>&, NSS
 #ifndef NSAccessibilityTextOperationReplacementString
 // Replacement text for operation replace.
 #define NSAccessibilityTextOperationReplacementString @"AXTextOperationReplacementString"
+#endif
+
+#ifndef NSAccessibilityTextOperationSmartReplace
+// Boolean specifying whether a smart replacement should be performed.
+#define NSAccessibilityTextOperationSmartReplace @"AXTextOperationSmartReplace"
 #endif
 
 // Math attributes
@@ -708,6 +718,7 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
     NSArray *markerRanges = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationMarkerRanges];
     NSString *operationType = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationType];
     NSString *replacementString = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationReplacementString];
+    NSNumber *smartReplace = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationSmartReplace];
 
     if ([markerRanges isKindOfClass:[NSArray class]]) {
         operation.textRanges = makeVector(markerRanges, [&axObjectCache] (id markerRange) {
@@ -719,6 +730,8 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
     if ([operationType isKindOfClass:[NSString class]]) {
         if ([operationType isEqualToString:NSAccessibilityTextOperationReplace])
             operation.type = AccessibilityTextOperationType::Replace;
+        else if ([operationType isEqualToString:NSAccessibilityTextOperationReplacePreserveCase])
+            operation.type = AccessibilityTextOperationType::ReplacePreserveCase;
         else if ([operationType isEqualToString:NSAccessibilityTextOperationCapitalize])
             operation.type = AccessibilityTextOperationType::Capitalize;
         else if ([operationType isEqualToString:NSAccessibilityTextOperationLowercase])
@@ -729,6 +742,9 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
 
     if ([replacementString isKindOfClass:[NSString class]])
         operation.replacementText = replacementString;
+
+    if ([smartReplace isKindOfClass:[NSNumber class]])
+        operation.smartReplace = [smartReplace boolValue] ? AccessibilityTextOperationSmartReplace::Yes : AccessibilityTextOperationSmartReplace::No;
 
     return operation;
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp
@@ -70,5 +70,10 @@ JSClassRef AccessibilityTextMarkerRange::wrapperClass()
 {
     return JSAccessibilityTextMarkerRange::accessibilityTextMarkerRangeClass();
 }
-    
+
+AccessibilityTextMarkerRange* toTextMarkerRange(JSObjectRef object)
+{
+    return static_cast<AccessibilityTextMarkerRange*>(JSObjectGetPrivate(object));
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h
@@ -71,4 +71,6 @@ inline bool AccessibilityTextMarkerRange::isEqual(AccessibilityTextMarkerRange*)
 inline std::optional<RefPtr<AccessibilityTextMarkerRange>> makeVectorElement(const RefPtr<AccessibilityTextMarkerRange>*, id range) { return { { AccessibilityTextMarkerRange::create(range) } }; }
 #endif
 
+AccessibilityTextMarkerRange* toTextMarkerRange(JSObjectRef);
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -128,6 +128,7 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textInputMarkedText
 void AccessibilityUIElement::setBoolAttributeValue(JSStringRef, bool) { }
 void AccessibilityUIElement::setValue(JSStringRef) { }
 JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef, JSValueRef, JSStringRef, JSStringRef) { return nullptr; }
+JSValueRef AccessibilityUIElement::performTextOperation(JSContextRef, JSStringRef, JSValueRef, JSStringRef, bool) { return nullptr; }
 bool AccessibilityUIElement::isOnScreen() const { return true; }
 JSValueRef AccessibilityUIElement::mathRootRadicand(JSContextRef) { return { }; }
 unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -298,6 +298,7 @@ public:
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity);
     JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction);
+    JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSStringRef replacement, bool shouldSmartReplace);
 
     // Text-specific
     JSRetainPtr<JSStringRef> characterAtOffset(int offset);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -216,6 +216,7 @@ interface AccessibilityUIElement {
     AccessibilityUIElement uiElementForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
     DOMString selectTextWithCriteria(DOMString ambiguityResolution, object searchStrings, DOMString replacementString, DOMString activity);
     object searchTextWithCriteria(object searchStrings, DOMString startFrom, DOMString direction);
+    object performTextOperation(DOMString operationType, object markerRanges, DOMString replacement, boolean shouldSmartReplace);
     boolean setSelectedTextRange(unsigned long location, unsigned long length);
 
     // Scroll area attributes.


### PR DESCRIPTION
#### c688b31fdd986a6fdbe6643d1d5983042b601af7
<pre>
AX: Allow strict replacements via AXTextOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=278458">https://bugs.webkit.org/show_bug.cgi?id=278458</a>
<a href="https://rdar.apple.com/134409037">rdar://134409037</a>

Reviewed by Tyler Wilcock.

The AXTextOperation accessibility API for macOS allows text replacement within a specified
list of text marker ranges, among other operations. This AX API is particularly beneficial
for clients like Grammarly for macOS, that utilize the accessibility subsystem to perform
text replacements. However, in its current form, AXTextOperation arbitrarily changes the
case of the replacement string and performs a “smart replacement” that adds spaces around
the replaced text, severely limiting the usability of the API. This commit introduces the
following modifications to the API to allow better control over the replacement. While the
same outcome can be achieved by chaining multiple calls to AX APIs/emitting CGEvents,
AXTextOperation allows for a more efficient implementation.

Preserving the Case of the Replacement String:

`TextOperationReplace` modifies the case of the replacement string supplied to the API,
changing it to either capitalized or lowercase, presumably to match the case of the text
being replaced. As a result, clients of AXTextOperation cannot enforce the case of the
replacement string they provide.

A real example of the existing behavior that makes incorrect/unexpected changes shows up
when the case of the replacement string must be preserved, e.g. when replacing “Mac OS X”
with “macOS”. The current implementation would infer that “Mac OS X” is capitalized and
would attempt to capitalize the replacement string “macOS” -&gt; “MacOS” to preserve the
case.

To address this, an additional `AXTextOperationType` called
&quot;TextOperationReplacePreserveCase&quot; has been introduced, which allows for text replacements
that preserve the case of the replacement string for clients that know/want the
replacement string to maintain its case. When supplying the new type, the replacement
string will be used as is, without attempting to match its case to the string being
replaced. Since this is an additive change, the existing clients of AXTextOperation will
remain unaffected.

Allow Disabling Smart Replacements:

All AXTextOperation types that replace text (i.e. all operations types except “select”),
always perform a “smart replace”, which assumes that the replacement string is not
replacing partial words and attempts to add spaces around it. While this is an excellent
feature for certain replacements, it can severely limit the usability of AXTextOperation
for partial word replacements.

For example, when replacing “MacOS” with “macOS”, we could attempt to perform a minimal
change, where the “M” is replaced with “m” (given we already have
`TextOperationReplacePreserveCase` from above). The current implementation would perform
a smart replacement and, therefore, add a space after the replaced “m”,
“MacOS” -&gt; “m acOS”.

To address this, a new key called &quot;AXTextOperationSmartReplace&quot; has been added to the
AXTextOperation dictionary to support _non-smart_ replacements. The value of this key is
a boolean, where NO/false disables smart replacements. Since this is an additive change,
the existing clients of AXTextOperation will remain unaffected.

Usage:

Client pseudo-code below:
```
// Replace “Mac OS X” -&gt; “macOS”
CFTypeRef result;
AXUIElementCopyParameterizedAttributeValue(element, &quot;AXTextOperation&quot;, @[
  NSAccessibilityTextOperationType: NSAccessibilityTextOperationReplacePreserveCase,
  NSAccessibilityTextOperationReplacementString: @&quot;macOS&quot;,
  NSAccessibilityTextOperationMarkerRanges: @[ rangeOfMacOSX ]
], &amp;result)

// Replace &quot;MacOS&quot; -&gt; &quot;macOS&quot;, by only replacing the first character
CFTypeRef result;
AXUIElementCopyParameterizedAttributeValue(element, &quot;AXTextOperation&quot;, @[
  NSAccessibilityTextOperationType: NSAccessibilityTextOperationReplacePreserveCase,
  NSAccessibilityTextOperationReplacementString: @&quot;m&quot;,
  NSAccessibilityTextOperationSmartReplace: kCFBooleanFalse,
  NSAccessibilityTextOperationMarkerRanges: @[ rangeOfM ]
], &amp;result)
```

Layout tests have been introduced for the various AXTextOperation types. At the time of
writing, AXTextOperation has a bug with replacements/transformations over multiple
ranges, which is why some of the tests cases are expected to fail until the bug is
resolved. See <a href="https://bugs.webkit.org/show_bug.cgi?id=278928">https://bugs.webkit.org/show_bug.cgi?id=278928</a>

* LayoutTests/accessibility/mac/text-operation/text-operation-capitalize-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-capitalize.html: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-lowercase-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-lowercase.html: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case.html: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-replace.html: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-select-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-select.html: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace.html: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-uppercase-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-uppercase.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AccessibilityTextOperation::AccessibilityTextOperation): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::performTextOperation):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(accessibilityTextOperationForParameterizedAttribute):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp:
(WTR::toTextMarkerRange):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::performTextOperation):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::textOperationParameterizedAttribute):
(WTR::AccessibilityUIElement::performTextOperation):

Canonical link: <a href="https://commits.webkit.org/283740@main">https://commits.webkit.org/283740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/573c135a49aa7994322c0a58d03de02be4a2783e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53664 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12143 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72645 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14902 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8926 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2542 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->