### PR TITLE
Add letter-spacing GTK crash test case

### DIFF
--- a/LayoutTests/fast/css/compute-preferred-logical-widths-crash-expected.txt
+++ b/LayoutTests/fast/css/compute-preferred-logical-widths-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it doesn't crash

--- a/LayoutTests/fast/css/compute-preferred-logical-widths-crash.html
+++ b/LayoutTests/fast/css/compute-preferred-logical-widths-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<table><td>Test passes if it doesn't crash
+<style>
+* { letter-spacing: 170141183460469231731687303715884105727mm; }
+</style>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>


### PR DESCRIPTION
#### 96ace0a27658cb30e164623e4915ab2e0335441f
<pre>
Add letter-spacing GTK crash test case
<a href="https://bugs.webkit.org/show_bug.cgi?id=202912">https://bugs.webkit.org/show_bug.cgi?id=202912</a>
<a href="https://rdar.apple.com/134527900">rdar://134527900</a>

Reviewed by Ryan Reno.

Add test to verify that GTK WebKit doesnt crash when letter-spacing has
values greater than std::numeric_limits&lt;float&gt;::max().

From chromium commit: source.chromium.org/chromium/chromium/src/+/012fda7476fc904c76f1a9f2dc82cb92076bddb4
* LayoutTests/fast/css/compute-preferred-logical-widths-crash-expected.txt: Added.
* LayoutTests/fast/css/compute-preferred-logical-widths-crash.html: Added.

Canonical link: <a href="https://commits.webkit.org/289971@main">https://commits.webkit.org/289971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be5b31b5682c6b65bc993c8d23c3668dff88bc2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92327 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25298 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33539 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94212 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10730 "Found 1 new test failure: swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75605 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7568 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14648 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->