### PR TITLE
Allow empty usernames for login status

### DIFF
--- a/Source/WebCore/page/LoginStatus.cpp
+++ b/Source/WebCore/page/LoginStatus.cpp
@@ -46,9 +46,6 @@ ExceptionOr<UniqueRef<LoginStatus>> LoginStatus::create(const RegistrableDomain&
     if (domain.isEmpty())
         return Exception { ExceptionCode::SecurityError, "LoginStatus status can only be set for origins with a registrable domain."_s };
 
-    if (username.isEmpty())
-        return Exception { ExceptionCode::SyntaxError, "LoginStatus requires a non-empty username."_s };
-
     unsigned length = username.length();
     if (length > UsernameMaxLength)
         return Exception { ExceptionCode::SyntaxError, makeString("LoginStatus usernames cannot be longer than "_s, UsernameMaxLength) };
@@ -79,7 +76,7 @@ void LoginStatus::setTimeToLive(Seconds timeToLive)
 
 bool LoginStatus::hasExpired() const
 {
-    ASSERT(!m_domain.isEmpty() && !m_username.isEmpty());
+    ASSERT(!m_domain.isEmpty());
     return WallTime::now() > m_loggedInTime + m_timeToLive;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/LoginStatus.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LoginStatus.cpp
@@ -194,4 +194,11 @@ TEST(LoginStatus, ClampedExpiryShort)
     ASSERT_FALSE(loggedIn.hasExpired());
 }
 
+TEST(LoginStatus, EmptyUsername)
+{
+    RegistrableDomain loginDomain { URL { "https://login.example.com"_s } };
+    auto loggedInResult = LoginStatus::create(loginDomain, emptyString(), LoginStatus::CredentialTokenType::HTTPStateToken, LoginStatus::AuthenticationType::Unmanaged);
+    ASSERT_FALSE(loggedInResult.hasException());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 060bb797611eec994f1cb330d09ea379e6a7dde0
<pre>
Allow empty usernames for login status
<a href="https://bugs.webkit.org/show_bug.cgi?id=278546">https://bugs.webkit.org/show_bug.cgi?id=278546</a>
<a href="https://rdar.apple.com/134532661">rdar://134532661</a>

Reviewed by Charlie Wolfe.

Providing usernames is optional in login status. So we should allow empty strings.

* Source/WebCore/page/LoginStatus.cpp:
(WebCore::LoginStatus::create):
(WebCore::LoginStatus::hasExpired const):
* Tools/TestWebKitAPI/Tests/WebCore/LoginStatus.cpp:
(TestWebKitAPI::TEST(LoginStatus, EmptyUsername)):

Canonical link: <a href="https://commits.webkit.org/282667@main">https://commits.webkit.org/282667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea8d8ca2697c1e1514aa448fc411fb19b6245942

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51398 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9951 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58723 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58869 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6436 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9657 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38961 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->