### PR TITLE
REGRESSION (280886@main) ReportingObserver can be garbage collected while a task is queued to make report callbacks.

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -130,19 +130,20 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
     if (m_queuedReports.size() > 1)
         return;
 
-    RefPtr context = m_callback->scriptExecutionContext();
-    if (!context)
-        return;
-
-    ASSERT(m_reportingScope && context == m_reportingScope->scriptExecutionContext());
+    ASSERT(m_reportingScope && scriptExecutionContext() == m_reportingScope->scriptExecutionContext());
 
     // Step 4.3.4: Queue a task to § 4.4
-    context->eventLoop().queueTask(TaskSource::Reporting, [protectedThis = RefPtr { this }, protectedCallback = Ref { m_callback }, context]() mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedThis = Ref { *this }, protectedCallback = Ref { m_callback }] {
+        RefPtr context = protectedThis->scriptExecutionContext();
+        ASSERT(context);
+        if (!context)
+            return;
+
         // Step 4.4: Invoke reporting observers with notify list with a copy of global’s registered reporting observer list.
         auto reports = protectedThis->takeRecords();
 
         InspectorInstrumentation::willFireObserverCallback(*context, "ReportingObserver"_s);
-        protectedCallback->handleEvent(reports, *protectedThis);
+        protectedCallback->handleEvent(reports, protectedThis);
         InspectorInstrumentation::didFireObserverCallback(*context);
     });
 }


### PR DESCRIPTION
#### b5502f0dc670c978232c2b14a3b075e9636d8351
<pre>
REGRESSION (280886@main) ReportingObserver can be garbage collected while a task is queued to make report callbacks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278534">https://bugs.webkit.org/show_bug.cgi?id=278534</a>
<a href="https://rdar.apple.com/133409507">rdar://133409507</a>

Reviewed by Brent Fulgham.

In 280886@main I tied the lifetime of the ReportingObserver object to
whether or not it is observing reports by making it an ActiveDOMObject.
In some cases (especially imported/w3c/web-platform-tests/reporting/disconnect.html)
the object and its callback can be garbage collected while there&apos;s an
outstanding task to make the callback with its reports which can
cause a null pointer dereference when attempting to invoke the callback.

This change will keep the object alive until after the callback has been
serviced, even if all references are dropped and the ReportingObserver
has disconnected.

* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::appendQueuedReportIfCorrectType):

Canonical link: <a href="https://commits.webkit.org/282645@main">https://commits.webkit.org/282645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48fbb7c4895c6f99db703dd3987a3ab2e660f67a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51374 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9924 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58697 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58844 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6399 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38924 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->