### PR TITLE
[WebGPU] GPUAdapterInfo.device/architecture/description should return the same as vendor() (278542)

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
@@ -40,9 +40,9 @@ public:
     }
 
     String vendor() const { auto v = m_name.split(' '); return v.size() ? normalizedIdentifier(v[0]) : ""_s; }
-    String architecture() const { return normalizedIdentifier(m_name); }
-    String device() const { return normalizedIdentifier(m_name); }
-    String description() const { return normalizedIdentifier(m_name); }
+    String architecture() const { return vendor(); }
+    String device() const { return vendor(); }
+    String description() const { return vendor(); }
 
 private:
     GPUAdapterInfo(String&& name)


### PR DESCRIPTION
#### 501b962b3159b23f860841c5b2dd0931df79f186
<pre>
[WebGPU] GPUAdapterInfo.device/architecture/description should return the same as vendor() (278542)
<a href="https://bugs.webkit.org/show_bug.cgi?id=278542">https://bugs.webkit.org/show_bug.cgi?id=278542</a>
<a href="https://rdar.apple.com/134528228">rdar://134528228</a>

Reviewed by Dan Glastonbury.

Previously we were returning a bit too much information on Apple
platforms, such as applem2ultra for AdapterInfo.device.

Instead, return the same as vendor(), which for all iPhones, Macs,
iPads, and the visionPro is simply &apos;apple&apos;.

* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h:
(WebCore::GPUAdapterInfo::architecture const):
(WebCore::GPUAdapterInfo::device const):
(WebCore::GPUAdapterInfo::description const):

Canonical link: <a href="https://commits.webkit.org/282649@main">https://commits.webkit.org/282649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a91b7854b4e80a09cdce8b68a9796fd820d50ad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51395 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12580 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58711 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55294 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58858 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6412 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9647 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38942 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40021 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->