### PR TITLE
[Writing Tools] Selection sometimes may not show up when a session's animations finish

### DIFF
--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -377,7 +377,11 @@ void WritingToolsController::showSelection() const
         return;
     }
 
-    document->selection().setSelection(*currentRange);
+    auto visibleSelection = VisibleSelection { *currentRange };
+    if (visibleSelection.isNoneOrOrphaned())
+        return;
+
+    document->selection().setSelection(visibleSelection);
 }
 
 void WritingToolsController::compositionSessionDidFinishReplacement()

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2302,11 +2302,12 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     }
 
     _partialIntelligenceTextPonderingAnimationCount -= 1;
-}
 
-- (BOOL)_intelligenceTextPonderingAnimationIsComplete
-{
-    return !_partialIntelligenceTextPonderingAnimationCount;
+    if (!_partialIntelligenceTextPonderingAnimationCount && _writingToolsTextReplacementsFinished) {
+        // If the entire replacement has already been completed, and this is the end of the last animation,
+        // then reveal the selection.
+        _page->showSelectionForActiveWritingToolsSession();
+    }
 }
 
 - (BOOL)_writingToolsTextReplacementsFinished

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -425,7 +425,6 @@ struct PerWebProcessState {
 #endif
 
 - (void)_didEndPartialIntelligenceTextPonderingAnimation;
-- (BOOL)_intelligenceTextPonderingAnimationIsComplete;
 - (BOOL)_writingToolsTextReplacementsFinished;
 
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -122,7 +122,6 @@ public:
     void writingToolsActiveDidChange() final;
 
     void didEndPartialIntelligenceTextPonderingAnimation() final;
-    bool intelligenceTextPonderingAnimationIsComplete() final;
     bool writingToolsTextReplacementsFinished() final;
 
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -303,11 +303,6 @@ void PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation()
     [m_webView _didEndPartialIntelligenceTextPonderingAnimation];
 }
 
-bool PageClientImplCocoa::intelligenceTextPonderingAnimationIsComplete()
-{
-    return [m_webView _intelligenceTextPonderingAnimationIsComplete];
-}
-
 bool PageClientImplCocoa::writingToolsTextReplacementsFinished()
 {
     return [m_webView _writingToolsTextReplacementsFinished];

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1308,16 +1308,12 @@ bool WebPageProxy::writingToolsTextReplacementsFinished()
     return protectedPageClient()->writingToolsTextReplacementsFinished();
 }
 
-void WebPageProxy::showSelectionForActiveWritingToolsSessionIfNeeded()
+void WebPageProxy::showSelectionForActiveWritingToolsSession()
 {
     if (!hasRunningProcess())
         return;
 
-    if (protectedPageClient()->intelligenceTextPonderingAnimationIsComplete() && writingToolsTextReplacementsFinished()) {
-        // If the entire replacement has already been completed, and this is the end of the last animation,
-        // then reveal the selection.
-        legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForActiveWritingToolsSession(), webPageIDInMainFrameProcess());
-    }
+    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForActiveWritingToolsSession(), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::removeTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -759,7 +759,6 @@ public:
     virtual void writingToolsActiveDidChange() = 0;
 
     virtual void didEndPartialIntelligenceTextPonderingAnimation() = 0;
-    virtual bool intelligenceTextPonderingAnimationIsComplete() = 0;
     virtual bool writingToolsTextReplacementsFinished() = 0;
 
     virtual void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2439,8 +2439,9 @@ public:
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
 
-    void showSelectionForActiveWritingToolsSessionIfNeeded();
     bool writingToolsTextReplacementsFinished();
+    void showSelectionForActiveWritingToolsSession();
+
     void didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&);
     void didEndPartialIntelligenceTextPonderingAnimationImpl();
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13333,7 +13333,6 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
 - (void)replacementEffectDidComplete
 {
     _page->didEndPartialIntelligenceTextPonderingAnimationImpl();
-    _page->showSelectionForActiveWritingToolsSessionIfNeeded();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -132,7 +132,6 @@
                 return;
 
             strongWebView->page().didEndPartialIntelligenceTextPonderingAnimationImpl();
-            strongWebView->page().showSelectionForActiveWritingToolsSessionIfNeeded();
 
             strongWebView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, true);
             strongWebView->page().callCompletionHandlerForAnimationID(*animationID, runMode);


### PR DESCRIPTION
#### 4c0d1d609b41524f449e15c28ce223cdfb57bdab
<pre>
[Writing Tools] Selection sometimes may not show up when a session&apos;s animations finish
<a href="https://bugs.webkit.org/show_bug.cgi?id=278532">https://bugs.webkit.org/show_bug.cgi?id=278532</a>
<a href="https://rdar.apple.com/134516446">rdar://134516446</a>

Reviewed by Abrar Rahman Protyasha.

There is currently a race condition between when the replace animation ends and when the replacement
is complete which causes `showSelectionForActiveWritingToolsSession` to not properly reveal the selection.

Fix by always checking the condition in `_didEndPartialIntelligenceTextPonderingAnimation` instead.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _didEndPartialIntelligenceTextPonderingAnimation]):
(-[WKWebView _intelligenceTextPonderingAnimationIsComplete]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::showSelectionForActiveWritingToolsSession):
(WebKit::WebPageProxy::showSelectionForActiveWritingToolsSessionIfNeeded): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView replacementEffectDidComplete]):
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):

Canonical link: <a href="https://commits.webkit.org/282666@main">https://commits.webkit.org/282666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a812b058c974692d687314e4512912fd76de9e97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67903 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/14489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50936 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/14769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/14489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66950 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13362 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/7828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/14769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7861 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/55394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/6501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9656 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->