### PR TITLE
[Win] Fix Wasm Compilation From Web Worker

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -237,6 +237,7 @@ private:
     static LRESULT CALLBACK RunLoopWndProc(HWND, UINT, WPARAM, LPARAM);
     LRESULT wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
     HWND m_runLoopMessageWindow;
+    HashSet<UINT_PTR> m_liveTimers;
 
     Lock m_loopLock;
 #elif USE(COCOA_EVENT_LOOP)

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -31,6 +31,8 @@
 namespace WTF {
 
 static const UINT PerformWorkMessage = WM_USER + 1;
+static const UINT SetTimerMessage = WM_USER + 2;
+static const UINT KillTimerMessage = WM_USER + 3;
 static const LPCWSTR kRunLoopMessageWindowClassName = L"RunLoopMessageWindow";
 
 LRESULT CALLBACK RunLoop::RunLoopWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -55,8 +57,21 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     case PerformWorkMessage:
         performWork();
         return 0;
+    case SetTimerMessage:
+        ::SetTimer(hWnd, wParam, lParam, nullptr);
+        return 0;
+    case KillTimerMessage:
+        ::KillTimer(hWnd, wParam);
+        return 0;
     case WM_TIMER:
-        bitwise_cast<RunLoop::TimerBase*>(wParam)->timerFired();
+        RunLoop::TimerBase* timer = nullptr;
+        {
+            Locker locker { m_loopLock };
+            if (m_liveTimers.contains(wParam))
+                timer = bitwise_cast<RunLoop::TimerBase*>(wParam);
+        }
+        if (timer != nullptr)
+            timer->timerFired();
         return 0;
     }
 
@@ -170,7 +185,8 @@ void RunLoop::TimerBase::start(Seconds interval, bool repeat)
     m_isActive = true;
     m_interval = interval;
     m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
-    ::SetTimer(m_runLoop->m_runLoopMessageWindow, bitwise_cast<uintptr_t>(this), interval.millisecondsAs<UINT>(), nullptr);
+    m_runLoop->m_liveTimers.add(bitwise_cast<uintptr_t>(this));
+    ::PostMessage(m_runLoop->m_runLoopMessageWindow, SetTimerMessage, bitwise_cast<uintptr_t>(this), interval.millisecondsAs<UINT>());
 }
 
 void RunLoop::TimerBase::stop()
@@ -180,7 +196,8 @@ void RunLoop::TimerBase::stop()
         return;
 
     m_isActive = false;
-    ::KillTimer(m_runLoop->m_runLoopMessageWindow, bitwise_cast<uintptr_t>(this));
+    m_runLoop->m_liveTimers.remove(bitwise_cast<uintptr_t>(this));
+    ::PostMessage(m_runLoop->m_runLoopMessageWindow, KillTimerMessage, bitwise_cast<uintptr_t>(this), 0LL);
 }
 
 bool RunLoop::TimerBase::isActiveWithLock() const

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -205,6 +205,15 @@ MessageQueueWaitResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalSc
     timeoutDelay = std::max(0_s, Seconds(timeUntilNextCFRunLoopTimerInSeconds));
 #endif
 
+#if OS(WINDOWS)
+    RunLoop::cycle();
+
+    if (auto* script = context->script()) {
+        JSC::VM& vm = script->vm();
+        timeoutDelay = vm.deferredWorkTimer->timeUntilFire().value_or(Seconds::infinity());
+    }
+#endif
+
     if (predicate.isDefaultMode() && m_sharedTimer->isActive())
         timeoutDelay = std::min(timeoutDelay, m_sharedTimer->fireTimeDelay());
 


### PR DESCRIPTION
#### f659dfd725626675c2e258e2b71b6ee9d037b330
<pre>
[Win] Fix Wasm Compilation From Web Worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=267323">https://bugs.webkit.org/show_bug.cgi?id=267323</a>

Reviewed by Yusuke Suzuki.

We were calling SetTimer from the wasm compilation thread, which isn&apos;t
the thread that owns the run loop message window. That silently failed,
the timer wass never registered / fires as it&apos;s on the wrong thread.

In addition - the WorkerRunLoop was not cycling the window message pump
run loop - on other platforms this worked as both run loops used similar
message queue mechanisms.

We could fix this through wrapping timer start operations in a run loop
dispatch(), but that increases complexity through introducing another
source / type of async tasks in the loop. There&apos;s also a number of call
sites, and the risk of additional call sites being added with Windows
being the only platform where TimerBase::start() must be called on the
run loop thread.

We could also fix this through using run loop dispatch inside
TimerBase::start() / TimerBase::stop() - however it&apos;s difficult to
capture the TimerBase safely for the dispatch lambda with various
subclasses of TimerBase involved. This is necessary because the dispatch
introduces cases where the timer is destroyed before the dispatch
callback runs.

The solution used here is to make RunLoopWin PostMessage to the window
for scheduling / killing timers, so it can call SetTimer / KillTimer
from the correct thread. A HashSet is used in addition to keep track
of live timers - as sometimes a timer is able to fire but not have the
WM_TIMER event processed before KillTimer (and the timer destructor
running).

WorkerRunLoop calls RunLoop::cycle, and adjusts it&apos;s timeout based on
when the next deferredWorkTimer will fire.

* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::wndProc):
(WTF::RunLoop::TimerBase::start):
(WTF::RunLoop::TimerBase::stop):
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::runInMode):

Canonical link: <a href="https://commits.webkit.org/282906@main">https://commits.webkit.org/282906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4152509d9921733fce997182165df1975cea66e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51893 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13964 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57594 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70205 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63727 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59214 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14251 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/656 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85488 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39661 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->