### PR TITLE
AX: Flakey failures in wpt.fyi Interop 2024 accessibility tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
@@ -655,7 +655,6 @@ window.test_driver_internal.get_computed_label = async function (element, contex
         return "";
     context = context ?? window;
 
-    await waitFor(() => context.internals.readyToRetrieveComputedRoleOrLabel(element));
     return context.internals.getComputedLabel(element);
 }
 
@@ -669,6 +668,5 @@ window.test_driver_internal.get_computed_role = async function (element, context
         return "";
     context = context ?? window;
 
-    await waitFor(() => context.internals.readyToRetrieveComputedRoleOrLabel(element));
     return context.internals.getComputedRole(element);
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -352,7 +352,7 @@ String AccessibilityObject::computedLabel()
 {
     // This method is being called by WebKit inspector, which may happen at any time, so we need to update our backing store now.
     // Also hold onto this object in case updateBackingStore deletes this node.
-    RefPtr<AccessibilityObject> protectedThis(this);
+    Ref protectedThis { *this };
     updateBackingStore();
     Vector<AccessibilityText> text;
     accessibilityText(text);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4100,7 +4100,7 @@ ExceptionOr<std::optional<Internals::CompositingPolicy>> Internals::compositingP
     return { Internals::CompositingPolicy::Normal };
 }
 
-void Internals::updateLayoutAndStyleForAllFrames()
+void Internals::updateLayoutAndStyleForAllFrames() const
 {
     auto* document = contextDocument();
     if (!document || !document->view())
@@ -7462,27 +7462,20 @@ AccessibilityObject* Internals::axObjectForElement(Element& element) const
 
 String Internals::getComputedLabel(Element& element) const
 {
-    if (auto* axObject = axObjectForElement(element))
-        return axObject->computedLabel();
-    return ""_s;
+    // Force a layout. If we don't, and this request has come in before the render tree was built,
+    // the accessibility object for this element will not be created (because it doesn't yet have its renderer).
+    updateLayoutAndStyleForAllFrames();
+
+    RefPtr axObject = axObjectForElement(element);
+    return axObject ? axObject->computedLabel() : ""_s;
 }
 
 String Internals::getComputedRole(Element& element) const
 {
-    if (auto* axObject = axObjectForElement(element))
-        return axObject->computedRoleString();
-    return ""_s;
-}
+    updateLayoutAndStyleForAllFrames();
 
-bool Internals::readyToRetrieveComputedRoleOrLabel(Element& element) const
-{
-    // If the element has a renderer, it should be ready to go.
-    if (element.renderer())
-        return true;
-
-    // If the RenderTree is not laid out, we aren't ready to query the computed accessibility role or label. Doing so will yield incorrect results.
-    auto& document = element.document();
-    return !document.inRenderTreeUpdate() && !(document.view() && document.view()->layoutContext().isInRenderTreeLayout());
+    RefPtr axObject = axObjectForElement(element);
+    return axObject ? axObject->computedRoleString() : ""_s;
 }
 
 bool Internals::hasScopeBreakingHasSelectors() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -679,7 +679,7 @@ public:
 
     ExceptionOr<void> setAllowAnimationControlsOverride(bool);
 
-    void updateLayoutAndStyleForAllFrames();
+    void updateLayoutAndStyleForAllFrames() const;
     ExceptionOr<void> updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks(Node*);
     unsigned layoutCount() const;
 
@@ -1461,7 +1461,6 @@ public:
         
     bool isUsingUISideCompositing() const;
 
-    bool readyToRetrieveComputedRoleOrLabel(Element&) const;
     String getComputedLabel(Element&) const;
     String getComputedRole(Element&) const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1383,7 +1383,6 @@ enum RenderingMode {
     
     boolean isUsingUISideCompositing();
 
-    boolean readyToRetrieveComputedRoleOrLabel(Element element);
     DOMString getComputedLabel(Element element);
     DOMString getComputedRole(Element element);
 


### PR DESCRIPTION
#### 4900d7a90e6ea0edfd43a2bfdf37db22ad682170
<pre>
AX: Flakey failures in wpt.fyi Interop 2024 accessibility tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=278540">https://bugs.webkit.org/show_bug.cgi?id=278540</a>
<a href="https://rdar.apple.com/134527513">rdar://134527513</a>

Reviewed by Chris Fleizach.

We suspect these flakey failures happen if WebDriver queries WebCore before the render tree has been built for the first
time, meaning we aren&apos;t going to create accessibility objects correctly, resulting in an empty string result for computed
role and computed label.

We actually worked around this problem in the implementation of test_driver_internal.{get_computed_label, get_computed_role}
by using a mechanism to asynchronously wait for the render tree to be laid out via `Internals::readyToRetrieveComputedRoleOrLabel`.
However, no such mechanism was put in place for the actual WebDriver implementation of getComputedRole and getComputedLabel,
so it is probably suffering from the same problem.

With this patch, `Internals::readyToRetrieveComputedRoleOrLabel` is removed, and instead we just force layout to ensure
renderers are attached to elements before querying these properties. We also now force layout in the WebDriver methods
for this functionality in WebAutomationSessionProxy.cpp, which should solve the flakiness.

* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::computedLabel):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getComputedLabel const):
(WebCore::Internals::getComputedRole const):
(WebCore::Internals::readyToRetrieveComputedRoleOrLabel const): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
(WebKit::WebAutomationSessionProxy::getComputedRole):
(WebKit::WebAutomationSessionProxy::getComputedLabel):

Canonical link: <a href="https://commits.webkit.org/282659@main">https://commits.webkit.org/282659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92842c0b07d700e9e43f6887b1e0ee2afc11ed5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51394 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9948 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69494 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12471 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58717 "Found 1 new test failure: fast/forms/search/search-size-with-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58864 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14124 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6425 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38954 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->