### PR TITLE
VoiceOver focus should be able to activate form fields when it lands on them.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -111,8 +111,6 @@ public:
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
 
-    WebCore::AXObjectCache* axObjectCache() const;
-
     WebCore::IntPoint convertFromPluginToPDFView(const WebCore::IntPoint&) const;
     WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPDFViewToRootView(const WebCore::IntRect&) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
@@ -57,6 +57,8 @@ class WeakPtrImplWithEventTargetData;
 - (id)accessibilityHitTest:(NSPoint)point;
 - (void)gotoDestination:(PDFDestination *)destination;
 - (NSRect)convertFromPDFPageToScreenForAccessibility:(NSRect)rectInPageCoordinate pageIndex:(WebKit::PDFDocumentLayout::PageIndex)pageIndex;
+- (id)accessibilityAssociatedControlForAnnotation:(PDFAnnotation *)annotation;
+- (void)setActiveAnnotation:(PDFAnnotation *)annotation;
 
 @end
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -246,6 +246,29 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return rectInPageCoordinate;
 }
 
+- (id)accessibilityAssociatedControlForAnnotation:(PDFAnnotation *)annotation
+{
+    RefPtr activeAnnotation = _pdfPlugin.get()->activeAnnotation();
+    if (!activeAnnotation)
+        return nil;
+
+    id wrapper = nil;
+    callOnMainRunLoopAndWait([activeAnnotation, protectedSelf = retainPtr(self), &wrapper] {
+        if (auto* axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
+            if (RefPtr annotationElementAxObject = axObjectCache->getOrCreate(activeAnnotation->element()))
+                wrapper = annotationElementAxObject->wrapper();
+        }
+    });
+
+    return wrapper;
+}
+
+- (void)setActiveAnnotation:(PDFAnnotation *)annotation
+{
+    RefPtr plugin = _pdfPlugin.get();
+    plugin->setActiveAnnotation({ WTFMove(annotation) });
+}
+
 - (id)accessibilityHitTest:(NSPoint)point
 {
     for (id element in [self accessibilityChildren]) {


### PR DESCRIPTION
#### 8cc0d6f40b1648df767a36dc783368cde765bc0b
<pre>
VoiceOver focus should be able to activate form fields when it lands on them.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278535">https://bugs.webkit.org/show_bug.cgi?id=278535</a>
<a href="https://rdar.apple.com/134522935">rdar://134522935</a>

Reviewed by Abrar Rahman Protyasha.

Implement the annotation connection point between webkit and pdf in WKAccessibilityPDFDocumentObject.h. In this way, VoiceOver can activate form fields when it lands on form fields

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject accessibilityAssociatedControlForAnnotation:]):
(WebKit::rectInViewSpaceForRectInLayoutSpace):
(WebKit::PDFPlugin::axObjectCache const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h:
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityAssociatedControlForAnnotation:]):
(-[WKAccessibilityPDFDocumentObject setActiveAnnotation:]):

Canonical link: <a href="https://commits.webkit.org/283281@main">https://commits.webkit.org/283281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6514bacc4683ff44992ecb2cc25fe18c6da0f5bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16702 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38379 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15296 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71543 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14107 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60420 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1709 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9969 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->