### PR TITLE
[WebGPU] GPUCanvasContext.surfaceBufferToImageBuffer doesn't handle failure when work is not submitted correctly

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-278545-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-278545-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-278545.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-278545.html
@@ -1,0 +1,17741 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let promise0 = navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {label: '\ua4ba\uc724\u17e6\u1a92\u0468\u548b\udc51\uc76e\u{1fad1}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxStorageBuffersPerShaderStage: 8,
+    maxUniformBufferBindingSize: 8903773,
+    maxStorageBufferBindingSize: 185588514,
+    maxUniformBuffersPerShaderStage: 12,
+  },
+});
+try {
+adapter0.label = '\u{1f678}\u091c\u{1fa46}\u{1f951}\u11f9\u0d22\u{1fe07}\u3e75\u1add\u02b6\u{1ff8f}';
+} catch {}
+let texture0 = device0.createTexture({
+  label: '\u7222\u282b\u44a3',
+  size: {width: 154},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u1abc\u64b4\uf538\u0cae\u{1f92b}\u19bc\u2427\u197d',
+  colorFormats: ['bgra8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let texture1 = device0.createTexture({
+  label: '\u04b2\ua90c\u00a4\u5fc3\u52d2\u{1f976}',
+  size: {width: 618},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u03d7\u{1ff61}\u{1ff9f}\u0b70\u{1fb4d}\ufcd4'});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u09e8\u{1fc81}\u0ff0'});
+let img0 = await imageWithData(29, 20, '#10101010', '#20202020');
+let commandEncoder0 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder0.finish({label: '\u403e\u08f0\u35a1\u4c7a'});
+let texture2 = device0.createTexture({
+  label: '\u051b\u1da2\u{1fc84}\uf2d4\u329b\u{1f997}\u02b3\ud22d\u089a\u{1ffdf}',
+  size: {width: 154},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1fee9}\u79c8\u{1fb1a}\u3d93\u00d7\u344e\ub77d',
+  entries: [
+    {
+      binding: 189,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 27, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 366,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 249,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 561,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 262,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 29,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 330, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 84, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 408,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 8, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 636,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 200,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 231,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 107,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 97, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 131,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 195,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 3846364, hasDynamicOffset: true },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 239,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 253,
+      visibility: 0,
+      buffer: { type: 'storage', minBindingSize: 6149982, hasDynamicOffset: false },
+    },
+    {
+      binding: 334,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 98, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 312,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 89, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 395, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 165, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {binding: 284, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 361,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 489,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 203, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {binding: 563, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 153,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 44, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 292,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 148,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 33, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 133, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 118, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 373});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u09db\u09f0\u{1f989}\u0345\uabfd\u231c\ua15a\u{1fea2}'});
+let renderBundle2 = renderBundleEncoder0.finish();
+let commandBuffer1 = commandEncoder1.finish({label: '\u0fb4\u{1ff8c}'});
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u2153\u0b3b\u5798\u0581\u0247\u8966\u{1fdc7}\u5d65', bindGroupLayouts: [bindGroupLayout0]});
+let textureView0 = texture1.createView({label: '\ufdc6\u3068\udae1\u7ee1\u52aa\u0745\u9f14\u3254\u0eb9', aspect: 'all'});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\ud5ff\u86e6\u{1fde1}\u12dd\u0932\u0fe3\u0b58\u28e9\u{1fe5f}\ubb9d',
+  bindGroupLayouts: [bindGroupLayout0],
+});
+let commandEncoder2 = device0.createCommandEncoder();
+let commandBuffer2 = commandEncoder2.finish();
+let commandEncoder3 = device0.createCommandEncoder({label: '\u09b2\u02cc'});
+let shaderModule0 = device0.createShaderModule({
+  label: '\u{1fcdf}\u7759\u4aeb\u0735\u{1fde0}\ud4cb',
+  code: `
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+struct T1 {
+  f0: T0,
+}
+@group(0) @binding(366) var tex1: texture_1d<u32>;
+@group(0) @binding(89) var et3: texture_external;
+@group(0) @binding(489) var<storage, read_write> buffer13: array<atomic<i32>>;
+@group(0) @binding(133) var et9: texture_external;
+@group(0) @binding(157) var<uniform> buffer7: mat2x2f;
+@group(0) @binding(34) var tex15: texture_depth_cube;
+@group(0) @binding(31) var<storage, read_write> buffer3: atomic<u32>;
+@group(0) @binding(249) var tex3: texture_depth_multisampled_2d;
+@group(0) @binding(95) var sam6: sampler;
+@group(0) @binding(408) var tex5: texture_depth_multisampled_2d;
+@group(0) @binding(334) var tex13: texture_depth_2d_array;
+@group(0) @binding(395) var et4: texture_external;
+@group(0) @binding(362) var tex12: texture_multisampled_2d<f32>;
+@group(0) @binding(105) var tex11: texture_depth_2d_array;
+@group(0) @binding(131) var sam8: sampler;
+@group(0) @binding(312) var<uniform> buffer11: mat2x4h;
+@group(0) @binding(75) var tex2: texture_multisampled_2d<f32>;
+@group(0) @binding(262) var<storage, read> buffer1: array<vec2h, 1>;
+@group(0) @binding(98) var et2: texture_external;
+@group(0) @binding(33) var et8: texture_external;
+@group(0) @binding(79) var sam14: sampler_comparison;
+@group(0) @binding(292) var<uniform> buffer14: array<mat3x2f, 1>;
+@group(0) @binding(206) var<uniform> buffer0: mat3x3h;
+@group(0) @binding(231) var tex6: texture_multisampled_2d<u32>;
+@group(0) @binding(8) var sam4: sampler;
+@group(0) @binding(7) var<storage, read_write> buffer5: atomic<i32>;
+@group(0) @binding(189) var st0: texture_storage_2d<rg32float, write>;
+@group(0) @binding(107) var sam5: sampler;
+@group(0) @binding(253) var<storage, read_write> buffer8: atomic<u32>;
+@group(0) @binding(999) var<uniform> buffer12: f16;
+@group(0) @binding(563) var et5: texture_external;
+@group(0) @binding(28) var<storage, read_write> buffer4: array<f32>;
+@group(0) @binding(284) var sam12: sampler_comparison;
+@group(0) @binding(120) var sam10: sampler;
+@group(0) @binding(43) var tex10: texture_depth_cube_array;
+@group(0) @binding(203) var sam15: sampler_comparison;
+@group(0) @binding(71) var tex8: texture_3d<f32>;
+@group(0) @binding(84) var sam3: sampler;
+@group(0) @binding(195) var tex9: texture_3d<u32>;
+@group(0) @binding(148) var<uniform> buffer15: mat3x4h;
+@group(0) @binding(16) var tex14: texture_multisampled_2d<f32>;
+@group(0) @binding(636) var<storage, read> buffer2: u32;
+@group(0) @binding(29) var tex4: texture_depth_cube;
+@group(0) @binding(118) var et10: texture_external;
+@group(0) @binding(22) var sam9: sampler_comparison;
+@group(0) @binding(561) var sam1: sampler_comparison;
+@group(0) @binding(101) var tex0: texture_1d<i32>;
+@group(0) @binding(97) var sam7: sampler;
+@group(0) @binding(153) var et6: texture_external;
+@group(0) @binding(15) var st1: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(137) var<uniform> buffer9: mat3x4f;
+@group(0) @binding(239) var<uniform> buffer6: vec4u;
+@group(0) @binding(218) var tex7: texture_depth_cube_array;
+@group(0) @binding(27) var et0: texture_external;
+@group(0) @binding(65) var sam2: sampler_comparison;
+@group(0) @binding(72) var sam0: sampler;
+@group(0) @binding(5) var st2: texture_storage_1d<rg32uint, read>;
+@group(0) @binding(165) var sam11: sampler_comparison;
+@group(0) @binding(361) var sam13: sampler;
+@group(0) @binding(42) var<storage, read_write> buffer10: vec2u;
+@group(0) @binding(330) var et1: texture_external;
+@group(0) @binding(200) var st3: texture_storage_2d_array<rgba32float, read>;
+@group(0) @binding(44) var et7: texture_external;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0() {
+  _ = textureSampleLevel(tex11, sam13, vec2f(), 0i, 0i);
+  _ = textureSampleLevel(tex10, sam7, vec3f(), 0i, 0i);
+  _ = textureSampleLevel(tex11, sam13, vec2f(), 0i, 0i, vec2i());
+  _ = textureSampleLevel(tex13, sam5, vec2f(), 0i, 0i, vec2i());
+  _ = textureSampleLevel(tex11, sam6, vec2f(), 0i, 0i);
+  _ = textureGather(tex13, sam10, vec2f(), 0i, vec2i());
+  _ = textureSampleCompareLevel(tex7, sam9, vec3f(), 0i, 0.);
+  _ = textureSampleLevel(tex13, sam6, vec2f(), 0i, 0i, vec2i());
+  _ = textureSampleBaseClampToEdge(et5, sam6, vec2f());
+  _ = textureLoad(tex14, vec2i(), 0);
+  _ = textureSampleLevel(tex13, sam5, vec2f(), 0i, 0i);
+  _ = textureGather(tex7, sam7, vec3f(), 0);
+  _ = textureGather(tex11, sam10, vec2f(), 0i, vec2i());
+  _ = textureLoad(tex0, 0, 0);
+  _ = textureGather(tex11, sam7, vec2f(), 0i, vec2i());
+  textureStore(st1, vec2i(), vec4f(0.1571, 0.04262, 0.3580, 0.1114));
+}
+
+struct S0 {
+  @builtin(instance_index) f0: u32,
+  @builtin(vertex_index) f1: u32,
+  @location(4) f2: vec4u,
+  @location(1) f3: u32,
+  @location(2) f4: f32,
+  @location(12) f5: vec3f,
+  @location(0) f6: vec4u,
+  @location(15) f7: f32,
+  @location(5) f8: vec4u
+}
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f
+}
+
+@vertex
+fn vertex0(@location(6) a0: f16, @location(13) a1: vec4f, @location(3) a2: vec3u, a3: S0, @location(7) a4: vec3h, @location(14) a5: vec3h, @location(10) a6: f32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureSampleLevel(tex15, sam8, vec3f(), 0i);
+  _ = textureSampleBaseClampToEdge(et6, sam0, vec2f());
+  _ = a1;
+  _ = textureGather(tex10, sam8, vec3f(), 0);
+  _ = textureSampleBaseClampToEdge(et9, sam13, vec2f());
+  _ = textureSampleBaseClampToEdge(et1, sam3, vec2f());
+  _ = buffer2;
+  _ = textureLoad(et1, vec2u());
+  _ = textureLoad(st3, vec2i(), 0);
+  _ = textureLoad(tex9, vec3i(), 0);
+  _ = textureSampleLevel(tex13, sam13, vec2f(), 0i, 0i);
+  _ = textureLoad(tex2, vec2i(), 0);
+  _ = textureSampleBaseClampToEdge(et4, sam13, vec2f());
+  _ = buffer0;
+  if bool(textureSampleCompareLevel(tex10, sam15, vec3f(), 0i, 0.)) {
+    var v: vec4f;
+  }
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureSample(tex11, sam10, vec2f(), 0i, vec2i());
+  _ = textureSampleLevel(tex11, sam5, vec2f(), 0i, 0i);
+  _ = textureSample(tex8, sam10, vec3f(), vec3i());
+  _ = textureLoad(tex3, vec2i(), 0);
+  _ = textureSampleCompareLevel(tex11, sam14, vec2f(), 0i, 0., vec2i());
+  _ = buffer1;
+  _ = textureSampleBaseClampToEdge(et1, sam6, vec2f());
+  _ = textureSampleBaseClampToEdge(et1, sam5, vec2f());
+  _ = textureSampleCompare(tex10, sam14, vec3f(), 0i, 0.);
+  _ = textureSampleGrad(tex8, sam5, vec3f(), vec3f(), vec3f(), vec3i());
+  _ = textureSampleBaseClampToEdge(et10, sam13, vec2f());
+  _ = textureSample(tex4, sam4, vec3f());
+  _ = textureSampleLevel(tex8, sam10, vec3f(), 0.0);
+  _ = textureSampleCompare(tex4, sam14, vec3f(), 0.);
+  _ = textureSampleCompareLevel(tex11, sam9, vec2f(), 0i, 0., vec2i());
+  _ = textureSampleLevel(tex11, sam0, vec2f(), 0i, 0i);
+  _ = textureSample(tex11, sam13, vec2f(), 0i, vec2i());
+  _ = textureSampleLevel(tex8, sam13, vec3f(), 0.0, vec3i());
+  _ = textureSampleCompare(tex10, sam2, vec3f(), 0i, 0.);
+  _ = buffer3;
+  _ = textureSample(tex8, sam6, vec3f());
+  _ = textureSampleBaseClampToEdge(et6, sam10, vec2f());
+  _ = textureGather(tex10, sam13, vec3f(), 0);
+  _ = textureSampleLevel(tex8, sam8, vec3f(), 0.0);
+  _ = textureGather(tex10, sam10, vec3f(), 0);
+  _ = buffer11;
+  _ = textureSampleLevel(tex7, sam10, vec3f(), 0i, 0i);
+  _ = textureSample(tex7, sam4, vec3f(), 0i);
+  _ = textureSample(tex4, sam0, vec3f());
+  _ = textureSampleBaseClampToEdge(et6, sam8, vec2f());
+  _ = textureSampleBaseClampToEdge(et5, sam5, vec2f());
+  out.f0 = textureGather(tex7, sam6, vec3f(), 0);
+  if bool(textureSample(tex11, sam13, vec2f(), 0i)) {
+    atomicStore(&buffer5, -13);
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u0a63\u130d\u31aa\ua8c2\u8466\uaff1\u5816\u0d0e\uecde\u{1f899}\u0c73'});
+let pipeline0 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, constants: {}}});
+let commandBuffer3 = commandEncoder3.finish({label: '\u05ee\u{1ffd3}\u0c67\u0326\u{1fb07}\u{1f8ab}'});
+let commandBuffer4 = commandEncoder4.finish({label: '\u{1feba}\u7485\u7a7d\u{1fde8}'});
+let commandEncoder5 = device0.createCommandEncoder();
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u03d8\u640d',
+  colorFormats: ['bgra8unorm-srgb'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle3 = renderBundleEncoder1.finish();
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 145, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise1 = navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let texture3 = device0.createTexture({
+  label: '\u5990\u{1fef8}\ue0e3',
+  size: {width: 618, height: 96, depthOrArrayLayers: 706},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let promise2 = device0.queue.onSubmittedWorkDone();
+let querySet1 = device0.createQuerySet({label: '\u{1f666}\ua7b3\u{1f62e}\uf2de\u180a\u{1f8ec}', type: 'occlusion', count: 783});
+let commandBuffer5 = commandEncoder5.finish({label: '\ud5c1\u{1fa41}\u0f93\ua18c\u2afd\ue921\u09dd'});
+let renderBundle4 = renderBundleEncoder0.finish({label: '\u0ecd\udfb2\u8d33\uea3c\u{1f6ce}\u0ed4'});
+try {
+  await promise2;
+} catch {}
+await gc();
+let commandEncoder6 = device0.createCommandEncoder();
+let commandBuffer6 = commandEncoder6.finish({label: '\u1e7f\u6982\u489e'});
+let offscreenCanvas0 = new OffscreenCanvas(100, 100);
+let buffer16 = device0.createBuffer({
+  label: '\u006e\udddd\u{1fef9}\ube34\ud75e',
+  size: 22908,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+});
+try {
+buffer16.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u3206\uf539\u05b7\ucecf\ue517\u0f6d',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle5 = renderBundleEncoder1.finish({label: '\u00a4\u9cb7'});
+try {
+renderBundleEncoder2.pushDebugGroup('\u08c2');
+} catch {}
+offscreenCanvas0.width = 402;
+try {
+renderBundleEncoder2.setVertexBuffer(6, undefined, 629_328_510, 848_260_189);
+} catch {}
+try {
+renderBundleEncoder2.popDebugGroup();
+} catch {}
+await gc();
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({label: '\u3e10\u25dc\uf6bc\u235b\u4eba\ubbb1\u3915\u4374\u0338\u0a24\ued8c'});
+let querySet2 = device0.createQuerySet({
+  label: '\u{1f653}\u4c9f\u012b\u89b7\ubdbc\u0627\u{1f7c1}\u480a\u09bf\u0703',
+  type: 'occlusion',
+  count: 34,
+});
+let renderBundle6 = renderBundleEncoder0.finish({label: '\u0cf0\u{1fa0c}\u0821\u{1f6ae}\u0bf0\u9344\u0b6f\u0881'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img0);
+let commandBuffer7 = commandEncoder7.finish({label: '\u{1f826}\uf956\uf123\u0c34\u{1fd9f}'});
+try {
+renderBundleEncoder2.setVertexBuffer(3, undefined, 0, 1_307_068_518);
+} catch {}
+let pipeline1 = device0.createComputePipeline({label: '\u033a\u032c', layout: pipelineLayout1, compute: {module: shaderModule0, constants: {}}});
+document.body.prepend(img0);
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let textureView1 = texture3.createView({label: '\ua24c\u00de\u{1f646}\uffcb\u04a2\u04cf\ua473\ub73d\ue490', mipLevelCount: 1});
+try {
+buffer16.unmap();
+} catch {}
+let textureView2 = texture1.createView({label: '\u8454\u55cf', baseMipLevel: 0});
+try {
+device0.queue.label = '\ue377\u03a3\u0c0c\u0d9b\u39a9\u0c4a\u{1fd5b}\u0fe7\u9454\u{1f9a8}\u7b8c';
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u{1f955}\u07a5\u32cc\uda1e\u{1fd5e}'});
+try {
+  await promise3;
+} catch {}
+let commandBuffer8 = commandEncoder8.finish({});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline2 = device0.createComputePipeline({label: '\u93df\u{1f895}', layout: pipelineLayout0, compute: {module: shaderModule0, constants: {}}});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+commandBuffer0.label = '\u0cf4\u2902\u458a\u028b\u{1fbec}\u0987\ua552\u{1fe25}\u{1fdad}';
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder();
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 87},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer9 = commandEncoder9.finish({label: '\u{1f7ce}\uf0e8'});
+let buffer17 = device0.createBuffer({
+  label: '\u0dcd\u0611\u6164\u0df5\u0308\u0369\uc324',
+  size: 2956,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+});
+let renderBundle7 = renderBundleEncoder2.finish({label: '\u2931\ube7c\u08d7\u{1ffcd}\u0ed6\u563e\u4416'});
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let pipeline3 = await device0.createComputePipelineAsync({
+  label: '\u0a4d\u2977\u{1fcba}\u81e9\uc899\uc4fe\ub341\u{1f7e5}\u{1fce8}\u206d\u{1ff8f}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let promise4 = device0.createRenderPipelineAsync({
+  label: '\ubd8f\ub8d0\u4501\ua003\u4d4e\u30f6\u{1fa26}\u015c\ue054\u{1f9ea}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 108489942,
+    stencilWriteMask: 203739811,
+    depthBiasSlopeScale: 716.9237533338063,
+  },
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {arrayStride: 44, attributes: []},
+      {arrayStride: 100, attributes: [{format: 'unorm8x4', offset: 12, shaderLocation: 2}]},
+      {arrayStride: 788, stepMode: 'instance', attributes: []},
+      {arrayStride: 764, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 456,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 12, shaderLocation: 14}],
+      },
+      {arrayStride: 64, attributes: [{format: 'uint32', offset: 4, shaderLocation: 0}]},
+      {
+        arrayStride: 28,
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 10},
+          {format: 'float16x4', offset: 0, shaderLocation: 12},
+          {format: 'uint32', offset: 4, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 13},
+          {format: 'float32x3', offset: 0, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 136,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 0, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 15},
+          {format: 'uint32x3', offset: 8, shaderLocation: 1},
+          {format: 'uint8x2', offset: 6, shaderLocation: 4},
+          {format: 'uint32', offset: 36, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let promise5 = adapter0.requestAdapterInfo();
+let commandEncoder11 = device0.createCommandEncoder({label: '\u99c1\ubfb1\u26ab\u06a5\u4d00\u{1fc27}\u76e6'});
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise5;
+} catch {}
+document.body.prepend(img0);
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let buffer18 = device0.createBuffer({
+  label: '\u894f\u0129\u0c50\u77b1\u694f\u0a11\u{1faef}',
+  size: 12448,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u591d\u4b58\u{1fb53}\ub171\uf92e\uc027\uff68\u03c0'});
+let textureView3 = texture1.createView({
+  label: '\u080f\ub7d6\uffea\u2f0f\u{1f71b}\u5e57\u{1f7e9}\u{1fbd2}\u2dd4\u{1fdba}\u6c4e',
+  dimension: '1d',
+  baseArrayLayer: 0,
+});
+let renderBundle8 = renderBundleEncoder1.finish({label: '\u0b9a\u{1f6de}\u197d\u0d68\ucf94\u3610\ub463\u{1f800}\u0e7e\ud835\u8663'});
+try {
+buffer16.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData0 = new ImageData(192, 16);
+let commandEncoder13 = device0.createCommandEncoder({label: '\u2e51\u0f62\u54d9\u92e4\u{1f711}\u7bcb'});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 142});
+let textureView4 = texture1.createView({});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+offscreenCanvas0.height = 103;
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0e18\u{1fe9e}\u0f53\ub634\u9db6\u6433'});
+let commandBuffer10 = commandEncoder13.finish({});
+let renderBundle9 = renderBundleEncoder2.finish({label: '\ucf7c\u0257'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture4 = device0.createTexture({
+  label: '\u0f74\u0555\u{1fb46}',
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle10 = renderBundleEncoder0.finish({label: '\u{1fa3b}\u779e\udd7e\u06a2\u2620\ub2b5\u00a8'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandBuffer11 = commandEncoder11.finish({label: '\ua6e2\u0a7c\u{1fd99}\u6b88\ufa87\u{1fe45}'});
+let texture5 = device0.createTexture({
+  label: '\u910a\u0026\ub0ec\ue160\u670e\u6623\u0ffb\u{1fadc}\u2732',
+  size: [309],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView5 = texture5.createView({label: '\u{1fd96}\u1813\u093c\u{1f7c2}\u0b5c', baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder0 = commandEncoder10.beginComputePass({label: '\ub69e\ubd06\u238e\u468e\u074c\u0893\u6c0c\u0b31\u0110\u8c80'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture6 = device0.createTexture({
+  label: '\ue307\u045e\u0de5\u0506\uc4fb\u{1fdd9}\u{1fdeb}\u8104\u37d6',
+  size: [618, 96, 15],
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+buffer18.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData1 = new ImageData(24, 12);
+let buffer19 = device0.createBuffer({
+  size: 14015,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder1 = commandEncoder12.beginComputePass({label: '\u{1fd30}\u7252\ub949\u{1f82b}\u0907\ufd01'});
+let sampler0 = device0.createSampler({
+  label: '\u0d6e\ue94d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 31.35,
+});
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 113, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline4 = device0.createComputePipeline({
+  label: '\ueb10\u{1ffea}\ub8b6\u33cd\ued7b\u003f\uce53\u05ed\u6a8f\u0a88',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline5 = await promise4;
+document.body.prepend(img0);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\u0015\u0409\u502c\uc3b1\u0e97',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+@group(0) @binding(7) var<storage, read_write> buffer25: array<vec2u>;
+@group(0) @binding(362) var tex28: texture_depth_multisampled_2d;
+@group(0) @binding(89) var et14: texture_external;
+@group(0) @binding(200) var st7: texture_storage_2d_array<rgba8snorm, read>;
+@group(0) @binding(16) var tex30: texture_multisampled_2d<i32>;
+@group(0) @binding(636) var<storage, read> buffer22: array<mat4x3f>;
+@group(0) @binding(22) var sam25: sampler_comparison;
+@group(0) @binding(561) var sam17: sampler_comparison;
+@group(0) @binding(79) var sam30: sampler_comparison;
+@group(0) @binding(153) var et17: texture_external;
+@group(0) @binding(75) var tex18: texture_depth_multisampled_2d;
+@group(0) @binding(489) var<storage, read_write> buffer33: array<vec3f>;
+@group(0) @binding(97) var sam23: sampler;
+@group(0) @binding(101) var tex16: texture_cube<f32>;
+@group(0) @binding(334) var tex29: texture_1d<u32>;
+@group(0) @binding(361) var sam29: sampler;
+@group(0) @binding(31) var<storage, read_write> buffer23: array<atomic<i32>, 1>;
+@group(0) @binding(312) var<uniform> buffer31: mat2x2h;
+@group(0) @binding(218) var tex23: texture_depth_cube_array;
+@group(0) @binding(239) var<uniform> buffer26: mat4x3h;
+@group(0) @binding(249) var tex19: texture_depth_multisampled_2d;
+@group(0) @binding(133) var et20: texture_external;
+@group(0) @binding(65) var sam18: sampler_comparison;
+@group(0) @binding(44) var et18: texture_external;
+@group(0) @binding(95) var sam22: sampler;
+@group(0) @binding(43) var tex26: texture_1d<i32>;
+@group(0) @binding(84) var sam19: sampler;
+@group(0) @binding(137) var<uniform> buffer29: mat4x2h;
+@group(0) @binding(195) var tex25: texture_depth_2d;
+@group(0) @binding(8) var sam20: sampler;
+@group(0) @binding(999) var<uniform> buffer32: vec3u;
+@group(0) @binding(29) var tex20: texture_depth_2d_array;
+@group(0) @binding(15) var st5: texture_storage_1d<rgba32float, write>;
+@group(0) @binding(203) var sam31: sampler_comparison;
+@group(0) @binding(120) var sam26: sampler;
+@group(0) @binding(231) var tex22: texture_multisampled_2d<u32>;
+@group(0) @binding(206) var<uniform> buffer20: vec3h;
+@group(0) @binding(131) var sam24: sampler;
+@group(0) @binding(395) var et15: texture_external;
+@group(0) @binding(330) var et12: texture_external;
+@group(0) @binding(105) var tex27: texture_depth_2d_array;
+@group(0) @binding(366) var tex17: texture_2d<f32>;
+@group(0) @binding(98) var et13: texture_external;
+@group(0) @binding(292) var<uniform> buffer34: f16;
+@group(0) @binding(165) var sam27: sampler_comparison;
+@group(0) @binding(157) var<uniform> buffer27: array<mat4x4h, 1>;
+@group(0) @binding(72) var sam16: sampler;
+@group(0) @binding(5) var st6: texture_storage_2d_array<rgba8sint, read>;
+@group(0) @binding(118) var et21: texture_external;
+@group(0) @binding(148) var<uniform> buffer35: vec3i;
+@group(0) @binding(284) var sam28: sampler_comparison;
+@group(0) @binding(563) var et16: texture_external;
+@group(0) @binding(262) var<storage, read> buffer21: array<vec4i>;
+@group(0) @binding(27) var et11: texture_external;
+@group(0) @binding(107) var sam21: sampler;
+@group(0) @binding(42) var<storage, read_write> buffer30: array<vec2i>;
+@group(0) @binding(28) var<storage, read_write> buffer24: T0;
+@group(0) @binding(253) var<storage, read_write> buffer28: T0;
+@group(0) @binding(189) var st4: texture_storage_3d<rg32float, write>;
+@group(0) @binding(71) var tex24: texture_cube<i32>;
+@group(0) @binding(34) var tex31: texture_depth_2d;
+@group(0) @binding(33) var et19: texture_external;
+@group(0) @binding(408) var tex21: texture_depth_multisampled_2d;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(workgroup_id) a0: vec3u) {
+  _ = textureLoad(et16, vec2u());
+  _ = textureSampleLevel(tex20, sam23, vec2f(), 0i, 0i, vec2i());
+  _ = textureSampleLevel(tex20, sam21, vec2f(), 0i, 0i);
+  _ = textureDimensions(et16);
+  _ = textureSampleLevel(tex20, sam26, vec2f(), 0i, 0i, vec2i());
+  _ = textureSampleCompareLevel(tex27, sam30, vec2f(), 0i, 0.);
+  _ = textureSampleLevel(tex27, sam23, vec2f(), 0i, 0i);
+  _ = textureGather(tex27, sam29, vec2f(), 0i, vec2i());
+  _ = textureSampleBaseClampToEdge(et17, sam22, vec2f());
+  _ = textureGather(2, tex16, sam21, vec3f());
+  _ = textureSampleLevel(tex23, sam21, vec3f(), 0i, 0i);
+  _ = textureSampleLevel(tex27, sam29, vec2f(), 0i, 0i, vec2i());
+  _ = textureLoad(et21, vec2u());
+  _ = textureLoad(st6, vec2i(), 0);
+  _ = textureLoad(et14, vec2u());
+}
+
+struct VertexOutput0 {
+  @location(5) f1: vec2f,
+  @builtin(position) f2: vec4f,
+  @location(4) f3: vec4f
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec4h, @location(12) a1: f32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureSampleLevel(tex25, sam24, vec2f(), 0i, vec2i());
+  _ = a0;
+  _ = textureDimensions(et19);
+  _ = textureSampleBaseClampToEdge(et20, sam16, vec2f());
+  _ = buffer34;
+  _ = buffer32;
+  _ = textureSampleCompareLevel(tex31, sam27, vec2f(), 0.);
+  if bool(textureSampleCompareLevel(tex31, sam31, vec2f(), 0.)) {
+    var v: vec4f;
+  }
+  return out;
+}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4f,
+  @location(2) f2: vec4u
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureGather(3, tex24, sam26, vec3f());
+  _ = textureSampleCompare(tex23, sam28, vec3f(), 0i, 0.);
+  _ = textureDimensions(et11);
+  _ = textureSampleLevel(tex20, sam29, vec2f(), 0i, 0i);
+  _ = textureSampleCompare(tex27, sam28, vec2f(), 0i, 0., vec2i());
+  _ = textureSampleCompare(tex27, sam17, vec2f(), 0i, 0., vec2i());
+  _ = textureSampleCompare(tex23, sam17, vec3f(), 0i, 0.);
+  _ = textureSampleCompare(tex27, sam30, vec2f(), 0i, 0.);
+  _ = textureSampleBaseClampToEdge(et14, sam16, vec2f());
+  _ = textureSampleLevel(tex16, sam29, vec3f(), 0.0);
+  _ = textureSample(tex20, sam16, vec2f(), 0i, vec2i());
+  _ = textureGather(tex20, sam26, vec2f(), 0i, vec2i());
+  _ = textureSampleBaseClampToEdge(et17, sam21, vec2f());
+  _ = textureGather(3, tex17, sam21, vec2f(), vec2i());
+  _ = textureSample(tex16, sam20, vec3f());
+  _ = textureSampleBias(tex16, sam20, vec3f(), 0.0);
+  _ = textureSample(tex16, sam26, vec3f());
+  _ = textureSampleBias(tex16, sam26, vec3f(), 0.0);
+  _ = textureSample(tex27, sam21, vec2f(), 0i);
+  _ = textureSample(tex17, sam16, vec2f());
+  _ = textureGather(tex23, sam22, vec3f(), 0);
+  _ = textureSampleCompareLevel(tex23, sam17, vec3f(), 0i, 0.);
+  _ = textureSampleBaseClampToEdge(et16, sam16, vec2f());
+  _ = textureSampleLevel(tex27, sam21, vec2f(), 0i, 0i, vec2i());
+  _ = textureSampleBias(tex17, sam26, vec2f(), 0.0, vec2i());
+  _ = textureSampleBaseClampToEdge(et17, sam20, vec2f());
+  _ = textureSampleLevel(tex20, sam16, vec2f(), 0i, 0i, vec2i());
+  buffer25[12345] = vec2u(bitcast<u32>(textureSampleCompare(tex20, sam17, vec2f(), 0i, 0.)));
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder2 = commandEncoder14.beginComputePass({label: '\udc48\u09b6\u5cbe\u0b4a\u2c78\u0b98\u8756\u1079'});
+let renderBundle11 = renderBundleEncoder0.finish();
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let texture7 = device0.createTexture({
+  size: {width: 154, height: 24, depthOrArrayLayers: 78},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let pipeline6 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule1}});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\uac07\u{1fb16}\u0cd5\u74ea\u{1fba8}\u3e03\u7092\u{1fce7}\u1b0c\u0de0\u7f83',
+  entries: [
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let commandBuffer12 = commandEncoder15.finish({});
+let commandEncoder17 = device0.createCommandEncoder();
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u0d0e\ua8f4\u075b\u08f7\u642c',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder3.finish({label: '\u385d\u8298\u{1fc2f}\u{1fe12}\u8662\u54cc\udc45\uc1f3\u0f51\u{1f9f6}\uec1b'});
+let commandBuffer13 = commandEncoder17.finish();
+await gc();
+let commandEncoder18 = device0.createCommandEncoder();
+try {
+computePassEncoder0.setPipeline(pipeline6);
+} catch {}
+let commandBuffer14 = commandEncoder18.finish({label: '\ufad0\u00ab\ud70b\u1d4c\u{1fac8}\u{1fa9b}'});
+let texture8 = device0.createTexture({
+  label: '\u538e\ucad8\u3478\u{1f67a}\u1c96\u09bb\u0c24\u08a3',
+  size: [618],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle13 = renderBundleEncoder1.finish();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData2 = new ImageData(40, 64);
+let buffer36 = device0.createBuffer({
+  label: '\u0f9f\u082d\u0d10\ud023\u{1fb61}\uf1bb',
+  size: 11453,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer15 = commandEncoder16.finish({});
+let texture9 = device0.createTexture({
+  label: '\u479c\uec0e\u0b59\u{1fec3}\u3be1\ud939',
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 85, y: 77, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 170, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 63, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer11, commandBuffer10]);
+} catch {}
+let promise7 = adapter0.requestAdapterInfo();
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u0fe4\u{1fc4b}\u447c\u{1ff6d}\u317a\uc1f2',
+  entries: [
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView6 = texture8.createView({label: '\u{1faac}\ud95a', mipLevelCount: 1});
+let computePassEncoder3 = commandEncoder10.beginComputePass({label: '\uf14c\u9a80'});
+let renderBundle14 = renderBundleEncoder1.finish();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 11, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder();
+let commandBuffer16 = commandEncoder19.finish({label: '\u4564\u{1ff49}\u{1f884}\uf6aa\uc245\u05f8\u4d35\u0563'});
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 12, y: 2, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(1_112), /* required buffer size: 1_112 */
+{offset: 329, bytesPerRow: 33, rowsPerImage: 20}, {width: 6, height: 4, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 68, new Float32Array(48712), 32732, 344);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+document.body.prepend(img0);
+let img1 = await imageWithData(20, 51, '#10101010', '#20202020');
+let renderBundle15 = renderBundleEncoder2.finish({label: '\ue06b\u5c39\u0037\u04e8'});
+let arrayBuffer0 = buffer18.getMappedRange(1328, 20);
+let promise8 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let commandBuffer17 = commandEncoder20.finish({label: '\u0f17\ua321\u8a78\u022c\u4e80\u0f6e\uae4d\u61c3\ud419'});
+let renderBundle16 = renderBundleEncoder2.finish({label: '\ub4f3\u0106'});
+let texture10 = gpuCanvasContext0.getCurrentTexture();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({
+  label: '\ud68c\ueca0\ucdb5\u{1fe1e}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, constants: {}},
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\udb28\ua17b\u1709\u72f8\u3fcd\u0cf8\u0732\u8a02\udb39\u{1f8e2}\u0562',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle17 = renderBundleEncoder4.finish({label: '\ufbce\ucedf\u0eef\u5948\u{1f8ef}\u1290\u2b11\u0865'});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let renderBundle18 = renderBundleEncoder4.finish({label: '\u0ec5\u10be\ue36c\u{1fc96}\u850a\u0f35'});
+try {
+computePassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\uceb5');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 1512, new Float32Array(4794), 904, 368);
+} catch {}
+let texture11 = gpuCanvasContext0.getCurrentTexture();
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u522f\ue1d3\u67aa\u35c5\uf96b',
+  entries: [
+    {
+      binding: 492,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let commandBuffer18 = commandEncoder21.finish({label: '\u0bc6\ud70f\ua4f3\u027a\u3163\u{1ffc1}\u0820\u{1fd01}'});
+let renderBundle19 = renderBundleEncoder2.finish({label: '\ub5cc\ua380\u0376\u0462\u0331\u0f82\uae2b'});
+let sampler1 = device0.createSampler({
+  label: '\ub8bf\u0c4a\uc819\u4406\u0db1',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 95.59,
+  lodMaxClamp: 95.74,
+});
+try {
+buffer18.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  label: '\u7699\ucab1\u0a25\u{1ff36}\uf5fe\u7f93\u2d77\u06f6\u6205\u{1f8f6}\u795f',
+  layout: pipelineLayout1,
+  multisample: {mask: 0x31a8acbe},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 340,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 8, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 14},
+          {format: 'uint16x4', offset: 20, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 0, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 6},
+          {format: 'uint8x4', offset: 40, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 44, stepMode: 'vertex', attributes: []},
+      {arrayStride: 408, stepMode: 'instance', attributes: []},
+      {arrayStride: 152, attributes: []},
+      {arrayStride: 168, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 672,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 260, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 44,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 8, shaderLocation: 13},
+          {format: 'uint8x2', offset: 16, shaderLocation: 0},
+          {format: 'float16x2', offset: 0, shaderLocation: 12},
+          {format: 'float32', offset: 4, shaderLocation: 2},
+          {format: 'uint32', offset: 8, shaderLocation: 5},
+          {format: 'float32x3', offset: 4, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+document.body.prepend(img0);
+try {
+renderBundle3.label = '\u03ef\u7a41\ud7d8\u36d6\u0e72\u{1f6ae}\u3f42';
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture12 = device0.createTexture({size: [77], dimension: '1d', format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_SRC});
+try {
+buffer19.unmap();
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u0986\u31d6\ufa0f\u{1fe1e}\u0cff\u04c4'});
+let textureView7 = texture2.createView({label: '\u7772\u{1f68a}\u0398\u0f05\uf7c1\u{1f8d9}\u{1f9c6}\u{1fd4c}\u{1f845}\u62c0\u094a'});
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE, 80);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u{1f902}\u{1fdc6}\uc1c1\ua1d9\u6d82\u8bd8\u0814\u2035\u071f',
+  entries: [
+    {
+      binding: 630,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let commandBuffer19 = commandEncoder22.finish({});
+try {
+device0.queue.writeBuffer(buffer36, 2596, new Float32Array(1323), 199, 252);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u0ee5\u4272\ufcf2\u0a6e\ucc30\u52a5\ue241\u01a3\u{1fcf2}\u5fc6',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout3],
+});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+let commandBuffer20 = commandEncoder23.finish({label: '\u0b3e\u5df8\u{1fe66}\u179b\u2de4\u68a5\u{1fa34}\u{1f95d}\u0ec3'});
+let texture13 = device0.createTexture({
+  label: '\u{1fc52}\udb9c\u04c5\u0572\u0f92\u05fc\ua7f8\ub004\ucd91',
+  size: {width: 77, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let texture14 = gpuCanvasContext0.getCurrentTexture();
+try {
+buffer18.unmap();
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({label: '\u2f96\u41ac'});
+let commandBuffer21 = commandEncoder24.finish({label: '\u020e\u04db\ua829\uafdb\u374c\ub640\u0b91\u1a16\u024e\ua07e\u{1fd15}'});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+let renderBundle20 = renderBundleEncoder1.finish();
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+await gc();
+let commandEncoder25 = device0.createCommandEncoder({label: '\u{1f8ef}\u08ae\u1d18\u00ac\u4031\u0c38\u3e42'});
+let querySet4 = device0.createQuerySet({
+  label: '\ud72f\u{1fbd7}\u{1f774}\u58a4\u5f70\u{1fc06}\u{1f94a}\u0ca2\u{1f6e9}',
+  type: 'occlusion',
+  count: 867,
+});
+let texture15 = gpuCanvasContext0.getCurrentTexture();
+try {
+  await promise9;
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let commandBuffer22 = commandEncoder26.finish({label: '\u8734\u{1f6d5}\u{1fd4e}\ub1a4\u{1f7ae}\u0e8c\u0e0c\u0216\u9bde'});
+try {
+commandEncoder25.copyBufferToBuffer(buffer16, 156, buffer36, 1044, 4500);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let video0 = await videoWithData();
+let commandBuffer23 = commandEncoder25.finish({label: '\u4606\u1d59\u{1fd3c}\ua073\u6f65'});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({label: '\u29fe\u0a5c\u{1f805}\u{1fbce}'});
+let commandBuffer24 = commandEncoder27.finish();
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE, 0, 8716);
+} catch {}
+let querySet5 = device0.createQuerySet({label: '\ub143\u00e7\ue7f0\u9587\u0232\ufa5a\u{1fdfe}\u018b\u896d', type: 'occlusion', count: 1038});
+let textureView8 = texture7.createView({mipLevelCount: 1});
+try {
+computePassEncoder1.setPipeline(pipeline7);
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData1);
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let texture16 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle21 = renderBundleEncoder0.finish();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], sampleCount: 1, stencilReadOnly: true});
+try {
+buffer17.unmap();
+} catch {}
+let renderBundle22 = renderBundleEncoder2.finish();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u8d5b\u{1fbea}\u0105\ua90f\u44bb\u0d90\u4884\ued60',
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint16', 6_244, 223);
+} catch {}
+await gc();
+let commandEncoder29 = device0.createCommandEncoder({});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 3, y: 5 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 55, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer25 = commandEncoder29.finish();
+let renderBundle23 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder1.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer16, 1212, buffer36, 2784, 932);
+} catch {}
+try {
+commandEncoder28.insertDebugMarker('\u40f0');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 3076, new DataView(new ArrayBuffer(522)), 99, 208);
+} catch {}
+let querySet6 = device0.createQuerySet({
+  label: '\u85e0\ua41c\u0b13\u0000\u{1f774}\u099f\u{1ff9c}\ub170\u70e6\u{1f87e}\uba6a',
+  type: 'occlusion',
+  count: 1099,
+});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer36, 984, 1_939);
+} catch {}
+let arrayBuffer1 = buffer18.getMappedRange(224, 420);
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 73, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer36, 356, 884);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 680, new Float32Array(23967), 1822, 156);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(12, 110);
+let commandBuffer26 = commandEncoder28.finish({label: '\u{1fb05}\u0b28\u09b9\u0764\u0715\ubeb3\uf7bf\u{1f7fb}'});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 24, y: 5, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 5, y: 51, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u0e0e');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder();
+let commandBuffer27 = commandEncoder12.finish();
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 43, y: 15 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 12, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+offscreenCanvas1.getContext('2d');
+} catch {}
+let commandBuffer28 = commandEncoder30.finish({});
+let renderBundle24 = renderBundleEncoder2.finish({label: '\u{1fbcd}\u3c1a\u02cb\ua0e8\uff73\u{1fb7c}\uca08\uf393'});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint16', 150, 1_161);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 2900, new BigUint64Array(10532), 417, 32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 2, y: 3 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder();
+let commandBuffer29 = commandEncoder31.finish({label: '\u8295\u8a5c\u889a\uac67\u02de\u0c7f\ub538\u6b19\u4cdf\u{1fe1f}'});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer19, 'uint16', 236, 164);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(4, buffer36, 0, 1_622);
+} catch {}
+let externalTexture0 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(5, buffer36, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 2180});
+let renderBundle25 = renderBundleEncoder1.finish({label: '\uce5d\ub61f\ud90b\u{1fdb0}\u{1fd48}\u{1fe8d}\u0af0\u4132\u0ed9\u4175'});
+let externalTexture1 = device0.importExternalTexture({label: '\u49f0\uf8e6\u5c2d\u09c1\uc9a2\u{1f8fa}\ufa39\u4d2b', source: video0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint16', 260, 91);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\u0848\ud908\uad64\u0d71\ua052\uf285\u0874\u056c\u0720'});
+let renderBundle26 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer36, 0);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u8efe');
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u0fc9\ud511\u00d6\ue815\u747e'});
+let texture17 = device0.createTexture({
+  label: '\ua000\u07e9\ud495\u08b2\u{1f92e}\u8467\u2420',
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 351, y: 38, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 2644, new DataView(new ArrayBuffer(20537)), 605, 604);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer30 = commandEncoder32.finish({label: '\u{1fe01}\u027e\ue4fc\u{1f92a}\u0b70\u0a2e\u6665'});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer19, 'uint16', 560, 2_901);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u5a56');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+  label: '\u94e6\u010a\u5f47\ufc2d',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let arrayBuffer2 = buffer18.getMappedRange(2888, 596);
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 2312, new DataView(new ArrayBuffer(15501)), 1736, 1968);
+} catch {}
+let video1 = await videoWithData();
+let commandBuffer31 = commandEncoder33.finish();
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer19, 'uint16', 2_274, 1_582);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+let renderBundle27 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint32', 2_508, 5_282);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 2, y: 18 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({label: '\u{1f663}\u8d2c'});
+let commandBuffer32 = commandEncoder34.finish({});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint16', 1_656, 920);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\u3581\u0b26\ue015\u{1fcfa}\u{1f86d}\u8b5e\u0782\ud033'});
+let commandBuffer33 = commandEncoder35.finish({label: '\u3ba8\u1fd2\ue189\u{1fc80}'});
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let commandEncoder36 = device0.createCommandEncoder();
+try {
+renderBundleEncoder5.setIndexBuffer(buffer36, 'uint16', 808, 2_105);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer16, 428, buffer36, 4540, 228);
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({label: '\u0179\u52e5\u2882\u{1fcd4}\uef3d\u75c5\u44b2\u0dfa\uda4c'});
+try {
+computePassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 48, new DataView(new ArrayBuffer(15015)), 2388, 572);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({label: '\ua8b4\u5fb5\u0952\ub8d0\u2337\u0100\u{1fe5b}\u4545\u028c\u041d\u0a91'});
+let renderBundle28 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder5.setIndexBuffer(buffer19, 'uint16', 1_038, 948);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(3, buffer36, 0, 1_789);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 168, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder();
+let renderBundle29 = renderBundleEncoder2.finish({label: '\u{1ffa0}\u{1f883}\u278b\u12d8\u045f\uf060\u{1fb49}\u{1fa0e}\u0c65\u0d8c\u0dc9'});
+let externalTexture2 = device0.importExternalTexture({label: '\u73aa\u933c\uc4e5\u0b26', source: video0});
+try {
+computePassEncoder2.end();
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u1aa3\u0aad\u0a28\u2fd0\u{1fed1}'});
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer36);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer29]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 3288, new BigUint64Array(2586), 185, 28);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder();
+let commandBuffer34 = commandEncoder36.finish();
+let commandEncoder42 = device0.createCommandEncoder({label: '\u294d\u{1f9c9}\u85e3\ue9e6\u{1ff61}'});
+let renderBundle30 = renderBundleEncoder5.finish({label: '\uee00\u{1f724}\u0625'});
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let renderBundle31 = renderBundleEncoder4.finish({label: '\u3c8c\u7158\u5d1f\u{1ffdc}\u039d\u0f86\u{1f92c}\u06f9\uefb9'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer30, commandBuffer2, commandBuffer19, commandBuffer8]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 47, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u0295\u{1f890}',
+  entries: [{binding: 25, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let commandBuffer35 = commandEncoder39.finish({label: '\u0cf0\u6340\ub10b\u04ee\u4926\u00e2\u0ed3\u{1fa7f}\u{1fead}\u5ae7\u{1fa7e}'});
+let textureView9 = texture13.createView({
+  label: '\u0e43\ue685\u091e\u09c7\u093b\ubc70\u{1fdf6}\u281b\ubc9e\u4d2e',
+  format: 'bgra8unorm',
+  baseMipLevel: 1,
+});
+let computePassEncoder4 = commandEncoder37.beginComputePass({label: '\u{1fac3}\u2d87\u5f60\ue5c9\u0cde\u661e\u{1fc84}\u0017\u356d\u3cc2'});
+try {
+computePassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u21e7');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 143, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap1 = await createImageBitmap(img0);
+let commandEncoder43 = device0.createCommandEncoder({label: '\u051c\ub092\u0387\u{1f8f1}'});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\uef16');
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  label: '\u0970\u9d22\udcc8\u8b03',
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 72,
+        attributes: [
+          {format: 'uint32', offset: 0, shaderLocation: 3},
+          {format: 'float16x2', offset: 8, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 248,
+        attributes: [
+          {format: 'snorm8x2', offset: 20, shaderLocation: 2},
+          {format: 'uint32x2', offset: 0, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 404,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 0, shaderLocation: 15}],
+      },
+      {arrayStride: 944, attributes: []},
+      {arrayStride: 440, stepMode: 'vertex', attributes: []},
+      {arrayStride: 216, stepMode: 'instance', attributes: []},
+      {arrayStride: 28, attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 10}]},
+      {
+        arrayStride: 256,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32', offset: 64, shaderLocation: 0},
+          {format: 'uint8x2', offset: 158, shaderLocation: 1},
+          {format: 'uint16x2', offset: 52, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let img2 = await imageWithData(152, 16, '#10101010', '#20202020');
+let buffer37 = device0.createBuffer({
+  label: '\u{1f98a}\u0644\u6110\u1657\uf83b\ub7ca\u0b3f\u34b3\u0041\u9eeb',
+  size: 1669,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u0f6b\u8065\u09e6\u062e\u8447\u{1f7c3}\u0048\u9232\u73dd'});
+let querySet8 = device0.createQuerySet({label: '\u{1fc28}\u{1fd0d}\uf3de\u8af5\u72ec\u{1fa42}', type: 'occlusion', count: 1000});
+try {
+device0.queue.writeBuffer(buffer36, 1748, new Int16Array(2472), 19, 248);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+externalTexture0.label = '\u0d5c\ufbe1\u001e\uefc0\u7edb\u4fe3';
+} catch {}
+let commandBuffer36 = commandEncoder14.finish({label: '\u703a\uf6dc\u0bcc\u9941\u{1f92d}\u2d1e\u4a5c\u63f1\u{1f82a}\u1d20'});
+let textureView10 = texture17.createView({label: '\u5291\u0c66\ue61c\ud5de', dimension: '2d-array'});
+let computePassEncoder5 = commandEncoder41.beginComputePass({label: '\uaba3\u0c18\udf9d'});
+let renderPassEncoder0 = commandEncoder42.beginRenderPass({
+  label: '\u0108\u0e53\u7ae7\ufd36\u5d7d',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 125.5, g: -922.9, b: -190.1, a: 945.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 432238026,
+});
+let renderBundle32 = renderBundleEncoder3.finish({label: '\u380c\udd89\ud4a3\u0c92\u143c\u53d0\uf94b\u{1f75e}\u2376\u{1fd2d}'});
+try {
+computePassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14, commandBuffer36]);
+} catch {}
+document.body.prepend(video0);
+try {
+adapter0.label = '\u51b3\u{1f7a9}\ua56c\ub3df\u02d7';
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u03fd\u7a79\u308a\u6fbd'});
+let textureView11 = texture6.createView({label: '\u3dba\u1591\u{1f725}\u4ea6\u024c\u0c6a', format: 'bgra8unorm-srgb', baseArrayLayer: 0});
+let renderPassEncoder1 = commandEncoder38.beginRenderPass({
+  label: '\u{1f7d2}\ue049\u01fe\u6a98\ub2b4',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 127.9, g: -324.2, b: -535.3, a: -477.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer19, 'uint32', 4_636, 245);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 37, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let buffer38 = device0.createBuffer({
+  label: '\uf11a\u{1f990}',
+  size: 16935,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({label: '\u{1f9b9}\u6a0c\u9e15', colorFormats: ['bgra8unorm-srgb'], depthReadOnly: true});
+try {
+renderPassEncoder0.setBlendConstant({ r: -333.3, g: 263.7, b: 908.4, a: -427.2, });
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({label: '\u0cce\u662e\ue59f\u99e5\u6ab3\ud389\u33c0\u046f\u07fd\u64f5'});
+let commandBuffer37 = commandEncoder46.finish({label: '\u8ff1\u0055\u{1fe46}\u{1ffbf}\u04be\ud08c'});
+let externalTexture3 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer19, 480, buffer36, 3272, 1192);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 105,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let commandEncoder47 = device0.createCommandEncoder();
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer37);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer38, 'uint32', 3_432, 1_136);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, undefined, 0, 2_361_116_969);
+} catch {}
+let imageData3 = new ImageData(4, 136);
+try {
+device0.label = '\u2925\u0cd2\u7a8f\u992b';
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\ucdfc\ue8fc\u3f50\u0215\u{1fd74}\u27b7\u3754'});
+let commandBuffer38 = commandEncoder43.finish();
+let textureView12 = texture7.createView({label: '\u489d\ua409\u9e37\u0bef\u4f2b\u738c', baseMipLevel: 1});
+let computePassEncoder6 = commandEncoder44.beginComputePass({});
+let renderPassEncoder2 = commandEncoder40.beginRenderPass({
+  label: '\u1e0c\ufecc\u3f5c\u24c5\u4806\ua706\u0dc5\u{1faf3}',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 128.1, g: 608.7, b: -852.0, a: -494.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer19, 'uint16', 6_372, 572);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u03de');
+} catch {}
+try {
+device0.queue.submit([commandBuffer38, commandBuffer16, commandBuffer12, commandBuffer24]);
+} catch {}
+let commandBuffer39 = commandEncoder47.finish({label: '\u{1fc9f}\u776d\u0f0a\u02af\u9965\u{1f769}\u6b18\u{1f8fb}\u0983\u282f\u{1fb77}'});
+let renderPassEncoder3 = commandEncoder45.beginRenderPass({
+  label: '\ud44b\u0a89\u0749\u0371',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 990.5, g: -588.9, b: -68.07, a: 224.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+let renderBundle33 = renderBundleEncoder5.finish({label: '\u6d54\u{1f74a}'});
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint32', 1_748, 375);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer37);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer38);
+} catch {}
+video0.width = 100;
+let commandEncoder49 = device0.createCommandEncoder({label: '\u{1fe29}\u0395\u{1fe87}\u1bae\u0a01'});
+let commandBuffer40 = commandEncoder48.finish({label: '\u84cd\u9437\ud6e9\ufc4f\uf9a0\u594a\u06ea\u858b\ud105\uff74'});
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint32', 2_344, 6_291);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer38, 0, 3_471);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer36, 10012, 188);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise13;
+} catch {}
+let commandBuffer41 = commandEncoder49.finish({label: '\u{1fd81}\u7c7c\u81e6\ue944\u{1f627}\u80ba\uaa6e\u9d86\udd2a\u06f7'});
+let externalTexture4 = device0.importExternalTexture({label: '\u2b81\ub86d\u{1fe64}\u0363', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u0ebb\u0ab1\u0a81\u{1fa0e}\ucbd6\u{1fe86}\ucf5e\u{1fa0a}\u{1fc9d}',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout7, bindGroupLayout5],
+});
+let commandEncoder50 = device0.createCommandEncoder({label: '\u9f41\ua2af\u0a8e\u10b0\uc5be\ue18a'});
+try {
+computePassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer38, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3, buffer38, 3_396, 5_598);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u{1f83a}\u09c9',
+  entries: [{binding: 239, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }}],
+});
+let commandEncoder51 = device0.createCommandEncoder({label: '\u{1f8df}\u8ad3\u0b42\u021f\u0ccd\uda86\u003f\u6ac9\u{1fbde}'});
+try {
+computePassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 1068, new DataView(new ArrayBuffer(24553)), 4656, 388);
+} catch {}
+let texture18 = device0.createTexture({
+  label: '\ube4d\ua3b3\u{1f79b}\u{1f9ea}\u6d1f\u{1f8b7}\u{1fa67}\u1b2f\u0e90\ueb14\u7567',
+  size: {width: 618, height: 96, depthOrArrayLayers: 190},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder7 = commandEncoder50.beginComputePass();
+let renderPassEncoder4 = commandEncoder51.beginRenderPass({
+  label: '\u{1fbbc}\uc680\ua197\u0f8b\u7253',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -316.5, g: -220.5, b: 23.00, a: 695.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer37, 112, 561);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  label: '\u1ddc\uc2f0\ueee7',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'invert'},
+    stencilReadMask: 2056218143,
+    stencilWriteMask: 405696058,
+    depthBiasSlopeScale: 482.23723464519514,
+    depthBiasClamp: 654.3801478131197,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 120, attributes: []},
+      {arrayStride: 180, attributes: []},
+      {arrayStride: 16, stepMode: 'instance', attributes: []},
+      {arrayStride: 548, attributes: []},
+      {arrayStride: 68, attributes: []},
+      {arrayStride: 256, stepMode: 'instance', attributes: []},
+      {arrayStride: 428, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 268, shaderLocation: 4},
+          {format: 'float16x2', offset: 272, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let renderBundle34 = renderBundleEncoder3.finish({});
+try {
+renderBundleEncoder6.setIndexBuffer(buffer37, 'uint32', 184, 207);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(7, buffer37, 0, 539);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u3811');
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u0a96\u576c',
+  entries: [
+    {binding: 14, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer38, 0, 3_715);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u0dfe\u05a4\ufe9f\u0a62\u06f8\u081f\u04f5\ua570\u6636\ub877\u02f7',
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder52 = device0.createCommandEncoder();
+let commandBuffer42 = commandEncoder52.finish({label: '\u01f6\u0711\u16e6\u087e\uadbd\ue28b\u0acf\uef11\u005e'});
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer36, 0, 2_325);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\ufa9f\u0543\u8b28\uae8d',
+  entries: [{binding: 53, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let textureView13 = texture5.createView({format: 'bgra8unorm-srgb'});
+let renderBundle35 = renderBundleEncoder2.finish({label: '\u40e7\u04b7\u{1f76c}\u471e\u672d\u{1f9c1}\u08d2\u010b\u{1fe7a}\ub7de\u97b3'});
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+document.body.prepend(img2);
+let buffer39 = device0.createBuffer({
+  size: 28291,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer36, 4_352, 538);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 964, new DataView(new ArrayBuffer(8253)), 38, 868);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u942d\u0d33\u0294\u0381',
+  code: `
+struct T0 {
+  f0: mat2x2h,
+}
+struct T1 {
+  f0: f32,
+}
+@group(0) @binding(89) var et25: texture_external;
+@group(0) @binding(636) var<storage, read> buffer42: array<array<vec2h, 1>>;
+@group(0) @binding(137) var<uniform> buffer49: vec4u;
+@group(0) @binding(133) var et31: texture_external;
+@group(0) @binding(98) var et24: texture_external;
+@group(0) @binding(561) var sam33: sampler_comparison;
+@group(0) @binding(105) var tex43: texture_1d<f32>;
+@group(0) @binding(262) var<storage, read> buffer41: array<mat2x3f>;
+@group(0) @binding(408) var tex37: texture_depth_multisampled_2d;
+@group(0) @binding(253) var<storage, read_write> buffer48: array<atomic<u32>>;
+@group(0) @binding(107) var sam37: sampler;
+@group(0) @binding(28) var<storage, read_write> buffer44: array<array<mat4x3f, 1>, 1>;
+@group(0) @binding(330) var et23: texture_external;
+@group(0) @binding(361) var sam45: sampler;
+@group(0) @binding(43) var tex42: texture_cube_array<u32>;
+@group(0) @binding(31) var<storage, read_write> buffer43: array<mat3x3f>;
+@group(0) @binding(65) var sam34: sampler_comparison;
+@group(0) @binding(42) var<storage, read_write> buffer50: array<mat3x3f, 1>;
+@group(0) @binding(118) var et32: texture_external;
+@group(0) @binding(75) var tex34: texture_depth_multisampled_2d;
+@group(0) @binding(203) var sam47: sampler_comparison;
+@group(0) @binding(27) var et22: texture_external;
+@group(0) @binding(189) var st8: texture_storage_3d<rgba8uint, write>;
+@group(0) @binding(395) var et26: texture_external;
+@group(0) @binding(206) var<uniform> buffer40: mat2x3f;
+@group(0) @binding(16) var tex46: texture_multisampled_2d<f32>;
+@group(0) @binding(231) var tex38: texture_multisampled_2d<i32>;
+@group(0) @binding(8) var sam36: sampler;
+@group(0) @binding(218) var tex39: texture_2d_array<u32>;
+@group(0) @binding(563) var et27: texture_external;
+@group(0) @binding(101) var tex32: texture_2d<u32>;
+@group(0) @binding(334) var tex45: texture_1d<u32>;
+@group(0) @binding(15) var st9: texture_storage_1d<r32uint, write>;
+@group(0) @binding(489) var<storage, read_write> buffer53: array<vec2f>;
+@group(0) @binding(95) var sam38: sampler;
+@group(0) @binding(362) var tex44: texture_multisampled_2d<u32>;
+@group(0) @binding(34) var tex47: texture_2d_array<f32>;
+@group(0) @binding(999) var<uniform> buffer52: mat4x2f;
+@group(0) @binding(97) var sam39: sampler;
+@group(0) @binding(71) var tex40: texture_depth_2d;
+@group(0) @binding(33) var et30: texture_external;
+@group(0) @binding(79) var sam46: sampler_comparison;
+@group(0) @binding(292) var<uniform> buffer54: mat2x4h;
+@group(0) @binding(148) var<uniform> buffer55: mat4x2h;
+@group(0) @binding(29) var tex36: texture_2d<i32>;
+@group(0) @binding(195) var tex41: texture_2d<f32>;
+@group(0) @binding(72) var sam32: sampler;
+@group(0) @binding(5) var st10: texture_storage_3d<r32uint, read>;
+@group(0) @binding(165) var sam43: sampler_comparison;
+@group(0) @binding(120) var sam42: sampler;
+@group(0) @binding(249) var tex35: texture_multisampled_2d<f32>;
+@group(0) @binding(153) var et28: texture_external;
+@group(0) @binding(284) var sam44: sampler_comparison;
+@group(0) @binding(131) var sam40: sampler;
+@group(0) @binding(22) var sam41: sampler_comparison;
+@group(0) @binding(312) var<uniform> buffer51: vec4f;
+@group(0) @binding(239) var<uniform> buffer46: vec2u;
+@group(0) @binding(44) var et29: texture_external;
+@group(0) @binding(157) var<uniform> buffer47: mat4x3h;
+@group(0) @binding(7) var<storage, read_write> buffer45: array<atomic<i32>, 1>;
+@group(0) @binding(84) var sam35: sampler;
+@group(0) @binding(200) var st11: texture_storage_2d<r32uint, read>;
+@group(0) @binding(366) var tex33: texture_depth_cube;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0() {
+  _ = textureSampleBaseClampToEdge(et32, sam42, vec2f());
+  _ = textureGather(3, tex32, sam39, vec2f());
+  _ = textureLoad(tex46, vec2i(), 0);
+  _ = textureGather(3, tex36, sam42, vec2f(), vec2i());
+  _ = textureLoad(tex32, vec2i(), 0);
+  _ = textureGather(1, tex39, sam45, vec2f(), 0i);
+  _ = textureGather(1, tex39, sam37, vec2f(), 0i, vec2i());
+  _ = textureLoad(st10, vec3i());
+  _ = textureSampleBaseClampToEdge(et24, sam37, vec2f());
+  _ = textureSampleBaseClampToEdge(et24, sam45, vec2f());
+  _ = textureLoad(tex37, vec2i(), 0);
+  if bool(textureLoad(et25, vec2u())[1]) {
+    return;
+  }
+}
+
+struct VertexOutput0 {
+  @builtin(position) f4: vec4f,
+  @location(15) f5: u32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureGather(2, tex42, sam40, vec3f(), 0);
+  _ = textureLoad(et28, vec2u());
+  _ = textureSampleLevel(tex41, sam35, vec2f(), 0.0);
+  _ = textureSampleGrad(tex47, sam45, vec2f(), 0i, vec2f(), vec2f(), vec2i());
+  _ = textureSampleBaseClampToEdge(tex41, sam35, vec2f());
+  _ = textureSampleLevel(tex47, sam40, vec2f(), 0, 0.0, vec2i());
+  _ = textureSampleBaseClampToEdge(et26, sam35, vec2f());
+  _ = buffer54;
+  _ = textureSampleBaseClampToEdge(et23, sam32, vec2f());
+  _ = textureSampleLevel(tex47, sam32, vec2f(), 0, 0.0);
+  _ = textureGather(1, tex41, sam32, vec2f());
+  _ = textureLoad(et31, vec2u());
+  _ = textureLoad(tex41, vec2i(), 0);
+  _ = textureSampleGrad(tex47, sam35, vec2f(), 0i, vec2f(), vec2f());
+  return out;
+}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureSampleBaseClampToEdge(et24, sam42, vec2f());
+  _ = textureSampleBaseClampToEdge(et22, sam42, vec2f());
+  _ = textureSample(tex43, sam37, 0.0);
+  _ = textureLoad(st11, vec2i());
+  _ = textureSampleBaseClampToEdge(et22, sam36, vec2f());
+  _ = textureGather(tex40, sam42, vec2f());
+  _ = textureGather(3, tex39, sam32, vec2f(), 0i, vec2i());
+  _ = textureGather(3, tex39, sam42, vec2f(), 0i);
+  _ = textureGather(1, tex42, sam36, vec3f(), 0);
+  _ = textureGather(0, tex39, sam37, vec2f(), 0i, vec2i());
+  _ = textureGather(0, tex32, sam42, vec2f(), vec2i());
+  _ = textureSampleCompareLevel(tex40, sam46, vec2f(), 0., vec2i());
+  _ = textureSampleCompare(tex40, sam44, vec2f(), 0.);
+  _ = textureGather(tex40, sam36, vec2f(), vec2i());
+  _ = textureGather(tex33, sam36, vec3f());
+  _ = textureDimensions(et27);
+  _ = textureGather(2, tex32, sam45, vec2f());
+  _ = textureGather(0, tex32, sam45, vec2f(), vec2i());
+  _ = textureLoad(tex37, vec2i(), 0);
+  _ = textureLoad(tex36, vec2i(), 0);
+  out.f1 = vec4f(bitcast<f32>(textureSampleCompare(tex40, sam46, vec2f(), 0., vec2i())));
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle36 = renderBundleEncoder5.finish({});
+try {
+renderPassEncoder4.setScissorRect(51, 5, 9, 6);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4_294_967_295, undefined, 955_939_677, 274_175_997);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 9, y: 2 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 20, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer37);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer36, 'uint32', 2_752, 300);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\uf7c5');
+} catch {}
+try {
+device0.queue.submit([commandBuffer26, commandBuffer28, commandBuffer4, commandBuffer33, commandBuffer39, commandBuffer6]);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u0a9a\udba9\u{1f9d9}\u30b9\u0b60\u63ae\u{1fa78}\u03bb'});
+let renderPassEncoder5 = commandEncoder53.beginRenderPass({
+  label: '\u079a\u8304\u{1fe7f}\ua5d2',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -747.7, g: -24.57, b: -620.0, a: 975.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(70, 20, 96, 2);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer38, 'uint32', 112, 1_681);
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({label: '\u7246\u{1fd23}\u62c4\u2d1c\u{1f72d}\u{1fa13}\uef8b'});
+let renderPassEncoder6 = commandEncoder54.beginRenderPass({
+  label: '\ufa19\u9a47\u4b09\u0ff0\u{1f7d6}\u{1fc60}\u6b76\u5b12\u3f6b\u0786\u{1ff9a}',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -820.3, g: -454.8, b: 719.1, a: -528.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let externalTexture5 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer37, 'uint32', 80, 35);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer38, 'uint32', 168, 1_451);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder();
+try {
+renderPassEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 188 */
+  offset: 188,
+  bytesPerRow: 256,
+  buffer: buffer19,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 5, y: 1, z: 1},
+  aspect: 'all',
+}, {width: 10, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer32, commandBuffer25]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 888, new DataView(new ArrayBuffer(3330)), 1477, 628);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 88, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({label: '\u{1fdd3}\ua1f5\u099d\u7b67\u90ed\u40e5\u04a7'});
+let renderPassEncoder7 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -515.6, g: 897.6, b: 772.5, a: -627.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder3.setPipeline(pipeline8);
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({label: '\u044b\u9614\u1501\u{1fcaa}\u{1fddc}\u92bf\u0634\u7c91\u6918\u051b'});
+let texture19 = device0.createTexture({
+  label: '\u415f\u02c6\u{1fa28}\u{1fa38}\u076c\u0192\u47be\ude5b\u059d',
+  size: [77, 12, 1],
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder8 = commandEncoder57.beginRenderPass({
+  label: '\u0928\uab91\u44d2\u666f\u07b1\u06cb\u083e\u0ba5\u{1f8ba}\u0921\u3d9c',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -756.6, g: 655.5, b: 153.0, a: -78.20, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 35799720,
+});
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer36, 'uint16', 198, 473);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer36, 'uint32', 596, 661);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer37, 0, 318);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 261, y: 43, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 31, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet6, 155, 645, buffer38, 768);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\ud579\u54ae\u8d22\u3886\u2059',
+  code: `
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+@group(2) @binding(23) var sam49: sampler;
+@group(0) @binding(102) var tex49: texture_depth_2d_array;
+@group(1) @binding(3) var sam48: sampler_comparison;
+@group(0) @binding(492) var tex48: texture_depth_cube;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+  _ = textureGather(tex49, sam49, vec2f(), 0i);
+  if bool(textureSampleLevel(tex49, sam49, vec2f(), 0i, 0i, vec2i())) {
+    return;
+  }
+}
+
+struct VertexOutput0 {
+  @builtin(position) f6: vec4f
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3f, @location(2) a1: vec2f, @location(5) a2: i32, @location(14) a3: i32, @location(11) a4: i32, @location(8) a5: vec2f) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureSampleCompareLevel(tex48, sam48, vec3f(), 0.);
+  _ = textureSampleCompare(tex49, sam48, vec2f(), 0i, 0., vec2i());
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandEncoder58 = device0.createCommandEncoder();
+let commandBuffer43 = commandEncoder55.finish({label: '\u3e29\u7361'});
+let renderPassEncoder9 = commandEncoder58.beginRenderPass({colorAttachments: [{view: textureView10, loadOp: 'load', storeOp: 'store'}]});
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 9, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let buffer56 = device0.createBuffer({
+  label: '\u{1fa99}\uab5f\ub337\u56f6',
+  size: 3558,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u55cb\u9386\u{1fdbb}\u07ea\u8bd9\u568a\u4fe1\u0645\ue2ee'});
+let commandBuffer44 = commandEncoder59.finish({label: '\u0904\u7f98\u9bc7\u0e27\u{1f991}\u6379\u0e19\u020a\u0d75'});
+let renderBundle37 = renderBundleEncoder3.finish({label: '\uff24\u0f63\u035b\u5837\u7228'});
+try {
+renderPassEncoder9.executeBundles([renderBundle15, renderBundle33, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer36);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let img3 = await imageWithData(39, 58, '#10101010', '#20202020');
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({label: '\uf79c\u0bea'});
+try {
+renderPassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13, commandBuffer15, commandBuffer21]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({label: '\u9b13\u3713\u6905'});
+let commandBuffer45 = commandEncoder60.finish({label: '\u{1fdaa}\u90b9\u{1fa20}\u7ef9\u2fec\u62dc\ua1e5\u18e5\u{1ffa1}'});
+let sampler2 = device0.createSampler({
+  label: '\u75c6\ub073\u0a6f\u55b5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.632,
+  compare: 'less',
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer37, 'uint16', 86, 98);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer38);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(7, buffer36, 4_736, 1_498);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u63d5\u39ec\u3c74\u{1fbca}\u5563\u581f',
+  code: `
+struct T0 {
+  f0: array<vec2u>,
+}
+@group(1) @binding(492) var tex50: texture_depth_cube;
+@group(1) @binding(102) var tex51: texture_1d<i32>;
+@group(0) @binding(630) var<storage, read_write> buffer57: array<atomic<u32>>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(num_workgroups) a0: vec3u) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f7: vec4f,
+  @location(4) f8: vec3u,
+  @location(11) f9: vec4f,
+  @location(12) f10: i32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(5) f0: u32,
+  @location(3) f1: vec4u,
+  @location(6) f2: u32,
+  @location(0) f3: vec4f
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4f, @location(4) a1: vec3u) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = a1;
+  if bool(textureLoad(tex51, 0, 0)[0]) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderPassEncoder10 = commandEncoder61.beginRenderPass({
+  label: '\u7930\u9706\u{1f74b}',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 423.4, g: -726.8, b: -940.1, a: -940.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer38, 'uint16', 100, 3_953);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 5288, new DataView(new ArrayBuffer(6185)), 1414, 148);
+} catch {}
+let querySet9 = device0.createQuerySet({label: '\u729a\u{1f68c}\u0edf\u{1f856}\u7d04\u0932\u7f70\u0ae2\u77fb', type: 'occlusion', count: 910});
+let textureView14 = texture9.createView({
+  label: '\u{1f8a6}\uf882\u{1f6fc}\u91e5\u26e7\u1a7c\u0a73',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundle38 = renderBundleEncoder2.finish({label: '\u068a\u{1fa62}\u01f9\u72da\u08da\u34ae\u3cb4\u5e09\u6ef9\u8ab4\ud00e'});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer36, 'uint16', 768, 3_132);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(3);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer34, commandBuffer20]);
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter();
+let renderBundle39 = renderBundleEncoder3.finish({label: '\ubfac\ud1f2\uf0fb\u3de6\u0914\u0355'});
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer37, 'uint32', 936, 128);
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u0a98');
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\ub154\u0426\u05dd\ub7af'});
+let computePassEncoder8 = commandEncoder62.beginComputePass({label: '\uaebc\uf1d6\u46f5\u0088\ub13d\uebd5\uabb0\u0f14\u0b0c\u64f3'});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u0f14\u{1fa8c}\ua49b',
+  colorFormats: ['bgra8unorm-srgb'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer36, 52);
+} catch {}
+let img4 = await imageWithData(34, 9, '#10101010', '#20202020');
+let renderBundle40 = renderBundleEncoder7.finish();
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer37, 16);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\u6494');
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer36, 'uint32', 4_032, 1_845);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer19, 'uint16', 3_746, 4_519);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 70, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let commandBuffer46 = commandEncoder63.finish({label: '\u750f\u{1f8e7}\u33a1\uf3b5\u77f5\u6606'});
+let externalTexture6 = device0.importExternalTexture({label: '\u5192\ub1b4\u41a5\uba65\u{1f8e4}', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(554);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture20 = device0.createTexture({
+  label: '\u{1fe16}\udf0c\u63ca\u0965\uba1f\u1924\uf600\u7ecb\ueca9\ue457',
+  size: {width: 309, height: 48, depthOrArrayLayers: 22},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler3 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 48.58,
+  lodMaxClamp: 73.91,
+});
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(1, undefined);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 729.4, g: -938.0, b: -666.4, a: 713.7, });
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer37, 'uint16', 146, 164);
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder();
+let commandBuffer47 = commandEncoder64.finish({label: '\u27af\u0fec\u{1f8ed}\u2ff7\u8e4b\u044c\u04b2\u{1ff26}\u{1f9d2}\u2acc'});
+let renderBundle41 = renderBundleEncoder4.finish();
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer37, 216, 1_022);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer19, 'uint16', 1_900, 3_566);
+} catch {}
+try {
+  await promise11;
+} catch {}
+document.body.prepend(img0);
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer38, 'uint32', 1_736, 849);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline8);
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u8f18\u0482\u5a57\u{1f917}\u1ddb\u9654\u{1f734}\u{1fc37}\u0892',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+@group(0) @binding(102) var tex53: texture_depth_2d_array;
+@group(1) @binding(3) var sam50: sampler_comparison;
+@group(0) @binding(492) var tex52: texture_depth_cube_array;
+@group(2) @binding(23) var sam51: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  if bool(textureGather(tex53, sam51, vec2f(), 0i, vec2i())[2]) {
+    return;
+  }
+}
+
+struct VertexOutput0 {
+  @location(0) f11: vec4u,
+  @builtin(position) f12: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec4u, @builtin(position) a1: vec4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(textureLoad(tex53, vec2i(), 0, 0)) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder65 = device0.createCommandEncoder({label: '\uf13a\u8d08\u816d\u{1fa4b}\u{1f692}\u0e45\u8808\u00b7\u{1ff3f}'});
+let computePassEncoder9 = commandEncoder65.beginComputePass({});
+let renderBundle42 = renderBundleEncoder6.finish({label: '\u0c7e\uda24\udfb6\ud9f6\u{1fd96}\ucf55\u{1f71d}\uf926\u2d1e\uf08a'});
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 1060, new Float32Array(3108), 2, 1416);
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({});
+let computePassEncoder10 = commandEncoder66.beginComputePass({label: '\uea67\ufba7\u6cd9\u03f4\u29da\u748e\u3d69\ua2b3\uec2c'});
+try {
+renderPassEncoder3.setIndexBuffer(buffer37, 'uint32', 16, 159);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer39);
+} catch {}
+document.body.prepend(video0);
+let texture21 = device0.createTexture({
+  label: '\ufcc6\u5074\u3910\uffbf\uad11\u0b40\u{1fe8a}',
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer36, 'uint16', 3_252, 220);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 46, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let querySet10 = device0.createQuerySet({label: '\ub84e\ucf9c\u550a\u{1fcf9}\u3f05\u64f5\uf133', type: 'occlusion', count: 323});
+let texture22 = device0.createTexture({
+  label: '\ua1fb\ub982\u851d\u4a2c\u4098\u6a73\ubd96\u986f\u{1f671}',
+  size: {width: 309, height: 48, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture23 = gpuCanvasContext0.getCurrentTexture();
+let textureView15 = texture12.createView({label: '\u0425\u{1fda3}\u5155\u9c95\u72d5'});
+let renderBundle43 = renderBundleEncoder0.finish();
+try {
+renderPassEncoder4.setIndexBuffer(buffer36, 'uint32', 348, 1_843);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u6195');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer37, 0, 817);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+let renderBundle44 = renderBundleEncoder3.finish({label: '\u011f\u380b'});
+try {
+renderPassEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer37]);
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  label: '\u{1fe45}\u9327\u{1f980}\u9354\u{1f9ac}\u{1ff76}\u500b',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {arrayStride: 68, stepMode: 'instance', attributes: []},
+      {arrayStride: 104, stepMode: 'instance', attributes: []},
+      {arrayStride: 124, attributes: []},
+      {arrayStride: 56, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 584, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 192,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x3', offset: 0, shaderLocation: 4},
+          {format: 'float32x3', offset: 40, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 3, resource: sampler2}]});
+let commandEncoder67 = device0.createCommandEncoder();
+let textureView16 = texture5.createView({label: '\ufd01\u040d\u03e8\u0e88\u{1fc13}\u162a\u0b5c\u03bf\u4739'});
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer39, 2_564, 1_956);
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  label: '\u{1f960}\u0cf1\u0c5b\uab94',
+  layout: pipelineLayout2,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm-srgb'}]},
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let promise14 = navigator.gpu.requestAdapter({});
+let renderPassEncoder11 = commandEncoder67.beginRenderPass({
+  label: '\u5a2e\ua16e\u0de6\u7f52\u04e6\u3e41\u24d3\u6396',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 165.1, g: -569.1, b: -629.3, a: 575.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle45 = renderBundleEncoder4.finish({label: '\u0172\u{1fdda}\u{1f7a4}'});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(545.8343914056323, 71.41857404998109, 15.205544669334357, 23.391471928271866, 0.4045908907905128, 0.49515679600421986);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer37, 788, 33);
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  label: '\u639d\u518c\ub89f\u{1fad0}',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x9921f6e},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 392, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 4, shaderLocation: 12},
+          {format: 'uint16x4', offset: 8, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 196,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 16, shaderLocation: 2},
+          {format: 'float32x4', offset: 0, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 328,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 74, shaderLocation: 14}],
+      },
+      {arrayStride: 56, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x2', offset: 308, shaderLocation: 15},
+          {format: 'uint32x4', offset: 704, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'float16x4', offset: 88, shaderLocation: 13},
+          {format: 'float32x4', offset: 60, shaderLocation: 6},
+          {format: 'uint16x2', offset: 32, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 52,
+        attributes: [
+          {format: 'unorm8x2', offset: 2, shaderLocation: 7},
+          {format: 'uint16x4', offset: 4, shaderLocation: 5},
+          {format: 'uint32x3', offset: 0, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'none'},
+});
+try {
+renderPassEncoder11.setPipeline(pipeline14);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 465,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle45, renderBundle34]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer38, 1_720);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({label: '\ucf26\u1db6\u082b\u7b4f'});
+let computePassEncoder11 = commandEncoder68.beginComputePass({label: '\u0d53\u{1fb0c}\u0b89\u0c57'});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({label: '\u0476\ua056\u624c\u{1f7f1}\u0008\u6245\u12a0\u609b'});
+let renderPassEncoder12 = commandEncoder69.beginRenderPass({
+  label: '\u5181\u6b7e\u0a41\u5b7f\u0127\ueb1d\u{1fc8c}\u06a2\ue1d8\u0d77\ub1ff',
+  colorAttachments: [{view: textureView14, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 806168624,
+});
+let renderBundle46 = renderBundleEncoder7.finish();
+try {
+renderPassEncoder4.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer39, 0);
+} catch {}
+let buffer58 = device0.createBuffer({
+  label: '\u046d\u0e6d\ue140\u{1fdcb}\u{1f63f}',
+  size: 7867,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let sampler4 = device0.createSampler({
+  label: '\u{1ffc4}\ubabe\u{1ff18}\u03b8\u3b53\u0b23\u0bab\u6dec',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 99.66,
+  lodMaxClamp: 99.91,
+  compare: 'equal',
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(3462), 583, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer37, 0, 164);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 70 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 11, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let video2 = await videoWithData();
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u8905\u026e\u0d2b',
+  entries: [
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer59 = device0.createBuffer({
+  label: '\u0bfa\ubd7d\uc791\u038b\u0f3f',
+  size: 9897,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder9.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer37, 'uint16', 42, 620);
+} catch {}
+try {
+device0.queue.submit([commandBuffer42, commandBuffer44]);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u{1fffb}\ue142\u03e0\u1824\u{1f9d0}\u0bda',
+  entries: [{binding: 103, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder70 = device0.createCommandEncoder({label: '\ufffe\u9fc6\u0818'});
+let computePassEncoder12 = commandEncoder70.beginComputePass({label: '\u8e51\u0be5\u0eea\u0452\u{1fe37}\u959c\ube41\u0471\ub6b4\uf0f2'});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderPassEncoder11.setViewport(137.23411765955217, 33.510181262513576, 52.1059523181091, 5.977845791573933, 0.971451670324671, 0.9771656785836731);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+device0.queue.submit([commandBuffer22]);
+} catch {}
+let imageData4 = new ImageData(64, 236);
+let commandEncoder71 = device0.createCommandEncoder({label: '\u392d\u2b91\u{1f9d0}\u485e\u040a\u{1fc54}\u7f0d\u5225\u0c10'});
+let texture24 = device0.createTexture({
+  label: '\u031c\u4b5c\u5cac\u2ece\u{1f631}\u7e20\ud971\ueac0\u20f6',
+  size: [154, 24, 1],
+  mipLevelCount: 5,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle47 = renderBundleEncoder2.finish({label: '\ubee6\u1686\u70a1\ud779\u242e\u4f41'});
+try {
+computePassEncoder10.setPipeline(pipeline7);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2, bindGroupLayout5, bindGroupLayout8]});
+let querySet11 = device0.createQuerySet({label: '\u04e9\u2d42\u9f57', type: 'occlusion', count: 570});
+let commandBuffer48 = commandEncoder71.finish({label: '\u6c67\u0bec\u0a73\u081b\ud5d4'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer37, 200);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer17, 528, buffer59, 6864, 316);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 7, y: 16, z: 12},
+  aspect: 'all',
+}, new ArrayBuffer(26_874), /* required buffer size: 26_874 */
+{offset: 16, bytesPerRow: 135, rowsPerImage: 22}, {width: 32, height: 1, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({label: '\u57d0\u6e2c\u102b\u036a\u3861\u21e6\u{1fb47}\ufc1d\u0fb8\ue51f'});
+let computePassEncoder13 = commandEncoder72.beginComputePass({});
+let renderPassEncoder13 = commandEncoder10.beginRenderPass({
+  label: '\u{1fabe}\u0955\u634c',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -258.1, g: -963.5, b: 528.0, a: -215.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 148305018,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView17 = texture22.createView({label: '\u000a\u8113\u{1fde1}\u{1fa9e}\u632d\u0fff\ub8f8\u0bee\u6c8c\u6aec\u97c4', aspect: 'all'});
+try {
+renderPassEncoder12.executeBundles([renderBundle39, renderBundle43]);
+} catch {}
+let texture25 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer59, 'uint32', 1_320, 1_476);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\u078f\uff6e\ucc47\u0b3e\u417e\u04e5\u092f\u060e\u5272',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule4},
+});
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(24);
+} catch {}
+try {
+renderPassEncoder1.setViewport(36.96106623527741, 25.065926146507657, 434.7852437238892, 41.58757357271611, 0.007403723246376281, 0.6280903022257257);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer60 = device0.createBuffer({
+  size: 29723,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(272);
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder73 = device0.createCommandEncoder({label: '\u5a51\u00d7\u{1f74a}\uf6e3\u{1f649}\u04a1\ue1d9'});
+let renderPassEncoder14 = commandEncoder73.beginRenderPass({
+  label: '\u{1ff9b}\ueea2\uce74\u{1fbdc}',
+  colorAttachments: [{view: textureView14, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 100258397,
+});
+let externalTexture7 = device0.importExternalTexture({label: '\uba33\u{1fb59}\u010a\u{1f9be}', source: video2, colorSpace: 'srgb'});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView18 = texture19.createView({
+  label: '\u5b75\u0468\u0d8d\u06f4\u99a5\u959e',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder12.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u0b1e\u8dda\u37f2\u02c6\u02c9'});
+let textureView19 = texture5.createView({label: '\u16f2\uf8c4'});
+let renderPassEncoder15 = commandEncoder74.beginRenderPass({
+  label: '\u60ae\u1c2f\u03cd\u{1f9fa}\u05d5\u2b41\ufb4f',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 790.4, g: 706.6, b: 395.0, a: 618.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 127824534,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(2733), 1657, 0);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer56, 1008, new Float32Array(20021), 1446, 124);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup0, new Uint32Array(832), 71, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer39, 0);
+} catch {}
+try {
+computePassEncoder7.pushDebugGroup('\u{1f65b}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 9},
+  aspect: 'all',
+}, new ArrayBuffer(149), /* required buffer size: 149 */
+{offset: 149, bytesPerRow: 56}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline16 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  multisample: {mask: 0x73fc6aed},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'zero'},
+    stencilReadMask: 4294967295,
+  },
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {arrayStride: 128, attributes: []},
+      {arrayStride: 40, attributes: []},
+      {arrayStride: 16, attributes: []},
+      {arrayStride: 60, attributes: []},
+      {arrayStride: 612, attributes: []},
+      {arrayStride: 88, attributes: []},
+      {arrayStride: 560, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 40,
+        attributes: [
+          {format: 'float32x2', offset: 8, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({});
+let commandBuffer49 = commandEncoder75.finish({});
+let textureView20 = texture22.createView({label: '\u{1fe46}\ud2ad', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture8 = device0.importExternalTexture({label: '\u0cf2\u1d30\u{1fac4}\uf6b3', source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer61 = device0.createBuffer({
+  label: '\u09b4\ucb0e\u0705\u4437\u{1fbd0}',
+  size: 1648,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline14);
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+let promise15 = device0.createRenderPipelineAsync({
+  label: '\u1063\uc293\u596c\uc43f\u6306\u0deb\u7aaf\u{1fdf1}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule2, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-list', unclippedDepth: true},
+});
+await gc();
+try {
+renderPassEncoder13.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer38, 'uint32', 3_712, 20);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline12);
+} catch {}
+let renderBundle48 = renderBundleEncoder4.finish({label: '\u5665\uc40e\ud017\uf204\u0228\u1293\u36b1'});
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder();
+let commandBuffer50 = commandEncoder76.finish({});
+let texture26 = device0.createTexture({
+  label: '\ubc49\ua257\u723c\u{1f6f5}\u0f39\u7750\u019e\u{1f7ef}\u18f6\u07f7\u0e5b',
+  size: [154, 24, 1],
+  sampleCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle49 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup0, new Uint32Array(1343), 637, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle29, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer37, 0, 6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 435, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder();
+let texture27 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder16 = commandEncoder77.beginRenderPass({
+  label: '\u9268\u60b7\u3d62\u94db',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: -671.1, g: 229.2, b: 953.2, a: 69.21, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 97609366,
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer59, 'uint16', 66, 241);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer36);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+document.body.prepend(img4);
+let renderBundle50 = renderBundleEncoder7.finish({label: '\u0c85\u{1f81e}\uf71e\u{1f6d5}\ud4eb\udb54\u074d'});
+let sampler5 = device0.createSampler({
+  label: '\u{1fd52}\ue775\uc8c7\u{1fd6b}\u{1f856}\ueb1f\ucd5d\u097c\u0e5e\u{1f9a8}\u9e41',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.50,
+  compare: 'always',
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup0);
+} catch {}
+document.body.prepend(img4);
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer60, 1_836, 7_930);
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let renderPassEncoder17 = commandEncoder78.beginRenderPass({
+  label: '\u98a8\u53fd',
+  colorAttachments: [{view: textureView10, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 145660638,
+});
+let renderBundle51 = renderBundleEncoder1.finish({label: '\u9cbe\u813c'});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup('\u1f14');
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({label: '\u0644\u{1fa04}\uf75c\u01da\u060b\u069f\u0fca\u31f8\u2f60\uc037\u039c'});
+let commandBuffer51 = commandEncoder79.finish();
+try {
+computePassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle38]);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\u050b\uac03\u5815\u57d7\ua10c\u0188\ua87e\ufc6c\u062e\uc76f\u41f1',
+  code: `
+struct T0 {
+  f0: f32,
+  f1: array<atomic<u32>>,
+}
+@group(1) @binding(23) var sam52: sampler;
+@group(0) @binding(80) var<uniform> buffer62: array<vec4i, 1>;
+@group(2) @binding(105) var tex54: texture_multisampled_2d<i32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f13: vec4f,
+  @location(13) f14: u32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder80 = device0.createCommandEncoder({label: '\u{1ffd5}\u9865\u171f'});
+let commandBuffer52 = commandEncoder80.finish({label: '\uf131\u019d\uf1fa'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb']});
+let externalTexture9 = device0.importExternalTexture({label: '\u3210\u0448\u02e1\u{1fd9e}\u6877\ua05d\u0175\u0a5c\u07d8\u501f', source: video0});
+try {
+renderPassEncoder12.executeBundles([renderBundle51]);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+let buffer63 = device0.createBuffer({
+  label: '\udc4d\ue707\u{1ff7d}\u6ca9\u0e57\uca51',
+  size: 11010,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 4, y: 3 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 230, y: 50, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({label: '\u479d\u9889\ufbaf\u0630'});
+let computePassEncoder14 = commandEncoder81.beginComputePass({label: '\u1583\u7efe\u99f9'});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(1362), 236, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer63, 656, 489);
+} catch {}
+try {
+buffer61.unmap();
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder();
+let renderPassEncoder18 = commandEncoder82.beginRenderPass({
+  colorAttachments: [{view: textureView10, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 44887392,
+});
+let renderBundle52 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(1161), 3, 0);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 1784, new BigUint64Array(3684), 188, 28);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u0358\u{1ff07}\ufa26\u{1fac5}\u763d\u2f9d\u852a\ud924\u{1fc10}\u{1fe6a}',
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout5, bindGroupLayout2],
+});
+let buffer64 = device0.createBuffer({
+  label: '\ucb4f\u{1ffe0}\uea23\u9185\u0c22\u2a8d\u5e1f\u6f0c\u{1f6f9}\u0df2\u{1ff3d}',
+  size: 25640,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder83 = device0.createCommandEncoder({label: '\u{1f8e3}\u{1f849}\u04c5\u46c1\u0837\u9897\u{1ff7f}'});
+let commandBuffer53 = commandEncoder83.finish({label: '\u{1f6c6}\u0d06\u0d3e\u0faf\u04a3\u9ec0\u{1ff6a}'});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer60);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 656 */
+  offset: 656,
+  bytesPerRow: 256,
+  buffer: buffer37,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 99, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 5, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder84 = device0.createCommandEncoder();
+let commandBuffer54 = commandEncoder62.finish();
+let textureView21 = texture4.createView({
+  label: '\u{1fc4d}\u0b5b\ua225\u0e2d\u11ef\u65da\uf03c\ub5cc\u36d3',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 1,
+});
+try {
+renderPassEncoder13.executeBundles([renderBundle26]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer54]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(106, 4, 32, 28);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer64, 780, buffer36, 1344, 232);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 117, y: 15, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [{binding: 112, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let commandEncoder85 = device0.createCommandEncoder({label: '\u{1f6e9}\u069a\ub585\u{1fbbe}\u{1feb1}\ub176\u{1f671}\u50f3\ue5f1\uc7e5'});
+let commandBuffer55 = commandEncoder85.finish({label: '\u7ab1\u0689\ua167\u{1f9cd}\u05b8\ua7c9\u2e1a\u79df\u{1fd6f}\u9b2f\ufe27'});
+let renderPassEncoder19 = commandEncoder84.beginRenderPass({
+  label: '\u{1fee2}\ue4f8\u9379\u0216',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -589.0, g: -534.2, b: -114.8, a: -261.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder6.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle25]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer50, commandBuffer18]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 104, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(67), /* required buffer size: 67 */
+{offset: 67}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 57 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer39, 0, 144);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(3783), 503, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer53, commandBuffer55]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 17, y: 18 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 15, y: 22, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer37, 'uint32', 216, 1_065);
+} catch {}
+video2.height = 55;
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer60, 0, 3_560);
+} catch {}
+let renderBundle53 = renderBundleEncoder1.finish({label: '\ud730\u86c7\u2006'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle36, renderBundle15, renderBundle6, renderBundle40, renderBundle40, renderBundle19, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline12);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+await gc();
+try {
+externalTexture8.label = '\u{1ff29}\u0880\u027c';
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder();
+let renderPassEncoder20 = commandEncoder86.beginRenderPass({
+  label: '\ucba9\u8009\ub305\u8d79\u11da',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: -511.4, g: 732.6, b: 916.4, a: -496.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline14);
+} catch {}
+let arrayBuffer3 = buffer64.getMappedRange();
+let pipeline17 = device0.createComputePipeline({
+  label: '\u0e2c\uabca\u5bd8\uaadc\u{1f77b}\u{1f8b3}\ua288\u{1f7fe}\uc7a6\ub576',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2},
+});
+try {
+renderPassEncoder8.setIndexBuffer(buffer37, 'uint16', 412, 518);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer38);
+} catch {}
+try {
+device0.queue.submit([commandBuffer51]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 14, y: 2 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 13, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 56, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(12, 124);
+try {
+computePassEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(72), 0, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer61, 'uint16', 104, 455);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let commandEncoder87 = device0.createCommandEncoder();
+let computePassEncoder15 = commandEncoder87.beginComputePass({label: '\ua71b\u528c\u{1fd5d}\u{1ff09}\u0b7c\u{1f7ef}\u{1fa4d}\u91b8\u867e\udf52\udc8d'});
+let renderBundle54 = renderBundleEncoder6.finish({label: '\uf458\u{1fd24}\udc00\u394c\uc1d9\u8cb2\u2d19\u{1fafa}\u{1fb7f}\u0c51\u{1fbd2}'});
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 7, y: 17, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 64 */
+{offset: 64, bytesPerRow: 945}, {width: 115, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let canvas0 = document.createElement('canvas');
+let texture28 = gpuCanvasContext0.getCurrentTexture();
+let pipeline18 = device0.createRenderPipeline({
+  label: '\ucd89\uda0f\u{1fc22}\udb99\ucf4e',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule6, entryPoint: 'vertex0', buffers: []},
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let buffer65 = device0.createBuffer({
+  label: '\ue127\u15a7\u{1f834}\u07af\u083f\u0414\u0651',
+  size: 1017,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle53, renderBundle36, renderBundle30]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+let renderBundle55 = renderBundleEncoder5.finish({label: '\u34bc\u75fd\u02af\u{1feaf}\u111a\u800f'});
+let sampler6 = device0.createSampler({
+  label: '\u7493\u{1f7e0}\u0493\u{1f692}\uffc7\ue453',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.76,
+  lodMaxClamp: 84.57,
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer59, 'uint16', 8_310, 371);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline8);
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+let promise17 = navigator.gpu.requestAdapter();
+let imageBitmap2 = await createImageBitmap(imageData3);
+let commandEncoder88 = device0.createCommandEncoder({label: '\udc65\u987a'});
+let commandBuffer56 = commandEncoder88.finish({label: '\u0703\uc397\u{1ff95}\u{1f613}\u6e4d\u8630\u0f56\u034d\ua604'});
+let textureView22 = texture7.createView({baseMipLevel: 1, baseArrayLayer: 0});
+try {
+computePassEncoder12.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 900, new BigUint64Array(979), 252, 56);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle56 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let commandEncoder89 = device0.createCommandEncoder({label: '\u06e1\uc836\u{1fbf0}\u0b7a'});
+let commandBuffer57 = commandEncoder89.finish();
+let promise19 = device0.queue.onSubmittedWorkDone();
+let commandEncoder90 = device0.createCommandEncoder({label: '\u{1fd6c}\u0fa8\ua7fc\u1122\u3ebe\u0243'});
+let renderPassEncoder21 = commandEncoder90.beginRenderPass({
+  label: '\uc204\u8e1a\u7776\uca3c',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -84.44, g: 860.8, b: 678.7, a: -433.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 152601685,
+});
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, undefined, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer23]);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let buffer66 = device0.createBuffer({
+  label: '\uc4a8\u{1fc36}\u0552\u0c30',
+  size: 27963,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u39d4\ua983\uc341\u{1f8fd}'});
+let textureView23 = texture3.createView({label: '\ua486\u6dc4\u{1f8f5}\u2bcd\u0421\u{1f95b}\u05bb\u0a17', baseMipLevel: 2});
+let renderPassEncoder22 = commandEncoder91.beginRenderPass({
+  label: '\u{1fc08}\u76aa\uaf62\u{1f7ea}\uc095\u0093\u0eaf\u04d8',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -554.1, g: 393.7, b: -990.1, a: -933.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 82038857,
+});
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup0, new Uint32Array(2014), 385, 0);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer64, 3_404);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise18;
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder92 = device0.createCommandEncoder({label: '\u0fc1\uba9d\u04a0\u53a9'});
+let commandBuffer58 = commandEncoder92.finish({label: '\u0ece\ufa7a\u01a7\uf65a'});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(video2);
+try {
+externalTexture8.label = '\u5d8c\u{1fa98}\u{1f7ec}\u11b9\u030a';
+} catch {}
+let buffer67 = device0.createBuffer({
+  label: '\udd9b\u{1fb84}\u828e\u{1fdc7}\u6e47\ua1e0',
+  size: 13772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder93 = device0.createCommandEncoder({});
+let computePassEncoder16 = commandEncoder93.beginComputePass();
+try {
+renderPassEncoder17.executeBundles([renderBundle54, renderBundle31, renderBundle1]);
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u0672\uc6ba\u254c\u8c8b\u221d\u{1fa4f}\u04da\u06a8',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+@group(0) @binding(102) var tex56: texture_2d<i32>;
+@group(1) @binding(3) var sam53: sampler_comparison;
+@group(0) @binding(492) var tex55: texture_cube_array<f32>;
+@group(2) @binding(23) var sam54: sampler;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+  _ = textureGather(1, tex56, sam54, vec2f(), vec2i());
+  _ = textureLoad(tex56, vec2i(), 0);
+}
+
+struct S1 {
+  @location(9) f0: vec2i,
+  @location(0) f1: f32
+}
+struct VertexOutput0 {
+  @builtin(position) f15: vec4f,
+  @location(13) f16: vec3i,
+  @location(4) f17: f16,
+  @location(8) f18: vec3h
+}
+
+@vertex
+fn vertex0(a0: S1, @location(13) a1: vec3h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec4f {
+  var out: vec4f;
+  _ = textureLoad(tex56, vec2i(), 0);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder19.setPipeline(pipeline12);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({});
+let commandBuffer59 = commandEncoder94.finish({label: '\u7942\u037b\u1807\u{1f6c0}\ua84f\u0d6d'});
+try {
+renderPassEncoder18.executeBundles([renderBundle54]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer65);
+} catch {}
+try {
+device0.queue.submit([commandBuffer48, commandBuffer59, commandBuffer43, commandBuffer46]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let videoFrame0 = new VideoFrame(video2, {timestamp: 0});
+let commandEncoder95 = device0.createCommandEncoder({label: '\u0b60\u0839\u{1f6fb}\u1026\u{1f611}\u03b2'});
+let renderPassEncoder23 = commandEncoder95.beginRenderPass({
+  label: '\u{1ff25}\u43d4',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 762.8, g: -243.2, b: -938.0, a: -493.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 277759262,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u0ed1\u6147\u55af\u08eb\u{1f7d2}\u0961\u81cd\u84fb\u8271\u{1fca5}',
+  colorFormats: ['bgra8unorm-srgb'],
+});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder23.end();
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 452, new BigUint64Array(2563), 1861, 0);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer19, 'uint16', 514, 2_707);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer36, 2_380, 208);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4_294_967_294, undefined, 2_022_272_946);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer47]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 2632, new Int16Array(65536), 2926, 444);
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({label: '\u6132\ucad3\u0793\u{1f711}\u51fe\u7128\ucf82\u{1f99e}'});
+let computePassEncoder17 = commandEncoder96.beginComputePass({label: '\u{1fe78}\u{1f72c}\ua43f\u111b\ua2ea\u8fe2'});
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer65, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup0);
+} catch {}
+let buffer68 = device0.createBuffer({
+  label: '\u0f05\u0a09\u0cfd\u{1fe94}\u0a4a\u{1ff04}',
+  size: 27742,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundle57 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer65, 'uint32', 52, 61);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let canvas1 = document.createElement('canvas');
+let img5 = await imageWithData(33, 131, '#10101010', '#20202020');
+let commandEncoder97 = device0.createCommandEncoder({label: '\u696d\u0ee1\ud278\u{1fd4b}\u4b3c\uf398'});
+let renderBundle58 = renderBundleEncoder1.finish({});
+try {
+renderBundleEncoder9.setPipeline(pipeline12);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder98 = device0.createCommandEncoder({label: '\u579a\u001f\u6452\u007f\u51be\u{1fd96}'});
+let querySet12 = device0.createQuerySet({label: '\ubdbe\udb0f\u{1fe68}', type: 'occlusion', count: 1229});
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer65);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer38);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 2, y: 20, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 508 widthInBlocks: 127 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 504 */
+  offset: 504,
+  bytesPerRow: 512,
+  buffer: buffer39,
+}, {width: 127, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer56, 36, 104);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer69 = device0.createBuffer({
+  label: '\u{1f79f}\uaff3\u0e55\ue04d\u1c07',
+  size: 4634,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderPassEncoder24 = commandEncoder97.beginRenderPass({
+  label: '\u3b62\u9c4d\u02d3\u{1f9c8}\u{1fb52}\u{1fdd4}\u00b0\u7171\uc4bc',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -584.9, g: -566.6, b: -562.7, a: 406.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet9,
+});
+let renderBundle59 = renderBundleEncoder1.finish({label: '\u0f6d\u59d7\u{1fae2}\ud08a\u0b1d'});
+try {
+computePassEncoder14.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer65);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 82, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder99 = device0.createCommandEncoder();
+let computePassEncoder18 = commandEncoder99.beginComputePass({label: '\u8a9d\u094b\u48d8\uc0f7\u{1f68e}\u6b8f\u{1f857}'});
+let renderPassEncoder25 = commandEncoder98.beginRenderPass({
+  label: '\u0ce8\u64a6\u14a8',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: -360.0, g: 238.5, b: -803.3, a: -437.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+let renderBundle60 = renderBundleEncoder5.finish({label: '\u9100\u295a\u1260\udcbf\u25a3\u194d\u2c89\u8cf8'});
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer37, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(785), 280, 0);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let imageData6 = new ImageData(20, 64);
+let textureView24 = texture2.createView({label: '\u039f\u4675\u{1f635}\ub6b0\u9d43\u583f\u0a86\u0aa5\u{1fd36}\uac14', format: 'bgra8unorm'});
+try {
+renderPassEncoder21.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer39, 0, 15_305);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer38, 'uint16', 6_494, 327);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let device1 = await adapter2.requestDevice({
+  label: '\u0d56\ub375\u01a5\uba85\u033e\u0b6d\u03fa',
+  defaultQueue: {label: '\u{1fd38}\u{1ffaf}\u0848\u0fef\u4eed\u73fe\u{1fcfb}\u7bd4'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 24991236, maxStorageBufferBindingSize: 143657632},
+});
+try {
+computePassEncoder18.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle38]);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer60, 148, 2_226);
+} catch {}
+let commandEncoder100 = device1.createCommandEncoder();
+let commandBuffer60 = commandEncoder100.finish({label: '\u0517\uc6cf\u{1f79e}\u{1f648}\ud9cc\u0cea\u06e4\u4f39\u5944\u8f8e\u6bd0'});
+let texture29 = device1.createTexture({
+  label: '\u0046\u323b\ua43e\ub62d\u0926\u9197\u9840\u{1f7f9}',
+  size: [52, 48, 1],
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+let commandEncoder101 = device1.createCommandEncoder({label: '\u{1f829}\u{1fe35}\u139e\u{1f79a}\u{1fa37}\u03af'});
+let bindGroupLayout18 = device1.createBindGroupLayout({
+  label: '\u0e81\uf573\u7017\uf05a\u064d\u0bbd\u171d\u7587\uc579',
+  entries: [
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let pipelineLayout6 = device1.createPipelineLayout({
+  label: '\uc45d\u4272\u0a33\u4604\u0e9b\u0608\ua23f\u{1facc}\ubf01',
+  bindGroupLayouts: [bindGroupLayout18, bindGroupLayout18],
+});
+let commandBuffer61 = commandEncoder101.finish();
+let sampler7 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.26,
+  compare: 'greater',
+});
+await gc();
+let commandEncoder102 = device1.createCommandEncoder();
+let textureView25 = texture29.createView({
+  label: '\udba4\ufce1\u{1fdb3}\u5138\u0ef3\u9bb3\u6c3c\ud211\u2b18',
+  aspect: 'all',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+let externalTexture10 = device1.importExternalTexture({label: '\u03b0\u8218\u{1f959}\u04fb\uff16\u0479\u{1ff8e}\ub7a3\u2ea9', source: video1});
+let imageData7 = new ImageData(28, 32);
+let shaderModule8 = device1.createShaderModule({
+  label: '\u8135\u5e19',
+  code: `
+struct T0 {
+  f0: array<array<atomic<i32>, 1>>,
+}
+@group(1) @binding(94) var sam56: sampler;
+@group(0) @binding(94) var sam55: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f19: vec4f,
+  @location(7) f20: f16,
+  @location(3) f21: f16
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f20 = f16(-58900.9);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(0) f1: vec4f
+}
+
+@fragment
+fn fragment0(@location(7) a0: f16, @builtin(position) a1: vec4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandBuffer62 = commandEncoder102.finish();
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\udbcd\u{1faa1}\u0c50\u0c21\u924b\u0f5b\uac78\u508f\ued95';
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(2104), 247, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet13 = device1.createQuerySet({label: '\u217b\uc59d\u{1f975}\ua9df\u{1f600}\u{1f6a2}\udc4f', type: 'occlusion', count: 694});
+let commandEncoder103 = device0.createCommandEncoder({label: '\u210f\u0e6b\u383e'});
+let computePassEncoder19 = commandEncoder103.beginComputePass({label: '\u{1f9ed}\u{1fa8e}\u3bfd\u{1ffff}\ub7ce\ud027'});
+let renderBundle61 = renderBundleEncoder6.finish({label: '\u{1f64e}\u5b9c\u14f1\u0bc8'});
+try {
+renderPassEncoder11.setIndexBuffer(buffer61, 'uint16', 18, 153);
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder104 = device1.createCommandEncoder({});
+let textureView26 = texture29.createView({label: '\u{1fac7}\u{1fc64}\u{1fbae}', dimension: '2d-array', mipLevelCount: 1});
+let canvas2 = document.createElement('canvas');
+let textureView27 = texture18.createView({aspect: 'all', baseMipLevel: 1});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, undefined);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer37, 'uint16', 26, 724);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer39, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+let commandBuffer63 = commandEncoder104.finish({label: '\ub0e0\u5381\u0345'});
+document.body.prepend(canvas2);
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({label: '\u8107\u{1fbbc}\u677a', bindGroupLayouts: []});
+let buffer70 = device0.createBuffer({
+  label: '\u0c5e\u12ab\u5366\u082e\uc1e1',
+  size: 8735,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet14 = device0.createQuerySet({label: '\u1c87\uc5db\u{1fa66}\u05ca\ub5fd', type: 'occlusion', count: 95});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle20, renderBundle54]);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer37);
+} catch {}
+let arrayBuffer4 = buffer64.getMappedRange(25640, 0);
+document.body.prepend(img2);
+let commandEncoder105 = device1.createCommandEncoder({label: '\u876d\u{1fe80}\u04ed\u087c\u{1ff95}\u0d44\u{1faea}\u8f81\u0736'});
+let computePassEncoder20 = commandEncoder105.beginComputePass();
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer65, 216, 247);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer36, 1_076, 3_389);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder106 = device1.createCommandEncoder({label: '\u00dd\ubbbf\u5288\u3330\u{1f749}\u{1fc48}\ua89b\u{1fc4a}'});
+let texture30 = device1.createTexture({
+  label: '\u19d7\u068d\u6d18\uc1f1\u{1faa0}\u7a8f\u6b41\uccfd\u94ae\u01fe',
+  size: {width: 26, height: 24, depthOrArrayLayers: 25},
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+document.body.prepend(canvas0);
+let img6 = await imageWithData(55, 41, '#10101010', '#20202020');
+let commandEncoder107 = device0.createCommandEncoder({label: '\u0852\u08fd'});
+let commandBuffer64 = commandEncoder107.finish({label: '\u{1f9ff}\ub6cb\ud1bc\u2864\u7621\udae1\u604e'});
+try {
+renderPassEncoder19.setPipeline(pipeline14);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder108 = device1.createCommandEncoder({});
+try {
+computePassEncoder20.end();
+} catch {}
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u92f6\u0855\uf5bc\u9bf0\u7b7a\u0b28\ub71b\u5898\u0553\uf5b6',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: false,
+});
+try {
+computePassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer37, 'uint32', 328, 329);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer39, 10_932, 947);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 640, new Float32Array(5582), 4450);
+} catch {}
+let renderBundle62 = renderBundleEncoder2.finish({label: '\uce49\u{1feeb}\u4083\u{1f935}\u{1f8b9}\uc561\u{1f8dd}\u{1f82f}\u0fa5'});
+try {
+computePassEncoder15.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder9.insertDebugMarker('\ua5dd');
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder();
+let renderPassEncoder26 = commandEncoder109.beginRenderPass({
+  label: '\u13f8\u59dd\u7eff\ue0f0\u{1fbf4}\uce71\u{1fd92}',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 541.6, g: -573.4, b: 431.2, a: 241.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(290.8933137116552, 11.52430120767196, 8.521777154618443, 29.883119357389166, 0.15618194601842084, 0.9542316344180287);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer36, 'uint16', 230, 239);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer60, 20_488);
+} catch {}
+try {
+  await buffer68.mapAsync(GPUMapMode.WRITE, 0, 5512);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 49, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(11), /* required buffer size: 11 */
+{offset: 11, bytesPerRow: 750}, {width: 184, height: 81, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer71 = device0.createBuffer({size: 17576, usage: GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer63);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer36, 212, 1_280);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+await gc();
+let commandEncoder110 = device1.createCommandEncoder({label: '\u962e\u{1f985}\u{1ff24}\ud696\u7ce3\u6734\u0301\u0145'});
+let commandBuffer65 = commandEncoder110.finish({label: '\u{1f915}\u2656\u0dc8\u{1f845}\u032f\u7439'});
+let computePassEncoder21 = commandEncoder108.beginComputePass({});
+let renderBundleEncoder11 = device1.createRenderBundleEncoder({
+  label: '\u{1fd50}\uc4c6\u{1f960}\u2c16\u7a5b',
+  colorFormats: ['bgra8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  stencilReadOnly: true,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline19 = await device1.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule8, constants: {}}});
+try {
+  await promise20;
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder111 = device1.createCommandEncoder({label: '\u009f\u04df\u076e'});
+try {
+  await promise19;
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({label: '\u30c9\u{1fb19}\u412e\uf1b6'});
+let renderBundle63 = renderBundleEncoder0.finish({label: '\u0e27\uc6e3\u40ae\u793c\u{1f76d}\ud1f0\u{1fcbe}\u{1f891}\u0f89\ueb89\u9c2b'});
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(351), /* required buffer size: 351 */
+{offset: 351}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet15 = device1.createQuerySet({label: '\u0aa9\u3ad9\u{1f6e8}\u0549\u02f3', type: 'occlusion', count: 698});
+let commandBuffer66 = commandEncoder106.finish({label: '\ud2b0\u02f5\u{1f741}\u36c5\u0902'});
+let textureView28 = texture29.createView({label: '\ub5a7\u7f7a'});
+let computePassEncoder22 = commandEncoder111.beginComputePass();
+let renderBundleEncoder12 = device1.createRenderBundleEncoder({
+  label: '\u0a89\u{1fae9}\u2f56',
+  colorFormats: ['bgra8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: false,
+});
+try {
+computePassEncoder21.setPipeline(pipeline19);
+} catch {}
+let bindGroupLayout19 = device1.createBindGroupLayout({
+  label: '\uf3f5\uf622\u0ec2\u6a1f\u0127\ua33e',
+  entries: [
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet16 = device1.createQuerySet({label: '\u6e24\ub86f\u71c4\u0ebc\u{1fe0e}\udd1d\ue781\uab78\u7cbf', type: 'occlusion', count: 500});
+let commandBuffer67 = commandEncoder105.finish({});
+let renderBundle64 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+canvas1.width = 50;
+let texture31 = device1.createTexture({
+  label: '\u07f3\u1a8b\uf8d1\u0cec\u99af\u21ee\u09c6\u0857\u9aba\u0f61\u404a',
+  size: [52, 48, 1],
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder113 = device1.createCommandEncoder();
+let renderBundle65 = renderBundleEncoder12.finish({label: '\u093d\u3eec\u2b54\u{1f733}\u0ee6\u6ec9\u1524\u8f3b\u131b\u0242'});
+try {
+computePassEncoder21.setPipeline(pipeline19);
+} catch {}
+let commandEncoder114 = device1.createCommandEncoder({label: '\u{1fc0f}\u2989\u09b6\u0ea9\ueae9\ucadf\uc6e2'});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline20 = device1.createRenderPipeline({
+  label: '\uf07e\u010a\ud678',
+  layout: pipelineLayout6,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule8, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+document.body.prepend(canvas1);
+let imageData8 = new ImageData(20, 164);
+let commandEncoder115 = device0.createCommandEncoder();
+try {
+computePassEncoder16.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer66, 'uint32', 4_112, 644);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer65, 32, 12);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer64, 3_876, 5_579);
+} catch {}
+try {
+commandEncoder115.resolveQuerySet(querySet2, 9, 0, buffer38, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline21 = device0.createComputePipeline({
+  label: '\u0acd\u5916\ue997\u0b0e\u{1f95c}\uaf94\u{1fcf5}\u92f7',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule5},
+});
+let commandBuffer68 = commandEncoder115.finish({label: '\u3397\u07e4\u3179\u9dc5'});
+let renderBundle66 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder6.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder1.setViewport(205.92285287236706, 86.27722136900276, 247.52862170600505, 2.6897415110215483, 0.3049123100981408, 0.6798503945848622);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer70, 2460, 1320);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({label: '\uaeff\u0ca2\u94ef\ub8c7\ud26b\u6c7e\uf98f\ud622\u9015'});
+let renderBundle67 = renderBundleEncoder7.finish({label: '\u3064\u6c57\u0d55'});
+try {
+renderPassEncoder20.setIndexBuffer(buffer65, 'uint16', 6, 1_000);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer60, 'uint32', 580, 3_750);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(14), /* required buffer size: 14 */
+{offset: 14, bytesPerRow: 110}, {width: 52, height: 48, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u44b5\uefe5\u{1f6fb}\u0817\u181a\u0cb7\u0ec0\u1016',
+  entries: [
+    {
+      binding: 360,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder117 = device0.createCommandEncoder({label: '\u2219\u05ec\u4efe\u03e1\uf5f8\u07c8\u3fe4\uce5a'});
+let commandBuffer69 = commandEncoder116.finish({label: '\u0a59\u852b\u00a7\u3567'});
+let texture32 = device0.createTexture({
+  label: '\ud806\u08b5\u0936\u005d',
+  size: [309],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder27 = commandEncoder112.beginRenderPass({
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 126.7, g: 212.7, b: -101.9, a: -954.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 3283731,
+});
+let renderBundle68 = renderBundleEncoder4.finish();
+let externalTexture11 = device0.importExternalTexture({label: '\u7431\u0822\u0d4d\u{1f79e}\u2bc1\u7c8d', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer40, commandBuffer27]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video0.width = 18;
+try {
+adapter0.label = '\u069d\u{1f692}\ufd92\u{1f6c3}\ue357\u0335\uda4d\u{1fdee}\u0628';
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u0d81\u0eb5\u5972\u83ec\u4f4b\uf2d8\u09f8\u085d',
+  entries: [
+    {
+      binding: 114,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let computePassEncoder23 = commandEncoder117.beginComputePass();
+try {
+computePassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer60, 'uint16', 7_722, 1_053);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer67, 0, 10_397);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0, new Uint32Array(97), 15, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(0, buffer63);
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\u9909');
+} catch {}
+let imageData9 = new ImageData(72, 4);
+let commandEncoder118 = device0.createCommandEncoder({label: '\u079e\ue440\u0b7f\u0ca6\u{1f995}\u4bf9\u39df'});
+let computePassEncoder24 = commandEncoder118.beginComputePass();
+try {
+buffer69.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+document.body.prepend(canvas0);
+let externalTexture12 = device0.importExternalTexture({label: '\u{1f838}\u{1fc36}\u90ea', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder9.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(12, 17, 175, 5);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer60, 3_316, 2_893);
+} catch {}
+try {
+device0.queue.submit([commandBuffer45, commandBuffer31]);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup0, new Uint32Array(3817), 353, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer67, 6_940, 1_909);
+} catch {}
+let arrayBuffer5 = buffer68.getMappedRange(0, 112);
+try {
+device0.queue.submit([commandBuffer57, commandBuffer41]);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+adapter1.label = '\u9770\u{1fe44}\u02cd';
+} catch {}
+try {
+commandEncoder113.insertDebugMarker('\u{1fb17}');
+} catch {}
+let textureView29 = texture22.createView({label: '\u05ed\u4bde\ud7d6\u1019\u52e0\u{1f86e}\uc208\u{1fd2e}\u{1f7da}\u08b7\u33cf'});
+try {
+renderPassEncoder20.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup0, new Uint32Array(1619), 187, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 1240, new Int16Array(3982), 615, 676);
+} catch {}
+await gc();
+let canvas4 = document.createElement('canvas');
+let imageData10 = new ImageData(32, 92);
+let commandBuffer70 = commandEncoder114.finish({label: '\u9e48\u{1fb76}\u049a\uf619\u3afa\u0c3a\u{1fb9c}\u453d'});
+let textureView30 = texture29.createView({label: '\u0c0c\u6427\u{1f917}', baseMipLevel: 0});
+let renderBundle69 = renderBundleEncoder8.finish({label: '\u7c69\u7e30\u988a'});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle43]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer39);
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\uc215');
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({label: '\ud69e\u{1fd2a}\u0fec\u{1fadb}\u0ce3\u0030', bindGroupLayouts: [bindGroupLayout9]});
+let commandEncoder119 = device0.createCommandEncoder({label: '\u{1f61c}\uefe6\u043b\uc0bd\u97f4\u04d5\u0969'});
+let renderPassEncoder28 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -195.0, g: 708.4, b: 179.1, a: -182.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle70 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder14.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 2248, new Float32Array(3220), 666, 304);
+} catch {}
+let imageData11 = new ImageData(32, 36);
+let textureView31 = texture31.createView({
+  label: '\u0e7a\u2625\u0c21\u0269\u3156\u9e63\ubc12\ub434\u{1f617}',
+  aspect: 'depth-only',
+  baseArrayLayer: 0,
+});
+let computePassEncoder25 = commandEncoder113.beginComputePass({label: '\ue961\ud957\ub5dc\u18ba\u1d5a\u{1feaa}\udbb6\u493d\u4a81\u03ce'});
+try {
+device1.queue.submit([commandBuffer66]);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device1, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let gpuCanvasContext5 = canvas4.getContext('webgpu');
+document.body.prepend(canvas3);
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder120 = device1.createCommandEncoder();
+let computePassEncoder26 = commandEncoder120.beginComputePass({label: '\ud529\u{1f878}\u0e80\u{1fe74}\u{1f659}\u8026\u28de\u{1f880}\u06cf'});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+device1.queue.submit([commandBuffer63, commandBuffer62, commandBuffer60]);
+} catch {}
+let commandBuffer71 = commandEncoder108.finish();
+let renderBundle71 = renderBundleEncoder11.finish();
+try {
+computePassEncoder25.setPipeline(pipeline19);
+} catch {}
+let texture33 = device0.createTexture({
+  size: [77, 12, 88],
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(242);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer37, 0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0, new Uint32Array(1725), 220, 0);
+} catch {}
+try {
+commandEncoder119.insertDebugMarker('\u{1f652}');
+} catch {}
+let pipelineLayout9 = device1.createPipelineLayout({
+  label: '\u{1f6b2}\u15fb\u{1fff7}\u{1f971}\u{1f733}\u0e9a\u0394\ud649\u8149\u5117\u3002',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout19, bindGroupLayout18, bindGroupLayout19],
+});
+let renderBundle72 = renderBundleEncoder11.finish();
+let bindGroup1 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 23, resource: sampler1}]});
+let commandEncoder121 = device0.createCommandEncoder({});
+let commandBuffer72 = commandEncoder121.finish({label: '\ud0bd\u0180\u{1f8f1}\u9ba0\uec3d\u0634\ufa74\u17eb\u35dc'});
+let textureView32 = texture32.createView({label: '\uc547\u5899'});
+let renderBundle73 = renderBundleEncoder6.finish({label: '\u096e\ubc0c\u25aa\u0695\u180b\u{1f60c}\u13de\u640a\u{1fa23}'});
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(3027), 522, 0);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer65, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 83, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(205), /* required buffer size: 205 */
+{offset: 205, bytesPerRow: 361}, {width: 83, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\u01f9\uaec5\u8ada',
+  entries: [
+    {
+      binding: 246,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let renderPassEncoder29 = commandEncoder119.beginRenderPass({
+  label: '\u{1f84d}\u4e54\u4885\u05c9\ube8b\u545b\ub08c\ub1d5',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 820.9, g: 954.2, b: 429.3, a: 423.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 76706602,
+});
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup1, new Uint32Array(4), 0, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(669);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(116), 1, 0);
+} catch {}
+let imageData12 = new ImageData(80, 172);
+let commandEncoder122 = device0.createCommandEncoder({label: '\u{1fdc0}\u{1f63f}\u0909\u0d72\ucf8d\ud7df\u1870\u54c8'});
+let textureView33 = texture8.createView({
+  label: '\uc2ee\u07d4\u3304\u091b\u{1f962}\ue8be\u{1fadc}\u247e\u{1fd57}',
+  format: 'bgra8unorm-srgb',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder10.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 38, y: 3, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 196 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 808 */
+  offset: 808,
+  bytesPerRow: 512,
+  buffer: buffer61,
+}, {width: 49, height: 8, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas4);
+let commandEncoder123 = device1.createCommandEncoder({});
+let commandBuffer73 = commandEncoder123.finish({label: '\u{1f82b}\u0304\u0399\u{1fc0b}\u8913\u7720\ua663'});
+await gc();
+try {
+computePassEncoder25.setPipeline(pipeline19);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let imageData13 = new ImageData(28, 24);
+let commandEncoder124 = device1.createCommandEncoder({label: '\ue624\u0159\u9836\u{1f80b}\u7616\u0883\u0eed\u{1feb3}\u{1f8bc}'});
+try {
+computePassEncoder25.setPipeline(pipeline19);
+} catch {}
+document.body.prepend(img1);
+let videoFrame1 = new VideoFrame(img3, {timestamp: 0});
+let commandBuffer74 = commandEncoder122.finish({label: '\u028c\udd08'});
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer67, 680, 3_951);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer65, 'uint32', 116, 115);
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\uae1c');
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(622);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle43]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(5, buffer67);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.submit([commandBuffer64]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline18);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u731b');
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder125 = device1.createCommandEncoder({});
+let commandBuffer75 = commandEncoder125.finish();
+let computePassEncoder27 = commandEncoder124.beginComputePass();
+try {
+computePassEncoder27.setPipeline(pipeline19);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+document.body.prepend(video2);
+let adapter3 = await navigator.gpu.requestAdapter();
+try {
+computePassEncoder11.setBindGroup(0, bindGroup1, new Uint32Array(51), 9, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup1, new Uint32Array(5639), 117, 0);
+} catch {}
+try {
+renderPassEncoder24.setViewport(71.88987880505721, 45.831398208518294, 43.1301620960909, 1.9255978818648265, 0.266243512369583, 0.7685618629379586);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer66, 'uint16', 86, 839);
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({label: '\u0638\u1fd9\u07eb\u0753\u{1f7b4}\u{1faa7}\u{1fdd5}'});
+let commandBuffer76 = commandEncoder126.finish({label: '\u30e3\u1f1f\u{1f802}\u02a1\ub445\uc6f3\u097a'});
+let renderBundle74 = renderBundleEncoder2.finish({label: '\ueae7\u8fdf\u{1ff55}\u9a3e\u01a2\u0748\u{1f729}\u{1fd19}\u0938\u47e2\u{1f9be}'});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(5, buffer60, 6_724, 3_733);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup0);
+} catch {}
+let arrayBuffer6 = buffer68.getMappedRange(112, 1104);
+let commandEncoder127 = device0.createCommandEncoder({label: '\u0e05\u{1fc52}\u3f4d\uacec\u0648\ucc16\u1254\ua720'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u0fa0\uee86\u0636\u{1fd3b}\u00be\u03b4\uf965',
+  colorFormats: ['rg32uint'],
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder17.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer66, 'uint32', 8_432, 445);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(4, buffer65);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder128 = device1.createCommandEncoder({label: '\u048b\u99d1\u8807\u{1f9bb}\uccc9\u0785\u0fb3'});
+let commandBuffer77 = commandEncoder128.finish({label: '\u{1f656}\u{1f656}\u{1f89b}\uab2f\ub427\u{1f66e}\u3dea\ud2cf\u01e0'});
+let video3 = await videoWithData();
+let shaderModule9 = device0.createShaderModule({
+  label: '\u{1f8fd}\u020e\u6011\u01b2\u{1fc18}',
+  code: `
+struct T0 {
+  f0: array<array<vec2i, 1>, 1>,
+}
+@group(0) @binding(999) var<uniform> buffer84: mat3x4h;
+@group(0) @binding(153) var et39: texture_external;
+@group(0) @binding(489) var<storage, read_write> buffer85: array<mat3x3h>;
+@group(0) @binding(362) var tex69: texture_multisampled_2d<i32>;
+@group(0) @binding(29) var tex61: texture_depth_cube;
+@group(0) @binding(8) var sam61: sampler;
+@group(0) @binding(28) var<storage, read_write> buffer76: T0;
+@group(0) @binding(292) var<uniform> buffer86: vec3h;
+@group(0) @binding(366) var tex58: texture_cube_array<i32>;
+@group(0) @binding(206) var<uniform> buffer72: f16;
+@group(0) @binding(16) var tex71: texture_depth_multisampled_2d;
+@group(0) @binding(395) var et37: texture_external;
+@group(0) @binding(636) var<storage, read> buffer74: vec3i;
+@group(0) @binding(95) var sam63: sampler;
+@group(0) @binding(79) var sam71: sampler_comparison;
+@group(0) @binding(107) var sam62: sampler;
+@group(0) @binding(118) var et43: texture_external;
+@group(0) @binding(361) var sam70: sampler;
+@group(0) @binding(249) var tex60: texture_multisampled_2d<u32>;
+@group(0) @binding(75) var tex59: texture_multisampled_2d<i32>;
+@group(0) @binding(34) var tex72: texture_cube_array<u32>;
+@group(0) @binding(120) var sam67: sampler;
+@group(0) @binding(148) var<uniform> buffer87: mat4x4f;
+@group(0) @binding(312) var<uniform> buffer83: vec4i;
+@group(0) @binding(5) var st14: texture_storage_3d<rg32sint, read>;
+@group(0) @binding(105) var tex68: texture_2d<u32>;
+@group(0) @binding(563) var et38: texture_external;
+@group(0) @binding(408) var tex62: texture_multisampled_2d<u32>;
+@group(0) @binding(561) var sam58: sampler_comparison;
+@group(0) @binding(284) var sam69: sampler_comparison;
+@group(0) @binding(101) var tex57: texture_1d<i32>;
+@group(0) @binding(22) var sam66: sampler_comparison;
+@group(0) @binding(44) var et40: texture_external;
+@group(0) @binding(33) var et41: texture_external;
+@group(0) @binding(334) var tex70: texture_cube<u32>;
+@group(0) @binding(131) var sam65: sampler;
+@group(0) @binding(42) var<storage, read_write> buffer82: array<mat2x2h>;
+@group(0) @binding(98) var et35: texture_external;
+@group(0) @binding(71) var tex65: texture_depth_cube;
+@group(0) @binding(189) var st12: texture_storage_2d<rg32sint, write>;
+@group(0) @binding(262) var<storage, read> buffer73: mat4x2h;
+@group(0) @binding(137) var<uniform> buffer81: mat4x4f;
+@group(0) @binding(239) var<uniform> buffer78: array<mat4x2h, 1>;
+@group(0) @binding(31) var<storage, read_write> buffer75: mat2x4h;
+@group(0) @binding(200) var st15: texture_storage_1d<rg32sint, read>;
+@group(0) @binding(15) var st13: texture_storage_2d_array<rgba16uint, write>;
+@group(0) @binding(195) var tex66: texture_1d<u32>;
+@group(0) @binding(43) var tex67: texture_depth_cube_array;
+@group(0) @binding(7) var<storage, read_write> buffer77: vec3i;
+@group(0) @binding(72) var sam57: sampler;
+@group(0) @binding(89) var et36: texture_external;
+@group(0) @binding(65) var sam59: sampler_comparison;
+@group(0) @binding(97) var sam64: sampler;
+@group(0) @binding(133) var et42: texture_external;
+@group(0) @binding(218) var tex64: texture_depth_cube;
+@group(0) @binding(84) var sam60: sampler;
+@group(0) @binding(330) var et34: texture_external;
+@group(0) @binding(203) var sam72: sampler_comparison;
+@group(0) @binding(165) var sam68: sampler_comparison;
+@group(0) @binding(27) var et33: texture_external;
+@group(0) @binding(253) var<storage, read_write> buffer80: array<vec3i>;
+@group(0) @binding(157) var<uniform> buffer79: mat3x3f;
+@group(0) @binding(231) var tex63: texture_depth_multisampled_2d;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = textureLoad(st14, vec3i());
+  _ = textureSampleLevel(tex61, sam63, vec3f(), 0i);
+  _ = textureSampleBaseClampToEdge(et38, sam63, vec2f());
+  _ = textureLoad(et40, vec2u());
+  _ = textureSampleBaseClampToEdge(et39, sam70, vec2f());
+  _ = textureLoad(et42, vec2u());
+  _ = textureSampleBaseClampToEdge(et42, sam70, vec2f());
+  _ = textureGather(1, tex68, sam64, vec2f(), vec2i());
+  _ = textureSampleLevel(tex61, sam64, vec3f(), 0i);
+  _ = textureSampleBaseClampToEdge(et42, sam64, vec2f());
+}
+
+struct VertexOutput0 {
+  @builtin(position) f22: vec4f
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3h, @location(7) a1: vec2h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureLoad(et39, vec2u());
+  _ = textureSampleCompareLevel(tex67, sam68, vec3f(), 0i, 0.);
+  _ = textureSampleBaseClampToEdge(et42, sam57, vec2f());
+  _ = textureSampleBaseClampToEdge(et37, sam57, vec2f());
+  _ = textureSampleLevel(tex67, sam60, vec3f(), 0i, 0i);
+  _ = textureGather(tex67, sam65, vec3f(), 0);
+  _ = textureGather(tex67, sam57, vec3f(), 0);
+  _ = textureGather(0, tex72, sam70, vec3f(), 0);
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec2u {
+  var out: vec2u;
+  _ = textureGather(tex64, sam63, vec3f());
+  _ = textureSampleCompareLevel(tex64, sam71, vec3f(), 0.);
+  _ = textureSampleBaseClampToEdge(et35, sam67, vec2f());
+  _ = textureSampleLevel(tex64, sam67, vec3f(), 0i);
+  _ = textureGather(tex64, sam62, vec3f());
+  _ = textureSampleCompare(tex64, sam71, vec3f(), 0.);
+  _ = textureSample(tex64, sam67, vec3f());
+  _ = textureSampleLevel(tex61, sam57, vec3f(), 0i);
+  _ = textureGather(2, tex58, sam61, vec3f(), 0);
+  _ = textureGather(tex67, sam67, vec3f(), 0);
+  _ = textureSampleCompare(tex61, sam69, vec3f(), 0.);
+  _ = textureSampleCompare(tex65, sam66, vec3f(), 0.);
+  _ = buffer83;
+  _ = textureLoad(st14, vec3i());
+  _ = textureSample(tex61, sam65, vec3f());
+  _ = textureGather(2, tex58, sam65, vec3f(), 0);
+  _ = textureSampleCompareLevel(tex67, sam66, vec3f(), 0i, 0.);
+  _ = buffer81;
+  if bool(textureGather(tex64, sam61, vec3f())[3]) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder129 = device0.createCommandEncoder({label: '\u07af\u6e72\u2e0c'});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 513});
+let commandBuffer78 = commandEncoder129.finish({label: '\u09e2\u58d9\u06fe\u0581\u8ec1'});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(1590);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle53, renderBundle63, renderBundle35, renderBundle44, renderBundle42, renderBundle50, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer37, 'uint16', 144, 136);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer70, 0, 974);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(5, buffer36, 0, 4_074);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+document.body.prepend(canvas0);
+let imageData14 = new ImageData(12, 4);
+let commandEncoder130 = device1.createCommandEncoder({label: '\u{1f690}\u059c\u098f\ue623\ud776\u04e6\u1038\u{1fe96}\u0b45\u{1ffa0}'});
+let computePassEncoder28 = commandEncoder127.beginComputePass({});
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(101.72389718129146, 14.626769573604385, 395.185368829567, 7.468949922950673, 0.4875154373664832, 0.672162680546778);
+} catch {}
+let commandEncoder131 = device1.createCommandEncoder({});
+let texture34 = device1.createTexture({
+  label: '\u5304\u4473\u37db\u{1fe75}\u0d79',
+  size: [52, 48, 1],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle75 = renderBundleEncoder12.finish({label: '\ufac3\u{1fb88}\uabde\u3e98\u{1fcf6}\ucb26\u{1ff31}\u161a\u{1f9b2}'});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let buffer88 = device1.createBuffer({
+  size: 13402,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer79 = commandEncoder130.finish({label: '\u0ab9\u5294\u{1f8d8}\u0ece\ud838\u{1fff9}\u{1f63f}\u{1ff67}\u3ddb\u{1fad8}'});
+let textureView34 = texture31.createView({label: '\u{1f65a}\u32aa\u{1fec0}\u{1f988}\u7ce9\ua3d4\u9633', aspect: 'depth-only'});
+let commandEncoder132 = device1.createCommandEncoder({label: '\u395d\u0f89\ud5ac\uc705\u01f1\u0411\u8845\ufa34\ufbec\u{1f653}'});
+try {
+computePassEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+let commandEncoder133 = device1.createCommandEncoder();
+let commandBuffer80 = commandEncoder133.finish({label: '\ue418\u1400\ucbbe\uf6a7\u0d61\u15c7\udfac\u6ecc\u07a7\u053b'});
+try {
+buffer88.unmap();
+} catch {}
+try {
+commandEncoder131.insertDebugMarker('\u08c5');
+} catch {}
+try {
+device1.queue.submit([commandBuffer67]);
+} catch {}
+document.body.prepend(canvas3);
+let bindGroupLayout23 = device1.createBindGroupLayout({
+  label: '\u21f1\u5a36\u469f\u{1f77b}\u10dd\u8db4',
+  entries: [{binding: 207, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder134 = device1.createCommandEncoder({label: '\u8291\u941a\u515b\ud6f8\u0723'});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder135 = device1.createCommandEncoder({label: '\uae60\u0026\u01d9\u03db\uc928\ucb76\u0069\u0b83\u{1fdf4}\u489d'});
+let querySet18 = device1.createQuerySet({label: '\u87a2\u{1f6df}', type: 'occlusion', count: 21});
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout17, bindGroupLayout14]});
+try {
+renderPassEncoder29.executeBundles([renderBundle50, renderBundle1, renderBundle40, renderBundle3, renderBundle30, renderBundle13, renderBundle69, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 10, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 26, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let img7 = await imageWithData(90, 248, '#10101010', '#20202020');
+let querySet19 = device1.createQuerySet({label: '\u005f\u{1ff79}\uec6a\u{1f983}\u91e5\u{1f884}', type: 'occlusion', count: 545});
+let commandBuffer81 = commandEncoder132.finish();
+let textureView35 = texture29.createView({label: '\ueb08\uc861\ua704\u444d\u{1f745}', dimension: '2d-array'});
+let renderBundle76 = renderBundleEncoder11.finish({label: '\ud188\u5a33\u0fe1\u0372\u0cc5\u5e29\u{1f7ac}\u0ff4\u0bdb\u{1fd40}'});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder131.pushDebugGroup('\u5e05');
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({label: '\u025e\u{1fca1}\u5381\u9268\u029e\u0371\u0fb1'});
+let commandBuffer82 = commandEncoder136.finish({label: '\ua35b\u3cbb\u0260\u00ee'});
+let textureView36 = texture19.createView({label: '\uc345\u{1f62c}\u0c7f', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer19, 'uint16', 2_912, 1_219);
+} catch {}
+let commandEncoder137 = device1.createCommandEncoder({});
+let computePassEncoder29 = commandEncoder134.beginComputePass({label: '\u2cb6\u0b0c\uc197\u7b94\ub79a\u0c8a\u523a\uc3fc'});
+let renderBundle77 = renderBundleEncoder11.finish({label: '\u{1f65c}\ufe45\u{1fca2}\u{1f615}\u885c\udfdc\u1f3a\u0085\ua95d\u{1f790}\u063a'});
+try {
+computePassEncoder27.setPipeline(pipeline19);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u0999\u0efd',
+  entries: [{binding: 90, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let querySet20 = device0.createQuerySet({label: '\u24cb\uc3b0\u2811', type: 'occlusion', count: 1335});
+try {
+computePassEncoder12.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 45, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let bindGroup2 = device1.createBindGroup({
+  label: '\u073e\u1bac\u{1f7c6}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 279, resource: {buffer: buffer88, offset: 5120, size: 468}}],
+});
+let commandBuffer83 = commandEncoder137.finish({label: '\u4cfc\u9117\uf16d\u0812'});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder135.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3660 */
+  offset: 3660,
+  bytesPerRow: 256,
+  buffer: buffer88,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 0},
+  aspect: 'depth-only',
+}, {width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0caa\u91c5\u0727\u06f7\u00d1\u7f9e\u2378',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup1, new Uint32Array(1140), 494, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer38, 'uint16', 2_312, 1_053);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline14);
+} catch {}
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({label: '\u3891\u0258', colorFormats: ['bgra8unorm-srgb'], stencilReadOnly: true});
+try {
+computePassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup0, new Uint32Array(2315), 523, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(2, buffer36, 0, 1_353);
+} catch {}
+video0.width = 37;
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], stencilReadOnly: true});
+try {
+computePassEncoder14.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup0, new Uint32Array(4716), 1792, 0);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(1571);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer67, 'uint16', 10_366, 283);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer60, 0, 1_242);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup1, new Uint32Array(517), 157, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer65);
+} catch {}
+try {
+renderPassEncoder18.insertDebugMarker('\ua263');
+} catch {}
+try {
+adapter2.label = '\u0226\u{1fb0e}';
+} catch {}
+let commandBuffer84 = commandEncoder135.finish({label: '\u0b86\u0c3a\u4b8b\u8417\ua91c\u{1fe05}\u02f5'});
+let computePassEncoder30 = commandEncoder131.beginComputePass({label: '\u09c7\u09fd\ub9fa\u{1f6ae}'});
+try {
+computePassEncoder27.setPipeline(pipeline19);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(28), /* required buffer size: 28 */
+{offset: 28, bytesPerRow: 167}, {width: 52, height: 48, depthOrArrayLayers: 0});
+} catch {}
+let imageData15 = new ImageData(4, 60);
+try {
+window.someLabel = commandEncoder114.label;
+} catch {}
+let commandEncoder138 = device1.createCommandEncoder();
+let commandBuffer85 = commandEncoder138.finish({label: '\ued78\uefe7'});
+let sampler8 = device1.createSampler({
+  label: '\u4b29\u7137\u0749\u33c2\u721c\u02f2\ueed4\u99a4\u0100\u0bc2',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.71,
+  lodMaxClamp: 71.31,
+  maxAnisotropy: 12,
+});
+let textureView37 = texture30.createView({label: '\u70d6\u0eb7\uce68', baseMipLevel: 0});
+try {
+computePassEncoder30.setPipeline(pipeline19);
+} catch {}
+let renderBundle78 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer38, 'uint16', 36, 1_430);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer61, 'uint16', 456, 260);
+} catch {}
+let commandEncoder139 = device1.createCommandEncoder({label: '\u0684\u0410'});
+let querySet21 = device1.createQuerySet({label: '\uda7a\u73a3\u0761\u6481\uaf7a\u5456\u13b3', type: 'occlusion', count: 1155});
+let commandBuffer86 = commandEncoder139.finish({label: '\ud329\u{1f9c6}\u0dc8\u8488\u924d\ub6f0\u4d72\ub793'});
+try {
+buffer88.unmap();
+} catch {}
+try {
+adapter2.label = '\u020c\u6d27\u45b7\uf991\u943a\udc24\u{1ff34}\u16c9\u024a\u0243\u8c89';
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(101, 2, 44, 4);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer69, 'uint16', 1_462, 649);
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u0ae1');
+} catch {}
+await gc();
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup1, new Uint32Array(4170), 248, 0);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -862.5, g: -273.2, b: -700.6, a: 209.5, });
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let texture35 = device1.createTexture({
+  label: '\ubfb3\u826e\ub627\ubd51\u56c1\u{1fd6d}',
+  size: [13, 12, 86],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle79 = renderBundleEncoder11.finish({label: '\ucab6\u{1fe26}\u69fa'});
+try {
+device1.queue.submit([commandBuffer61]);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline8);
+} catch {}
+try {
+  await promise21;
+} catch {}
+try {
+querySet19.label = '\u2fca\u{1fec2}\uf9b1\u0b74';
+} catch {}
+let bindGroupLayout25 = device1.createBindGroupLayout({
+  label: '\u60b6\uf4ce\u{1f63f}\u{1f7a7}\u0a34\u0fea\u0452\ub598',
+  entries: [{binding: 157, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }}],
+});
+let commandEncoder140 = device1.createCommandEncoder({label: '\u{1f672}\ua967\u12eb\u4647\u5f20\udf25\uf6c8'});
+let renderBundle80 = renderBundleEncoder11.finish({label: '\u{1fb70}\u0a9d\u{1fffa}\uab00\uac82\u976b\u{1ffb8}\uf89e\u0f5a\u5d12'});
+try {
+commandEncoder140.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'depth-only',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4316 */
+  offset: 980,
+  bytesPerRow: 256,
+  rowsPerImage: 8,
+  buffer: buffer88,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 3},
+  aspect: 'all',
+}, {width: 2, height: 6, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder141 = device1.createCommandEncoder({label: '\u{1f954}\ua486\u07c6\u{1fa8e}\u0496\u0e59\ub414\u248a\u288d'});
+let renderBundle81 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline19);
+} catch {}
+try {
+device1.queue.submit([commandBuffer86, commandBuffer75]);
+} catch {}
+let pipeline22 = device1.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule8, constants: {}}});
+let img8 = await imageWithData(43, 94, '#10101010', '#20202020');
+let bindGroupLayout26 = device1.createBindGroupLayout({label: '\u0248\u77aa\u{1f665}\u02b3\u{1fe83}', entries: []});
+let computePassEncoder31 = commandEncoder141.beginComputePass({label: '\u0bdb\uccaf'});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup2, new Uint32Array(330), 82, 0);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device1, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'opaque'});
+} catch {}
+let renderBundle82 = renderBundleEncoder1.finish({label: '\u30a9\u0713\u3dbc\u09af\u07e0\u0593\u{1f6e1}\ub8b7'});
+try {
+renderPassEncoder24.beginOcclusionQuery(118);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer64, 'uint32', 2_980, 854);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(7, buffer38);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer65, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 15, y: 28, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle83 = renderBundleEncoder12.finish({label: '\uf819\u03b7\ue43d\u{1f66a}'});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+device1.queue.submit([commandBuffer81]);
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u5e36\u{1fe51}\u{1f66d}',
+  layout: bindGroupLayout16,
+  entries: [{binding: 98, resource: {buffer: buffer17, offset: 512}}],
+});
+let textureView38 = texture21.createView({
+  label: '\u667c\ud393\u0064\ud459\u{1f9f3}\u589b\u456f\u{1fc63}',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup0);
+} catch {}
+await gc();
+let commandEncoder142 = device0.createCommandEncoder({label: '\u0dc2\uf7fc\u{1ffec}\u95fd\u{1f712}\u9900\u6036\u1bb6\u0396'});
+let computePassEncoder32 = commandEncoder142.beginComputePass({label: '\ub81f\u0c5c\u{1f704}'});
+try {
+renderPassEncoder19.setIndexBuffer(buffer59, 'uint16', 528, 7_674);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup0, new Uint32Array(2867), 265, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(7, buffer38, 324, 243);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let commandEncoder143 = device0.createCommandEncoder({});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup0, new Uint32Array(3389), 1071, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder143.copyBufferToBuffer(buffer66, 32, buffer67, 428, 184);
+} catch {}
+let renderPassEncoder30 = commandEncoder143.beginRenderPass({
+  label: '\uad30\u1f4d\u424d\u09b8\u0d9b\u5c6c\u099c',
+  colorAttachments: [{view: textureView14, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+computePassEncoder28.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer56, commandBuffer49]);
+} catch {}
+let device2 = await adapter3.requestDevice({
+  label: '\u01e2\ueb76\u1d87\u0f22\u740e',
+  defaultQueue: {label: '\u860a\u4c70\u07f7\u85cc\u06c9\u0603\u3b63\u{1fd24}\u06b0\u21d1'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxStorageBuffersPerShaderStage: 8,
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    maxVertexBuffers: 8,
+    maxUniformBufferBindingSize: 2727428,
+    maxStorageBufferBindingSize: 144635553,
+  },
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer60, 7_752, 2_803);
+} catch {}
+let renderPassEncoder31 = commandEncoder37.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 832.6, g: -141.8, b: -871.6, a: -525.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer39, 0);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+let texture36 = device0.createTexture({
+  label: '\u0530\u5b0c\uf0da\u07ea\u2a72\u09e8\u{1fdb9}\u2c73\u5ed0\u48cb',
+  size: [618, 96, 401],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView39 = texture5.createView({label: '\u0366\u0765\u0865\u{1f761}', mipLevelCount: 1});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle2, renderBundle33, renderBundle43, renderBundle35]);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer66, 'uint16', 1_146, 9_172);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(4_294_967_294, undefined, 0, 359_429_352);
+} catch {}
+let arrayBuffer7 = buffer68.getMappedRange(1216, 24);
+try {
+buffer19.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 47, y: 9 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 36, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let img9 = await imageWithData(70, 84, '#10101010', '#20202020');
+let sampler9 = device2.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.85,
+  lodMaxClamp: 52.84,
+  maxAnisotropy: 18,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder144 = device1.createCommandEncoder({label: '\u6b99\u618a\u{1f8c0}\udf89\u044e\u0be7\ub0af\u0342\u{1f7ce}\u70eb\u8efb'});
+let commandBuffer87 = commandEncoder144.finish({label: '\u0233\u{1fb33}\ud4ce\u0e78\u3f64\u0bc6\u3b50\u036f\u{1f8e1}'});
+try {
+buffer88.unmap();
+} catch {}
+let commandEncoder145 = device1.createCommandEncoder({label: '\ua504\u3a11\u0bad'});
+let commandBuffer88 = commandEncoder145.finish({label: '\u{1f80a}\u7444'});
+let computePassEncoder33 = commandEncoder140.beginComputePass({label: '\u24a8\u03e5\u1c9a\u06a2\u0c51\u68c8\u1dfb\u02c9'});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let promise22 = adapter1.requestAdapterInfo();
+let bindGroupLayout27 = device1.createBindGroupLayout({
+  label: '\u04f3\u39bc\ue996\uf5a9\u09c9\u0ab3\uc1bc',
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 3631855, hasDynamicOffset: true },
+    },
+  ],
+});
+try {
+device1.queue.submit([commandBuffer85]);
+} catch {}
+let pipeline23 = device1.createRenderPipeline({
+  label: '\u0112\uaefa\u6709\u792b\uc5d8\u{1ffee}\u0071\u0e34',
+  layout: pipelineLayout6,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule8, buffers: []},
+});
+try {
+computePassEncoder31.end();
+} catch {}
+video2.height = 24;
+canvas2.height = 1726;
+let texture37 = device1.createTexture({
+  label: '\u6055\u02ac\u22fb\u{1f7fc}\u0c73\u23a5\u9218',
+  size: [13, 12, 12],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let video4 = await videoWithData();
+let textureView40 = texture24.createView({
+  label: '\u{1f72d}\uf759\u0cb4\ue609\u{1ff83}\uef0f\u{1fa56}\u553d\u0d8f\u06be',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder24.setPipeline(pipeline7);
+} catch {}
+try {
+  await buffer56.mapAsync(GPUMapMode.READ, 0, 324);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 2 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 1, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder146 = device1.createCommandEncoder({label: '\u0435\u0971\u{1f6de}\u0891\u{1f99b}\u018c\u0dea\u0196\ud27a'});
+try {
+computePassEncoder27.setPipeline(pipeline19);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 4 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 28},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder147 = device2.createCommandEncoder({label: '\uee2d\u0a7d\u{1f77e}\u4802\ubc44\u0cab'});
+let computePassEncoder34 = commandEncoder147.beginComputePass({label: '\u0424\u1c2f\u{1fb97}\u{1ff42}\u0437\u91f7\ufbeb\u93be\u{1f626}'});
+let promise23 = adapter3.requestAdapterInfo();
+let externalTexture13 = device2.importExternalTexture({source: video3, colorSpace: 'srgb'});
+let imageData16 = new ImageData(8, 4);
+let externalTexture14 = device2.importExternalTexture({
+  label: '\u3583\u{1f9d2}\u07bb\ud98a\ueed9\u{1f779}\u{1fcd9}\uf98c\u04f9\ued60\u8aef',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+  await promise22;
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({label: '\u{1faf8}\u683d'});
+try {
+renderPassEncoder21.setIndexBuffer(buffer36, 'uint32', 4, 1_001);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder28.pushDebugGroup('\u0aa9');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 0, y: 15 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 17, y: 29, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandBuffer89 = commandEncoder146.finish({label: '\ubb7f\ud358\u09e0\u1ca8\u{1f966}\u8963\u0642'});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({
+  label: '\ud6f1\u8ae8\ub48d\u3fe5\u03d0\u0c17',
+  colorFormats: ['bgra8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let commandEncoder149 = device2.createCommandEncoder({label: '\u2f4b\u046e'});
+let querySet22 = device2.createQuerySet({label: '\u9260\u06ef\u5ca7\u89e7\ub8fd\u4043\u0341\u0b57\ud41c', type: 'occlusion', count: 39});
+let renderBundleEncoder18 = device2.createRenderBundleEncoder({
+  label: '\u0046\u0460\u{1fbcc}',
+  colorFormats: ['rg8unorm'],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+let renderBundle84 = renderBundleEncoder18.finish({label: '\u56c5\u08dd\uc8a9\u{1fc0b}\u0f92'});
+try {
+device2.pushErrorScope('validation');
+} catch {}
+let commandBuffer90 = commandEncoder141.finish({label: '\u{1f97c}\ud60b\u9526\u{1f950}\u46dd'});
+let renderBundle85 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer88, 'uint16', 5_038, 170);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(173, 155);
+let commandBuffer91 = commandEncoder148.finish({});
+let textureView41 = texture5.createView({label: '\u0e53\u0177\u884a\ubfb1\u9593\u32a1\ua549\u{1f69a}\u8bb8'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer60, 'uint16', 2_932, 1_354);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer38);
+} catch {}
+let commandEncoder150 = device1.createCommandEncoder({label: '\u{1ff86}\u4b5e\u3cbb\u0118\u4b7e\u3dca\u2b52\udbd0'});
+let renderBundle86 = renderBundleEncoder17.finish({label: '\u{1fed0}\uae19\u044d\u2536\uee51\u{1f6d9}\u5a52\u460d'});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup2, new Uint32Array(79), 10, 0);
+} catch {}
+try {
+commandEncoder150.resolveQuerySet(querySet16, 17, 46, buffer88, 0);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas2.getContext('webgpu');
+let promise24 = adapter3.requestAdapterInfo();
+let commandEncoder151 = device0.createCommandEncoder({label: '\u068a\u{1ffbf}\u0073\u0654\u0995\u0d53\u0e36\u0564\u10f3'});
+let sampler10 = device0.createSampler({
+  label: '\u0402\u{1fb28}\ua5f8\u7591\u916b\u{1f640}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 75.89,
+});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 58, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise24;
+} catch {}
+let imageData17 = new ImageData(68, 12);
+let commandEncoder152 = device1.createCommandEncoder({label: '\u0a3d\u38de\uc826\u1b7f\u775c\u{1fdd6}\u{1ffc0}\u8c6e\u7e86\u0f41\u070a'});
+let commandBuffer92 = commandEncoder150.finish();
+let computePassEncoder35 = commandEncoder152.beginComputePass({});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer89 = device0.createBuffer({
+  label: '\ud358\ucf13\ub4b6',
+  size: 19280,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let commandEncoder153 = device0.createCommandEncoder({label: '\u0a34\u5033\u{1f761}\u03db'});
+let renderPassEncoder32 = commandEncoder153.beginRenderPass({
+  label: '\u8627\u01c0\u6fa1\u0584\u0d04',
+  colorAttachments: [{view: textureView10, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 308533968,
+});
+let renderBundle87 = renderBundleEncoder2.finish({label: '\u00bd\u9cc4\u0dcd\u2a2c\u0eea'});
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer38, 0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+let renderBundle88 = renderBundleEncoder18.finish({label: '\u{1fb3f}\uaf2f\u033a\ue5ba'});
+try {
+device2.queue.submit([]);
+} catch {}
+let commandEncoder154 = device1.createCommandEncoder();
+try {
+computePassEncoder29.setPipeline(pipeline22);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let texture38 = device2.createTexture({size: [216, 1, 42], format: 'stencil8', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let textureView42 = texture38.createView({dimension: '2d', aspect: 'stencil-only', format: 'stencil8', baseArrayLayer: 1});
+try {
+device2.queue.submit([]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let externalTexture15 = device2.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+let pipelineLayout11 = device1.createPipelineLayout({label: '\ue047\u03ec\u{1f988}\ufff3', bindGroupLayouts: [bindGroupLayout23, bindGroupLayout26]});
+let commandEncoder155 = device1.createCommandEncoder({label: '\u0037\ubfcb\u0f86'});
+let texture39 = device1.createTexture({
+  size: [52, 48, 51],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let commandEncoder156 = device0.createCommandEncoder();
+try {
+computePassEncoder32.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 76, new Float32Array(23122), 45, 20);
+} catch {}
+let commandEncoder157 = device2.createCommandEncoder({label: '\u3559\u{1f9ea}\u{1fd49}\u0c1e'});
+let commandBuffer93 = commandEncoder147.finish();
+let renderBundle89 = renderBundleEncoder18.finish({label: '\u0456\u{1f7f7}'});
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let texture40 = device1.createTexture({
+  label: '\u{1fca1}\u26e9\u0b01\uf7aa\u05de\udd61\u350a\ub36b\u07bb\u{1ff18}\u2302',
+  size: {width: 13, height: 12, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup2);
+} catch {}
+let commandEncoder158 = device1.createCommandEncoder({label: '\u0854\u0f2b'});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+let commandBuffer94 = commandEncoder149.finish();
+let renderBundle90 = renderBundleEncoder18.finish({label: '\u{1ff50}\u9b80\u881b'});
+let commandBuffer95 = commandEncoder151.finish();
+let computePassEncoder36 = commandEncoder156.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder32.setViewport(604.8347013231175, 90.63909545046576, 4.460059394675676, 1.1998953693236496, 0.16449866688602088, 0.43817297530615784);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer65);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(4, buffer37, 144, 167);
+} catch {}
+await gc();
+let commandEncoder159 = device0.createCommandEncoder({label: '\ub161\u3e9c\u{1faec}\u{1f895}\ubbb5\ufdca\u9767\u{1f9d7}\u0248'});
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer70, 0, 264);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer60, 424, 12_597);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder159.insertDebugMarker('\u0fe3');
+} catch {}
+let computePassEncoder37 = commandEncoder159.beginComputePass();
+let renderBundle91 = renderBundleEncoder9.finish({});
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup0, new Uint32Array(672), 17, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer61, 'uint16', 90, 422);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 0, y: 9 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 83, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 25, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder();
+let renderPassEncoder33 = commandEncoder160.beginRenderPass({
+  label: '\ufbdc\u{1f7c5}\u38ab\ue5e4\u{1fbaa}\u{1fcb8}\u1c64\u{1fa43}\u00df\u3f1a',
+  colorAttachments: [{view: textureView10, loadOp: 'load', storeOp: 'store'}],
+});
+try {
+computePassEncoder13.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup1, new Uint32Array(668), 4, 0);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer89, 'uint16', 1_384, 2_263);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer65, 'uint32', 92, 424);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u4ae9');
+} catch {}
+try {
+device0.queue.submit([commandBuffer52, commandBuffer95]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData18 = new ImageData(64, 16);
+try {
+computePassEncoder29.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let texture41 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderBundleEncoder16.setIndexBuffer(buffer19, 'uint16', 8_172, 2_576);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer67, 0, 795);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 4676, new Int16Array(12356), 345, 3840);
+} catch {}
+let commandEncoder161 = device2.createCommandEncoder();
+let externalTexture16 = device2.importExternalTexture({label: '\u0f6f\ua4d6\uaa1e\u{1fd34}\ud28b\u01ae', source: videoFrame1, colorSpace: 'srgb'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder162 = device1.createCommandEncoder({label: '\u{1f714}\ub433\u3ff1\u{1f7a5}'});
+let commandBuffer96 = commandEncoder162.finish({label: '\ua796\u04c9'});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let imageData19 = new ImageData(12, 32);
+let texture42 = device0.createTexture({
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let externalTexture17 = device0.importExternalTexture({
+  label: '\u288d\u5f1a\ub92d\u0087\u3868\u3658\uf4a4\u{1faa4}\u{1fbca}\u51d0',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup1, new Uint32Array(1728), 444, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer89, 'uint16', 1_612, 4_223);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup0, new Uint32Array(3927), 2910, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer59, 'uint32', 532, 2_488);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer60, 3_312, 8_924);
+} catch {}
+try {
+  await buffer58.mapAsync(GPUMapMode.WRITE, 0, 144);
+} catch {}
+try {
+device0.queue.submit([commandBuffer69, commandBuffer72]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle92 = renderBundleEncoder17.finish({label: '\udcc2\u0ae3\u0746\u026b\u8fb3\u7010'});
+let externalTexture18 = device1.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline22);
+} catch {}
+let img10 = await imageWithData(176, 4, '#10101010', '#20202020');
+let commandEncoder163 = device0.createCommandEncoder({label: '\u{1f8d8}\u0ba4\u0ece\u0fb4\uda9f\u0d4f\uf5f5\u{1f769}'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u{1fa25}\u803a\u8a96\u{1f8e3}\u{1f925}\u{1f8f3}\u25c7\uc080',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: true,
+});
+let renderBundle93 = renderBundleEncoder4.finish({label: '\u0ba8\u2c64\u{1f9aa}'});
+try {
+renderPassEncoder27.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer60, 1_572);
+} catch {}
+let arrayBuffer8 = buffer56.getMappedRange(136, 104);
+try {
+commandEncoder163.copyBufferToBuffer(buffer61, 324, buffer67, 84, 152);
+} catch {}
+try {
+commandEncoder163.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 26, y: 24, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 220 widthInBlocks: 55 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1960 */
+  offset: 1960,
+  bytesPerRow: 256,
+  buffer: buffer67,
+}, {width: 55, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer97 = commandEncoder158.finish({label: '\u06a9\u3f3e\ucca5\u02e7\uacff'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u0cc2\u{1fcca}\u{1fee0}\u5ffa\ua80f\u4ba8\u{1f791}',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout7],
+});
+let commandEncoder164 = device0.createCommandEncoder();
+let commandBuffer98 = commandEncoder164.finish({});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer58]);
+} catch {}
+let commandBuffer99 = commandEncoder154.finish({label: '\u{1ffe9}\uc9a0\u0162\u0bbc\u0ea0\u0c2d'});
+let textureView43 = texture39.createView({label: '\u2f00\u08fa\uae68\u0fc4\u{1fe6b}\u{1fd2a}', baseArrayLayer: 0});
+let computePassEncoder38 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline19);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: video4,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle94 = renderBundleEncoder18.finish({label: '\u{1fcd8}\udf44\u{1fd9e}\u0d95\u5960\u408b\ubcc6\u600f'});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+externalTexture18.label = '\u6fea\u{1ff72}\u{1fa30}';
+} catch {}
+let texture43 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder25.setPipeline(pipeline19);
+} catch {}
+try {
+device1.queue.submit([commandBuffer84]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 52, y: 0 },
+  flipY: true,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 11, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 76, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let textureView44 = texture12.createView({label: '\u7d43\u0cf5\ub944'});
+let renderBundle95 = renderBundleEncoder5.finish({label: '\u191a\u{1f722}\ucca6\uea1e\ua110\ua290\u{1fea8}\u95eb\u{1fad7}'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(169.16263723709005, 8.108507046157644, 6.110478753471751, 18.139101757761093, 0.5092494351400737, 0.9756774722442043);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup1, new Uint32Array(1553), 870, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer70);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer91]);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandBuffer100 = commandEncoder161.finish({label: '\u67d8\u02c4\u3fba\u{1fc25}\u3b8c\u03e0\u0d36\u7786\ufc6d'});
+let texture44 = gpuCanvasContext2.getCurrentTexture();
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder165 = device2.createCommandEncoder({label: '\u{1fa30}\uf675\u06cf\uae11\u{1facd}'});
+let querySet23 = device2.createQuerySet({label: '\ue811\u2c08\u056b\ud188\u033b\u{1ffdf}\ud241\u05f4', type: 'occlusion', count: 967});
+let commandBuffer101 = commandEncoder165.finish({label: '\ub81d\u6ace\u9afe\ubceb\ua61b\u0cc7\u102c\u0fdc\u065b'});
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let computePassEncoder39 = commandEncoder157.beginComputePass({});
+try {
+device2.queue.submit([commandBuffer100]);
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({label: '\uc3ae\u{1fecf}\ue525\u0bae'});
+let renderPassEncoder34 = commandEncoder163.beginRenderPass({
+  label: '\ua4e3\u4354\u8395\u7104',
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: -586.2, g: -696.1, b: 333.5, a: -603.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 149430964,
+});
+try {
+computePassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(7, buffer37, 0, 509);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer59, 200, buffer36, 1756, 1984);
+} catch {}
+let textureView45 = texture0.createView({label: '\u05f1\uecfb\u06d5\u7b39\ua17e\u{1f737}'});
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer39);
+} catch {}
+try {
+commandEncoder166.clearBuffer(buffer59, 2644, 1508);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\u59d5\uaca8\uf0df\u1e7d\u{1ff05}',
+  entries: [
+    {
+      binding: 302,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder167 = device0.createCommandEncoder({});
+let computePassEncoder40 = commandEncoder93.beginComputePass({label: '\u90ea\u{1ff1a}'});
+let renderBundle96 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer67, 1_636, 5_414);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer63);
+} catch {}
+try {
+commandEncoder167.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 67, y: 6, z: 127},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 168, new DataView(new ArrayBuffer(9261)), 987, 68);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData20 = new ImageData(4, 20);
+let bindGroup4 = device1.createBindGroup({
+  label: '\ufe57\u0fa3\u{1fd14}\u08b1\u3211',
+  layout: bindGroupLayout19,
+  entries: [{binding: 279, resource: {buffer: buffer88, offset: 0, size: 1000}}],
+});
+let texture45 = gpuCanvasContext5.getCurrentTexture();
+let renderPassEncoder35 = commandEncoder131.beginRenderPass({
+  label: '\u0f55\u3a74\u0c4d\uf566\u{1ffbb}\u071d',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 4,
+  clearValue: { r: 318.5, g: -512.7, b: 518.4, a: -607.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet13,
+  maxDrawCount: 131881069,
+});
+try {
+computePassEncoder38.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint32', 2_940, 249);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(12), /* required buffer size: 12 */
+{offset: 12}, {width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer90 = device0.createBuffer({
+  label: '\u551b\u3631\u{1f710}\u0770\u0e26\u9ff4\u09f8\u{1fbca}\u5397\ue2da',
+  size: 19991,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer102 = commandEncoder166.finish({});
+let renderBundle97 = renderBundleEncoder14.finish({label: '\u{1f76e}\u{1fce9}\u{1fde6}\u4a29\u0937\u5116'});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup1, new Uint32Array(881), 17, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle3, renderBundle55]);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer60, 'uint16', 5_500, 292);
+} catch {}
+try {
+commandEncoder167.copyBufferToBuffer(buffer90, 180, buffer36, 1372, 1368);
+} catch {}
+try {
+renderPassEncoder28.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder36.setBindGroup(2, bindGroup1, new Uint32Array(116), 4, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup0, new Uint32Array(934), 11, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle25, renderBundle95]);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline12);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let commandEncoder168 = device2.createCommandEncoder({});
+await gc();
+let texture46 = device2.createTexture({
+  label: '\uea59\u5f64\u0e60\u0aa3\u0cbb\ue9cb\u0676\u019d\u93bc',
+  size: [108, 1, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandBuffer103 = commandEncoder168.finish();
+let renderBundle98 = renderBundleEncoder20.finish({label: '\u00ef\u6aff\ua3ed\u04ff\u{1f64c}'});
+try {
+adapter1.label = '\uf3c4\u{1fc19}\uf8c7\u0aa6\u{1f8b2}\u0c1f\ud646';
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder({label: '\u91b7\u010c\u8989\u6fcc\uf128\u{1fba1}\u64ac\u0642'});
+let renderPassEncoder36 = commandEncoder167.beginRenderPass({
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: -950.5, g: 206.7, b: 34.84, a: 908.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle99 = renderBundleEncoder7.finish();
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer89, 'uint16', 2_560, 774);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline8);
+} catch {}
+let arrayBuffer9 = buffer68.getMappedRange(1616, 436);
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder169.resolveQuerySet(querySet14, 6, 49, buffer60, 6656);
+} catch {}
+document.body.prepend(video0);
+let commandBuffer104 = commandEncoder44.finish({label: '\u3f09\u68c1\u42c9\uaacb\uef49\ub2bb'});
+let textureView46 = texture24.createView({label: '\uc0fb\ub0b6\u{1faf8}', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle100 = renderBundleEncoder9.finish({label: '\u01e8\u43d3\u02c7\u0e7b\u0cce\u0bd3\u677e\u2a4a\uf8f5\u88f9'});
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(16, 7, 38, 25);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(3, buffer39, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup0);
+} catch {}
+let pipeline24 = device0.createComputePipeline({label: '\u0bc6\u6c7c\u0c2a', layout: pipelineLayout1, compute: {module: shaderModule2}});
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\u4efb\u{1f7ab}\u0df1\ucd58\u{1fb31}\uf8f2\u5c33',
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 545976, hasDynamicOffset: false },
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 148,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 529,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 375, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 118,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 235,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 728,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 101, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 253,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 150,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 136,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 36, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 314,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 257,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 447,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 14, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 453, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {binding: 164, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 198,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 11,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 41, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 578,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 565,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 142398, hasDynamicOffset: false },
+    },
+    {
+      binding: 419,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 95, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 598, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 78,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 120, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 103, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 191, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 132,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 39, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 1873977, hasDynamicOffset: false },
+    },
+    {binding: 62, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 360, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 76, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 270, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 92,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 188,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 63, visibility: 0, externalTexture: {}},
+    {binding: 514, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 555,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 623, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 173,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 53, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 54, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 70, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 32,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 21, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 144, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 1551575, hasDynamicOffset: false },
+    },
+    {
+      binding: 181,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 636,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 129, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 396, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 174, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 123, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let commandBuffer105 = commandEncoder41.finish({label: '\u03de\u0d6e\u0a43\u0d75\u2912\u0fdb\ua19f\ub66f\u9ae4\u0a2f'});
+let computePassEncoder41 = commandEncoder169.beginComputePass({label: '\u0744\u09e6'});
+try {
+computePassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup0, new Uint32Array(995), 45, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(253);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 348.6, g: 815.5, b: -170.2, a: 237.6, });
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer63, 276, 614);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup0, new Uint32Array(1440), 338, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline14);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({label: '\u0209\u1b73\u0c75\u{1f88a}\u89c9\u3f7e\u{1f7b1}\u9958\u{1f949}'});
+try {
+renderBundleEncoder15.setIndexBuffer(buffer60, 'uint32', 2_804, 3_888);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(3, buffer67, 1_024, 1_265);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder();
+let texture47 = device0.createTexture({
+  label: '\u0385\ubed3\u{1f909}\u4d14\u60d1\u00ad\u{1f9bc}\udf9e\u1e58',
+  size: {width: 77, height: 12, depthOrArrayLayers: 17},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture19 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+renderPassEncoder14.executeBundles([renderBundle55]);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+try {
+externalTexture5.label = '\u42f6\ue940\u1809\uc05a\u75de\udf86\u{1f9f9}\u44be';
+} catch {}
+let commandBuffer106 = commandEncoder171.finish();
+let textureView47 = texture3.createView({label: '\u0375\u190f\u0d23', baseMipLevel: 2});
+let computePassEncoder42 = commandEncoder170.beginComputePass({});
+try {
+computePassEncoder36.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer37, 'uint32', 192, 211);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer38, 0, 3_744);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\u4642');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 2636, new Float32Array(16457), 2273, 36);
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({label: '\u2c6b\u025c\u09de\u33a5\u7942\u4dd6'});
+let commandBuffer107 = commandEncoder172.finish({label: '\u0914\u04b8\ud4a7\u{1fad0}'});
+try {
+computePassEncoder15.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer38, 6_108, 285);
+} catch {}
+try {
+buffer68.unmap();
+} catch {}
+try {
+computePassEncoder9.insertDebugMarker('\u00eb');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 12, y: 7 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 44, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder37.setBindGroup(2, bindGroup0, new Uint32Array(586), 78, 0);
+} catch {}
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let bindGroup5 = device1.createBindGroup({
+  label: '\ua7d2\u06ff',
+  layout: bindGroupLayout23,
+  entries: [{binding: 207, resource: externalTexture18}],
+});
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup4);
+} catch {}
+let commandEncoder173 = device1.createCommandEncoder({});
+let querySet24 = device1.createQuerySet({label: '\udb0f\u{1fb07}\ue52f', type: 'occlusion', count: 234});
+let commandBuffer108 = commandEncoder173.finish({label: '\u0ddc\ua9ca\u0de5\ub53a\u{1f76d}\u84ba\ufa1f\u0bc5'});
+try {
+computePassEncoder35.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint32', 1_164, 2_357);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let bindGroupLayout30 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder38.setPipeline(pipeline22);
+} catch {}
+let pipeline25 = device1.createRenderPipeline({
+  layout: pipelineLayout6,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule8, buffers: []},
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: false,
+},
+});
+await gc();
+try {
+adapter0.label = '\u03e0\udd13\u5a44\u8204';
+} catch {}
+let querySet25 = device2.createQuerySet({
+  label: '\u1bc6\u0f7a\u0e54\u0f72\uf66b\u{1f8bb}\u{1fe32}\u5ff9\u{1fb7a}',
+  type: 'occlusion',
+  count: 254,
+});
+let commandEncoder174 = device2.createCommandEncoder({});
+let externalTexture20 = device2.importExternalTexture({label: '\u3348\u9d25\ua324\u1942\ue0f7\u4959\ue456\ubc60\u6d38\u08eb\u0041', source: video0});
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData8);
+try {
+computePassEncoder25.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint32', 3_676, 2_052);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData19,
+  origin: { x: 4, y: 3 },
+  flipY: true,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 41, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 27, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder37 = commandEncoder87.beginRenderPass({
+  label: '\u{1f69a}\u0bd6\u7e80',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 749.9, g: -168.4, b: 439.8, a: 467.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle101 = renderBundleEncoder4.finish({label: '\u7164\u0a5a'});
+try {
+computePassEncoder28.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer67, 0, 1_002);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+try {
+canvas5.getContext('2d');
+} catch {}
+let commandBuffer109 = commandEncoder174.finish({label: '\u0d1e\ubec5\u0b80\u{1f949}\ubc69\u0a0a'});
+let texture48 = device2.createTexture({
+  label: '\u09a1\u371d\u0139\u{1f7bf}\u0fa0\u03d8\u0ef0\u99ca\u39f3\u8632\u0a97',
+  size: [1752],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+window.someLabel = externalTexture20.label;
+} catch {}
+let externalTexture21 = device2.importExternalTexture({source: videoFrame1});
+let renderBundle102 = renderBundleEncoder18.finish({label: '\ue3f0\uad6b\u0816\u{1f729}\u1aca'});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+computePassEncoder26.insertDebugMarker('\u{1f7c6}');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: canvas1,
+  origin: { x: 20, y: 21 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder175 = device2.createCommandEncoder({label: '\u290c\u1eb2\ubd5d\u{1fef2}\u08d6\u0773'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let shaderModule10 = device0.createShaderModule({
+  label: '\u0fde\u5916\ub598\u{1f876}\u0fc4\u{1fddd}\u005f\ud7cc\u0506',
+  code: `
+struct T0 {
+  f0: array<array<mat3x3h, 1>>,
+}
+@group(1) @binding(3) var sam73: sampler_comparison;
+@group(0) @binding(102) var tex74: texture_1d<f32>;
+@group(2) @binding(23) var sam74: sampler;
+@group(0) @binding(492) var tex73: texture_1d<f32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+  _ = textureLoad(tex74, 0, 0);
+}
+
+struct VertexOutput0 {
+  @location(9) f23: vec4i,
+  @builtin(position) f24: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4u,
+  @location(0) f1: vec4f,
+  @location(6) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(textureLoad(tex74, 0, 0)[3]) {
+    discard;
+  }
+  out.f2 = f32(textureLoad(tex73, 0, 0)[2]);
+  return out;
+}
+`,
+  sourceMap: {},
+});
+try {
+computePassEncoder40.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer37, 84);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let computePassEncoder43 = commandEncoder175.beginComputePass({});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(6500), 1099, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 1388, new DataView(new ArrayBuffer(2010)), 130, 168);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 4, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video2);
+let img11 = await imageWithData(74, 28, '#10101010', '#20202020');
+let textureView48 = texture40.createView({label: '\u0901\u0a00\u{1fa0f}\u46b7', baseArrayLayer: 0});
+let renderBundle103 = renderBundleEncoder11.finish();
+let externalTexture22 = device1.importExternalTexture({label: '\u{1fb81}\u{1f92a}\u{1fecd}\ue492\u384c\u838e', source: videoFrame0});
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+let renderBundle104 = renderBundleEncoder11.finish({label: '\u0c06\u{1fd84}'});
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint16', 1_760, 383);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandBuffer110 = commandEncoder157.finish({label: '\u034e\u639a\u08d5'});
+let bindGroup6 = device1.createBindGroup({
+  label: '\u{1fe34}\ud0ea\u3d2f\u6f7d\u0a06\u0b3d\u2879\ucf3b\u6ee7',
+  layout: bindGroupLayout26,
+  entries: [],
+});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+document.body.prepend(canvas1);
+await gc();
+let commandBuffer111 = commandEncoder175.finish({label: '\u0751\u06e5\ucff4\ucdc1\ub4a2\u2fa8\u{1ffea}\u04f6\u013f'});
+let querySet26 = device0.createQuerySet({label: '\u0421\u0063\ud5dc\u2805', type: 'occlusion', count: 402});
+let texture49 = device0.createTexture({
+  size: {width: 77, height: 12, depthOrArrayLayers: 542},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(8532), 357, 0);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(2, buffer63, 396, 143);
+} catch {}
+let promise26 = navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let commandEncoder176 = device0.createCommandEncoder({label: '\ua6c8\ud674\u{1fac5}\uca42\ue705\u05af\ubd07\u{1fc69}\u{1fdf8}\ua3ed'});
+let commandBuffer112 = commandEncoder176.finish({label: '\u{1fb0b}\u5474\uee59'});
+let renderPassEncoder38 = commandEncoder70.beginRenderPass({
+  label: '\u9478\u0312\u3708\ub1d0\u98e5',
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: -298.8, g: 94.76, b: 904.6, a: -886.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+});
+try {
+computePassEncoder23.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup1, new Uint32Array(499), 27, 0);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer70, 2_144, 151);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer59, 'uint16', 208, 5_476);
+} catch {}
+try {
+  await buffer71.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 2324, new Float32Array(6687), 296, 12);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer39);
+} catch {}
+try {
+renderBundleEncoder16.insertDebugMarker('\udab7');
+} catch {}
+let commandEncoder177 = device1.createCommandEncoder({label: '\u{1f924}\u2a90\u{1fb89}\u1534\ubef2'});
+let querySet27 = device1.createQuerySet({label: '\uc5dd\u0dd3\ucb96\u{1ff9e}\u07ea\u5698\u801f', type: 'occlusion', count: 76});
+let commandBuffer113 = commandEncoder134.finish();
+let renderPassEncoder39 = commandEncoder177.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 16,
+  clearValue: { r: 99.85, g: 654.3, b: -540.6, a: 263.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet21,
+});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup5, new Uint32Array(489), 78, 0);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: 358.1, g: -332.9, b: -783.4, a: -372.1, });
+} catch {}
+try {
+renderPassEncoder39.setViewport(20.721153479528876, 37.08251243251599, 7.632646361277434, 6.308508837455649, 0.8608651110240814, 0.965843867570292);
+} catch {}
+try {
+device1.queue.submit([commandBuffer79, commandBuffer99, commandBuffer90]);
+} catch {}
+try {
+texture48.label = '\u03c3\u364c\u47e8\u00f1\u2322\ucb6e';
+} catch {}
+let commandEncoder178 = device2.createCommandEncoder();
+let texture50 = device2.createTexture({
+  label: '\u{1fa3e}\u50a8\u268a\ue923\u{1f73b}\u3993\ub9ce',
+  size: [3504, 1, 1],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let canvas6 = document.createElement('canvas');
+try {
+device2.queue.submit([commandBuffer103, commandBuffer93]);
+} catch {}
+let buffer91 = device1.createBuffer({
+  label: '\u4d88\u3538\u37ed\u045c\u2bc4\u081d\ucd32\u43b4\u457b\u5f9d',
+  size: 1753,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder39.setViewport(1.6699128739094693, 1.7428438131110404, 19.88923731668528, 43.61740778256357, 0.12343156179045167, 0.6158751301625869);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer88, 'uint16', 1_502, 4_294);
+} catch {}
+let renderBundle105 = renderBundleEncoder20.finish({label: '\u{1fb4d}\u090f\u724e\u0c0e'});
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise25;
+} catch {}
+let externalTexture23 = device2.importExternalTexture({label: '\u2c14\u{1fa3b}\u932b\u0914\u1b18\u5bed\ub5dc', source: video1, colorSpace: 'display-p3'});
+let gpuCanvasContext7 = canvas6.getContext('webgpu');
+await gc();
+let commandEncoder179 = device2.createCommandEncoder({label: '\uea97\uee9c\u0eda\u7b7a\u{1fbf3}\u{1f7ec}\u1cbc\u2eb7\ub86d\u{1f6cd}\u0f56'});
+let texture51 = device2.createTexture({
+  label: '\ubd34\u5bb3\u{1fe8f}\u{1ff02}\u{1ffa6}\ua600\u09fc\u18e0\u73f4',
+  size: {width: 864, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView49 = texture51.createView({label: '\u{1fa7f}\u{1f7e8}\u9e32\u{1fea9}\u{1f6db}', dimension: '2d-array'});
+let texture52 = device0.createTexture({
+  size: [618],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup0, new Uint32Array(1325), 125, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle59, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let buffer92 = device2.createBuffer({
+  label: '\uc767\u4e94\u0f76\u5a70\u05d3\u5f17\u17f9\u9d1a',
+  size: 8687,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+computePassEncoder42.setBindGroup(3, bindGroup1, new Uint32Array(1478), 213, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup1, new Uint32Array(1615), 188, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer65, 'uint16', 204, 13);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 272, new Int16Array(1364), 192, 12);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 12, y: 4 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 2, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 11, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder180 = device2.createCommandEncoder({label: '\uc42c\u3f4b\u0d7b'});
+let commandBuffer114 = commandEncoder178.finish({label: '\uf205\u8147\uca20\u0c1c\ue5ce\u{1ff90}\uf3f3'});
+let computePassEncoder44 = commandEncoder179.beginComputePass({label: '\u{1f6a6}\u0998\uc581\u03af'});
+try {
+device2.queue.submit([commandBuffer109]);
+} catch {}
+offscreenCanvas0.height = 33;
+try {
+externalTexture22.label = '\u0dc6\u0014\u0bbc\u6274\u0ca9\ua63e\u{1ff84}\uf4bf\u0c59\u{1f6a6}\u0e58';
+} catch {}
+try {
+computePassEncoder38.setBindGroup(2, bindGroup4, new Uint32Array(348), 32, 0);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup5, new Uint32Array(722), 95, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint16', 4_830, 1_781);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 124, new DataView(new ArrayBuffer(24790)), 12134, 212);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let renderBundle106 = renderBundleEncoder14.finish({});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer37, 'uint32', 52, 532);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer65, 0, 184);
+} catch {}
+try {
+computePassEncoder19.insertDebugMarker('\u0a91');
+} catch {}
+try {
+device0.queue.submit([commandBuffer76, commandBuffer102]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 56, y: 6, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(319), /* required buffer size: 319 */
+{offset: 319, bytesPerRow: 430}, {width: 88, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video3);
+let querySet28 = device2.createQuerySet({
+  label: '\u{1f8f1}\u2ff0\uce64\u{1f8fe}\u9238\u87dc\ub2cd\uc0aa\uf673\u56b4',
+  type: 'occlusion',
+  count: 469,
+});
+let texture53 = device2.createTexture({
+  label: '\ubb8f\u1d1f\ub27e\u09f7',
+  size: {width: 1752, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder44.end();
+} catch {}
+let texture54 = device1.createTexture({
+  label: '\ub2ec\u0535\u46d5\u0cb4',
+  size: [52],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData5,
+  origin: { x: 2, y: 24 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 29},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle107 = renderBundleEncoder13.finish();
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle3, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(4_294_967_295, undefined, 0, 371_169_160);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 1600, new Float32Array(22922), 957, 680);
+} catch {}
+try {
+  await promise27;
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({label: '\ub700\u320a\udeb7\u{1fcb9}\u{1fd08}'});
+try {
+computePassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer60);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer64);
+} catch {}
+document.body.prepend(canvas6);
+let commandEncoder182 = device2.createCommandEncoder({});
+let computePassEncoder45 = commandEncoder179.beginComputePass({label: '\u3a45\u03f6\ub645\u{1fffb}\u0097\u{1f775}'});
+let commandEncoder183 = device0.createCommandEncoder({label: '\u2bcb\uc338\u8af3\u0cdb\uc91a\u1e87\u25f6'});
+let renderBundle108 = renderBundleEncoder10.finish({label: '\u0d8e\ub603'});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline18);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 12, y: 32, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(54), /* required buffer size: 54 */
+{offset: 54, bytesPerRow: 84}, {width: 15, height: 40, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  label: '\ud087\u{1f98d}\uc958\u66cd\u00c8\ub30a\u{1f86b}\u0592\uff5a\u0061',
+  layout: bindGroupLayout7,
+  entries: [{binding: 3, resource: sampler2}],
+});
+let texture55 = device0.createTexture({
+  label: '\u{1ffe8}\u0886\u5fab\uf09d\u0431\u{1f6e3}\u1f16\u1dc6\u78bc',
+  size: {width: 77, height: 12, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder37.executeBundles([renderBundle30, renderBundle108, renderBundle67]);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer64, 0, 4_048);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder183.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1424 */
+  offset: 1424,
+  bytesPerRow: 256,
+  buffer: buffer67,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 162, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView50 = texture48.createView({label: '\u5066\udb16', dimension: '1d'});
+let renderBundle109 = renderBundleEncoder20.finish({});
+try {
+renderPassEncoder28.setIndexBuffer(buffer66, 'uint16', 27_962, 0);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer37, 44);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer37, 'uint16', 196, 135);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer39);
+} catch {}
+try {
+commandEncoder181.copyBufferToBuffer(buffer66, 976, buffer90, 6752, 6228);
+} catch {}
+try {
+commandEncoder181.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder181.insertDebugMarker('\ueee6');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder184 = device1.createCommandEncoder();
+let commandBuffer115 = commandEncoder184.finish({label: '\u{1f750}\u351a'});
+let renderBundle110 = renderBundleEncoder17.finish({label: '\u1ce1\u{1ffd0}\u{1f677}\u{1f65f}\u0014'});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: 230.3, g: -385.8, b: -44.42, a: 636.0, });
+} catch {}
+let texture56 = device1.createTexture({
+  label: '\u0472\u0d0e',
+  size: {width: 104, height: 96, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(7, 1, 2, 15);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData12,
+  origin: { x: 5, y: 3 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView51 = texture0.createView({label: '\u{1fdb5}\ufd87\u{1feaa}\u3370\ua84d\u4fbc\ub57a\u9bab', dimension: '1d'});
+let renderBundle111 = renderBundleEncoder13.finish({label: '\u065b\u0d23\u01f3\ud10e'});
+try {
+renderPassEncoder20.executeBundles([renderBundle37]);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline8);
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder({label: '\u{1f723}\u8ea2\ub584\uc92f\ubca3\u12b3'});
+let computePassEncoder46 = commandEncoder185.beginComputePass();
+let renderBundle112 = renderBundleEncoder8.finish({label: '\u0918\ua9e5\u{1fc3c}\uf226\u0dcf\ue957\u5f81\u{1fcde}\u{1ffc6}\u{1fd31}'});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer37, 'uint32', 64, 183);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, undefined, 0, 426_662_285);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u{1fb96}');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let shaderModule11 = device1.createShaderModule({
+  label: '\u050a\u{1ff25}',
+  code: `
+struct T0 {
+  f0: vec4u,
+}
+@group(1) @binding(94) var sam76: sampler;
+@group(0) @binding(94) var sam75: sampler;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(5) f25: vec2u,
+  @builtin(position) f26: vec4f
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec4i, @builtin(instance_index) a1: u32, @location(15) a2: vec4i, @location(14) a3: f32, @location(5) a4: vec3h, @location(3) a5: vec4f) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f25 = vec2u(bitcast<u32>(a3));
+  return out;
+}
+
+struct S2 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0(@location(5) a0: vec2u, a1: S2) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandEncoder186 = device1.createCommandEncoder({});
+let commandBuffer116 = commandEncoder186.finish({label: '\ua958\u6ba8\ucfeb\u{1f9c5}\u0c0f\uea9a\u{1f981}'});
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint16', 7_708, 129);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData13,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter3.label = '\u0800\ua17c\u09c4\uba3a\u{1fef1}\u{1fe51}\u{1f60e}';
+} catch {}
+let buffer93 = device2.createBuffer({
+  label: '\ua0bc\u{1fd7b}\u{1fdc8}\u0aae\u0675\u86d8\ue91a\u06f6\u{1f9c1}\u0378',
+  size: 5020,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder187 = device2.createCommandEncoder({label: '\u{1fd9f}\u0f9a'});
+let texture57 = device2.createTexture({
+  label: '\u468d\u8c0f\u09d4\u032c\u072b\u1ae0\u{1ff37}\udc9e\u0364\ucaba\u8bb1',
+  size: [1752, 1, 19],
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let renderBundle113 = renderBundleEncoder20.finish();
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer117 = commandEncoder182.finish({label: '\u0d27\ua7d4\ueda4\u07cb\u8f3e\ua1b2\u818f'});
+let textureView52 = texture38.createView({
+  label: '\ua3fa\u{1fbef}\u1fa2',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+let textureView53 = texture35.createView({baseArrayLayer: 2, arrayLayerCount: 3});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup5);
+} catch {}
+let texture58 = gpuCanvasContext6.getCurrentTexture();
+let renderBundle114 = renderBundleEncoder18.finish();
+let commandBuffer118 = commandEncoder183.finish({label: '\uc08b\u{1f617}\ub3ab\u{1f8b7}\u66f4\ub6f1'});
+let computePassEncoder47 = commandEncoder181.beginComputePass({label: '\u01d3\u{1f670}\u15e8\u0975\ude49'});
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer65);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder();
+let commandBuffer119 = commandEncoder188.finish({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer37, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer98, commandBuffer112]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder189 = device2.createCommandEncoder({});
+let commandBuffer120 = commandEncoder187.finish({label: '\u0001\u069f\uc13e'});
+document.body.prepend(img3);
+try {
+adapter0.label = '\u0441\u539d\u{1fee3}\u3f43\u7a35\ue37c\u03a4\u06b8\u6cea\u{1fc4b}\u77b7';
+} catch {}
+let commandEncoder190 = device2.createCommandEncoder({label: '\u35f9\u06a8\u{1f808}\u{1f60b}\u{1fd7d}\u0ff0\ub979\u8481\uab93\u{1ff53}'});
+let commandBuffer121 = commandEncoder180.finish({label: '\ud958\uc502\u929c\u0c9b\u1aea\u0b97\u0cac\u4f8a'});
+let renderBundle115 = renderBundleEncoder20.finish({label: '\u0e23\uedc2\u0af8\u2d5b'});
+let sampler11 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.40,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder45.insertDebugMarker('\u0226');
+} catch {}
+let commandEncoder191 = device2.createCommandEncoder({label: '\u4e29\u3264\u2609\ubf97\u07c2\u{1ff11}\u0dd3\u9c66\u36ce\u35a2\uf26e'});
+let commandBuffer122 = commandEncoder190.finish({label: '\u3a63\u0d6f\u00ce\ud1f6\u0cab\u07b8\u0e05\u4ea2\u8bfd'});
+let renderBundle116 = renderBundleEncoder18.finish({label: '\u6879\ua124\u00d4\u6c23\u7de8\u689e\u0574\ud3db\u{1fb22}\ubf94\ud3fa'});
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let adapter4 = await promise1;
+let shaderModule12 = device0.createShaderModule({
+  code: `
+struct T0 {
+  f0: mat3x4f,
+  f1: i32,
+  f2: array<atomic<u32>>,
+}
+@group(1) @binding(3) var sam77: sampler_comparison;
+@group(0) @binding(103) var et44: texture_external;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(num_workgroups) a0: vec3u) {
+}
+
+struct S3 {
+  @location(9) f0: vec2u,
+  @location(5) f1: vec2f,
+  @location(11) f2: vec2h,
+  @builtin(instance_index) f3: u32
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec4h, @location(4) a1: vec4u, @location(14) a2: vec3u, a3: S3) -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = a2;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4u,
+  @location(0) f1: vec4u,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder192 = device0.createCommandEncoder({label: '\u2d3a\u0452\u{1fafa}\u43a7\ubb4f\u40bc'});
+let texture59 = device0.createTexture({
+  label: '\ud2d1\u59f1\u060b\u7d35\u660c\u848d\u5baa',
+  size: {width: 618, height: 96, depthOrArrayLayers: 37},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder48 = commandEncoder192.beginComputePass({});
+try {
+renderPassEncoder27.setScissorRect(27, 3, 98, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer36, 'uint16', 2_782, 2_548);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker('\u6091');
+} catch {}
+let commandBuffer123 = commandEncoder189.finish({});
+let renderBundle117 = renderBundleEncoder18.finish({label: '\u0e99\u5d04\u{1f6f3}\u752f\u040a\uf47f\u0443\u9a80\u{1fc88}'});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(video0);
+let bindGroupLayout31 = device2.createBindGroupLayout({
+  label: '\u03cf\u1c14\u{1fec3}\u010b',
+  entries: [
+    {
+      binding: 319,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 74616359, hasDynamicOffset: false },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 451, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 63,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 180,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 611,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 4433527, hasDynamicOffset: false },
+    },
+    {
+      binding: 285,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 215,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 259,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 430,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 47, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+  ],
+});
+let querySet29 = device2.createQuerySet({label: '\u005e\u{1fada}\udcff\u862d\u{1f6b1}\u0304', type: 'occlusion', count: 936});
+let arrayBuffer10 = buffer93.getMappedRange(0, 304);
+try {
+device2.queue.submit([commandBuffer120]);
+} catch {}
+let commandEncoder193 = device2.createCommandEncoder();
+let commandBuffer124 = commandEncoder193.finish({});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let commandEncoder194 = device2.createCommandEncoder({label: '\ub308\u{1fd24}\u{1f79b}'});
+let texture60 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle118 = renderBundleEncoder18.finish({label: '\u507a\u07a1\u11a6\u{1fb42}\ub2bd\u0a48\u4576\u7b07\u1196\u0828\u0ba0'});
+try {
+commandEncoder194.resolveQuerySet(querySet25, 15, 29, buffer93, 2048);
+} catch {}
+try {
+device2.queue.submit([commandBuffer114]);
+} catch {}
+let promise28 = device2.queue.onSubmittedWorkDone();
+let offscreenCanvas3 = new OffscreenCanvas(118, 221);
+try {
+renderPassEncoder13.beginOcclusionQuery(1885);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline14);
+} catch {}
+let renderBundle119 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup0, new Uint32Array(5843), 1372, 0);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas3.getContext('webgpu');
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer89, 'uint32', 3_644, 1_470);
+} catch {}
+try {
+device0.queue.submit([commandBuffer68]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 24, y: 29 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img8);
+let pipelineLayout13 = device2.createPipelineLayout({
+  label: '\uea29\u{1ff64}\u0248\u32f8\ufbe3\u{1f679}\uc07b\u0d42',
+  bindGroupLayouts: [bindGroupLayout31],
+});
+let commandBuffer125 = commandEncoder191.finish({label: '\u0933\u9b2e\u0d00\ucc1d\u0836\u053c\u0717\ucc17'});
+try {
+buffer93.unmap();
+} catch {}
+try {
+commandEncoder194.resolveQuerySet(querySet25, 128, 31, buffer92, 2048);
+} catch {}
+let commandEncoder195 = device2.createCommandEncoder({label: '\u9a7e\u0fc2'});
+let commandBuffer126 = commandEncoder194.finish({label: '\u04d1\u6a8a\u0c02\u0b99\u07fc\u{1fbbb}\u0988\u02ca\ue1a1\u04ac\u03d0'});
+try {
+commandEncoder195.insertDebugMarker('\u0609');
+} catch {}
+let shaderModule13 = device2.createShaderModule({
+  label: '\u5e6f\u{1ffd3}\u0345',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+struct T1 {
+  f0: array<mat3x4h>,
+}
+@group(0) @binding(430) var tex81: texture_cube<i32>;
+@group(0) @binding(451) var et45: texture_external;
+@group(0) @binding(232) var<uniform> buffer96: mat4x2f;
+@group(0) @binding(259) var st18: texture_storage_3d<r32float, read_write>;
+@group(0) @binding(84) var tex79: texture_3d<u32>;
+@group(0) @binding(8) var tex82: texture_multisampled_2d<f32>;
+@group(0) @binding(215) var tex80: texture_3d<f32>;
+@group(0) @binding(3) var<storage, read> buffer95: array<mat4x3h>;
+@group(0) @binding(32) var tex76: texture_3d<i32>;
+@group(0) @binding(319) var<storage, read_write> buffer94: atomic<u32>;
+@group(0) @binding(285) var st17: texture_storage_1d<rgba32sint, write>;
+@group(0) @binding(129) var<storage, read> buffer98: mat3x3f;
+@group(0) @binding(93) var sam78: sampler;
+@group(0) @binding(47) var sam79: sampler;
+@group(0) @binding(12) var st16: texture_storage_1d<r32float, read>;
+@group(0) @binding(63) var tex75: texture_depth_cube_array;
+@group(0) @binding(180) var et46: texture_external;
+@group(0) @binding(611) var tex78: texture_multisampled_2d<f32>;
+@group(0) @binding(192) var tex77: texture_depth_2d;
+@group(0) @binding(65) var<storage, read> buffer97: f32;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+  _ = buffer96;
+  _ = textureSampleBaseClampToEdge(et46, sam79, vec2f());
+  _ = textureSampleLevel(tex80, sam78, vec3f(), 0.0);
+  _ = textureLoad(st18, vec3i());
+  if bool(textureGather(tex77, sam78, vec2f())[0]) {
+    return;
+  }
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = textureGather(1, tex81, sam78, vec3f());
+  _ = textureLoad(st16, 0);
+  if bool(textureLoad(et46, vec2u())[3]) {
+    var v: vec4f;
+  }
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec4f {
+  var out: vec4f;
+  _ = textureLoad(tex77, vec2i(), 0);
+  _ = textureSampleBaseClampToEdge(et46, sam78, vec2f());
+  _ = buffer98;
+  atomicStore(&buffer94, 130);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder196 = device2.createCommandEncoder({label: '\u{1faae}\u43a2\u0294\u0afc\ufa80\u654d\u0420\ufd2f\uec03\ud6dc'});
+let bindGroupLayout32 = device2.createBindGroupLayout({
+  label: '\ua65d\u94a7\u0489\u09ba\uc94c\u19d9',
+  entries: [
+    {
+      binding: 510,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let externalTexture24 = device2.importExternalTexture({label: '\u9105\u0613\uba6d\u00d2\u0350\ua5eb\u0969\u0260\u0002\u4654', source: videoFrame0});
+try {
+  await promise28;
+} catch {}
+let canvas7 = document.createElement('canvas');
+let commandEncoder197 = device2.createCommandEncoder({label: '\u3353\ue88c'});
+let commandBuffer127 = commandEncoder195.finish({label: '\u{1fe53}\u0c52\u3adb\u{1f9ac}\uf9b6\ub0bb\u{1fd2a}\uce6d\u0c9a'});
+let texture61 = device2.createTexture({
+  label: '\u0d08\u{1ff4c}\u{1f96f}\ufa68\ua430',
+  size: [432, 1, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+device2.queue.submit([commandBuffer110]);
+} catch {}
+let gpuCanvasContext9 = canvas7.getContext('webgpu');
+let texture62 = device0.createTexture({
+  label: '\u0be7\uae09\u23ba\ubad3\u{1f918}\u841f\u02d8\ud06a\u3eeb\u4700',
+  size: {width: 77, height: 12, depthOrArrayLayers: 9},
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler12 = device0.createSampler({
+  label: '\u{1fffd}\u{1ffd0}\uc732\u07ee\u{1ff44}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.75,
+  maxAnisotropy: 19,
+});
+try {
+renderBundleEncoder15.setIndexBuffer(buffer64, 'uint16', 344, 2_810);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 6, y: 33 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 228, y: 28, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder198 = device1.createCommandEncoder({label: '\u8a4b\u{1fbb7}\u{1fd47}'});
+let renderPassEncoder40 = commandEncoder198.beginRenderPass({
+  label: '\ucef3\u4dcf\ub3e6\u{1fa2e}\u{1f90b}\udf3c\u08e2\u61f2\u16e2\ub8cb\u{1fe72}',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 31,
+  clearValue: { r: 390.6, g: -222.5, b: -677.2, a: 784.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 94009551,
+});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  label: '\u33e3\u516a\ud946\u3319\u{1f641}\u0a10\u{1fcaf}',
+  colorFormats: ['bgra8unorm'],
+  depthStencilFormat: 'depth16unorm',
+});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup6, new Uint32Array(2746), 193, 0);
+} catch {}
+try {
+renderPassEncoder35.setViewport(28.083067835553443, 44.17228337703784, 21.164202848480272, 2.581942115680589, 0.12843199933464788, 0.4163215067818932);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData2,
+  origin: { x: 19, y: 1 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let textureView54 = texture40.createView({label: '\uf1e2\u0d22\u051b\u0afe\u4ee8\u1445\u0cfd\u{1fe48}', dimension: '2d-array'});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({
+  label: '\uacb2\u05b9\u32ef\u21ff\u{1f873}',
+  colorFormats: ['bgra8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+});
+let sampler13 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.996,
+  lodMaxClamp: 76.59,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder25.end();
+} catch {}
+let commandEncoder199 = device1.createCommandEncoder({label: '\u24f8\u{1fb8d}\u{1fa70}\u079c\u0584\u099a\u04e5\u{1ffc2}\u0bf7\u072f'});
+let querySet30 = device1.createQuerySet({label: '\u0293\u0860\u5742\u{1ffa8}\ue020\u4aa1\uf553\uaad7', type: 'occlusion', count: 172});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup5, new Uint32Array(3263), 503, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint16', 1_822, 11_308);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup2, new Uint32Array(702), 81, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer65]);
+} catch {}
+await gc();
+let commandEncoder200 = device2.createCommandEncoder({label: '\u{1f980}\u0b26\u{1f66b}\uca13\u06ea\u{1f64f}\u0959\ub61e\ue8fb'});
+let texture63 = device2.createTexture({
+  label: '\u882f\u5565\u022d\uc91a\u091a\u7442\u5b6c\u074f\u02c4\u0a20\u0bfb',
+  size: [432, 1, 17],
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+commandEncoder200.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 108, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder201 = device1.createCommandEncoder({label: '\u06f7\ub4d3\u59f4\u0afb\u0ddf\u{1fbc3}\u{1fd91}'});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(2, 1, 0, 28);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer88, 'uint16', 6_448, 848);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer89]);
+} catch {}
+let buffer99 = device0.createBuffer({
+  label: '\u936a\u0c9a\u296f\ua779\u050e\u8085\u44ae',
+  size: 35014,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder202 = device0.createCommandEncoder();
+try {
+computePassEncoder19.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(0, buffer38, 436);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer38, 'uint16', 544, 743);
+} catch {}
+let renderBundle120 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup0, new Uint32Array(1620), 267, 0);
+} catch {}
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup1);
+} catch {}
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 165});
+let commandBuffer128 = commandEncoder202.finish();
+let renderPassEncoder41 = commandEncoder181.beginRenderPass({
+  label: '\u849a\u07e8\u0146\u{1fd6d}\ua2bb\uf5e5\u1a50\u0039\ud1b4\u0bc5\u06ca',
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 31.80, g: 313.7, b: -774.9, a: 135.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+});
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder38.beginOcclusionQuery(398);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer67, 0, 2_385);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 1092, new Int16Array(11185), 555, 196);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({label: '\u0990\u9b71'});
+try {
+computePassEncoder48.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 112, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder204 = device0.createCommandEncoder({label: '\u15d9\u0763\u5dcb\u0ffc\ua4f0\u02dc'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\ufa05\u20af\u4f2c\u0e4f\u169c\u020b\u00df\u{1fcf8}\u098a\u0331\u{1fab0}',
+  colorFormats: ['rg32uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder38.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder203.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 312 widthInBlocks: 78 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 900 */
+  offset: 900,
+  bytesPerRow: 512,
+  rowsPerImage: 95,
+  buffer: buffer39,
+}, {width: 78, height: 45, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder203.clearBuffer(buffer70, 3820, 404);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let computePassEncoder49 = commandEncoder113.beginComputePass({label: '\u212d\u06c4\u23d9'});
+let renderPassEncoder42 = commandEncoder199.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 34,
+  clearValue: { r: -410.0, g: -944.7, b: -409.9, a: -840.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+  await promise29;
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder();
+let commandBuffer129 = commandEncoder205.finish({label: '\u2d13\u80d7\u{1f82c}\uc8f7\u8ad5'});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u037a\u{1ffdf}\u1782\u7787\u0662',
+  colorFormats: ['bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder24.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer38, 'uint16', 4_154, 2_616);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let querySet32 = device0.createQuerySet({
+  label: '\u5c02\udf91\u{1f724}\u0049\u{1face}\ub36c\u9b28\u{1fb56}\u62de\u{1ffc3}\u5a95',
+  type: 'occlusion',
+  count: 76,
+});
+let renderPassEncoder43 = commandEncoder204.beginRenderPass({
+  label: '\ub132\u030e\u0bd5\uc602\u{1fbf3}\ud60e\u{1ff2a}\u{1f71a}',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -782.7, g: 549.8, b: -846.4, a: 654.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup7, new Uint32Array(4264), 286, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer65, 'uint16', 44, 92);
+} catch {}
+let commandEncoder206 = device2.createCommandEncoder({label: '\u7736\u{1f647}\ubfc7\u0ece\u0279\u{1fdc6}\u{1fb02}\u47e7'});
+let commandBuffer130 = commandEncoder206.finish({label: '\u9dca\u2970\u0308\u0c26\u0f28\u{1f7e9}\u4258\u651b\u0096\u07aa'});
+let externalTexture25 = device2.importExternalTexture({
+  label: '\u0a4b\u{1f7d5}\u{1fa27}\ua791\u{1fb1b}\u97df\u05ba\u{1ffab}\u75ad',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(136_843), /* required buffer size: 136_843 */
+{offset: 339, bytesPerRow: 466, rowsPerImage: 73}, {width: 432, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let texture64 = device0.createTexture({
+  label: '\u{1fff1}\uf334\uede2\u2ea1\u164b\u000e',
+  size: [77, 12, 1],
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer90, 'uint16', 2_474, 655);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer90, 'uint32', 16_896, 72);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer90);
+} catch {}
+try {
+adapter0.label = '\udc59\u{1f701}\u0110\u445c\u6eb6\u0d04\u0fed';
+} catch {}
+let commandEncoder207 = device2.createCommandEncoder();
+let texture65 = device2.createTexture({
+  label: '\ucacd\u14f9\ubbf3\u039d\u0f2a\u98d7\uc0aa',
+  size: [438, 1, 29],
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder197.resolveQuerySet(querySet25, 29, 15, buffer92, 1024);
+} catch {}
+try {
+adapter2.label = '\u0301\u029c\u04f5\u005a\u9a69\u{1fde7}';
+} catch {}
+let renderPassEncoder44 = commandEncoder201.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 11,
+  clearValue: { r: 884.7, g: 724.5, b: 712.0, a: 194.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 165228741,
+});
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer88, 'uint32', 3_132, 633);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer88, 'uint16', 698, 2_115);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer70, commandBuffer97]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 109, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(88), /* required buffer size: 88 */
+{offset: 88, bytesPerRow: 102, rowsPerImage: 103}, {width: 16, height: 22, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer63);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer38, 'uint32', 148, 460);
+} catch {}
+try {
+commandEncoder203.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 51, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder16.insertDebugMarker('\u{1fd54}');
+} catch {}
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({
+  label: '\ud057\ua6d3\u5523\ub8d6\uccf6\uce43\u0f23\u61e9\uf03b\u06c2',
+  colorFormats: ['bgra8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+});
+let renderBundle121 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer88, 'uint16', 1_228, 2_453);
+} catch {}
+document.body.prepend(canvas2);
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 60, new DataView(new ArrayBuffer(3649)), 700, 72);
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  label: '\u06ef\uf107\u70ce\u382d\u072c\u7f0a\u{1fde8}\u0290\u{1fa5c}',
+  entries: [
+    {
+      binding: 188,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandBuffer131 = commandEncoder203.finish();
+let texture66 = device0.createTexture({
+  size: {width: 618, height: 96, depthOrArrayLayers: 3},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setScissorRect(53, 6, 168, 6);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer67, 0, 957);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer90, 'uint16', 2_098, 2_387);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline26 = await device0.createComputePipelineAsync({label: '\uad26\ubf3a', layout: pipelineLayout12, compute: {module: shaderModule12, constants: {}}});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.prepend(img1);
+let commandEncoder208 = device0.createCommandEncoder({label: '\u299a\u67bd\u6a99\uee88\u85e8\u0d0d\u7031\u{1f695}'});
+let commandBuffer132 = commandEncoder208.finish();
+let texture67 = device0.createTexture({
+  label: '\ua75d\u233b\uce86\ucf12',
+  size: {width: 77, height: 12, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture68 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder20.executeBundles([renderBundle74]);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline18);
+} catch {}
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE, 0, 4980);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView55 = texture67.createView({label: '\u575a\ud01f\uad2a\u91aa\u7fdd\u3137\u7590'});
+let renderBundle122 = renderBundleEncoder2.finish({label: '\u45e3\u{1f746}\u08e7\u6652\u{1f933}'});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer67);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(4, buffer37, 612, 230);
+} catch {}
+let arrayBuffer11 = buffer18.getMappedRange(48, 584);
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\u{1fe45}\uf345\u057a\udd19\u{1ff02}\u034b\u{1fd48}\u{1ffa4}\u8373\u{1fc5d}',
+  bindGroupLayouts: [],
+});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer88, 'uint32', 2_460, 5);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, undefined, 0);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder209 = device1.createCommandEncoder({label: '\u{1fe97}\u1a56\u6599\u0f15\u8a05\u6728\u4690'});
+let renderPassEncoder45 = commandEncoder113.beginRenderPass({
+  label: '\u03f4\ub33e',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 12,
+  clearValue: { r: -852.1, g: -653.5, b: 465.2, a: 500.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+});
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder39.setStencilReference(241);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer88, 'uint16', 9_634, 410);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 224, new Int16Array(3785), 597, 116);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let buffer100 = device2.createBuffer({
+  label: '\uc329\ub412\u{1fd8c}\u{1f688}\ueffd\ue785\u87e7',
+  size: 19745,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet33 = device2.createQuerySet({label: '\u8512\u{1f9e6}\u0c3a\u7cce\ubf95\u{1f7f6}', type: 'occlusion', count: 531});
+let commandBuffer133 = commandEncoder207.finish({label: '\ub23b\ubc84\u{1f8e0}\u{1fb42}\u56fd\u282d\u2f07\u{1fcd6}'});
+let renderBundle123 = renderBundleEncoder20.finish({label: '\ub1c0\u0038\u{1fd79}\u4fbe\uc6e8\uc284\u253e\u{1f9ad}\ue9e6\ua843'});
+try {
+buffer93.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer121]);
+} catch {}
+let pipeline27 = await device2.createComputePipelineAsync({
+  label: '\u{1fe05}\u0cbf\u687e\u{1fe85}\u4af3',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule13, constants: {}},
+});
+video0.height = 20;
+let videoFrame2 = new VideoFrame(img8, {timestamp: 0});
+let commandEncoder210 = device1.createCommandEncoder();
+let commandBuffer134 = commandEncoder209.finish({label: '\u46d3\u{1fb1d}\u0c6f\ufedf\u{1fdde}\u6731\u01af\u4567\uac44\uaf52\ued34'});
+try {
+computePassEncoder26.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer88, 'uint16', 1_340, 638);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(0, undefined);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 212, new DataView(new ArrayBuffer(9290)), 674, 224);
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder({});
+let renderPassEncoder46 = commandEncoder211.beginRenderPass({
+  label: '\u{1fb06}\u9fe5',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 989.1, g: 748.7, b: 609.4, a: 163.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle124 = renderBundleEncoder13.finish({label: '\u{1fc3d}\u5c0c\ucae8\u092c\u0929\u0d63\u0365'});
+try {
+renderPassEncoder38.executeBundles([renderBundle17, renderBundle54, renderBundle17, renderBundle68]);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup1, new Uint32Array(1274), 61, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer67);
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  label: '\ubf64\u65ab\u4609\u0645\ua098\u8629\u{1fb46}',
+  entries: [
+    {
+      binding: 157,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer59, 'uint16', 1_966, 4_736);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer64, 3_272, 3_564);
+} catch {}
+let commandBuffer135 = commandEncoder210.finish({label: '\u3971\ue7a6\u{1f97c}\u3a87\ucfeb\u0360\u964f'});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder42.setViewport(51.630037499492495, 2.981266933795604, 0.023719979961872178, 28.339455083396324, 0.8105855742117583, 0.9655287361912009);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer88, 'uint32', 1_996, 3_104);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(4_294_967_295, undefined, 0, 90_443_711);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(503, 75);
+let commandEncoder212 = device0.createCommandEncoder({label: '\u{1fcd9}\u{1ff78}\ude95\u7335\u{1f6d9}\uc497\u3775\u{1fc3a}\u{1f6b3}\u0151'});
+let commandBuffer136 = commandEncoder212.finish({});
+try {
+computePassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(308);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer66, 'uint32', 80, 4_462);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer12 = buffer58.getMappedRange(0, 8);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture66,
+  mipLevel: 2,
+  origin: {x: 16, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer101 = device2.createBuffer({
+  label: '\u{1faa0}\u097c\u{1fd79}\uceb1',
+  size: 3071,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder213 = device2.createCommandEncoder();
+let texture69 = device2.createTexture({
+  label: '\ubf31\ud9db\ud3c5\u02e8\u1266',
+  size: {width: 432, height: 1, depthOrArrayLayers: 71},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle125 = renderBundleEncoder18.finish({label: '\u4b57\u{1fb0d}\u01c6'});
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(185), /* required buffer size: 185 */
+{offset: 185}, {width: 432, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder214 = device1.createCommandEncoder();
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(534);
+} catch {}
+try {
+commandEncoder214.resolveQuerySet(querySet13, 237, 4, buffer88, 0);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\u4623');
+} catch {}
+try {
+renderPassEncoder35.insertDebugMarker('\u{1fc3d}');
+} catch {}
+try {
+device1.queue.submit([commandBuffer113]);
+} catch {}
+await gc();
+let texture70 = device0.createTexture({
+  label: '\u0098\u{1f615}\u003b\u{1fa0e}\u518d\u2d7f\u6689\u0552\u821f',
+  size: [618, 96, 1],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer67, 0, 7_227);
+} catch {}
+let commandEncoder215 = device0.createCommandEncoder({});
+let renderPassEncoder47 = commandEncoder215.beginRenderPass({
+  label: '\u{1f994}\u{1fa0b}\u3e29\u63db\u{1f80e}\u224f\u5fd4\ue65d\uce8a\u2be8\u0da5',
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: -646.9, g: 178.0, b: 413.8, a: 716.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 146493553,
+});
+let renderBundle126 = renderBundleEncoder4.finish();
+let sampler14 = device0.createSampler({
+  label: '\u0497\u0018\u064c\uaf3d\u0d00\u7872\u{1f807}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 8.465,
+  lodMaxClamp: 52.18,
+});
+try {
+renderPassEncoder41.setViewport(168.84121894123018, 25.898261029294368, 233.47210584832789, 15.294540668067249, 0.43851070478167076, 0.4720087347185207);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer66, 'uint32', 344, 8_181);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let adapter5 = await promise0;
+let commandEncoder216 = device0.createCommandEncoder({label: '\u062b\udbd0\uaac9\u7b7c\ued3c\u0c59\u0503\u6a4f\u{1fae9}'});
+try {
+renderPassEncoder18.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup0, new Uint32Array(550), 171, 0);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline14);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas4.getContext('webgpu');
+try {
+renderPassEncoder19.setIndexBuffer(buffer89, 'uint32', 1_856, 584);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup1, new Uint32Array(701), 36, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer36, 'uint32', 424, 708);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer67, 868);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup6, new Uint32Array(220), 10, 0);
+} catch {}
+try {
+renderPassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(4_294_967_295, undefined, 0, 545_225_724);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup4, new Uint32Array(189), 0, 0);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer88, 'uint16', 2_250, 1_495);
+} catch {}
+try {
+buffer91.unmap();
+} catch {}
+try {
+commandEncoder214.copyBufferToBuffer(buffer88, 280, buffer91, 64, 52);
+} catch {}
+try {
+device1.queue.submit([commandBuffer83, commandBuffer134, commandBuffer80, commandBuffer77]);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let renderBundle127 = renderBundleEncoder18.finish();
+try {
+device2.queue.submit([commandBuffer123]);
+} catch {}
+await gc();
+let commandBuffer137 = commandEncoder214.finish({label: '\u01eb\u{1ff05}\uec55\ua734'});
+try {
+renderPassEncoder35.beginOcclusionQuery(659);
+} catch {}
+try {
+device1.queue.submit([commandBuffer116, commandBuffer96, commandBuffer135]);
+} catch {}
+await gc();
+let textureView56 = texture6.createView({label: '\u{1ff77}\u7dc5', dimension: '3d', mipLevelCount: 1});
+let renderPassEncoder48 = commandEncoder216.beginRenderPass({
+  label: '\u1832\u0590',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: -199.5, g: -619.8, b: 572.8, a: 114.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 257152913,
+});
+let renderBundle128 = renderBundleEncoder3.finish({label: '\u{1f606}\u59fd\u85a8\uf316\u4731\ubba0\u0254\u92db'});
+try {
+renderPassEncoder18.setIndexBuffer(buffer89, 'uint16', 6_596, 168);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline8);
+} catch {}
+try {
+buffer70.unmap();
+} catch {}
+try {
+  await buffer68.mapAsync(GPUMapMode.WRITE, 0, 6800);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 424, new Float32Array(1736), 168, 448);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas7,
+  origin: { x: 192, y: 7 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 0, y: 31, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 7, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder217 = device0.createCommandEncoder({label: '\u0dd2\udab8\u{1f723}\u6f81\u0e59\u{1fd04}'});
+let textureView57 = texture18.createView({baseMipLevel: 1});
+try {
+renderPassEncoder48.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer36, 3_292);
+} catch {}
+try {
+commandEncoder217.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 976 */
+  offset: 976,
+  bytesPerRow: 256,
+  buffer: buffer61,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 21, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder217.resolveQuerySet(querySet3, 43, 38, buffer59, 0);
+} catch {}
+let buffer102 = device0.createBuffer({
+  label: '\u051b\u{1ff6e}',
+  size: 1438,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer138 = commandEncoder217.finish({label: '\u0c94\u069a\u4451\uada5\u0d71\u080f\ue44d'});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer37, 'uint32', 64, 652);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer38, 1_300, 1_288);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let buffer103 = device0.createBuffer({
+  label: '\u2108\ue3c4\u7a51\uce05\u{1fa16}\u0581\u{1ffbc}\u{1fc54}\ud2d6',
+  size: 21129,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder218 = device0.createCommandEncoder();
+let textureView58 = texture27.createView({label: '\u0e4f\u0a59\u02c1\ub532\u{1fc4c}\u0ebf'});
+let renderBundle129 = renderBundleEncoder4.finish({label: '\u1fcc\u7b26\u0520'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer61, 'uint16', 1_160, 105);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(0, buffer38);
+} catch {}
+try {
+commandEncoder218.copyBufferToBuffer(buffer36, 3376, buffer59, 1008, 2184);
+} catch {}
+try {
+commandEncoder72.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 96, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4128 */
+  offset: 4128,
+  bytesPerRow: 256,
+  buffer: buffer67,
+}, {width: 11, height: 21, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\u1d4d\u0906\u2aa5\ub1cd\u{1fe92}\u06a7\u0c83',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+struct T1 {
+  f0: array<array<vec2f, 1>, 1>,
+  f1: array<atomic<u32>>,
+}
+@group(0) @binding(53) var et47: texture_external;
+@group(1) @binding(23) var sam80: sampler;
+@group(2) @binding(80) var<uniform> buffer104: vec3h;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(8) f27: vec3i,
+  @builtin(position) f28: vec4f,
+  @location(6) f29: f16
+}
+
+@vertex
+fn vertex0(@location(1) a0: f16, @location(10) a1: vec2h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec3u {
+  var out: vec3u;
+  _ = textureLoad(et47, vec2u());
+  return out;
+}
+`,
+});
+let computePassEncoder50 = commandEncoder72.beginComputePass({label: '\u{1f651}\u8db9\ua813\u71ad\u0e50\uf3f0'});
+let renderPassEncoder49 = commandEncoder218.beginRenderPass({
+  label: '\uac0d\u0e61\u{1f6fd}\u0af0\ua68d\u027a',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 291.0, g: -135.4, b: -61.50, a: 899.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder28.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(4_294_967_295, undefined, 2_430_522_618, 158_533_516);
+} catch {}
+try {
+computePassEncoder46.insertDebugMarker('\uf195');
+} catch {}
+document.body.prepend(canvas0);
+try {
+window.someLabel = commandEncoder56.label;
+} catch {}
+let renderBundle130 = renderBundleEncoder0.finish({label: '\u1dfc\u87a1\ud673'});
+try {
+computePassEncoder48.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer90, 'uint32', 220, 1_270);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer70);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer36, 'uint16', 378, 2_708);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(1, buffer37);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let promise30 = adapter1.requestAdapterInfo();
+let commandEncoder219 = device1.createCommandEncoder({label: '\ub658\u2296\uf4f1\ue249\u70b6\u0e22\u{1f8e3}\u97f5'});
+let commandBuffer139 = commandEncoder219.finish({label: '\u8a1b\u7b43\u{1fcb3}\u{1fb09}\u238e\u0412\ucefc\u8ffc\u00f7\u06d7'});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder22.pushDebugGroup('\u426b');
+} catch {}
+let commandEncoder220 = device0.createCommandEncoder({});
+let renderBundle131 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup1, new Uint32Array(181), 4, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(4, buffer39, 0, 2_072);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 1024, new BigUint64Array(588));
+} catch {}
+let computePassEncoder51 = commandEncoder120.beginComputePass({label: '\u0198\ufa4c\uafcd\u0dcf\u01ce\u6c0c\u{1ff0f}\u0229'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline22);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let renderPassEncoder50 = commandEncoder220.beginRenderPass({
+  label: '\u6dbf\u0ff6\u738d\u{1f7fa}\u029a\uf06f\u0da4\u0ede',
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 665.6, g: -446.0, b: 685.5, a: -985.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder22.setScissorRect(63, 7, 232, 6);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let renderBundle132 = renderBundleEncoder22.finish({label: '\u497c\u2960\u{1fd01}'});
+try {
+renderBundleEncoder21.setVertexBuffer(7, undefined, 0, 215_093_146);
+} catch {}
+let commandEncoder221 = device1.createCommandEncoder({label: '\u{1fbff}\u91dc\u0765\u845a\u0e22\u{1fbf0}\u0884\ub125'});
+let renderPassEncoder51 = commandEncoder221.beginRenderPass({
+  label: '\u0391\uc6c0\u7b5f\u0387\u{1f73b}\u{1fa3a}\u0d29\u0b5e\u409a\u0f55',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 32,
+  clearValue: { r: -292.7, g: 116.2, b: -717.3, a: 973.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet24,
+});
+let renderBundle133 = renderBundleEncoder25.finish({label: '\uafdb\u02d7\u00be\u0e42\ucf62\u7bc4'});
+try {
+device1.queue.submit([commandBuffer71]);
+} catch {}
+let renderBundle134 = renderBundleEncoder1.finish({label: '\uc1d8\u0b6e\u{1f804}\uc293\u07aa\u{1f71d}\u0217\u042e'});
+try {
+renderPassEncoder50.setIndexBuffer(buffer60, 'uint16', 9_782, 133);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup7, new Uint32Array(6395), 346, 0);
+} catch {}
+try {
+buffer68.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 154, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 4, y: 40 },
+  flipY: false,
+}, {
+  texture: texture66,
+  mipLevel: 2,
+  origin: {x: 35, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let imageData21 = new ImageData(84, 12);
+let commandEncoder222 = device0.createCommandEncoder({label: '\u0e5c\u0654\udbc3\u09bc\u956f\u{1fb24}\ua81c\u4a11\u{1fe97}'});
+let texture71 = device0.createTexture({
+  label: '\u1e03\u0955\uc253',
+  size: {width: 618},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder52 = commandEncoder222.beginComputePass({label: '\u{1fb6e}\u224a\u5207'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle61, renderBundle70, renderBundle41]);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline18);
+} catch {}
+let commandEncoder223 = device0.createCommandEncoder({});
+let commandBuffer140 = commandEncoder223.finish({label: '\u4cdb\u{1f805}\uc0a7\uf750\ua453\u066d\udb62\u{1fa37}\u{1fa13}'});
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(video2);
+let img12 = await imageWithData(66, 6, '#10101010', '#20202020');
+let imageData22 = new ImageData(72, 8);
+let commandEncoder224 = device1.createCommandEncoder({});
+let texture72 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder53 = commandEncoder140.beginComputePass({label: '\ueb41\u{1f764}\u{1fc2f}\u0602\u98e5\u{1fc28}\ub086'});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup6, new Uint32Array(2637), 79, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder51.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer88, 'uint16', 434, 30);
+} catch {}
+try {
+commandEncoder224.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 52 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 624 */
+  offset: 624,
+  bytesPerRow: 256,
+  buffer: buffer91,
+}, {width: 26, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder22.popDebugGroup();
+} catch {}
+try {
+device1.queue.submit([commandBuffer139]);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(230, 567);
+try {
+renderPassEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer90, 'uint32', 1_088, 4_328);
+} catch {}
+try {
+  await buffer68.mapAsync(GPUMapMode.WRITE, 4632, 1788);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer102, 920, new BigUint64Array(1779), 8, 12);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let commandEncoder225 = device2.createCommandEncoder();
+let computePassEncoder54 = commandEncoder197.beginComputePass({});
+let pipeline28 = device2.createComputePipeline({layout: pipelineLayout13, compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}}});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer67, 'uint16', 3_560, 571);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer65);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 3}
+*/
+{
+  source: imageData17,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 47, y: 32, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder226 = device0.createCommandEncoder({});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle99]);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup1, new Uint32Array(84), 14, 0);
+} catch {}
+let pipelineLayout15 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout25, bindGroupLayout23]});
+let renderBundle135 = renderBundleEncoder11.finish({label: '\u0920\u0b4e\u72d7\u{1fa4d}\u9cd8\u3a0d\u052b'});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(14, 11, 3, 4);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer88, 'uint32', 504, 1_716);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, undefined, 0, 32_884_496);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+let commandBuffer141 = commandEncoder179.finish({label: '\ub19a\u725e\u0de8\udfbc\u7f52\u0b67\u72d6'});
+let computePassEncoder55 = commandEncoder196.beginComputePass({label: '\u0ab1\u04c2\u0e5d\u11d3'});
+let renderPassEncoder52 = commandEncoder224.beginRenderPass({
+  label: '\u754b\u120e\u7889\u5852\u4a4f',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 31,
+  clearValue: { r: 561.0, g: 673.3, b: -742.4, a: -36.57, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let commandEncoder227 = device1.createCommandEncoder({label: '\u{1f673}\u{1ffaa}\u8cbf\u{1ff86}'});
+let texture73 = device1.createTexture({
+  size: {width: 104, height: 96, depthOrArrayLayers: 116},
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth16unorm'],
+});
+let renderBundle136 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder53.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder51.setViewport(10.328058510239302, 24.07959269142232, 29.775435385601185, 3.11178996565817, 0.11963984357021085, 0.4683227144075376);
+} catch {}
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let commandEncoder228 = device0.createCommandEncoder({label: '\u1d3a\u{1f834}'});
+let renderBundle137 = renderBundleEncoder3.finish({label: '\u9640\u08ab\u151e\u62e5\u65e9\uea64\u92af'});
+let externalTexture26 = device0.importExternalTexture({label: '\u{1fe6f}\u840d', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder37.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer89, 'uint32', 3_008, 1_032);
+} catch {}
+let device3 = await adapter4.requestDevice({
+  label: '\u03fa\u0840\uc8d9\u{1fc64}\u32a9\u0607\u0246',
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let texture74 = device2.createTexture({
+  label: '\u3cc9\u8a1b\uadb2\u63db\u1d06\u7b6e\u2c6a\u{1ff8c}\u079d',
+  size: [108, 1, 1],
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView59 = texture69.createView({aspect: 'stencil-only', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 17});
+let renderBundleEncoder26 = device2.createRenderBundleEncoder({
+  label: '\u0118\u4a86\ubd0a\u{1ffd4}\u4564',
+  colorFormats: ['rg8unorm'],
+  depthStencilFormat: 'stencil8',
+});
+try {
+renderBundleEncoder26.setVertexBuffer(7, buffer92);
+} catch {}
+try {
+commandEncoder213.resolveQuerySet(querySet29, 60, 22, buffer100, 0);
+} catch {}
+try {
+computePassEncoder54.insertDebugMarker('\u64ed');
+} catch {}
+let commandEncoder229 = device0.createCommandEncoder({});
+try {
+device0.queue.submit([commandBuffer35, commandBuffer107, commandBuffer138]);
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas5.getContext('webgpu');
+let commandEncoder230 = device3.createCommandEncoder({label: '\u0c9b\u7abf\u0c46\u{1fd40}\u033c\u{1f624}\u13c6\u{1fc25}\u0ad8\ub701\u{1fd9d}'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  label: '\uaa0c\u6afe\u{1fdbf}\u0029\u7a91',
+  entries: [
+    {binding: 50, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 40,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 407,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 168, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 460,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 75110973, hasDynamicOffset: false },
+    },
+    {
+      binding: 893,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 487,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {binding: 296, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 247, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 102, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 234,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 375,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 348,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 225,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 352,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 581, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 181,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 206, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {binding: 52, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 281,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 12,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 298, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 165,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 271,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 235,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 361, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 26603, hasDynamicOffset: false },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 97,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 192, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 284, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 156,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 123,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 93, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 87, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 293, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 29, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 57, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 367,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 440,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 374, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 68, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderPassEncoder53 = commandEncoder227.beginRenderPass({
+  label: '\u0ecd\u7700\u{1f944}',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 28,
+  clearValue: { r: -577.1, g: -388.8, b: -561.8, a: -621.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle138 = renderBundleEncoder12.finish({label: '\u0a1b\u2caa\u{1fffc}\u1ede\u27a9\u21d8\u01a1'});
+try {
+renderBundleEncoder21.setVertexBuffer(2, undefined);
+} catch {}
+let commandBuffer142 = commandEncoder213.finish({label: '\uc550\u6241\u0b04\u48d9\u{1f968}\ue1e3\uff68'});
+try {
+commandEncoder225.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 876 widthInBlocks: 876 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 792 */
+  offset: 792,
+  buffer: buffer101,
+}, {width: 876, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, undefined, 334_006_953, 479_420_796);
+} catch {}
+try {
+buffer101.unmap();
+} catch {}
+try {
+commandEncoder200.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 108, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData23 = new ImageData(36, 8);
+let commandBuffer143 = commandEncoder229.finish();
+let renderPassEncoder54 = commandEncoder228.beginRenderPass({colorAttachments: [{view: textureView55, loadOp: 'load', storeOp: 'store'}]});
+let renderBundle139 = renderBundleEncoder19.finish({label: '\u14c3\u012d\u0962\u0665\u{1ff37}\u{1fc78}\ue783\u0ca3\u{1f9f9}\ud39f\u5d4b'});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer67, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer90, 6_172, 175);
+} catch {}
+document.body.prepend(video0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView60 = texture12.createView({label: '\uc59f\u0074\u7e9b\u04e1\u46d5\u164c\u747e'});
+let renderPassEncoder55 = commandEncoder226.beginRenderPass({
+  label: '\u43fa\u0088\u0c4f\u4d12\ua170\u000b',
+  colorAttachments: [{view: textureView21, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 237616773,
+});
+let renderBundle140 = renderBundleEncoder3.finish();
+try {
+computePassEncoder52.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer90, 5_276, 678);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet2, 4, 2, buffer36, 256);
+} catch {}
+try {
+device0.queue.submit([commandBuffer129]);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline19);
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u{1fe53}\u035b\uc9fa\u9335\u0b9d',
+  layout: bindGroupLayout7,
+  entries: [{binding: 3, resource: sampler4}],
+});
+let commandEncoder231 = device0.createCommandEncoder({});
+let textureView61 = texture66.createView({label: '\u48ec\u0f1a\ub2d4\u024b\u0e22\u06c9', mipLevelCount: 1});
+let renderPassEncoder56 = commandEncoder96.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 432.8, g: 191.4, b: 565.9, a: -736.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder24.setVertexBuffer(5, undefined, 657_021_874, 1_054_371_633);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+renderPassEncoder43.insertDebugMarker('\u0dbe');
+} catch {}
+try {
+device0.queue.submit([commandBuffer74]);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder200.insertDebugMarker('\u{1f6bd}');
+} catch {}
+let texture75 = device0.createTexture({
+  size: {width: 77, height: 12, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder57 = commandEncoder231.beginRenderPass({
+  label: '\u59f4\u0531',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 744.6, g: 253.0, b: 10.64, a: 305.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(5, buffer63, 5_032);
+} catch {}
+let commandBuffer144 = commandEncoder200.finish();
+let computePassEncoder56 = commandEncoder225.beginComputePass({label: '\u0e79\u5fe3\u09d6'});
+let renderBundle141 = renderBundleEncoder20.finish({label: '\u0470\u0375\u279b\u3f3a'});
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer92, 356);
+} catch {}
+try {
+device2.queue.submit([commandBuffer142]);
+} catch {}
+let pipeline29 = device2.createRenderPipeline({
+  label: '\u{1facd}\uc5f1\u{1fae8}\u58d5\ufc5e\uf585\u0df1\u{1faf1}',
+  layout: pipelineLayout13,
+  multisample: {mask: 0x1509de89},
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule13, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder232 = device0.createCommandEncoder({label: '\ua629\u56fd\u64d6\ua30e\ub5fb\u681d\u185d\u{1fc26}\u5b0d\ud041\ud749'});
+let querySet34 = device0.createQuerySet({label: '\u505f\u8807\u02e9\u{1f6be}\u71b2\uea73\u2b86', type: 'occlusion', count: 414});
+let commandBuffer145 = commandEncoder232.finish({label: '\u{1fbd0}\u792f\u03ef\u3f4e'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(850), 209, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer19, 'uint32', 1_396, 2_229);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline8);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 476, new Float32Array(5040), 1512, 676);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder233 = device1.createCommandEncoder({label: '\u87e1\u{1f73d}\u{1fb03}\ud23b\u0959\u0786\u{1f789}\u{1feed}\uf492\ub94e'});
+let commandBuffer146 = commandEncoder233.finish({label: '\ua624\u{1ffa1}\udb67\u{1fe25}\u3c08\u0b01\u00da\u342b\u5b6d\u0d9e\u02ca'});
+let renderBundle142 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 2, y: 2 },
+  flipY: true,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 30, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder234 = device3.createCommandEncoder({label: '\u15a3\u8a37\u936d\uc9fd'});
+let querySet35 = device3.createQuerySet({type: 'occlusion', count: 330});
+let commandBuffer147 = commandEncoder230.finish({label: '\u{1f63e}\u0c8f\u721e\uca77\u{1fe2d}\u507b\u{1f9aa}'});
+let computePassEncoder57 = commandEncoder234.beginComputePass({});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let renderBundle143 = renderBundleEncoder12.finish();
+let externalTexture27 = device1.importExternalTexture({label: '\u7465\u{1fbca}\u02a3\u{1f7e9}', source: video1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device3.pushErrorScope('validation');
+} catch {}
+let texture76 = device0.createTexture({
+  label: '\u0a86\u82ac\uab1f',
+  size: [154, 24, 1],
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle144 = renderBundleEncoder10.finish({label: '\u{1fc20}\ucd68\u950f\u6109'});
+try {
+renderPassEncoder54.executeBundles([renderBundle107, renderBundle124]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer37, 'uint32', 112, 265);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer67, 920);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup7, new Uint32Array(634), 41, 0);
+} catch {}
+let video5 = await videoWithData();
+let bindGroupLayout36 = device1.createBindGroupLayout({
+  label: '\u0900\u61f1\u52e3\u4c68\u60e9\u{1fe41}\u0004\ud72a\u{1fe92}\ufd80\u{1f961}',
+  entries: [{binding: 322, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }}],
+});
+let texture77 = device1.createTexture({
+  label: '\u{1ff4f}\u047a',
+  size: {width: 104},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let externalTexture28 = device1.importExternalTexture({
+  label: '\u6be0\u8157\u119b\u8eb9\u01b1\u0790\u{1f87a}\ubfa4\u035d\u005d\u{1f8a9}',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder38.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder44.setBlendConstant({ r: 286.1, g: 960.8, b: 458.3, a: 410.2, });
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer88, 'uint16', 2_748, 956);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 368, new Int16Array(9615), 11, 64);
+} catch {}
+let renderBundle145 = renderBundleEncoder16.finish({label: '\u951d\u0918'});
+try {
+renderPassEncoder28.setVertexBuffer(1, undefined, 0, 993_829_025);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(5, buffer38, 3_180, 676);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+video3.height = 14;
+let buffer105 = device2.createBuffer({
+  label: '\u9e61\uf4a6\u32e6\ue42c\u2e2d\u5110\u9dd2',
+  size: 31192,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+try {
+renderBundleEncoder26.setVertexBuffer(7, undefined, 1_068_026_349, 138_169_455);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+device2.queue.submit([commandBuffer111]);
+} catch {}
+let commandEncoder235 = device2.createCommandEncoder({label: '\u31a3\u{1f95c}'});
+let commandBuffer148 = commandEncoder235.finish();
+let pipeline30 = await device2.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule13, constants: {}}});
+let commandEncoder236 = device3.createCommandEncoder({});
+let texture78 = device3.createTexture({
+  label: '\u564d\u8664\u9508\u925a\u{1fb5d}\u{1f873}\u6f32\u9e1e\u{1fc86}\ub3ee\u048d',
+  size: {width: 147},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder58 = commandEncoder236.beginComputePass({label: '\u04cd\u0c9d\u6a90\u014b\u0fdf'});
+let commandEncoder237 = device2.createCommandEncoder({label: '\u04bf\u{1fdf9}\u9a8a\u06c1\ub195'});
+let commandBuffer149 = commandEncoder237.finish({});
+let texture79 = device2.createTexture({
+  label: '\u{1ff97}\u0a6e\u01d6\ufbcf\u{1f9c8}\u5031\ubd4b\u{1ffc9}\uad69\ua322',
+  size: {width: 1752, height: 1, depthOrArrayLayers: 29},
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer92, 0, 329);
+} catch {}
+try {
+computePassEncoder55.insertDebugMarker('\u9657');
+} catch {}
+try {
+device2.queue.submit([commandBuffer94]);
+} catch {}
+let promise31 = device2.queue.onSubmittedWorkDone();
+let imageData24 = new ImageData(88, 28);
+try {
+adapter3.label = '\u256d\u{1fb6d}\u{1fe6c}\u81e7\ub21a';
+} catch {}
+let commandEncoder238 = device1.createCommandEncoder({});
+try {
+computePassEncoder35.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(7, undefined, 223_730_328, 402_904_169);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(34), /* required buffer size: 34 */
+{offset: 34}, {width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({label: '\ud266\u0d07\u5a6e\u033b', bindGroupLayouts: [bindGroupLayout3, bindGroupLayout7]});
+let texture80 = device0.createTexture({
+  label: '\u5f0a\u6b55\u{1f9ed}\u46f4\u62a9\u2b35\u211a\u2f40\u0e41',
+  size: [77],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView62 = texture33.createView({label: '\ue640\u{1fe8a}\u{1fa8f}\u37cf\uf0bc\u08e9', dimension: '3d'});
+let sampler15 = device0.createSampler({
+  label: '\u0d9d\u57da\uc6d1\u0817\ud4e0\ue7ae\u2747\u075c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.271,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle47]);
+} catch {}
+try {
+renderPassEncoder27.setViewport(104.15469892406654, 34.393863881758776, 33.27986947658814, 6.544809620215221, 0.8873706182807342, 0.9658242644796796);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(2, buffer90);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 12, y: 15 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 24, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer150 = commandEncoder169.finish({label: '\u0b72\u19d9\u0cad\u5f4e\u050d\ub8fc\ue92d\u{1f777}\u4576\u06d1\uf93b'});
+let pipelineLayout17 = device2.createPipelineLayout({
+  label: '\u04b5\ubfa7\ua10e\u{1f64b}\uaf8c\u70d3\u9ee6\ua7a2\udadf\u9046',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout32],
+});
+try {
+computePassEncoder56.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer92);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  label: '\u07dd\u690e\u04b0\u1c28\u{1f9e9}\u6e77\ua09d',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+@group(2) @binding(23) var sam82: sampler;
+@group(0) @binding(102) var tex84: texture_1d<i32>;
+@group(0) @binding(492) var tex83: texture_cube<u32>;
+@group(1) @binding(3) var sam81: sampler_comparison;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f30: vec4f,
+  @location(4) f31: vec2i,
+  @location(10) f32: vec3u,
+  @location(1) f33: vec2h
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3f, @location(13) a1: vec4h, @location(5) a2: vec3i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(a2[0]) {
+    var v: vec4f;
+  }
+  return out;
+}
+
+struct S4 {
+  @location(4) f0: vec2i,
+  @location(10) f1: vec3u
+}
+struct S5 {
+  @builtin(position) f0: vec4f
+}
+
+@fragment
+fn fragment0(a0: S4, @location(1) a1: vec2h, @builtin(front_facing) a2: bool, a3: S5, @builtin(sample_mask) a4: u32) -> @location(200) vec4u {
+  var out: vec4u;
+  _ = textureLoad(tex84, 0, 0);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u{1f99e}\u32c2\u04ff', bindGroupLayouts: [bindGroupLayout20]});
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer67, 'uint32', 3_572, 791);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer102, 'uint16', 494, 277);
+} catch {}
+let commandEncoder239 = device2.createCommandEncoder();
+let texture81 = device2.createTexture({
+  label: '\uf41d\u3eef\u0d5e\u{1f731}\u0bfa\u{1f732}\u0baf\u{1fafe}',
+  size: [216, 1, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle146 = renderBundleEncoder26.finish({label: '\u{1f60c}\uc278\u{1fd15}\u0ee2\u80b4\u0480\ufea0\u0e4b\ue16e\uadb8'});
+let arrayBuffer13 = buffer105.getMappedRange(6592);
+let commandEncoder240 = device2.createCommandEncoder({});
+let computePassEncoder59 = commandEncoder240.beginComputePass({label: '\u04d5\u{1fd39}\u0952\u05f6\ua659\u9f7e\u{1f7a7}\u04c9\u3479\u7752\u503d'});
+try {
+computePassEncoder54.setPipeline(pipeline30);
+} catch {}
+let arrayBuffer14 = buffer105.getMappedRange(0, 1628);
+try {
+commandEncoder239.copyBufferToTexture({
+  /* bytesInLastRow: 108 widthInBlocks: 108 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 24 */
+  offset: 24,
+  bytesPerRow: 256,
+  buffer: buffer93,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 108, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline31 = device2.createComputePipeline({label: '\u195a\u0589\u0544\u13bf', layout: pipelineLayout13, compute: {module: shaderModule13}});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+try {
+  await promise31;
+} catch {}
+let commandEncoder241 = device0.createCommandEncoder({label: '\u8a5a\u{1f9c4}\u0ec6\u{1f833}\u735a\u9dfb\u607b\uea52\u4e17\u89ea'});
+let commandBuffer151 = commandEncoder241.finish({label: '\u705d\ueef1\u9a2f'});
+try {
+renderPassEncoder41.beginOcclusionQuery(370);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+computePassEncoder50.pushDebugGroup('\u{1f83a}');
+} catch {}
+video5.height = 30;
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderPassEncoder58 = commandEncoder238.beginRenderPass({
+  label: '\u0ebe\u09b8\u0c7f\ub527\u8854\u2c4d',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 41,
+  clearValue: { r: -271.2, g: -444.6, b: -927.3, a: 713.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet19,
+});
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer88, 'uint16', 5_282, 1_440);
+} catch {}
+try {
+device1.queue.submit([commandBuffer115]);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder41.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer19, 'uint32', 376, 2_635);
+} catch {}
+try {
+device0.queue.submit([commandBuffer128]);
+} catch {}
+let textureView63 = texture18.createView({label: '\ueb53\u099a\u070a', baseMipLevel: 1});
+let renderBundle147 = renderBundleEncoder6.finish({label: '\u0dbe\u9cca\u2a90\u6fda\ub36c\u{1f8e7}\ub923\u17aa\u897e'});
+try {
+renderPassEncoder43.setIndexBuffer(buffer67, 'uint32', 6_840, 549);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 8896, new DataView(new ArrayBuffer(18964)), 4872, 3408);
+} catch {}
+let querySet36 = device3.createQuerySet({label: '\u{1faa5}\u0469\ua759\u1ae2\u{1fa76}\u089c\u{1fa92}\u34b0', type: 'occlusion', count: 1178});
+let promise32 = device3.queue.onSubmittedWorkDone();
+let commandEncoder242 = device2.createCommandEncoder();
+let commandBuffer152 = commandEncoder242.finish({label: '\u{1fd52}\ufbac'});
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let adapter6 = await promise26;
+let commandBuffer153 = commandEncoder140.finish({label: '\u0a31\u51ce\u{1fd82}\u{1ff4e}\u{1f90d}'});
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder52.setBlendConstant({ r: -85.42, g: -353.8, b: 939.4, a: -921.9, });
+} catch {}
+let textureView64 = texture78.createView({label: '\u431d\u19c8\uda42\u{1fe74}\u{1f72c}\u99a8'});
+let commandEncoder243 = device3.createCommandEncoder({});
+await gc();
+let commandBuffer154 = commandEncoder243.finish();
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer38);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder244 = device3.createCommandEncoder({label: '\u{1ffca}\u08fe\u066e\ud3cc\u53b2\ub570\u0997\u00ee\u5435'});
+let commandBuffer155 = commandEncoder244.finish({label: '\u{1f687}\u{1febc}'});
+let promise33 = device3.queue.onSubmittedWorkDone();
+try {
+  await promise32;
+} catch {}
+await gc();
+let bindGroupLayout37 = device3.createBindGroupLayout({
+  label: '\uad84\u071e\uf4dd\u27f5\u0eff\u{1fc53}\u0bd4\uef5e\u36c7\u0abe\u{1fa25}',
+  entries: [{binding: 475, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }}],
+});
+let commandEncoder245 = device3.createCommandEncoder({label: '\u0322\uc810\u35c4\u74fd\ue534\u00c9\u37c8\u5633\u39f1\ue267\u{1f91b}'});
+let texture82 = device3.createTexture({
+  size: {width: 147},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+gpuCanvasContext11.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let renderBundle148 = renderBundleEncoder17.finish({label: '\uf906\u0f02\u26b0\u{1fd5f}\u02b7\u{1f7e1}\ufb53\u6a2a\u0df1\u7a14'});
+try {
+renderPassEncoder45.beginOcclusionQuery(516);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4_294_967_294, undefined, 108_371_814);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, undefined, 622_838_183, 197_469_057);
+} catch {}
+document.body.prepend(canvas3);
+let commandEncoder246 = device1.createCommandEncoder();
+let commandBuffer156 = commandEncoder246.finish({label: '\u0fa2\u{1f679}\u{1f9b8}\u4d13\u078a\ubc2f\u0a8c\u{1f677}\u0c7c\u0ea8'});
+let renderBundle149 = renderBundleEncoder21.finish({label: '\u0f72\u{1f75b}\ue878\u00c0\ubae8\u04ca\ud4e2\u04b8\u0bfb\u{1ff44}\ucd30'});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup2, new Uint32Array(2348), 187, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer88, 'uint16', 3_624, 686);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle150 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer70, 0);
+} catch {}
+try {
+buffer102.unmap();
+} catch {}
+try {
+computePassEncoder50.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer131, commandBuffer106]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer103, 2444, new Float32Array(9493), 213, 1020);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+let commandEncoder247 = device1.createCommandEncoder({label: '\u61f7\u{1fa43}\uc409\u9efe\u0f6d\u8d66\u1838\ucd55\ufd97'});
+let querySet37 = device1.createQuerySet({
+  label: '\u{1fb56}\uf272\u5807\u074a\u{1ff1a}\u0dc6\u06de\u066c\u090b\u164c',
+  type: 'occlusion',
+  count: 295,
+});
+let computePassEncoder60 = commandEncoder247.beginComputePass({label: '\u3035\u{1fa03}\u{1fcac}\u6658\u0c4f\ua49b\u{1fa07}\u09f7'});
+try {
+renderPassEncoder51.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder45.setScissorRect(10, 6, 18, 3);
+} catch {}
+let pipelineLayout19 = device1.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder248 = device1.createCommandEncoder({label: '\u0a37\ub770\u319a\u04a1\u7304'});
+let computePassEncoder61 = commandEncoder248.beginComputePass({});
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer88, 'uint16', 246, 353);
+} catch {}
+let commandEncoder249 = device3.createCommandEncoder({label: '\u9909\u3c49\u0a57\uc793'});
+let computePassEncoder62 = commandEncoder249.beginComputePass();
+canvas1.height = 3024;
+let bindGroupLayout38 = device1.createBindGroupLayout({
+  label: '\u{1fe0b}\uc750\uca09\u{1ff60}\u9f48\u3683\u{1f8e6}',
+  entries: [
+    {
+      binding: 59,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let renderBundle151 = renderBundleEncoder22.finish();
+try {
+computePassEncoder60.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder44.setBlendConstant({ r: -830.6, g: -850.9, b: -536.7, a: 503.7, });
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+video5.height = 104;
+let commandEncoder250 = device2.createCommandEncoder({label: '\u{1ffbc}\u66df'});
+let texture83 = device2.createTexture({
+  label: '\udbcc\u095b\udb38\u{1fe99}\u{1f942}\u79fc\u{1fb83}\u5c5d\ue353\u1045',
+  size: {width: 108, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder239.resolveQuerySet(querySet28, 182, 23, buffer93, 0);
+} catch {}
+let commandEncoder251 = device1.createCommandEncoder({label: '\u0c4f\u06d7\ue996\u7885\u{1fb0a}\u099e'});
+let commandBuffer157 = commandEncoder251.finish({label: '\udf59\uc34d\u{1fab9}\u44a9\u6d87\u1373\u50ed\uacd7\u0db4'});
+try {
+buffer88.unmap();
+} catch {}
+let texture84 = device0.createTexture({
+  label: '\u{1fff5}\u05d4\u7c82\u0d9f\u0ab3\u69b9\u0109\u{1fe1c}\u8033\u9421',
+  size: [618, 96, 450],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder30.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(1, buffer38, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 77, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData24,
+  origin: { x: 2, y: 5 },
+  flipY: true,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder61.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(4_294_967_295, undefined, 526_222_496, 33_135_405);
+} catch {}
+let texture85 = device3.createTexture({
+  label: '\u06f1\u{1f7a7}\u28e7',
+  size: [36],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView65 = texture82.createView({dimension: '1d', baseArrayLayer: 0});
+let promise34 = device3.queue.onSubmittedWorkDone();
+try {
+  await buffer101.mapAsync(GPUMapMode.READ, 0, 480);
+} catch {}
+try {
+commandEncoder239.copyBufferToBuffer(buffer100, 3440, buffer101, 400, 960);
+} catch {}
+let bindGroup9 = device1.createBindGroup({
+  label: '\u9601\u{1fc3d}\u{1f957}\u4a22\u02c7\u{1f68c}\u{1fbea}\u1328',
+  layout: bindGroupLayout23,
+  entries: [{binding: 207, resource: externalTexture18}],
+});
+let commandEncoder252 = device1.createCommandEncoder({label: '\ucb4c\uc44d\u0de3\u7c11\u{1fa84}\u07ea\uaad2'});
+let commandBuffer158 = commandEncoder252.finish({});
+let texture86 = device1.createTexture({
+  label: '\ua8d6\u0e72\u9cc6\u3688\u020d\u{1f78a}\u0752\u3045',
+  size: [52, 48, 1],
+  mipLevelCount: 4,
+  format: 'eac-r11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle152 = renderBundleEncoder12.finish({label: '\ue652\u7b8d\u048b\ua7d4\u0e81\u1844\u{1fa17}\u075f\uf6ad\u0e9e'});
+let externalTexture29 = device1.importExternalTexture({label: '\u4ef7\u749e\u2a17\u{1f6ce}\u08ba\u02f1', source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer88, 'uint32', 896, 29);
+} catch {}
+let renderBundle153 = renderBundleEncoder11.finish({label: '\u063e\u0bfd\u{1f738}\u0159\u{1f855}\u0cbb\u{1f7af}\u4859'});
+try {
+renderPassEncoder58.setStencilReference(21);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer88, 'uint32', 2_220, 1_239);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, undefined);
+} catch {}
+let promise35 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise34;
+} catch {}
+let buffer106 = device2.createBuffer({
+  label: '\ud746\u{1fb20}\u20c9',
+  size: 9228,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandBuffer159 = commandEncoder245.finish({label: '\u718c\u3866\u03ad\u0cdd'});
+let buffer107 = device2.createBuffer({
+  label: '\u{1fb8c}\u01e7\u5eda\u4ae3',
+  size: 20961,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let renderBundleEncoder27 = device2.createRenderBundleEncoder({
+  label: '\u6d57\u352a\ub505\u0bcb\u661b\u8cd7\u0689\u0e13\u27f5',
+  colorFormats: ['rg8unorm'],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let buffer108 = device0.createBuffer({size: 12558, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder24.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer36);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer64, 'uint32', 2_916, 17_016);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer65);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer102, 472, new DataView(new ArrayBuffer(32046)), 7314, 144);
+} catch {}
+let commandEncoder253 = device1.createCommandEncoder({label: '\u332a\ub8aa\u{1ff96}\u0b01\u05de\u054f\u6342\u6988\ub3f8\u{1f845}\u2913'});
+let commandBuffer160 = commandEncoder253.finish({label: '\u01bc\u6c2c\u682f\u081b\u09a4\u2a66\u3749'});
+let textureView66 = texture29.createView({label: '\u{1fcd4}\uea4c\u326b\u0947\ua8c4\u5ec9\u{1fa97}', dimension: '2d-array', baseMipLevel: 0});
+let renderBundle154 = renderBundleEncoder11.finish({label: '\u6312\u0a17'});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 7 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 76, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let textureView67 = texture31.createView({label: '\ua0fa\u02c5\u0276\u06ed\u07d2\u82c1', aspect: 'depth-only'});
+let renderBundle155 = renderBundleEncoder21.finish({label: '\u06e6\ucb08\u0aab\u7521\u0dda\u3f81\u{1fb7e}\u5f83\u0fa9\u{1fe69}'});
+let sampler16 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 90.78,
+});
+try {
+device1.queue.writeBuffer(buffer91, 92, new BigUint64Array(2512), 310, 28);
+} catch {}
+let querySet38 = device1.createQuerySet({type: 'occlusion', count: 226});
+let renderBundle156 = renderBundleEncoder22.finish({label: '\u{1f726}\u5adb\uda88'});
+try {
+computePassEncoder35.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(6, undefined, 0, 222_576_904);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let img13 = await imageWithData(70, 3, '#10101010', '#20202020');
+let commandEncoder254 = device2.createCommandEncoder({label: '\u{1f655}\u7ff2\ue22f\u0b7e\u074a\ua758\u08fa\u0f07\u86ee'});
+let querySet39 = device2.createQuerySet({type: 'occlusion', count: 1684});
+let commandBuffer161 = commandEncoder254.finish({label: '\u{1faad}\u8dea\u{1f6f3}\u08bb\uf1a7\u9e7c\u5aa8\u0cc9'});
+try {
+renderBundleEncoder27.setVertexBuffer(2, buffer93, 336);
+} catch {}
+let arrayBuffer15 = buffer101.getMappedRange(0, 96);
+try {
+commandEncoder239.insertDebugMarker('\u4a47');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(124), /* required buffer size: 124 */
+{offset: 124}, {width: 108, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder255 = device1.createCommandEncoder({label: '\u01c4\u3a75\ua4de\u0349\u0acc'});
+let commandBuffer162 = commandEncoder255.finish({label: '\u08a8\u5cea'});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(4_294_967_294, undefined, 413_178_090, 853_117_432);
+} catch {}
+try {
+renderPassEncoder53.insertDebugMarker('\u1eec');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+}, new ArrayBuffer(116_842), /* required buffer size: 116_842 */
+{offset: 50, bytesPerRow: 24, rowsPerImage: 76}, {width: 2, height: 3, depthOrArrayLayers: 65});
+} catch {}
+let arrayBuffer16 = buffer101.getMappedRange(96, 24);
+let commandEncoder256 = device3.createCommandEncoder({label: '\u{1ff4c}\uca5d\u7610\u0c48\u79ff\u8a3f\u1ec4\u0eb5'});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let commandEncoder257 = device3.createCommandEncoder({label: '\ud066\ub9e7\u4cbf\u{1f963}'});
+let commandBuffer163 = commandEncoder257.finish();
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise35;
+} catch {}
+let commandBuffer164 = commandEncoder256.finish({});
+let texture87 = device3.createTexture({
+  label: '\u5aff\u12f4\ubd1c\u3d14\u0047\u242e\uf053\u4200\uc23b',
+  size: {width: 73, height: 3, depthOrArrayLayers: 22},
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView68 = texture87.createView({
+  label: '\u0137\u{1fb65}\u{1f940}\ucae4\u044c\ue261\ud960\u05fc\u1701\u0b2b',
+  dimension: '2d',
+  aspect: 'all',
+  baseArrayLayer: 3,
+});
+await gc();
+let commandEncoder258 = device3.createCommandEncoder({label: '\u{1f744}\u{1fe8e}\ub79f\ub50c'});
+let commandBuffer165 = commandEncoder258.finish({});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let textureView69 = texture48.createView({
+  label: '\u06c3\u{1ffd1}\u7453\u{1f9c7}\u{1f823}\u1f04\uab83\u0150\u{1f787}\uaeed',
+  dimension: '1d',
+  aspect: 'all',
+});
+try {
+device2.queue.submit([commandBuffer126]);
+} catch {}
+let textureView70 = texture54.createView({label: '\u065d\u0c83\ud33b\u0297\ub560\ud2be\u03b6\u{1ff97}', dimension: '1d'});
+let renderBundle157 = renderBundleEncoder21.finish({label: '\u046d\ube50\u{1fbbd}\u032b\u{1f6c4}\u{1f6d6}\u74be\u0067\u02d6\u1d9e'});
+try {
+computePassEncoder60.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder52.end();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 6 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 21},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+window.someLabel = commandBuffer33.label;
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(0, bindGroup9, new Uint32Array(6003), 161, 0);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(1, undefined, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer156, commandBuffer87, commandBuffer88]);
+} catch {}
+canvas5.height = 475;
+try {
+  await promise33;
+} catch {}
+document.body.prepend(img5);
+let bindGroup10 = device0.createBindGroup({
+  label: '\u0127\ub957\u0739\u5a6f\ue535\u{1f8f3}\u{1f70d}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: externalTexture1}],
+});
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 956, new Int16Array(10033), 3360, 72);
+} catch {}
+await gc();
+let renderBundle158 = renderBundleEncoder21.finish({label: '\u88ff\u1d8c'});
+try {
+computePassEncoder60.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(7, undefined, 0, 496_937_924);
+} catch {}
+let commandBuffer166 = commandEncoder250.finish({});
+let commandBuffer167 = commandEncoder239.finish({label: '\u1212\ud85a\uf797\u5a98'});
+try {
+computePassEncoder55.setPipeline(pipeline31);
+} catch {}
+let pipelineLayout20 = device2.createPipelineLayout({label: '\udb45\ue23a\u07ff\u996f\u0e73\uc65a\u2826\u423d', bindGroupLayouts: []});
+let renderBundleEncoder28 = device2.createRenderBundleEncoder({
+  label: '\ueb15\u9550\u9728\u07cd\u0446\ud436\u8997',
+  colorFormats: ['rg8unorm'],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+commandEncoder196.copyBufferToBuffer(buffer107, 4280, buffer101, 1380, 48);
+} catch {}
+let commandEncoder259 = device3.createCommandEncoder({label: '\u{1fca7}\u06cd\u{1fca6}'});
+let commandBuffer168 = commandEncoder234.finish({label: '\u{1fce6}\u00b5\u21a4\u{1fac9}'});
+let renderBundleEncoder29 = device3.createRenderBundleEncoder({label: '\u0a13\u{1fcc8}\u08a5', colorFormats: ['rg32uint'], stencilReadOnly: false});
+try {
+commandEncoder259.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.submit([commandBuffer147]);
+} catch {}
+let texture88 = device0.createTexture({
+  label: '\ud5d7\uec0d\u5024\u{1fb72}\ufb30\u{1f7a6}',
+  size: [309, 48, 33],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder54.setViewport(75.85654145613694, 11.423177452406568, 0.24696547371643282, 0.35119061341473723, 0.8175527914147335, 0.8917800637873026);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(4, buffer38, 104);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup9, new Uint32Array(3081), 203, 0);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer88, 'uint32', 1_972, 210);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, undefined, 286_528_304, 467_771_786);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let imageData25 = new ImageData(132, 8);
+let commandEncoder260 = device2.createCommandEncoder({label: '\u{1fb8c}\ud118\ubac6\u01b2\ud839\u08f4\uf036\ua5d8\u9c24'});
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer100, 2_112, 1_099);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder260.resolveQuerySet(querySet22, 3, 0, buffer106, 512);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+window.someLabel = externalTexture29.label;
+} catch {}
+let commandEncoder261 = device1.createCommandEncoder({label: '\u021e\udc0e\u{1f78d}'});
+let texture89 = device1.createTexture({
+  label: '\u79bb\uebf9',
+  size: {width: 104, height: 96, depthOrArrayLayers: 20},
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder59 = commandEncoder261.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 7,
+  clearValue: { r: -310.4, g: -639.8, b: -978.9, a: -111.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet19,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+let renderBundle159 = renderBundleEncoder21.finish({label: '\ubd5d\u0b1d\u302b\u2ab0'});
+let externalTexture30 = device1.importExternalTexture({label: '\u019d\u{1ffcb}\u{1feb0}', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+let renderBundle160 = renderBundleEncoder17.finish({label: '\ua8e3\u9e9c\u50c0\u3c18\u{1fbae}\u0a6c\u0609\u85c2\ubcdc'});
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+device1.queue.submit([commandBuffer162, commandBuffer108, commandBuffer73, commandBuffer92]);
+} catch {}
+document.body.prepend(img0);
+let video6 = await videoWithData();
+let renderBundle161 = renderBundleEncoder23.finish({label: '\u03ed\u{1f889}'});
+try {
+renderPassEncoder24.setIndexBuffer(buffer19, 'uint32', 4_072, 204);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer38, 0, 1_161);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer64, 'uint16', 656, 3_121);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline18);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(54, 149);
+let shaderModule16 = device2.createShaderModule({
+  label: '\u06bf\u68ff\u0fc6\u70da\u1e81\uc390\uecec\u1110\ufbfa\u0339\u0dbd',
+  code: `
+struct T0 {
+  f0: atomic<u32>,
+}
+@group(0) @binding(47) var sam84: sampler;
+@group(0) @binding(129) var<storage, read> buffer113: array<array<f32, 1>>;
+@group(0) @binding(63) var tex85: texture_3d<i32>;
+@group(0) @binding(32) var tex86: texture_3d<u32>;
+@group(0) @binding(319) var<storage, read_write> buffer109: array<mat3x2h>;
+@group(0) @binding(12) var st19: texture_storage_3d<rgba16float, read>;
+@group(0) @binding(93) var sam83: sampler;
+@group(0) @binding(611) var tex88: texture_multisampled_2d<u32>;
+@group(0) @binding(65) var<storage, read> buffer112: T0;
+@group(0) @binding(8) var tex92: texture_multisampled_2d<u32>;
+@group(0) @binding(285) var st20: texture_storage_2d<rg32float, write>;
+@group(0) @binding(430) var tex91: texture_1d<u32>;
+@group(0) @binding(451) var et48: texture_external;
+@group(0) @binding(192) var tex87: texture_2d_array<u32>;
+@group(0) @binding(180) var et49: texture_external;
+@group(0) @binding(232) var<uniform> buffer111: mat3x3h;
+@group(0) @binding(259) var st21: texture_storage_3d<r32uint, read_write>;
+@group(0) @binding(215) var tex90: texture_2d<f32>;
+@group(0) @binding(84) var tex89: texture_2d_array<f32>;
+@group(0) @binding(3) var<storage, read> buffer110: array<f16, 1>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  _ = textureLoad(tex92, vec2i(), 0);
+  _ = textureLoad(tex86, vec3i(), 0);
+  _ = buffer109;
+  _ = textureSampleBaseClampToEdge(tex90, sam84, vec2f());
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = buffer111;
+  if bool(textureLoad(st19, vec3i())[1]) {
+    var v: vec4f;
+  }
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3f
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureSampleGrad(tex90, sam83, vec2f(), vec2f(), vec2f(), vec2i());
+  _ = textureSampleGrad(tex90, sam83, vec2f(), vec2f(), vec2f());
+  _ = textureGather(2, tex87, sam83, vec2f(), 0i, vec2i());
+  _ = textureSample(tex89, sam83, vec2f(), 0i);
+  _ = textureSample(tex90, sam83, vec2f());
+  _ = textureLoad(tex89, vec2i(), 0, 0);
+  _ = textureGather(3, tex90, sam83, vec2f());
+  _ = textureSampleGrad(tex89, sam83, vec2f(), 0i, vec2f(), vec2f());
+  if bool(textureSampleBaseClampToEdge(et49, sam83, vec2f())[3]) {
+    textureStore(st20, vec2i(), vec4f(0.03541, 0.3057, 0.5365, 0.02690));
+  }
+  if bool(textureLoad(tex88, vec2i(), 0)[2]) {
+    buffer109[12345] = mat3x2h();
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout21 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout31]});
+let commandBuffer169 = commandEncoder260.finish({label: '\uf441\u8289\u0def\u0834\ud839\u0fb0\u{1fc03}\u24f9\u175f\u{1fe5c}\u{1fb51}'});
+let renderBundle162 = renderBundleEncoder20.finish({label: '\ue466\u077b\u0d44\u{1ff06}'});
+video3.height = 61;
+try {
+buffer91.unmap();
+} catch {}
+let buffer114 = device1.createBuffer({
+  label: '\u0ca6\u{1ffaa}\u{1f818}\u{1fc2a}\u04ff\u1257',
+  size: 9318,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder262 = device1.createCommandEncoder({label: '\u0cb6\u5f0c\u9b8f\u17bb\u{1feb6}\u0c83\u82e4\uff5f\ub46b\ua2a0'});
+try {
+computePassEncoder22.insertDebugMarker('\uc5ee');
+} catch {}
+try {
+renderPassEncoder45.insertDebugMarker('\u3dcd');
+} catch {}
+let pipelineLayout22 = device3.createPipelineLayout({
+  label: '\u40a7\u1210\uf1f6\u0875\u{1f8af}\u0d3c\u142f\ub68d\u388e\ufd7a',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37],
+});
+try {
+renderBundleEncoder29.setVertexBuffer(3, undefined, 0);
+} catch {}
+let commandBuffer170 = commandEncoder262.finish({label: '\u6b4b\u12f6\uc672\u1227\u03e2\u04b2\u0a0e\u{1f641}\u{1f927}'});
+try {
+computePassEncoder38.setPipeline(pipeline22);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 16, new BigUint64Array(8088), 216, 0);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let buffer115 = device0.createBuffer({
+  label: '\u39b5\u841f\u0b6a\u7f58\u1712\u{1fcee}',
+  size: 11316,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder263 = device0.createCommandEncoder({label: '\u{1fe47}\u{1fd03}\ua1f3\u064b\u1fe4\uebe1\u{1ff36}\u709f\u8110'});
+try {
+renderPassEncoder14.setViewport(288.07320229826666, 16.615254828322747, 10.13525956116328, 7.105457349520416, 0.7544475170812781, 0.9494862357948232);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer67, 'uint32', 1_184, 2_077);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline14);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  label: '\u096f\ub624\u0eb5\u6745\u073e\u029c',
+  entries: [
+    {
+      binding: 527,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 5511471, hasDynamicOffset: false },
+    },
+    {
+      binding: 93,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder264 = device0.createCommandEncoder({label: '\u06e4\ud2e2\u0262\u08db\u{1f789}\u0de3\u9020\u{1fb49}'});
+let commandBuffer171 = commandEncoder264.finish({label: '\u0862\udef7\u48ef\u{1f64a}\u{1fbea}\u{1f8de}\u{1fea0}\u{1fd22}\u036c\u0a24\u0726'});
+let renderPassEncoder60 = commandEncoder263.beginRenderPass({
+  label: '\ub9ab\u{1fc44}\u{1f89f}',
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 993.1, g: -9.588, b: 364.1, a: -458.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle163 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder40.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder41.beginOcclusionQuery(45);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer38, 'uint32', 7_044, 5_702);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+let texture90 = device3.createTexture({
+  label: '\ufafa\u86b8\u{1f706}\ub181\u02f5\ud2bd\u6d24',
+  size: {width: 147, height: 6, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder29.setVertexBuffer(1, undefined);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let commandBuffer172 = commandEncoder259.finish({label: '\u0d28\u0b2c\u0c76\u0a46\u{1f72c}\uf05c\u{1f988}'});
+let gpuCanvasContext12 = offscreenCanvas6.getContext('webgpu');
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer60, 'uint32', 5_892, 2_921);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(6, buffer64);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer69, 'uint16', 806, 1_046);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer90, 1_636);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(4_294_967_295, undefined, 289_698_443);
+} catch {}
+try {
+device3.queue.submit([commandBuffer154]);
+} catch {}
+video3.width = 21;
+let bindGroup11 = device2.createBindGroup({
+  label: '\u1ab0\u0afc\u2bdb\u{1f641}\u{1f62d}\u{1ff4d}',
+  layout: bindGroupLayout32,
+  entries: [{binding: 510, resource: {buffer: buffer106, offset: 2560}}],
+});
+let buffer116 = device2.createBuffer({
+  label: '\u7896\uc472\ued11',
+  size: 15741,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder265 = device2.createCommandEncoder({});
+let commandBuffer173 = commandEncoder196.finish({label: '\u0502\u1212\u{1f82d}\uf4db\u36eb\ub489'});
+let texture91 = device2.createTexture({
+  label: '\u0631\u0c7d\u4350',
+  size: {width: 864, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView71 = texture74.createView({label: '\u{1f979}\ue364\u1c7d\ue133\u{1fd6f}\u0ed8\ub69f\u4395', dimension: '2d-array'});
+let renderBundle164 = renderBundleEncoder28.finish({label: '\u088b\uad97\u3fc2'});
+try {
+computePassEncoder56.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer100, 0, 5_960);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer67, 'uint32', 636, 2_116);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer64, 4_684, 250);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup0, new Uint32Array(1558), 122, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer65, 'uint16', 30, 316);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer60, 0, 1_961);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(141), /* required buffer size: 141 */
+{offset: 141, bytesPerRow: 268}, {width: 67, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout23 = device2.createPipelineLayout({
+  label: '\u{1fb9c}\u3e65\u0c16\u8c53\u{1f819}\u{1fee8}\u59be',
+  bindGroupLayouts: [bindGroupLayout31, bindGroupLayout32],
+});
+let commandEncoder266 = device2.createCommandEncoder();
+let renderBundle165 = renderBundleEncoder26.finish({label: '\u80d5\u0a4c\u{1fc23}\u34aa'});
+try {
+commandEncoder266.clearBuffer(buffer106);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\u{1ffb9}\u{1fa3c}\u01c5\u0ff5\u0c1b\u29e3\u0d93\u{1f6c4}\u{1f947}',
+  layout: bindGroupLayout28,
+  entries: [{binding: 302, resource: {buffer: buffer59, offset: 512, size: 992}}],
+});
+let textureView72 = texture3.createView({label: '\u{1f82f}\ude8b\u0163\u268f', baseMipLevel: 2});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup1, new Uint32Array(613), 152, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup10, new Uint32Array(313), 11, 0);
+} catch {}
+try {
+renderPassEncoder41.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer70, 324, 1_938);
+} catch {}
+let commandEncoder267 = device3.createCommandEncoder({label: '\u0007\uf203\u00db\u015b\uc2a9\u0224\u0db0\u4726\uaf0c\u044c'});
+let texture92 = device3.createTexture({
+  size: [73],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise36 = adapter6.requestAdapterInfo();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData22,
+  origin: { x: 7, y: 0 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 43},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer174 = commandEncoder267.finish({label: '\u{1f747}\u75fa\u016a\u0ab1'});
+let sampler17 = device3.createSampler({
+  label: '\u00fc\u{1f72d}',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.30,
+  maxAnisotropy: 10,
+});
+let externalTexture31 = device3.importExternalTexture({
+  label: '\u06f1\uea8b\u0ed6\u34d2\uc614\u0b3e\u52e6\u76b8\u{1feab}\u{1fcef}\u{1f876}',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder266.copyBufferToTexture({
+  /* bytesInLastRow: 432 widthInBlocks: 432 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1012 */
+  offset: 1012,
+  rowsPerImage: 38,
+  buffer: buffer100,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'stencil-only',
+}, {width: 432, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder266.copyTextureToTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 432, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder268 = device3.createCommandEncoder({label: '\u1e14\u{1fbea}\ud2c1\u19d6\ub95c\u{1f9cd}\u07fa\uc0b7\uac09\u94f4'});
+let renderBundleEncoder30 = device3.createRenderBundleEncoder({label: '\u0631\u0994\u04fe\u5574\u026d\ua4d0\u8fdd\u{1f7bb}', colorFormats: ['rg32uint']});
+let renderBundle166 = renderBundleEncoder29.finish({label: '\u{1f724}\u2a7d\u{1f9ce}\u27a6\u4269\u25b9\u0808'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let buffer117 = device1.createBuffer({
+  label: '\u0a51\u0747\u5925\u{1fdff}\u02d7\u{1fd43}\u9980\u09f8\u{1f7b1}\u0dff\uff2c',
+  size: 8323,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder269 = device1.createCommandEncoder({});
+let externalTexture32 = device1.importExternalTexture({label: '\u8337\u0d2e\u0af7\u5b63', source: video3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u0ee0');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer175 = commandEncoder266.finish();
+let renderBundle167 = renderBundleEncoder28.finish({label: '\ube6b\u{1fa69}\u{1f6d2}'});
+let externalTexture33 = device2.importExternalTexture({label: '\ud293\uc185', source: video3, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer100, 0, 137);
+} catch {}
+try {
+commandEncoder265.clearBuffer(buffer101, 564, 472);
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  label: '\u{1fb14}\u8a0c\u0263',
+  layout: bindGroupLayout17,
+  entries: [{binding: 112, resource: externalTexture5}],
+});
+try {
+renderPassEncoder57.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup10, new Uint32Array(1179), 197, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer105]);
+} catch {}
+let adapter7 = await promise14;
+let commandBuffer176 = commandEncoder269.finish({label: '\u726a\u007c\u9650'});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder45.setScissorRect(2, 11, 3, 11);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer114, 'uint16', 2_158, 393);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(2, undefined);
+} catch {}
+let texture93 = device2.createTexture({
+  label: '\u{1fdae}\ufab9\u0f92\u0165\u{1f9c4}\u0942',
+  size: [1752, 1, 109],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle168 = renderBundleEncoder26.finish({label: '\u05fb\u70e7\ud1dd\u04df\udf0a\u0423\u{1f8bc}\u9502\u0e5d\u4dac'});
+let externalTexture34 = device2.importExternalTexture({
+  label: '\ucb86\u8a45\u01f2\u{1f61e}\u0124\u0989\u260b\u795a\u6056',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder54.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4_294_967_295, undefined, 356_170_736);
+} catch {}
+try {
+device2.queue.submit([commandBuffer101]);
+} catch {}
+let pipeline32 = device2.createComputePipeline({
+  label: '\u50e5\u6739\u02d7\u0cbb\u0742\u{1fd69}\udcdc\ud137\u3729\u095b',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule13, constants: {}},
+});
+document.body.prepend(img10);
+let commandEncoder270 = device0.createCommandEncoder({label: '\u002b\u9ec6\u05a2\u{1fe8a}\u0bab\u6fb9\u04da\u6320'});
+let commandBuffer177 = commandEncoder270.finish({label: '\u21d9\u084b\u0020\uca29\uf2a9'});
+try {
+renderPassEncoder46.setIndexBuffer(buffer38, 'uint32', 628, 44);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(7, buffer64);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline8);
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({label: '\u00d8\u6d9b\u0380\u0aa6\u2315\u32b9\u0faa'});
+let texture94 = device0.createTexture({
+  label: '\udbe0\u{1fc98}\u{1f916}\u{1fe38}\u4f09\u0124',
+  size: [309, 48, 241],
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let renderPassEncoder61 = commandEncoder271.beginRenderPass({
+  label: '\u50b6\ucab1\u7476\u0a12\u{1f815}\u{1f74a}\u0421\u856e',
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 609.2, g: -640.3, b: -313.6, a: -443.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({label: '\u62e6\ufdc3\u{1f6ee}', colorFormats: ['rg32uint']});
+let renderBundle169 = renderBundleEncoder6.finish({label: '\u0a6d\u{1ff5c}'});
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+let arrayBuffer17 = buffer115.getMappedRange(3144);
+await gc();
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup12, new Uint32Array(65), 32, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer90, 2_016);
+} catch {}
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer92, 844);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup7, new Uint32Array(2204), 287, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer38, 1_652, 1_458);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer177]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise36;
+} catch {}
+let buffer118 = device0.createBuffer({
+  label: '\u{1fa8b}\u9e80\u8821\u518d\u0df7\u5b8d',
+  size: 4248,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture95 = device0.createTexture({
+  label: '\u0f28\u7de0\ue468\u01ec\u{1fc53}\u608a\u64bc\uc18c',
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder18.setStencilReference(422);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer69, 'uint32', 56, 774);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer60, 2_596, 3_507);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let commandBuffer178 = commandEncoder225.finish({});
+let computePassEncoder63 = commandEncoder265.beginComputePass();
+let renderBundle170 = renderBundleEncoder20.finish({label: '\uf333\u0cb1\u0ea9\u12b3\ua71d\u0b9f\u1afc\u0fe5\u57c7\u7d1a\u6d59'});
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer141, commandBuffer125, commandBuffer148]);
+} catch {}
+let commandEncoder272 = device3.createCommandEncoder({label: '\u94fe\u0a75\uc923\u0e62\u0f5f'});
+let buffer119 = device0.createBuffer({
+  label: '\uf563\u0d21\u{1fb7e}\ufc21\ue78b\u2a32\u2581',
+  size: 3120,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer38, 'uint32', 1_628, 1_434);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 352 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1944 */
+  offset: 1944,
+  bytesPerRow: 512,
+  buffer: buffer90,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 95, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer179 = commandEncoder65.finish({label: '\u898c\u035a\u0086\u451e\u10a0\u{1ff47}\u01f4'});
+try {
+renderPassEncoder28.setIndexBuffer(buffer60, 'uint16', 3_940, 490);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline12);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync({label: '\ube9c\ubcfd\uf4cc', layout: pipelineLayout4, compute: {module: shaderModule6, constants: {}}});
+let shaderModule17 = device3.createShaderModule({
+  code: `
+struct T0 {
+  f0: vec3u,
+}
+@group(0) @binding(475) var sam85: sampler;
+@group(1) @binding(475) var sam86: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(8) f34: vec4h,
+  @location(14) f35: u32,
+  @builtin(position) f36: vec4f,
+  @location(1) f37: vec3f,
+  @location(5) f38: vec4u,
+  @location(6) f39: i32,
+  @location(7) f40: u32,
+  @location(9) f41: vec4i,
+  @location(4) f42: vec3i,
+  @location(13) f43: u32
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(a0[3]) {
+    var v: vec4f;
+  }
+  out.f34 = vec4h(-37977.2);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2u,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec3f, @location(8) a1: vec4h) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  hints: {},
+});
+let buffer120 = device3.createBuffer({size: 6905, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet40 = device3.createQuerySet({label: '\ufc92\u090c\u{1fb96}\ue437\u{1fd6a}', type: 'occlusion', count: 333});
+let commandBuffer180 = commandEncoder272.finish({label: '\u{1fbfb}\u{1f84a}\u0eb7\u407c'});
+let textureView73 = texture92.createView({label: '\u{1f69c}\udf29\u02ef\udb46\u293d\uabc8\ueb3e\u{1fa7a}\u667d\u31ea'});
+let computePassEncoder64 = commandEncoder268.beginComputePass({label: '\u01e6\u69a5\u9da5\u9b58\u8563\u0717\u{1f7ed}'});
+video2.width = 6;
+try {
+externalTexture14.label = '\u0fdd\uced8\u0a28\u0f1c\u6a3d\u{1f609}\u0ed4\u{1fa55}';
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer92, 5_132);
+} catch {}
+let shaderModule18 = device3.createShaderModule({
+  label: '\u{1fb20}\u{1fa8b}\u02e1\ubfda\u5800\u7b16\ufe28\u7139\ud702',
+  code: `
+struct T0 {
+  f0: array<array<vec4f, 1>, 1>,
+}
+@group(1) @binding(475) var sam88: sampler;
+@group(0) @binding(475) var sam87: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f44: vec4f
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2f, @location(2) a1: vec2i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(a0[0]) {
+    out.f44 = bitcast<vec4f>(a1.xyxy);
+  }
+  return out;
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> @location(200) vec2u {
+  var out: vec2u;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder62.insertDebugMarker('\ubcb4');
+} catch {}
+try {
+adapter4.label = '\u396d\u{1f8af}\ud06e\u437f\u{1f950}\u0693';
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+device1.queue.submit([commandBuffer158]);
+} catch {}
+let textureView74 = texture92.createView({label: '\u8f92\u{1f88a}\udde9\ud9b2\u{1fa1e}\u8503\u81d6', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle171 = renderBundleEncoder29.finish({label: '\u1091\u0c81\u56b1\u02da\u141d\uc919\u{1fa28}'});
+try {
+renderBundleEncoder30.setVertexBuffer(2, undefined, 2_663_042_706, 73_229_930);
+} catch {}
+try {
+  await buffer120.mapAsync(GPUMapMode.READ, 336, 3656);
+} catch {}
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer64, 'uint16', 16_816, 2_561);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer114, 'uint16', 2_016, 1_881);
+} catch {}
+let commandEncoder273 = device1.createCommandEncoder({});
+let renderPassEncoder62 = commandEncoder273.beginRenderPass({
+  label: '\ue11a\u06b8\u{1f925}\u0980\u67be\u{1fba1}\u{1fe35}\u7a3d\u0091',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 35,
+  clearValue: { r: 488.9, g: 15.55, b: -118.6, a: -20.94, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+});
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder44.setBlendConstant({ r: 43.35, g: 360.6, b: 681.1, a: 472.5, });
+} catch {}
+try {
+buffer91.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline27);
+} catch {}
+video6.width = 11;
+await gc();
+let device4 = await adapter6.requestDevice({
+  label: '\u998c\u8fea\u26d7\u{1f831}\u{1fc34}\u2168\u0896\u0b9c\u3202\ua79c',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder59.beginOcclusionQuery(301);
+} catch {}
+try {
+renderPassEncoder59.endOcclusionQuery();
+} catch {}
+await gc();
+let video7 = await videoWithData();
+let commandEncoder274 = device1.createCommandEncoder({label: '\u0881\u1fda\u4318\u{1f8bb}\u{1fbf5}\u{1fcc8}'});
+let commandBuffer181 = commandEncoder274.finish({label: '\u0dc5\u0e6b\u{1f9ad}'});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder45.setViewport(39.25666765065836, 10.443626582942864, 9.667236159708299, 17.227782418557933, 0.4755611072028447, 0.4976133461755936);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, undefined, 1_183_301_416);
+} catch {}
+let commandEncoder275 = device1.createCommandEncoder();
+let commandBuffer182 = commandEncoder275.finish({label: '\u{1ff28}\u6394\uafc2\ub17d\u9302\u06a9\u5324\u{1fb86}\u98f7'});
+let texture96 = device1.createTexture({
+  size: {width: 13, height: 12, depthOrArrayLayers: 48},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let texture97 = gpuCanvasContext7.getCurrentTexture();
+let renderBundle172 = renderBundleEncoder22.finish({label: '\u3204\u0267\u986d\u4f51\u0129\u{1fe67}\u0a25'});
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup9, new Uint32Array(1070), 25, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(3, undefined, 28_320_974, 352_430_102);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let promise37 = device1.queue.onSubmittedWorkDone();
+let renderBundle173 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup13, new Uint32Array(1422), 330, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle41, renderBundle67, renderBundle60]);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup8, new Uint32Array(798), 73, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(5, buffer37, 352, 116);
+} catch {}
+let textureView75 = texture91.createView({label: '\u1be5\ua591\ucfbe\u05dc\u70f1', dimension: '2d-array', mipLevelCount: 1});
+let externalTexture35 = device2.importExternalTexture({
+  label: '\ud403\u0b55\u0612\u320c\ua165\u43a8\u793c\u{1fe5d}\u0716\u6b7e\ue7a9',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder54.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer100, 2_140, 11_290);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let arrayBuffer18 = buffer101.getMappedRange(120, 28);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let shaderModule19 = device2.createShaderModule({
+  label: '\ufcf1\u1993\u2131\u0eeb\u{1f61a}\u4d7f\u8906\uf309\u3050\uf474\u{1fd79}',
+  code: `
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+@group(0) @binding(32) var tex94: texture_3d<i32>;
+@group(0) @binding(451) var et50: texture_external;
+@group(0) @binding(65) var<storage, read> buffer124: array<mat3x2h>;
+@group(1) @binding(510) var<uniform> buffer126: array<vec2i, 1>;
+@group(0) @binding(3) var<storage, read> buffer122: array<vec4u>;
+@group(0) @binding(63) var tex93: texture_3d<f32>;
+@group(0) @binding(215) var tex98: texture_depth_2d;
+@group(0) @binding(430) var tex99: texture_2d_array<f32>;
+@group(0) @binding(93) var sam89: sampler;
+@group(0) @binding(84) var tex97: texture_depth_2d;
+@group(0) @binding(319) var<storage, read_write> buffer121: atomic<i32>;
+@group(0) @binding(611) var tex96: texture_depth_multisampled_2d;
+@group(0) @binding(12) var st22: texture_storage_2d<rgba32sint, read>;
+@group(0) @binding(8) var tex100: texture_depth_multisampled_2d;
+@group(0) @binding(47) var sam90: sampler;
+@group(0) @binding(129) var<storage, read> buffer125: array<mat4x3f>;
+@group(0) @binding(259) var st24: texture_storage_2d<r32uint, read_write>;
+@group(0) @binding(180) var et51: texture_external;
+@group(0) @binding(232) var<uniform> buffer123: vec2i;
+@group(0) @binding(192) var tex95: texture_depth_2d;
+@group(0) @binding(285) var st23: texture_storage_2d<r32uint, write>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0() {
+  _ = buffer121;
+  _ = textureSampleLevel(tex95, sam89, vec2f(), 0i);
+  _ = textureSampleLevel(tex98, sam90, vec2f(), 0i);
+  _ = textureGather(tex95, sam89, vec2f(), vec2i());
+  _ = textureLoad(tex98, vec2i(), 0);
+  textureStore(st24, vec2i(), vec4u(162, 39, 505, 157));
+}
+
+struct VertexOutput0 {
+  @builtin(position) f45: vec4f
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(7) a1: vec2f) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureSampleLevel(tex99, sam89, vec2f(), 0, 0.0);
+  _ = textureSampleBaseClampToEdge(et51, sam89, vec2f());
+  _ = textureLoad(st22, vec2i());
+  return out;
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4f) -> @location(200) vec2f {
+  var out: vec2f;
+  _ = textureLoad(tex94, vec3i(), 0);
+  _ = textureLoad(st22, vec2i());
+  _ = textureSample(tex95, sam89, vec2f());
+  _ = textureGather(tex95, sam89, vec2f());
+  _ = textureSample(tex93, sam89, vec3f(), vec3i());
+  _ = textureDimensions(et51);
+  _ = textureSampleBaseClampToEdge(et51, sam89, vec2f());
+  _ = buffer121;
+  if bool(textureSampleLevel(tex95, sam89, vec2f(), 0i)) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipeline34 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout23,
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'src'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'always', failOp: 'invert', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 192154858,
+    stencilWriteMask: 142000065,
+    depthBias: -2022650071,
+    depthBiasSlopeScale: 530.9312422805867,
+    depthBiasClamp: -82.2422134269427,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 240, stepMode: 'instance', attributes: []},
+      {arrayStride: 636, stepMode: 'instance', attributes: []},
+      {arrayStride: 232, attributes: []},
+      {arrayStride: 324, stepMode: 'instance', attributes: []},
+      {arrayStride: 256, attributes: []},
+      {arrayStride: 1476, attributes: []},
+      {arrayStride: 296, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1216,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32', offset: 88, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+await gc();
+let bindGroupLayout40 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 432,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder276 = device2.createCommandEncoder({});
+let commandBuffer183 = commandEncoder276.finish({label: '\u{1f8bd}\u{1f9d8}\u0e38\u0595\u{1feb8}\u{1f729}\u3ba0\ubd2f'});
+try {
+computePassEncoder59.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer93);
+} catch {}
+let buffer127 = device3.createBuffer({
+  label: '\u086c\u{1fbd4}\u1c8d\u{1ff8b}\ub044\u0257\u09ab\u0b70\uaf44\u733e',
+  size: 6783,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle174 = renderBundleEncoder30.finish();
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+device3.queue.submit([]);
+} catch {}
+let pipelineLayout24 = device3.createPipelineLayout({
+  label: '\uba24\u0aba\u02b6\u85cd\u2392\u{1f768}\uc5c5\u29ef\u33b0\u0a36\uc7f7',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37, bindGroupLayout37, bindGroupLayout37],
+});
+let commandEncoder277 = device3.createCommandEncoder({label: '\u2222\u{1fb77}'});
+let textureView76 = texture78.createView({
+  label: '\u7f39\uaad2\u0254\u{1ff20}\u3dda\u4557\u0a53',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder65 = commandEncoder277.beginComputePass();
+try {
+  await buffer127.mapAsync(GPUMapMode.READ, 0, 440);
+} catch {}
+try {
+computePassEncoder65.pushDebugGroup('\u9ec0');
+} catch {}
+await gc();
+let videoFrame3 = new VideoFrame(img5, {timestamp: 0});
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+try {
+querySet35.label = '\u0fd4\u3999';
+} catch {}
+let renderBundle175 = renderBundleEncoder29.finish({label: '\u{1f96f}\u0868\ua5c1\u0252\u4e65\u7fa4\ucc82\u{1fc29}\u3747'});
+try {
+computePassEncoder58.pushDebugGroup('\u{1fe76}');
+} catch {}
+let commandEncoder278 = device3.createCommandEncoder({});
+try {
+buffer120.unmap();
+} catch {}
+try {
+computePassEncoder65.insertDebugMarker('\u0108');
+} catch {}
+let commandEncoder279 = device2.createCommandEncoder({label: '\uac1e\u{1fe99}\u{1f945}\u5675\u{1fbc2}\u{1f8f2}\u0a3b\u{1fdea}\ub631'});
+let renderBundleEncoder32 = device2.createRenderBundleEncoder({
+  label: '\u{1ff3e}\ubedb\ubb95',
+  colorFormats: ['rg8unorm'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: false,
+});
+try {
+renderBundleEncoder27.setVertexBuffer(2, buffer92, 0, 2_628);
+} catch {}
+document.body.prepend(img7);
+let imageData26 = new ImageData(32, 148);
+let commandEncoder280 = device3.createCommandEncoder({label: '\u3b78\u5625\u0951\u3874\u{1fee2}\u{1ff2c}\ubf51\u{1fd9b}\u{1f674}\u0afd\u{1f9fc}'});
+let commandBuffer184 = commandEncoder278.finish();
+let renderBundle176 = renderBundleEncoder30.finish();
+let sampler18 = device3.createSampler({
+  label: '\uc788\u6823\u32e0\u0ff3\u0ea8\u56d8',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.96,
+  lodMaxClamp: 51.76,
+});
+try {
+commandEncoder280.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder49.setBlendConstant({ r: -206.5, g: 746.9, b: -86.50, a: -828.4, });
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(5, buffer36);
+} catch {}
+let textureView77 = texture90.createView({aspect: 'all', format: 'rg32uint'});
+let externalTexture36 = device3.importExternalTexture({label: '\u{1f8cf}\u{1f85b}\u05b9', source: videoFrame0});
+await gc();
+try {
+renderPassEncoder57.setPipeline(pipeline14);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise37;
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer64, 'uint32', 260, 2_037);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(2, buffer37, 0, 560);
+} catch {}
+document.body.prepend(video5);
+let texture98 = device4.createTexture({
+  label: '\u7a9d\u8379\u0524\u03b6\ub0d7\uc1b6',
+  size: {width: 965, height: 88, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'astc-5x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer60, 'uint32', 12_844, 1_260);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer38);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+let imageData27 = new ImageData(20, 8);
+let commandEncoder281 = device0.createCommandEncoder({label: '\ua1b3\u0d05\u0b91\u{1fef8}\u7219\u07c6\u0e8b\u8656\u{1fac2}\uca81\u4f00'});
+let textureView78 = texture8.createView({label: '\u1214\u8294\u6059\u0502\u{1fddf}\u{1f985}\u1a5a\u09fd', aspect: 'all', arrayLayerCount: 1});
+let renderPassEncoder63 = commandEncoder281.beginRenderPass({
+  label: '\uab1e\u{1fcba}\u{1fa68}\u{1fa1d}\u03cc\u7718\u9927\u022a',
+  colorAttachments: [{view: textureView14, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 118353778,
+});
+try {
+renderPassEncoder48.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer61, 'uint32', 732, 138);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer38, 0);
+} catch {}
+try {
+computePassEncoder54.insertDebugMarker('\u0589');
+} catch {}
+try {
+renderBundleEncoder32.insertDebugMarker('\u{1fd92}');
+} catch {}
+let commandBuffer185 = commandEncoder280.finish({});
+let sampler19 = device3.createSampler({
+  label: '\u6ae2\u0f9c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.16,
+  lodMaxClamp: 82.31,
+  compare: 'greater-equal',
+  maxAnisotropy: 20,
+});
+let commandEncoder282 = device1.createCommandEncoder({label: '\u4fa3\u9d53\u6a07\u077c\ue1b0\u{1f726}\u0597\u{1ff1b}\u8136'});
+let textureView79 = texture96.createView({label: '\u3613\u227a\u08e7\u3d19\u60bb\u{1ffc5}', dimension: '2d', aspect: 'all', baseMipLevel: 0});
+let renderPassEncoder64 = commandEncoder282.beginRenderPass({
+  label: '\u28d6\u0496\u{1f9a3}\u{1fc5b}\u9397\u1e04\u6455\u3f3c\u5457\u536b\u5ac1',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 46,
+  clearValue: { r: 506.6, g: -779.3, b: -43.92, a: 565.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 9367871,
+});
+try {
+renderPassEncoder51.setBlendConstant({ r: 198.6, g: 792.9, b: -109.2, a: -926.7, });
+} catch {}
+await gc();
+try {
+window.someLabel = computePassEncoder30.label;
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder44.setStencilReference(1018);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(6, undefined, 0, 1_420_372_183);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let externalTexture37 = device1.importExternalTexture({source: video2});
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise38 = device1.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder283 = device1.createCommandEncoder({label: '\u{1fb46}\u{1fd10}\u4aab\u{1ffc0}\u{1f632}'});
+let commandBuffer186 = commandEncoder283.finish();
+let texture99 = device1.createTexture({
+  label: '\u07fa\u05c3\u58ff\u224d\udb73\u78c1',
+  size: [104, 96, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle177 = renderBundleEncoder12.finish();
+try {
+computePassEncoder27.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder284 = device4.createCommandEncoder({label: '\u9c6b\u0047\uc6ba\u0448\u{1fb44}\u0098\u{1ffb6}'});
+let commandBuffer187 = commandEncoder284.finish({label: '\u0fd0\u43c7\uf773\udbe0\u{1f80c}\uba66\u8a89\u4967\u0186\u0412\u{1fc60}'});
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer65, 32, 17);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer36, 'uint32', 3_296, 167);
+} catch {}
+let pipeline35 = device0.createRenderPipeline({
+  label: '\u{1fcac}\uaeb5\uc6ca\u1f69\u{1fce9}',
+  layout: pipelineLayout3,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'keep'},
+    stencilReadMask: 33808577,
+    stencilWriteMask: 484088656,
+    depthBias: -2006450534,
+    depthBiasClamp: 3.9650629676790174,
+  },
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 40, stepMode: 'instance', attributes: []},
+      {arrayStride: 940, stepMode: 'instance', attributes: []},
+      {arrayStride: 168, stepMode: 'instance', attributes: []},
+      {arrayStride: 64, attributes: []},
+      {arrayStride: 348, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 216,
+        attributes: [
+          {format: 'snorm16x4', offset: 156, shaderLocation: 2},
+          {format: 'float32x4', offset: 8, shaderLocation: 13},
+          {format: 'sint32x2', offset: 8, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout41 = device1.createBindGroupLayout({
+  label: '\u6806\u732c\u0fb3\ue0be\u0688',
+  entries: [
+    {
+      binding: 66,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet41 = device1.createQuerySet({type: 'occlusion', count: 733});
+let renderBundle178 = renderBundleEncoder12.finish();
+try {
+computePassEncoder35.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer114, 'uint32', 792, 1_433);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(148), /* required buffer size: 148 */
+{offset: 148, bytesPerRow: 138, rowsPerImage: 48}, {width: 52, height: 48, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture31.label = '\u9439\u0769\uf4c7\u{1fe99}\uf8c7\u0d27\u{1fc91}';
+} catch {}
+let commandEncoder285 = device3.createCommandEncoder();
+let renderBundleEncoder33 = device3.createRenderBundleEncoder({
+  label: '\u0c1e\u0e43\ucca6\u56ed',
+  colorFormats: ['rg32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle179 = renderBundleEncoder33.finish({});
+try {
+  await promise38;
+} catch {}
+let commandEncoder286 = device4.createCommandEncoder();
+let textureView80 = texture98.createView({
+  label: '\u071e\u0788\u0d5b\u{1fdce}\u3f50\u0df5\u5abf',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+try {
+commandEncoder286.insertDebugMarker('\u00b6');
+} catch {}
+let commandBuffer188 = commandEncoder279.finish({label: '\u{1ff0e}\u498d'});
+try {
+device2.queue.submit([commandBuffer127]);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let buffer128 = device1.createBuffer({
+  label: '\u46f6\ufb68\u0172\u9367\u{1fe13}\u07bb',
+  size: 27561,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+let commandEncoder287 = device1.createCommandEncoder({});
+let commandBuffer189 = commandEncoder287.finish();
+try {
+renderPassEncoder64.setVertexBuffer(0, buffer128, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer181]);
+} catch {}
+let textureView81 = texture85.createView({label: '\u86b6\uc2e0\udddc\u92ab\ue8e2\ua88e\u18f8', baseArrayLayer: 0});
+try {
+buffer127.unmap();
+} catch {}
+try {
+commandEncoder285.insertDebugMarker('\u0145');
+} catch {}
+try {
+device3.queue.submit([commandBuffer163, commandBuffer180]);
+} catch {}
+let commandEncoder288 = device2.createCommandEncoder({label: '\u9db4\u{1ff32}\u3dd6\u0085\u74d6\u04ef\u{1fe6e}\u01e8'});
+let commandBuffer190 = commandEncoder288.finish({label: '\u084b\u64fb\u0685\uf28c\u1e82\u2c20\uc353\u26be\u03ed\u{1f847}'});
+let renderBundle180 = renderBundleEncoder27.finish();
+try {
+computePassEncoder63.end();
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(7, buffer93, 228, 226);
+} catch {}
+try {
+device2.queue.submit([commandBuffer166, commandBuffer117]);
+} catch {}
+let videoFrame4 = new VideoFrame(video1, {timestamp: 0});
+let commandEncoder289 = device0.createCommandEncoder({label: '\u{1fd52}\u{1ff01}\u4bdd\u{1f684}\u4bea\ube82'});
+let commandBuffer191 = commandEncoder289.finish({});
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup10, new Uint32Array(6263), 218, 0);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(1471);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer37, 'uint32', 84, 217);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer39, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 880, new BigUint64Array(6990), 830, 192);
+} catch {}
+let commandEncoder290 = device1.createCommandEncoder();
+let renderPassEncoder65 = commandEncoder290.beginRenderPass({
+  label: '\ufeab\u7658\u7e47\u{1f6b4}\u5d58\u{1f668}',
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: -936.4, g: -987.5, b: 517.1, a: 984.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 60265159,
+});
+let renderBundle181 = renderBundleEncoder22.finish({});
+try {
+renderPassEncoder62.end();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 244, new Float32Array(41597), 8640, 92);
+} catch {}
+let renderBundleEncoder34 = device3.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true});
+try {
+renderBundleEncoder34.setVertexBuffer(6, undefined);
+} catch {}
+try {
+commandEncoder285.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet42 = device3.createQuerySet({label: '\u39af\uf1c3', type: 'occlusion', count: 2641});
+let texture100 = device3.createTexture({
+  label: '\u0515\uf2ce\udaee\u0b07\u0363\u4b5d',
+  size: {width: 147, height: 6, depthOrArrayLayers: 45},
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder66 = commandEncoder285.beginComputePass({label: '\u0811\u5da7\ue287\uaad9\u{1ffd1}\u{1f981}\u0897\u081c\u0b8e'});
+let commandEncoder291 = device2.createCommandEncoder({label: '\u3621\u287e\u7df2'});
+let computePassEncoder67 = commandEncoder291.beginComputePass({label: '\u53e3\u3aa1\u{1fa26}\u04b5\u0b4b\u52d9\u0645\u21f9'});
+try {
+computePassEncoder67.setPipeline(pipeline28);
+} catch {}
+try {
+device2.queue.submit([commandBuffer190, commandBuffer161, commandBuffer188]);
+} catch {}
+let promise39 = device2.queue.onSubmittedWorkDone();
+let commandEncoder292 = device1.createCommandEncoder({label: '\u59f9\u{1f8ed}\u0d5f\u0e61\u00d4\u8eee\u68b4'});
+let commandBuffer192 = commandEncoder292.finish({label: '\uee81\u35a9\uf4f2\u0159\u2d18\u0f10\u0a3d\ue428\u0c35'});
+let renderBundle182 = renderBundleEncoder12.finish({});
+try {
+buffer117.unmap();
+} catch {}
+let commandEncoder293 = device2.createCommandEncoder({label: '\ua40e\u{1f8e7}\uc752'});
+let renderBundle183 = renderBundleEncoder28.finish({label: '\u04a6\u06b2\ub87c\u{1fd50}\u4655\u72b9\u247e'});
+try {
+renderBundleEncoder32.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer100, 0);
+} catch {}
+let arrayBuffer19 = buffer101.getMappedRange(152, 28);
+try {
+device2.queue.submit([commandBuffer122]);
+} catch {}
+try {
+  await promise39;
+} catch {}
+let promise40 = adapter1.requestDevice({
+  label: '\u49f6\u0f3b\u0e5a',
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxVertexBufferArrayStride: 2048,
+    maxBindingsPerBindGroup: 1000,
+    maxUniformBufferBindingSize: 22404096,
+    maxStorageBufferBindingSize: 138834302,
+  },
+});
+let commandEncoder294 = device4.createCommandEncoder({label: '\u0a8b\u36d0\u02fa\u{1fa73}\uca8c\u15d1\u0228\uf252'});
+document.body.prepend(img12);
+let commandEncoder295 = device1.createCommandEncoder({label: '\u6b71\u85d6\ubd1e\uf356\u0ebd\u7b08'});
+let commandBuffer193 = commandEncoder295.finish({label: '\u0fe7\u{1fc72}\ud45a\uf1dc\u433b\uef78\u{1ff36}\u{1f9dd}\uf431'});
+try {
+renderPassEncoder64.end();
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+await gc();
+let renderBundle184 = renderBundleEncoder25.finish({label: '\u045a\u24c9\u0403\u9fda\u{1f8e9}'});
+try {
+renderPassEncoder45.beginOcclusionQuery(867);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer88, 'uint32', 1_768, 429);
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageData5);
+let commandEncoder296 = device1.createCommandEncoder({label: '\u7210\u{1f622}\ufc78\u{1f715}\u{1f638}'});
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 54, y: 5, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(589), /* required buffer size: 589 */
+{offset: 589, bytesPerRow: 42}, {width: 9, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder297 = device3.createCommandEncoder({label: '\u{1f897}\u010e\u7a61\ue7ef\uf231\u0e6c'});
+let texture101 = gpuCanvasContext2.getCurrentTexture();
+let renderBundle185 = renderBundleEncoder34.finish({label: '\u37bb\u0ab1\u{1f816}\u110f\u03d5\u1ac3\u{1ffb2}'});
+try {
+commandEncoder297.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 1, y: 447, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 694, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 220, depthOrArrayLayers: 0});
+} catch {}
+canvas3.width = 357;
+let renderBundle186 = renderBundleEncoder22.finish({label: '\u000f\u{1f99f}\u433b\uc261\u325a\ua451\u0d0c\u{1fd86}\u{1fc52}\u{1fcce}'});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+commandEncoder155.copyTextureToBuffer({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1784 */
+  offset: 1784,
+  bytesPerRow: 256,
+  rowsPerImage: 2,
+  buffer: buffer117,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(340), /* required buffer size: 340 */
+{offset: 340}, {width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView82 = texture5.createView({label: '\u069f\u339b\ubbee\u0eac\u0833\uaeec\u22f7\u0c26', baseArrayLayer: 0});
+try {
+renderPassEncoder60.setBlendConstant({ r: -630.1, g: 166.8, b: -463.6, a: -280.4, });
+} catch {}
+try {
+renderPassEncoder54.setViewport(17.889144714584738, 7.592144223646278, 24.65630517886206, 0.12986335935271542, 0.17158199659845386, 0.25963824644400696);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer90, 'uint16', 2_254, 2_656);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(1, buffer64);
+} catch {}
+let commandEncoder298 = device2.createCommandEncoder({label: '\u2373\u75a5\ubc9f\u4e42\uf606'});
+let commandBuffer194 = commandEncoder265.finish({label: '\u0a3f\u0fb7\u08cb\u756e'});
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer93, 0);
+} catch {}
+try {
+commandEncoder293.copyBufferToBuffer(buffer92, 628, buffer106, 6100, 600);
+} catch {}
+let buffer129 = device2.createBuffer({size: 3332, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder299 = device2.createCommandEncoder({});
+let renderBundle187 = renderBundleEncoder18.finish();
+try {
+computePassEncoder67.setPipeline(pipeline31);
+} catch {}
+let promise41 = device2.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle161]);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer37, 'uint32', 248, 238);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(121), /* required buffer size: 121 */
+{offset: 121, bytesPerRow: 15}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer195 = commandEncoder299.finish({label: '\udefb\u{1f612}\uea1c\ua411\u6f7c\u0047\ue8a1\ucb69'});
+try {
+computePassEncoder59.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder293.copyTextureToTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 432, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder300 = device0.createCommandEncoder({label: '\u0ddd\u2356\u3648\u{1f7b2}\u0e70\u{1f73c}\u0aa5\ue0cf\u0ab7\u0e47'});
+let commandBuffer196 = commandEncoder300.finish({label: '\u5967\u08a3\u{1f7e2}\ua6be\u2d26\u0766\u38ab'});
+let renderBundle188 = renderBundleEncoder9.finish();
+try {
+computePassEncoder52.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder21.setViewport(305.1887049720507, 32.64079448565846, 0.23770287092346365, 13.705148503484489, 0.37383245668555865, 0.5783705600049978);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer38);
+} catch {}
+let shaderModule20 = device2.createShaderModule({
+  code: `
+struct T0 {
+  f0: atomic<i32>,
+}
+struct T1 {
+  f0: mat4x3h,
+}
+@group(0) @binding(451) var et52: texture_external;
+@group(0) @binding(12) var st25: texture_storage_2d_array<rg32float, read>;
+@group(0) @binding(63) var tex101: texture_cube_array<i32>;
+@group(0) @binding(32) var tex102: texture_2d<u32>;
+@group(0) @binding(259) var st27: texture_storage_2d_array<r32float, read_write>;
+@group(1) @binding(510) var<uniform> buffer135: vec4f;
+@group(0) @binding(93) var sam91: sampler;
+@group(0) @binding(430) var tex107: texture_cube_array<u32>;
+@group(0) @binding(180) var et53: texture_external;
+@group(0) @binding(3) var<storage, read> buffer131: vec3i;
+@group(0) @binding(215) var tex106: texture_depth_cube_array;
+@group(0) @binding(319) var<storage, read_write> buffer130: vec2i;
+@group(0) @binding(129) var<storage, read> buffer134: T1;
+@group(0) @binding(232) var<uniform> buffer132: array<vec2u, 1>;
+@group(0) @binding(192) var tex103: texture_3d<i32>;
+@group(0) @binding(611) var tex104: texture_depth_multisampled_2d;
+@group(0) @binding(8) var tex108: texture_multisampled_2d<f32>;
+@group(0) @binding(285) var st26: texture_storage_1d<r32uint, write>;
+@group(0) @binding(65) var<storage, read> buffer133: array<vec3i>;
+@group(0) @binding(84) var tex105: texture_depth_2d_array;
+@group(0) @binding(47) var sam92: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+  _ = textureGather(0, tex102, sam92, vec2f());
+}
+
+struct S6 {
+  @location(13) f0: vec2i,
+  @location(9) f1: vec2h
+}
+
+@vertex
+fn vertex0(a0: S6, @location(4) a1: f16) -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = textureLoad(st25, vec2i(), 0);
+  _ = a0.f1;
+  _ = textureSampleLevel(tex105, sam91, vec2f(), 0i, 0i);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3f,
+  @location(6) f1: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = buffer135;
+  textureStore(st27, vec2i(), 0, vec4f(0.01599, 0.1909, 0.02401, 0.1135));
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder301 = device2.createCommandEncoder({label: '\u1053\u5584\u297d\u15cb'});
+let sampler20 = device2.createSampler({
+  label: '\u0817\u{1f9bc}\u{1fa4c}\ue50e\u64c9\ud3ad\u{1f61c}\u0d2d\u2a44\u1457',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.69,
+  lodMaxClamp: 75.65,
+});
+try {
+commandEncoder298.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1260 */
+  offset: 1260,
+  bytesPerRow: 256,
+  buffer: buffer129,
+}, {width: 1, height: 101, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout42 = device2.createBindGroupLayout({
+  label: '\u391a\uf08e\u5cac\u3b4c\u0dee\u0517',
+  entries: [
+    {
+      binding: 187,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder302 = device2.createCommandEncoder({label: '\ub68b\u{1f6e2}'});
+let commandBuffer197 = commandEncoder298.finish({});
+let computePassEncoder68 = commandEncoder301.beginComputePass({label: '\ucdf2\u060f\u075b\u0960\u{1f8ab}\u0044\ub3a3\u8e20\u038e\u0d2c'});
+let textureView83 = texture7.createView({
+  label: '\ub68a\ube99\ucc91\u{1f711}\u07ae\ued17\ub695\ue5b5\u{1f88d}\uf873',
+  dimension: '3d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u00f2\u08b8\u{1fc59}\u{1f80c}\u3c15\u9bc5\u8b9e',
+  colorFormats: ['rg32uint'],
+  depthReadOnly: true,
+});
+let renderBundle189 = renderBundleEncoder3.finish({label: '\ua942\u{1f8d8}\u37a3\u{1fb41}\u{1f89c}\u07d8\u0c7d\u47a3\u0a45\u{1fdab}\u{1fb7e}'});
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer39, 0);
+} catch {}
+try {
+  await promise41;
+} catch {}
+let sampler21 = device4.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.17,
+  lodMaxClamp: 80.71,
+  compare: 'less',
+});
+let commandEncoder303 = device4.createCommandEncoder({label: '\u{1ffc0}\u06a2\u0e75\u0a78\u5048\u6e1f'});
+let commandBuffer198 = commandEncoder286.finish({label: '\u86f5\u{1f8bb}\u3e19'});
+try {
+gpuCanvasContext5.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandBuffer199 = commandEncoder302.finish({label: '\u{1f719}\u{1fe5c}\u0188\u4469\u{1fbe8}\udb28\u0d17\uc768'});
+try {
+commandEncoder293.copyBufferToBuffer(buffer92, 928, buffer106, 1264, 72);
+} catch {}
+await gc();
+let bindGroupLayout43 = device4.createBindGroupLayout({
+  label: '\u7a8b\u085a\u3e5d\u776e\u02de\u1fac\u5dbd\ubaee',
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandBuffer200 = commandEncoder303.finish();
+let texture102 = gpuCanvasContext6.getCurrentTexture();
+try {
+commandEncoder294.pushDebugGroup('\u{1f8ba}');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+let commandBuffer201 = commandEncoder293.finish({label: '\u{1f798}\ued73\u38a6\u3608\u{1f725}\u0186\u{1f6a5}'});
+let texture103 = device2.createTexture({
+  label: '\u{1f650}\uc81b\u{1fafd}\u9110\uc515\u0c5e\uddc8',
+  size: {width: 876, height: 1, depthOrArrayLayers: 23},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder67.setPipeline(pipeline27);
+} catch {}
+let renderBundleEncoder36 = device2.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthStencilFormat: 'stencil8', sampleCount: 1, depthReadOnly: true});
+let renderBundle190 = renderBundleEncoder18.finish();
+try {
+renderBundleEncoder32.setPipeline(pipeline34);
+} catch {}
+let renderPassEncoder66 = commandEncoder155.beginRenderPass({
+  label: '\u{1fbc1}\u2189\u1cb4',
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 66.91, g: 259.4, b: 589.7, a: -916.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 103255639,
+});
+try {
+renderPassEncoder42.setBlendConstant({ r: 503.7, g: -780.4, b: 404.8, a: 36.77, });
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: img9,
+  origin: { x: 5, y: 0 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 149, y: 27, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let video8 = await videoWithData();
+let computePassEncoder69 = commandEncoder296.beginComputePass({label: '\ud780\u058a\u{1fa75}\ucdaf\ua6b9\u0210\u{1f870}'});
+let renderBundle191 = renderBundleEncoder25.finish();
+try {
+computePassEncoder60.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer88, 'uint16', 898, 537);
+} catch {}
+let commandEncoder304 = device1.createCommandEncoder();
+let renderPassEncoder67 = commandEncoder304.beginRenderPass({
+  label: '\u0260\uaafd\u6b74\u0784',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 17,
+  clearValue: { r: -601.2, g: 183.2, b: 933.1, a: -131.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 18240918,
+});
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup6);
+} catch {}
+let commandEncoder305 = device0.createCommandEncoder({label: '\u15dc\u55e2\u{1fbb1}\u{1fa0d}\ud3bb\u{1fb6e}\u7ee0\u{1fa67}'});
+let texture104 = device0.createTexture({
+  label: '\u{1fe9b}\u0dd0\u13e0\u19d0\u5d9c\u5613\u09bb\u{1fe49}\u2cf6',
+  size: {width: 618, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder68 = commandEncoder305.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 700.7, g: -36.63, b: -91.63, a: 514.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 124032645,
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb']});
+let renderBundle192 = renderBundleEncoder35.finish({label: '\u{1f978}\u0e15\uae5f\u{1ff4a}\ub0b7\u0e27\u{1fd29}\u8ba5'});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline8);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let pipeline36 = await device0.createRenderPipelineAsync({
+  label: '\u0da3\u474b\u9d2b\u7c6d',
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm-srgb'}]},
+  vertex: {module: shaderModule2, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+adapter5.label = '\ud0ef\u{1fdae}\ud72f\u9f89\u085f';
+} catch {}
+let pipelineLayout25 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout31, bindGroupLayout32, bindGroupLayout32]});
+let commandEncoder306 = device2.createCommandEncoder({label: '\u{1fee4}\u0b17\u6254\u05ad'});
+let commandBuffer202 = commandEncoder306.finish({label: '\u06ec\u602c\u{1fe88}\u{1f618}\u8777\u0284\udeb1\ube84\udc16\udd97\u{1ff3b}'});
+let externalTexture38 = device2.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder32.setVertexBuffer(3, buffer93, 0, 3_935);
+} catch {}
+try {
+device2.queue.submit([commandBuffer152, commandBuffer199]);
+} catch {}
+let pipelineLayout26 = device4.createPipelineLayout({label: '\ub776\u02cf\u0c3a\uc32c\uec7a\ubaee\u8a53', bindGroupLayouts: []});
+let texture105 = device4.createTexture({
+  label: '\u0130\u235a\u545b\u2411\u586c\u{1f9cf}\u{1f9c5}',
+  size: {width: 864, height: 1, depthOrArrayLayers: 4},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+gpuCanvasContext5.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+video7.width = 8;
+let imageData28 = new ImageData(24, 4);
+let commandEncoder307 = device2.createCommandEncoder({});
+let commandBuffer203 = commandEncoder307.finish({label: '\u338d\u0e82\ua1b6'});
+try {
+renderBundleEncoder36.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer100, 0);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+device4.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(187), /* required buffer size: 187 */
+{offset: 187}, {width: 864, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder308 = device0.createCommandEncoder({label: '\u010c\u0abf\u7921\u672a'});
+let commandBuffer204 = commandEncoder159.finish();
+try {
+renderPassEncoder13.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(2, buffer38);
+} catch {}
+let commandEncoder309 = device1.createCommandEncoder({label: '\u1e71\ub625\u3b48\u7428\u453b\u07ab\u{1f7cd}\u0d0a\u8732'});
+let externalTexture39 = device1.importExternalTexture({label: '\u92c6\u6e58\u{1fc09}\u0a50', source: video8, colorSpace: 'display-p3'});
+try {
+computePassEncoder61.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(2, buffer128, 0, 641);
+} catch {}
+try {
+commandEncoder309.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 27, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageBitmap5 = await createImageBitmap(img11);
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer36, 0, 1_362);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(5, buffer63, 0, 1_128);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder310 = device4.createCommandEncoder({label: '\u{1f888}\u0cea\uc1a0\uee31\ucae9\u{1f8c5}\u07ab'});
+let renderBundle193 = renderBundleEncoder32.finish();
+try {
+device2.queue.writeBuffer(buffer129, 1880, new BigUint64Array(26562), 2146, 8);
+} catch {}
+document.body.prepend(canvas7);
+let bindGroupLayout44 = device4.createBindGroupLayout({
+  label: '\ubdd9\u8206\uc91e\u{1f9e8}\u0454\uceb7\u{1fbfd}',
+  entries: [
+    {
+      binding: 148,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandBuffer205 = commandEncoder310.finish({label: '\uf479\u452b\u2a28\u112c\u688c\u{1f738}'});
+let textureView84 = texture105.createView({
+  label: '\u0a98\u6285\u087a\ua7c2\u{1f705}\u0609\u0a8e\u0528\u0a34',
+  dimension: '2d',
+  arrayLayerCount: 1,
+});
+try {
+device4.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture106 = gpuCanvasContext6.getCurrentTexture();
+try {
+commandEncoder294.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder311 = device3.createCommandEncoder();
+try {
+commandEncoder311.clearBuffer(buffer120, 1284, 2496);
+} catch {}
+let promise42 = device3.queue.onSubmittedWorkDone();
+let buffer136 = device3.createBuffer({
+  label: '\ub454\u014f',
+  size: 884,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder312 = device3.createCommandEncoder({label: '\u0a18\u879f\udfa1\u0116\u057d\u0b67\u{1faf3}'});
+let querySet43 = device3.createQuerySet({label: '\uea94\ufea4\u4a3b\uae82\u1dd4', type: 'occlusion', count: 369});
+let commandBuffer206 = commandEncoder312.finish();
+let textureView85 = texture92.createView({label: '\ue374\u51fa\u8f57\u{1fe12}\u{1fba6}', baseArrayLayer: 0});
+let computePassEncoder70 = commandEncoder311.beginComputePass({label: '\u0d25\u0c9a\u14de\ua78d\u17b7\ud048\u8c3d\uc318\u03bb'});
+try {
+buffer120.unmap();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer136, 224, new Int16Array(3019), 1734, 40);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let computePassEncoder71 = commandEncoder294.beginComputePass({label: '\u279a\u{1ff7f}\u2cf7\u0dfb\u0486\u{1f965}\u5560\u{1f8ec}\u5321'});
+try {
+computePassEncoder71.end();
+} catch {}
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+let commandEncoder313 = device3.createCommandEncoder({label: '\u3353\u04c3\u{1f890}'});
+let commandBuffer207 = commandEncoder294.finish({label: '\u682a\ub516\u{1f91e}\u6f74\u785f'});
+try {
+gpuCanvasContext2.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let renderBundle194 = renderBundleEncoder36.finish({label: '\u0a0f\u{1fabe}\u0eba\u021e\u538d\u{1ff5e}\u{1fe08}'});
+try {
+device2.queue.submit([commandBuffer197]);
+} catch {}
+let computePassEncoder72 = commandEncoder297.beginComputePass({label: '\u7cd2\u5196\u{1ff12}'});
+try {
+device3.queue.writeBuffer(buffer120, 552, new BigUint64Array(23915), 12924, 80);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder73 = commandEncoder309.beginComputePass({label: '\uf27f\u1572\u{1fd55}'});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(1, buffer128, 8_172, 1_468);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer117, 1188, new BigUint64Array(611), 33, 16);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let canvas8 = document.createElement('canvas');
+let computePassEncoder74 = commandEncoder313.beginComputePass({label: '\u0acd\u{1fd6b}\u0018'});
+try {
+computePassEncoder23.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer37, 0, 216);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(0, undefined, 859_951_749, 13_273_629);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer114, 'uint16', 9_318, 0);
+} catch {}
+let commandEncoder314 = device2.createCommandEncoder({});
+let querySet44 = device2.createQuerySet({label: '\u078d\u{1ff85}\u930f\u0708\u01d2', type: 'occlusion', count: 1944});
+let commandBuffer208 = commandEncoder314.finish();
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline31);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let device5 = await adapter5.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let commandEncoder315 = device5.createCommandEncoder({label: '\uc7ee\u0a5e\u0556\udbf5\u015d\u{1fee8}\u{1f734}\u200e\u6156\u0b05'});
+let commandBuffer209 = commandEncoder315.finish({label: '\u3204\u1e9f\u89ad\ud995\u9fe4\uafca'});
+let img14 = await imageWithData(52, 1, '#10101010', '#20202020');
+try {
+adapter6.label = '\uc0f8\udf68\u7273\u4a4c';
+} catch {}
+try {
+device2.queue.label = '\uf881\u{1fefa}\ueca0\u8550\u6bc4\uf192\u06b5';
+} catch {}
+let pipelineLayout27 = device2.createPipelineLayout({label: '\u33b2\ua25b', bindGroupLayouts: [bindGroupLayout42, bindGroupLayout32]});
+try {
+computePassEncoder67.setPipeline(pipeline30);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer129, 60, new DataView(new ArrayBuffer(17073)), 866, 544);
+} catch {}
+let gpuCanvasContext13 = canvas8.getContext('webgpu');
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+let pipeline37 = device1.createRenderPipeline({
+  label: '\u0ece\u0553\u94a4\u{1fba1}',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilWriteMask: 1910820957,
+    depthBias: -1918917300,
+    depthBiasClamp: 410.34650247897224,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 124, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'unorm8x2', offset: 126, shaderLocation: 14}]},
+      {arrayStride: 28, stepMode: 'instance', attributes: []},
+      {arrayStride: 412, stepMode: 'instance', attributes: []},
+      {arrayStride: 224, stepMode: 'instance', attributes: []},
+      {arrayStride: 284, attributes: []},
+      {
+        arrayStride: 604,
+        attributes: [
+          {format: 'float32x2', offset: 36, shaderLocation: 5},
+          {format: 'sint32x3', offset: 24, shaderLocation: 15},
+          {format: 'sint32', offset: 160, shaderLocation: 13},
+          {format: 'float32x4', offset: 116, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'none', unclippedDepth: true},
+});
+let texture107 = device1.createTexture({
+  label: '\u045e\u0a78\u350a',
+  size: {width: 104, height: 96, depthOrArrayLayers: 54},
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder51.setVertexBuffer(6, buffer128, 2_944, 3_953);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: canvas0,
+  origin: { x: 39, y: 21 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 54},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer210 = commandEncoder301.finish({label: '\uc6bd\u2b9e\u{1f7ca}\u43a6'});
+let renderBundle195 = renderBundleEncoder36.finish({});
+let bindGroup14 = device1.createBindGroup({
+  label: '\uf171\u8d62\u{1f66f}\u4028\u{1f8f0}\u{1ffad}',
+  layout: bindGroupLayout18,
+  entries: [{binding: 94, resource: sampler16}],
+});
+let commandEncoder316 = device1.createCommandEncoder();
+let textureView86 = texture86.createView({label: '\u51c7\uec04\ufcf1\u63ca\ubefd\ued51\u97b8\uf9ea', baseMipLevel: 3});
+let computePassEncoder75 = commandEncoder316.beginComputePass({label: '\u0990\u{1fe2d}'});
+let externalTexture40 = device1.importExternalTexture({source: video6, colorSpace: 'display-p3'});
+try {
+computePassEncoder61.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer128, 740, 383);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer117, 3716, new DataView(new ArrayBuffer(2054)), 460, 276);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 2, y: 3 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 33, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder317 = device2.createCommandEncoder({label: '\uf750\u9f46'});
+let commandBuffer211 = commandEncoder317.finish({label: '\u0e79\u{1ff46}\u9b41\u016b\u005e\u{1fff5}'});
+try {
+computePassEncoder67.setPipeline(pipeline32);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline19);
+} catch {}
+let buffer137 = device2.createBuffer({
+  label: '\u{1fe98}\u02eb\u02f0\u6681\u{1fa4b}\u{1fbb9}\ud3f2',
+  size: 19701,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder318 = device2.createCommandEncoder({label: '\u33a1\u0144\u65c8\ud83c'});
+let texture108 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder67.setPipeline(pipeline28);
+} catch {}
+try {
+gpuCanvasContext7.configure({device: device2, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder319 = device2.createCommandEncoder({label: '\u{1fd40}\u0062\u{1f8de}\u00fc'});
+let commandEncoder320 = device3.createCommandEncoder({label: '\u{1ff9a}\u24ba\u8214\u{1f9ea}\u0868\uca35\uf973'});
+let renderBundle196 = renderBundleEncoder30.finish({label: '\u09b9\u511c\u0dbb\u73ef\u0078\u0a06\ue6e9'});
+try {
+computePassEncoder72.end();
+} catch {}
+let commandEncoder321 = device1.createCommandEncoder({label: '\u2214\u0932'});
+let renderPassEncoder69 = commandEncoder124.beginRenderPass({
+  label: '\u{1f9b5}\u1391\u0a59\ue820\u{1ff9f}',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 19,
+  clearValue: { r: -826.6, g: 357.5, b: -912.6, a: -865.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder51.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup14, new Uint32Array(113), 24, 0);
+} catch {}
+try {
+renderPassEncoder59.setViewport(50.022892608004426, 24.01187728544198, 0.11767039722702054, 3.8528629704263935, 0.26247383558200876, 0.7903361249527733);
+} catch {}
+let commandBuffer212 = commandEncoder320.finish({label: '\u1f93\u393f\u3e5e\ud8e7\u0fa6\u{1f6cd}\u9e8f\u8441\uf162\ua37b\ua175'});
+let textureView87 = texture85.createView({label: '\u0592\u0920\u633b'});
+let renderBundle197 = renderBundleEncoder33.finish({label: '\u{1ffb1}\u7742\u03e8'});
+let computePassEncoder76 = commandEncoder93.beginComputePass();
+let renderPassEncoder70 = commandEncoder308.beginRenderPass({
+  label: '\u96c3\u{1f9bf}\u0efe\ueeb6\u753c\u{1fafc}\u0590\u060a\u5a30\u7806\u{1f826}',
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 568.8, g: -967.3, b: 910.9, a: 367.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 4703528,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+  await promise42;
+} catch {}
+let renderBundleEncoder38 = device5.createRenderBundleEncoder({
+  label: '\u287a\u2c58\u{1f787}\u0847\u{1f912}\u{1f873}\u92d3\ucf4c\uce21',
+  colorFormats: ['rgba16sint'],
+  depthReadOnly: true,
+});
+try {
+gpuCanvasContext6.configure({
+  device: device5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let promise43 = device5.queue.onSubmittedWorkDone();
+try {
+  await promise43;
+} catch {}
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+try {
+device4.queue.submit([commandBuffer200]);
+} catch {}
+let commandBuffer213 = commandEncoder319.finish({});
+let textureView88 = texture81.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 1});
+let computePassEncoder77 = commandEncoder318.beginComputePass({label: '\u00f0\uff2e\u79a3\u0c9b\u0ec7\u{1f932}\u7213\ud591\u2e7d\u02de'});
+try {
+buffer137.unmap();
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder322 = device5.createCommandEncoder({label: '\u4889\uffb1\u0592\u{1fa7c}\u{1f7cf}\u88de\u0692\u{1ff8e}\u982d\u06e6\ued87'});
+let commandEncoder323 = device2.createCommandEncoder({label: '\uc48e\u{1fb89}\u0e9a'});
+try {
+commandEncoder323.clearBuffer(buffer106);
+} catch {}
+try {
+computePassEncoder54.pushDebugGroup('\u{1fcdd}');
+} catch {}
+try {
+device2.queue.submit([commandBuffer195]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+video5.height = 4;
+let buffer138 = device5.createBuffer({
+  label: '\u0e18\uf4d2\u5d63\u0e29\u8367\u2eeb\ue1bb\ubc3a\u07ee\u583d\u{1fc59}',
+  size: 5689,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder324 = device5.createCommandEncoder();
+let commandBuffer214 = commandEncoder324.finish({});
+let texture109 = device5.createTexture({
+  label: '\u32a2\u366d\u09c0\u03bc\u{1f9a1}\u03a8\u0107\ubd64\u0d21\uc3dd',
+  size: [3, 2, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder38.insertDebugMarker('\u1a78');
+} catch {}
+let commandBuffer215 = commandEncoder297.finish({label: '\ud7bc\uc134\u0195\u00a8\u3a42\u6c58\u{1f7ec}\u9b4f'});
+let promise44 = navigator.gpu.requestAdapter({});
+try {
+adapter2.label = '\u026e\u{1f737}\u{1fd50}\u012a';
+} catch {}
+try {
+computePassEncoder58.popDebugGroup();
+} catch {}
+try {
+device3.queue.submit([commandBuffer212]);
+} catch {}
+let texture110 = device1.createTexture({
+  label: '\uc453\u{1fb21}\u2a26',
+  size: {width: 104, height: 96, depthOrArrayLayers: 47},
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer114, 'uint16', 1_176, 355);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(4, buffer128, 2_832, 5_582);
+} catch {}
+let promise45 = navigator.gpu.requestAdapter({});
+let commandEncoder325 = device5.createCommandEncoder({label: '\u{1fce0}\ub412\u{1f7b7}\u0e4e\u0bd0\u{1f887}\ue198\u{1f7eb}\u{1f8c4}\u6151'});
+try {
+device5.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer150]);
+} catch {}
+let promise46 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 618, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 3, y: 17 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 231, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise46;
+} catch {}
+let bindGroupLayout45 = device1.createBindGroupLayout({
+  label: '\u9617\u0819\ud87f\ua1cc\u03fc\u599a\u9d64\ua82b',
+  entries: [
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 222,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 319,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 193,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 3, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 275,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 57, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {binding: 164, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 419, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 322,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 331,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 693,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 343,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {binding: 368, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 140,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 318,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 326,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 246,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 955,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 111, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 52,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 41343077, hasDynamicOffset: false },
+    },
+    {
+      binding: 172,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 300,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 491,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 11215213, hasDynamicOffset: false },
+    },
+    {binding: 44, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 168,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 175,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 731,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 317,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 431,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 138, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 2438639, hasDynamicOffset: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 143,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 466, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 31, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 417,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 163, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 135, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 63, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 125,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 118, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 754, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 302, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 528, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 112, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 11333914, hasDynamicOffset: false },
+    },
+    {binding: 181, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 369,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 12, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 40, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 23, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 55, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 187, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 273, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 259, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 288, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 93, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 406,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder326 = device1.createCommandEncoder();
+let commandBuffer216 = commandEncoder326.finish({label: '\u2651\u27ac\u0bbb\u00cd\u1bf2\uf067\u632d\ub422\u0980\u090e'});
+let renderPassEncoder71 = commandEncoder321.beginRenderPass({
+  label: '\u0830\u002a\u{1fe0a}',
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 277.3, g: -312.5, b: -771.8, a: 629.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 102123294,
+});
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup2);
+} catch {}
+let commandEncoder327 = device1.createCommandEncoder({});
+let commandBuffer217 = commandEncoder327.finish();
+let renderBundle198 = renderBundleEncoder11.finish({label: '\u0be4\u0183\u{1fe10}\u4dba\u0052\u{1f74e}\u02fb\u{1f915}'});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(6, buffer36, 0, 774);
+} catch {}
+let arrayBuffer20 = buffer71.getMappedRange(488, 768);
+let bindGroupLayout46 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 235, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 163,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 250,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 81,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 180,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 93,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 277,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 161,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 22, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 36970602, hasDynamicOffset: false },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 483, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 28,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 367, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 254,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 53, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 189, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 69,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 301,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 461,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 984, hasDynamicOffset: true },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 12107258, hasDynamicOffset: false },
+    },
+    {binding: 106, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 491, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {binding: 608, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 199,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 164,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 173,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {binding: 54, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 159, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 19, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 999,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 785, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 91,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 712, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 52,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 25, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 57, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder328 = device4.createCommandEncoder({label: '\u{1fd5b}\u06eb\u0bc2\ua61f\u0e5f'});
+let commandBuffer218 = commandEncoder328.finish({});
+document.body.prepend(canvas4);
+let commandBuffer219 = commandEncoder222.finish({label: '\u4864\u047e\u63d7\uaa79\ubf04\u4b53'});
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer64, 'uint16', 78, 7_221);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 584, new Int16Array(6400), 1220, 4);
+} catch {}
+await gc();
+let imageData29 = new ImageData(20, 16);
+let textureView89 = texture85.createView({label: '\u0e0e\uab1a\u6411\u5439\uec9b\ub1d6\u154d\uf758\u{1fca1}\u0346'});
+try {
+computePassEncoder74.insertDebugMarker('\u064d');
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline38 = await device3.createRenderPipelineAsync({
+  label: '\u{1f927}\u6653\u{1fa25}\u0419\ua26f\ud417\u4edb\u622b\u0aa8\uc2a3\u{1f7b2}',
+  layout: pipelineLayout22,
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'keep'},
+    stencilReadMask: 50863580,
+    depthBias: -1572346931,
+    depthBiasClamp: 998.8878810940853,
+  },
+  vertex: {
+    module: shaderModule17,
+    buffers: [
+      {arrayStride: 192, attributes: []},
+      {arrayStride: 460, stepMode: 'instance', attributes: []},
+      {arrayStride: 52, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1528, attributes: []},
+      {arrayStride: 100, attributes: []},
+      {arrayStride: 140, stepMode: 'instance', attributes: []},
+      {arrayStride: 44, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 60,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 0, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+await gc();
+let imageBitmap6 = await createImageBitmap(canvas1);
+let bindGroupLayout47 = device2.createBindGroupLayout({
+  label: '\ue596\u{1fea4}\u0b70\uf79d\ub3aa\uf07a\u{1fe7e}\u5e18\u125d\ud5b1',
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let computePassEncoder78 = commandEncoder323.beginComputePass({});
+let renderBundle199 = renderBundleEncoder18.finish({});
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(6, buffer138, 236);
+} catch {}
+try {
+device2.queue.submit([commandBuffer202, commandBuffer183, commandBuffer203]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer137, 9200, new Int16Array(6353), 1001, 808);
+} catch {}
+let promise47 = device2.queue.onSubmittedWorkDone();
+let buffer139 = device1.createBuffer({
+  label: '\uda27\u{1fcd9}\u{1f892}\udd34\u30c1\u00e9\u3936\u194d\ub963',
+  size: 4020,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle200 = renderBundleEncoder21.finish({label: '\ud637\u{1fcb9}\u0e7e\u{1f871}\u0524\ud404\u4cf5\ucf2f\udbd8\u03e6\ud38e'});
+try {
+computePassEncoder61.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(3, 3, 12, 8);
+} catch {}
+let buffer140 = device4.createBuffer({
+  label: '\u08e2\ub9fd\uaf12\ubf48\u5585\u5561',
+  size: 20242,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle201 = renderBundleEncoder20.finish({label: '\ud8dd\u{1feda}\uc8c1\u0785'});
+try {
+computePassEncoder77.setPipeline(pipeline30);
+} catch {}
+let commandEncoder329 = device3.createCommandEncoder({label: '\udc10\u{1f89c}\udb63\u16dd\ub356\u{1f9eb}\u8580\u0fb0\u27c3'});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+computePassEncoder74.insertDebugMarker('\uae0d');
+} catch {}
+let img15 = await imageWithData(27, 67, '#10101010', '#20202020');
+let pipelineLayout28 = device0.createPipelineLayout({
+  label: '\u{1fa02}\u08e6\u6334\u0f9f\u{1f829}\u{1fb8b}\ua6c0\udd62\u0cff\uae36',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout2, bindGroupLayout2, bindGroupLayout13],
+});
+let commandEncoder330 = device0.createCommandEncoder({label: '\ub0ad\u{1f689}\u4df6\u{1f896}\u25b3\u5074\ueca5\u5142\u{1fb9a}\u0653'});
+let commandBuffer220 = commandEncoder330.finish({label: '\u0b29\u0100\u0034\u{1f9fc}'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup8, new Uint32Array(346), 78, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer90, 'uint32', 17_500, 70);
+} catch {}
+let commandBuffer221 = commandEncoder325.finish();
+let computePassEncoder79 = commandEncoder322.beginComputePass({label: '\ucec1\u{1fe9a}\u{1fd1f}'});
+try {
+renderBundleEncoder38.setVertexBuffer(5, buffer138, 0, 13);
+} catch {}
+try {
+device5.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await promise47;
+} catch {}
+let pipelineLayout29 = device3.createPipelineLayout({
+  label: '\u{1fa03}\u59b1\ua224\u5ab2\u5877\u4edc',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37],
+});
+try {
+computePassEncoder70.insertDebugMarker('\u2caf');
+} catch {}
+let imageBitmap7 = await createImageBitmap(imageBitmap3);
+try {
+computePassEncoder67.setPipeline(pipeline32);
+} catch {}
+try {
+buffer137.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer149, commandBuffer130]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline39 = device2.createRenderPipeline({
+  layout: pipelineLayout23,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 1788828535,
+  },
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 20, stepMode: 'instance', attributes: []},
+      {arrayStride: 404, stepMode: 'instance', attributes: []},
+      {arrayStride: 432, attributes: [{format: 'float32', offset: 32, shaderLocation: 9}]},
+      {arrayStride: 276, attributes: []},
+      {arrayStride: 160, stepMode: 'instance', attributes: []},
+      {arrayStride: 140, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 380,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 0, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 56, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let texture111 = device5.createTexture({
+  size: [400],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder331 = device0.createCommandEncoder({label: '\u016a\uf77f\u0f48\u0625\u3f67\u352c'});
+let renderPassEncoder72 = commandEncoder331.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -85.13, g: 990.7, b: 223.6, a: 571.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 529907543,
+});
+let renderBundle202 = renderBundleEncoder2.finish({label: '\u4c37\u13c6\u096f'});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup12, new Uint32Array(620), 37, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder43.beginOcclusionQuery(222);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer89, 'uint16', 260, 1_933);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer59, 'uint16', 3_490, 1_318);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline14);
+} catch {}
+await gc();
+try {
+computePassEncoder77.pushDebugGroup('\u{1fa29}');
+} catch {}
+let pipelineLayout30 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout38, bindGroupLayout18]});
+try {
+computePassEncoder75.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup4, new Uint32Array(1218), 222, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+buffer128.unmap();
+} catch {}
+let commandEncoder332 = device3.createCommandEncoder({label: '\u992e\u{1fa85}\ua141\u4c2c\u{1fc58}\u0a07\u{1f74c}\u3ecc\u58cf'});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder333 = device1.createCommandEncoder({label: '\u{1f60b}\ue134\u3e0d\u0ed2\ufd28\u0e3b\u{1fd6a}\u0308\u1a4d\u0dd6\u{1f6dd}'});
+let texture112 = device1.createTexture({
+  label: '\u0e01\ue0b4\u999a\u3cc2\u33ee\ua999\u{1fe4d}',
+  size: [13, 12, 81],
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder80 = commandEncoder333.beginComputePass({label: '\u094c\u{1feb2}\ub48f\u04de\u0825\u{1fda5}\u4de9\u8725\u{1fb72}\u3f1e'});
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer114, 'uint16', 458, 2_613);
+} catch {}
+let promise48 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise48;
+} catch {}
+let renderBundle203 = renderBundleEncoder15.finish({label: '\u4f2c\u{1fc39}'});
+try {
+renderPassEncoder19.setIndexBuffer(buffer59, 'uint16', 1_558, 680);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 1060, new BigUint64Array(4868), 2085, 344);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(img3);
+let commandEncoder334 = device4.createCommandEncoder({label: '\u092b\u1834\u00c2'});
+let buffer141 = device2.createBuffer({
+  label: '\u1ba2\u1c49\u2ff3\ue448\ud80a\u0906\u{1f984}\u{1faa5}\u90c5\uef5f',
+  size: 7325,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let texture113 = gpuCanvasContext11.getCurrentTexture();
+try {
+computePassEncoder59.setPipeline(pipeline30);
+} catch {}
+let commandEncoder335 = device3.createCommandEncoder({});
+let texture114 = device3.createTexture({
+  label: '\u0cbf\u{1f61f}\u5f78\u08f2\u{1f9b8}\uff54\u0fd5\u{1f992}\ude29',
+  size: {width: 147, height: 6, depthOrArrayLayers: 43},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device3.queue.submit([commandBuffer165]);
+} catch {}
+await gc();
+let commandEncoder336 = device1.createCommandEncoder({});
+let commandBuffer222 = commandEncoder336.finish({label: '\u033b\u007a\u{1f790}\u2e7b\u{1fb81}\uc391\ucf71\uf0aa\u0a76\uaafb\u007c'});
+let commandEncoder337 = device4.createCommandEncoder({label: '\uaafa\u7368\u0286\u5fd3'});
+let textureView90 = texture105.createView({label: '\u0939\u0dbb\ua76b', dimension: '2d', aspect: 'stencil-only'});
+let computePassEncoder81 = commandEncoder337.beginComputePass({label: '\u04e2\ucefa\u3d9d\ub0c7\udd27\u{1fd85}\u0d3d\u6c46\ue20a'});
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout48 = device0.createBindGroupLayout({
+  label: '\u{1fc81}\ufbe4\u{1fda4}\u5674\u095e\ua174\u00f2\u057d\u{1fffe}\u14c8',
+  entries: [
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let renderBundle204 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer151, commandBuffer191]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 308, new DataView(new ArrayBuffer(6733)), 1241);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandEncoder338 = device3.createCommandEncoder();
+let querySet45 = device3.createQuerySet({
+  label: '\u49b6\u04b3\u0a35\u{1f87b}\uf28c\ua834\u0d21\ue136\ua532\uf222\u{1ff04}',
+  type: 'occlusion',
+  count: 181,
+});
+try {
+commandEncoder335.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 664 */
+  offset: 664,
+  bytesPerRow: 256,
+  buffer: buffer136,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 10, y: 202, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 50, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder54.popDebugGroup();
+} catch {}
+try {
+device2.queue.submit([commandBuffer144, commandBuffer124]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer137, 888, new Int16Array(4875), 750, 1768);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder339 = device3.createCommandEncoder({label: '\u1715\u42ba\u01cc\u{1f6a1}\u0663\u71d5\uf5bb'});
+let externalTexture41 = device5.importExternalTexture({label: '\u8ef9\u06ba\u{1fdaa}', source: video7});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+await gc();
+let bindGroupLayout49 = device2.createBindGroupLayout({
+  label: '\uef6e\u0838\u{1fbd1}\ubc02\u{1fd8f}\u{1ff03}\u9ac6\u0cfc',
+  entries: [
+    {
+      binding: 405,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 231,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 251,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 306,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 280,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 7374952, hasDynamicOffset: false },
+    },
+    {
+      binding: 511,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 204,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 170,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 309, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 221, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 262,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 96801252, hasDynamicOffset: false },
+    },
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 74,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 159,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 272, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 447,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 199,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 13, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 476, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 952512, hasDynamicOffset: false },
+    },
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 792,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 84, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 87, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 436,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 457,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 250,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 440,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 665734, hasDynamicOffset: false },
+    },
+    {binding: 608, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 156, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 18, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 2, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 147, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 166,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 105, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 194,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 413,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 10, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 9, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 245,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 110, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 135, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 146, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 433, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 114, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 228,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 295,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 202, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 108, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 152, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 201, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 5, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 71, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 215, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 388, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 64, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 125, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 43, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+try {
+computePassEncoder77.popDebugGroup();
+} catch {}
+offscreenCanvas3.width = 187;
+await gc();
+try {
+commandBuffer218.label = '\uff79\u{1fb4a}\u{1f7e8}\u{1f655}\u23da\u{1fa72}\u{1ff71}\u09db';
+} catch {}
+let commandBuffer223 = commandEncoder334.finish({label: '\u0dd6\ua775\u418e\uc6e6\u0620\ub707\uc123\u{1fa6c}'});
+let commandEncoder340 = device2.createCommandEncoder({label: '\u{1fcda}\uf94b\u0387\u483d'});
+let texture115 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder54.insertDebugMarker('\u09e3');
+} catch {}
+try {
+device2.queue.submit([commandBuffer213]);
+} catch {}
+let renderBundle205 = renderBundleEncoder11.finish();
+try {
+computePassEncoder35.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(0, bindGroup5, new Uint32Array(3023), 90, 0);
+} catch {}
+try {
+renderPassEncoder42.end();
+} catch {}
+try {
+buffer114.unmap();
+} catch {}
+await gc();
+let commandEncoder341 = device0.createCommandEncoder({label: '\udece\u{1fa49}'});
+let querySet46 = device0.createQuerySet({label: '\u9a01\u{1fb28}\u0998\ucbd0\u06cb\u8c89', type: 'occlusion', count: 1797});
+let renderPassEncoder73 = commandEncoder341.beginRenderPass({
+  label: '\ua682\u925c\uff3a\u{1fd61}\u{1fd85}\ufff1\u09bc\u{1fe16}\u4aca\uc6f5',
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -870.4, g: -470.1, b: -550.3, a: 245.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder36.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle150]);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer64, 'uint32', 6_076, 1_264);
+} catch {}
+let bindGroup15 = device1.createBindGroup({layout: bindGroupLayout26, entries: []});
+try {
+computePassEncoder75.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer139, 3_684, 67);
+} catch {}
+let pipelineLayout31 = device1.createPipelineLayout({label: '\u{1fd3d}\u{1fffc}\u6f66\u58e3', bindGroupLayouts: [bindGroupLayout45, bindGroupLayout41]});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(97);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder342 = device4.createCommandEncoder();
+try {
+computePassEncoder75.setBindGroup(0, bindGroup14, new Uint32Array(3171), 1323, 0);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(2, buffer128, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer217, commandBuffer186]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let imageData30 = new ImageData(48, 28);
+let commandEncoder343 = device3.createCommandEncoder({label: '\uf757\ubc99\u17e8\ucdcf'});
+let computePassEncoder82 = commandEncoder335.beginComputePass();
+try {
+commandEncoder339.copyBufferToBuffer(buffer136, 24, buffer127, 296, 248);
+} catch {}
+try {
+commandEncoder332.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 496 */
+  offset: 496,
+  bytesPerRow: 256,
+  rowsPerImage: 232,
+  buffer: buffer136,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 309, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 160, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.submit([commandBuffer159, commandBuffer185, commandBuffer215]);
+} catch {}
+let externalTexture42 = device2.importExternalTexture({label: '\u370d\u0860', source: video8});
+try {
+computePassEncoder59.setPipeline(pipeline32);
+} catch {}
+try {
+commandEncoder340.copyBufferToBuffer(buffer141, 136, buffer106, 4476, 196);
+} catch {}
+let computePassEncoder83 = commandEncoder337.beginComputePass({});
+let renderBundleEncoder39 = device4.createRenderBundleEncoder({
+  label: '\u58f2\u0043\ubc29\uff80\u{1ff3d}',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder83.end();
+} catch {}
+try {
+commandEncoder337.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 864, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder344 = device0.createCommandEncoder({label: '\ufaed\u0168\u{1f86a}\u6c2d\u05ce\uef5b\u01ed\u{1fb8a}\u025b\u0738\u1909'});
+let commandBuffer224 = commandEncoder344.finish();
+let renderBundle206 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(3, bindGroup1, new Uint32Array(1246), 52, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder43.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle4, renderBundle134, renderBundle204]);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline12);
+} catch {}
+let commandEncoder345 = device1.createCommandEncoder();
+let texture116 = device1.createTexture({
+  label: '\u0cdc\ub7e8\ud291\u{1f85d}\ude76\u8e20',
+  size: [13, 12, 12],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder74 = commandEncoder345.beginRenderPass({
+  label: '\u{1fea3}\u0735\u1e63\u6846\u{1f88b}\u036c',
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 292.4, g: 365.9, b: 939.8, a: -703.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet27,
+  maxDrawCount: 21530663,
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let commandBuffer225 = commandEncoder329.finish({label: '\u001d\u0c19'});
+let commandEncoder346 = device0.createCommandEncoder();
+let textureView91 = texture49.createView({label: '\u0c90\ucd2b\u{1fb0e}\u{1f6ad}\u01ad\u{1fa67}', baseMipLevel: 4, baseArrayLayer: 0});
+let renderPassEncoder75 = commandEncoder346.beginRenderPass({
+  label: '\u{1fcfa}\u0077',
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 0,
+  clearValue: { r: -167.1, g: -838.9, b: -393.8, a: -568.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer220, commandBuffer145]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer226 = commandEncoder337.finish({});
+let renderBundleEncoder40 = device4.createRenderBundleEncoder({
+  label: '\u90d4\u{1fab5}\u{1f7c7}\ub304\u0728\ud6c2\u6b1e',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder39.setIndexBuffer(buffer140, 'uint16', 1_100, 8_742);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(6, undefined, 0, 934_558_092);
+} catch {}
+let imageData31 = new ImageData(72, 44);
+let commandBuffer227 = commandEncoder340.finish({label: '\ufd04\ub0dc\u{1fb25}\u0747\u{1f9cc}\u{1fc7c}\uccbc\ub55f\ubb09\u4268\u0bc7'});
+try {
+device2.queue.writeBuffer(buffer137, 1132, new Int16Array(2789), 97, 4);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(36_854), /* required buffer size: 36_854 */
+{offset: 260, bytesPerRow: 441, rowsPerImage: 41}, {width: 432, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle62, renderBundle78]);
+} catch {}
+let arrayBuffer21 = buffer115.getMappedRange(160, 336);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+try {
+externalTexture17.label = '\u93d3\u0737\uae96\u0271\u{1fe4a}\ua688\u0ae8\ud15b\u0721\u0b18\u2daf';
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup1, new Uint32Array(878), 113, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle202]);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup0, new Uint32Array(1988), 8, 0);
+} catch {}
+let texture117 = device1.createTexture({
+  label: '\u559e\u{1f900}\u04cb\ud516\u4f22\ue29c\u03c8',
+  size: [13],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder74.setStencilReference(744);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let renderBundle207 = renderBundleEncoder1.finish({label: '\ua2e5\u048e'});
+try {
+renderPassEncoder56.setScissorRect(1, 8, 14, 0);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup10, new Uint32Array(688), 319, 0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(4, buffer39, 0, 11_024);
+} catch {}
+try {
+device0.queue.submit([commandBuffer118]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+textureView30.label = '\u839b\u095f\ua14a\ue56f\u6ba1\u36d3\u6f25\u0c88\u{1f7d1}\u62bd';
+} catch {}
+let commandEncoder347 = device1.createCommandEncoder();
+let commandBuffer228 = commandEncoder347.finish({label: '\u{1fd66}\u0c61\ue3d4\ua0ca'});
+let texture118 = device1.createTexture({
+  label: '\ud886\u{1f725}\u042d\u7b3e\u2fd7\ub816\u073f',
+  size: [104, 96, 12],
+  sampleCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup6, new Uint32Array(524), 39, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup14, new Uint32Array(1088), 251, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 12, depthOrArrayLayers: 86}
+*/
+{
+  source: imageData22,
+  origin: { x: 16, y: 0 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder348 = device5.createCommandEncoder();
+try {
+renderBundleEncoder38.setVertexBuffer(7, buffer138, 1_440);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+computePassEncoder28.setBindGroup(0, bindGroup12, new Uint32Array(2134), 216, 0);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+let pipelineLayout32 = device4.createPipelineLayout({
+  label: '\u01cf\u{1f634}\u{1fdea}\u{1fe2c}',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout44, bindGroupLayout43],
+});
+let renderBundle208 = renderBundleEncoder40.finish({label: '\u73e6\ub61c\u0966\u01a9\u0f6e\ub6fc\u2b54\u0ce8\u438c\u60a4\u31d7'});
+try {
+renderBundleEncoder39.setIndexBuffer(buffer140, 'uint16', 1_378, 2_405);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandBuffer229 = commandEncoder332.finish({});
+let renderBundleEncoder41 = device3.createRenderBundleEncoder({
+  label: '\u0860\ud38f\u92b0\u{1fe30}\u72db\u293a\u0b75\u85b2',
+  colorFormats: ['rg32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle209 = renderBundleEncoder41.finish({label: '\u9b93\uc610\u2dcf\u0b7e\uac8c\u{1fc77}\ue0b8\u{1f818}\u{1f976}\u52c6\u7979'});
+document.body.prepend(canvas0);
+let shaderModule21 = device0.createShaderModule({
+  label: '\ud3c7\u681e\u08ca\u49ab\u6b4c',
+  code: `
+struct T0 {
+  f0: mat3x3h,
+}
+@group(1) @binding(3) var sam93: sampler_comparison;
+@group(0) @binding(102) var tex110: texture_3d<f32>;
+@group(0) @binding(492) var tex109: texture_cube<i32>;
+struct S8 {
+  @builtin(local_invocation_id) f0: vec3u
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(a0: S8) {
+  if bool(textureLoad(tex110, vec3i(), 0)[1]) {
+    return;
+  }
+}
+
+struct S7 {
+  @location(15) f0: vec4h,
+  @location(11) f1: i32
+}
+
+@vertex
+fn vertex0(@location(9) a0: u32, @location(12) a1: vec4i, a2: S7) -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder349 = device0.createCommandEncoder();
+let renderBundle210 = renderBundleEncoder31.finish({label: '\u{1fbee}\u{1fd49}\u86c8\u0ff9\u{1f672}\u0b01\ub5cc\u77e4\u4657'});
+let sampler22 = device0.createSampler({
+  label: '\u5c54\u0100',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.43,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder68.setViewport(18.21284457977843, 4.996184179677288, 39.205569309120705, 6.699329368892117, 0.35562824800845716, 0.6623383325304866);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer66, 'uint16', 10_790, 4_472);
+} catch {}
+try {
+renderPassEncoder75.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline12);
+} catch {}
+let promise49 = device0.queue.onSubmittedWorkDone();
+let commandEncoder350 = device1.createCommandEncoder({label: '\u919b\u0700\uf360\uc5e1\u0fcf\u0393'});
+try {
+renderPassEncoder51.setVertexBuffer(4, buffer139);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 402, height: 103, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 16, y: 0 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 366, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let shaderModule22 = device0.createShaderModule({
+  code: `
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+@group(0) @binding(112) var et54: texture_external;
+@group(1) @binding(84) var sam94: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(num_workgroups) a0: vec3u) {
+  _ = textureLoad(et54, vec2u());
+  _ = textureSampleBaseClampToEdge(et54, sam94, vec2f());
+  if bool(textureLoad(et54, vec2u())[1]) {
+    return;
+  }
+}
+
+struct VertexOutput0 {
+  @location(13) f46: vec2u,
+  @location(14) f47: u32,
+  @location(0) f48: vec2h,
+  @builtin(position) f49: vec4f,
+  @location(7) f50: vec2u
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec2u,
+  @location(0) f1: vec4f
+}
+
+@fragment
+fn fragment0(@location(14) a0: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(a0) {
+    discard;
+  }
+  out.f0 = bitcast<vec2u>(textureSampleBaseClampToEdge(et54, sam94, vec2f()).rr);
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder351 = device0.createCommandEncoder({label: '\ue03e\uafce\u{1fe74}\u34f2\ud29a\u71e3\u0f5c\u4e7b\u0fee'});
+let commandBuffer230 = commandEncoder349.finish({label: '\uabf4\u09bc\u{1f6cd}\u7336\u05e9\u5640\ud3a5\u4ce4\u0d59'});
+let textureView92 = texture6.createView({label: '\uc5dc\ud0da', baseArrayLayer: 0});
+let renderPassEncoder76 = commandEncoder351.beginRenderPass({
+  label: '\u63ad\u0178\u3da2\uc7b9',
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 247.8, g: 746.8, b: -673.6, a: 502.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup1, new Uint32Array(126), 2, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer37);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer19, 'uint32', 9_888, 256);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(7, buffer70);
+} catch {}
+let commandBuffer231 = commandEncoder338.finish({label: '\u0e4e\u70da\u063c\u{1ff2d}\u00ef'});
+try {
+computePassEncoder66.end();
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder352 = device2.createCommandEncoder();
+try {
+computePassEncoder67.setPipeline(pipeline27);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+device2.queue.writeBuffer(buffer129, 944, new Float32Array(13737), 5742, 84);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder353 = device1.createCommandEncoder({label: '\u0ba3\u{1fbb7}\u0731\u{1fdaa}\ua1db\u5c50\u1f03\u0435\u0fe6\uaf3e\u0ae4'});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup5, new Uint32Array(471), 153, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup13, new Uint32Array(767), 38, 0);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer59, 'uint32', 2_296, 1_765);
+} catch {}
+let promise50 = device0.queue.onSubmittedWorkDone();
+let pipeline40 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule6}});
+let commandBuffer232 = commandEncoder352.finish({label: '\ub0b7\u{1fef9}\u00ed\u{1fac1}\u0bef\u34c8\uc43b\u90f4\ud91f\u0e53\u{1ff33}'});
+try {
+computePassEncoder59.setPipeline(pipeline28);
+} catch {}
+let imageData32 = new ImageData(28, 80);
+let commandBuffer233 = commandEncoder342.finish({label: '\u8e56\ue70b\u08c2\u3e70'});
+let renderBundle211 = renderBundleEncoder39.finish({label: '\u{1f9d9}\u8b5a\u09ad\ud03f\u{1fa74}\u5aea\u{1f962}\uac46\u0e1b\u0c10'});
+try {
+renderBundleEncoder37.setIndexBuffer(buffer61, 'uint32', 48, 67);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 616, new Int16Array(17421), 836, 1368);
+} catch {}
+let videoFrame5 = new VideoFrame(video7, {timestamp: 0});
+let texture119 = device4.createTexture({
+  label: '\u045e\ufe12\u3736\uce86\uff0d\u0b20\u0784\u{1f9c0}',
+  size: {width: 10},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture120 = device4.createTexture({
+  label: '\u99c5\u05b5\u975a\u{1fc05}\u{1ff67}\u{1fb17}\u756d\ue53f\u0edd',
+  size: {width: 10, height: 3, depthOrArrayLayers: 10},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle212 = renderBundleEncoder40.finish({});
+document.body.prepend(canvas7);
+try {
+renderPassEncoder36.setScissorRect(9, 1, 80, 3);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer66, 'uint16', 1_780, 6_675);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE, 0, 876);
+} catch {}
+let texture121 = device0.createTexture({size: {width: 77}, dimension: '1d', format: 'rg32uint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder38.setIndexBuffer(buffer69, 'uint16', 440, 47);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(7, buffer65);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 1,
+  origin: {x: 15, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(269), /* required buffer size: 269 */
+{offset: 269, bytesPerRow: 46}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle213 = renderBundleEncoder37.finish({label: '\u778c\u08ac\u6218\u{1fec6}\u{1f654}\ud738'});
+try {
+computePassEncoder32.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline14);
+} catch {}
+let computePassEncoder84 = commandEncoder348.beginComputePass();
+try {
+renderBundleEncoder38.setVertexBuffer(6, buffer138, 0, 239);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer38, 'uint32', 1_900, 4_226);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+try {
+  await buffer108.mapAsync(GPUMapMode.WRITE, 0, 200);
+} catch {}
+try {
+device0.queue.submit([commandBuffer119, commandBuffer204, commandBuffer82]);
+} catch {}
+let promise51 = device0.queue.onSubmittedWorkDone();
+let commandEncoder354 = device2.createCommandEncoder({label: '\ub918\u8e90\ua9b2\u0784\u06a9\u83d9\u3398\u1fe9\u9b6b\ub649'});
+let computePassEncoder85 = commandEncoder354.beginComputePass({label: '\u{1f928}\ubf2b\ubf23\u97d0\u5afa\u{1fa2c}\u0cb7\u8a99\ufb6a\uca6e'});
+let renderBundle214 = renderBundleEncoder36.finish({label: '\udc84\u20c3\ue1d8\ua3a3\u{1f61a}\u{1f6db}\ua849\udfc7\ueded\ua792\u{1f8ce}'});
+let textureView93 = texture3.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(212.82167986094623, 29.26717063204992, 366.0709083839146, 61.81482766474555, 0.7351820521333432, 0.8960611508680342);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup7);
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder355 = device5.createCommandEncoder({label: '\ucdb4\u297e'});
+let imageData33 = new ImageData(136, 64);
+let commandEncoder356 = device0.createCommandEncoder();
+let commandBuffer234 = commandEncoder356.finish({label: '\ucf26\u{1f678}\u1139\u0a80\u0441\uef6c\u83b9\u{1fba6}\u0e6c'});
+let texture122 = gpuCanvasContext12.getCurrentTexture();
+let renderBundle215 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder70.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline14);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let externalTexture43 = device1.importExternalTexture({source: video7, colorSpace: 'srgb'});
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup2);
+} catch {}
+let commandEncoder357 = device5.createCommandEncoder({label: '\u0e41\u33ae\u35c6'});
+let renderBundle216 = renderBundleEncoder38.finish({label: '\u0c3b\uc7aa\u{1ffd1}\u{1f60a}\u{1fef1}\u0f51\ud89b\u01b2\u4ced'});
+document.body.prepend(video8);
+try {
+computePassEncoder48.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle163, renderBundle111]);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer171, commandBuffer136, commandBuffer196, commandBuffer219, commandBuffer143]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 38, height: 6, depthOrArrayLayers: 1}
+*/
+{
+  source: video3,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture76,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle217 = renderBundleEncoder38.finish({label: '\u0bd4\u8173\ubf1e\u{1f680}\u0e6c'});
+try {
+device5.queue.submit([commandBuffer209]);
+} catch {}
+let pipelineLayout33 = device2.createPipelineLayout({label: '\u{1fe2c}\u{1fbc9}\u11af\u8c3c\u{1faf8}\u9ca7', bindGroupLayouts: [bindGroupLayout40]});
+let arrayBuffer22 = buffer106.getMappedRange(0, 380);
+let shaderModule23 = device4.createShaderModule({
+  code: `
+struct T0 {
+  f0: atomic<i32>,
+  f1: array<mat4x3f>,
+}
+@group(0) @binding(148) var tex111: texture_cube<f32>;
+@group(1) @binding(148) var tex112: texture_cube<f32>;
+@group(2) @binding(153) var sam95: sampler_comparison;
+struct S9 {
+  @builtin(local_invocation_index) f0: u32
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(a0: S9) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f51: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f51 = vec4f(0.2416, 0.1436, 0.02609, 0.5061);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let querySet47 = device4.createQuerySet({label: '\u521f\u7a62', type: 'occlusion', count: 441});
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let commandEncoder358 = device5.createCommandEncoder({label: '\u{1f8db}\u07ae\u555a\u9f3e\u1c0e\ua44b\u0d5f\u3356'});
+let commandBuffer235 = commandEncoder355.finish({});
+let texture123 = device5.createTexture({
+  label: '\u{1ffc2}\u0309\u68a8',
+  size: {width: 14, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder359 = device1.createCommandEncoder({});
+let querySet48 = device1.createQuerySet({label: '\u84c3\u0814\u{1f8c6}\u{1fcf0}\u{1f6ad}\u4f1a\u075d\u09f7', type: 'occlusion', count: 275});
+let renderPassEncoder77 = commandEncoder359.beginRenderPass({
+  label: '\u0822\u15ae\ud79e\u09a9\uaaf8',
+  colorAttachments: [{view: textureView79, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 34566486,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(0, buffer128, 8_632, 2_469);
+} catch {}
+let querySet49 = device4.createQuerySet({label: '\u0e25\u4f16', type: 'occlusion', count: 1393});
+let renderBundleEncoder42 = device4.createRenderBundleEncoder({
+  label: '\u6e66\u{1f78f}\u0aa0\u0eca',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device4.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle218 = renderBundleEncoder38.finish({label: '\u0675\u{1fb4b}\ueea8'});
+let renderPassEncoder78 = commandEncoder350.beginRenderPass({
+  label: '\u024a\u{1ffba}\u{1ffd4}\u9ac0\u60d1\ub516\udff6\u370d',
+  colorAttachments: [{view: textureView79, loadOp: 'load', storeOp: 'store'}],
+});
+let renderBundle219 = renderBundleEncoder11.finish();
+try {
+computePassEncoder51.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([]);
+} catch {}
+let texture124 = gpuCanvasContext12.getCurrentTexture();
+try {
+computePassEncoder67.setPipeline(pipeline28);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer137, 336, new Int16Array(9264), 1430, 2208);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(133), /* required buffer size: 133 */
+{offset: 133, bytesPerRow: 453}, {width: 432, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise52 = device2.createRenderPipelineAsync({
+  label: '\u{1f9d7}\u0662\ue7a9\u{1ff95}\ud1b2\u09e7',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 1196447459,
+    depthBiasSlopeScale: 883.4331027595766,
+  },
+  vertex: {module: shaderModule16, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let querySet50 = device0.createQuerySet({label: '\u682f\u0a70\u14e2\u{1f797}', type: 'occlusion', count: 713});
+let externalTexture44 = device0.importExternalTexture({source: video3, colorSpace: 'srgb'});
+try {
+renderBundleEncoder24.setIndexBuffer(buffer37, 'uint16', 234, 121);
+} catch {}
+try {
+device0.queue.submit([commandBuffer224]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 309, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 8, y: 0 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 101, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 3, depthOrArrayLayers: 1});
+} catch {}
+video4.width = 128;
+let commandEncoder360 = device2.createCommandEncoder();
+let commandBuffer236 = commandEncoder360.finish();
+try {
+computePassEncoder77.setPipeline(pipeline27);
+} catch {}
+try {
+  await promise51;
+} catch {}
+let shaderModule24 = device0.createShaderModule({
+  label: '\uad8d\u00d6\udef9\u002c',
+  code: `
+struct T0 {
+  f0: array<atomic<u32>, 1>,
+}
+@group(0) @binding(630) var<storage, read_write> buffer142: atomic<i32>;
+@group(1) @binding(492) var tex113: texture_1d<f32>;
+@group(1) @binding(102) var tex114: texture_depth_2d;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f52: vec4f
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4h, @location(5) a1: vec2f, @location(9) a2: vec4u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = a2;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: f32,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec4u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let sampler23 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.36,
+  lodMaxClamp: 80.64,
+});
+try {
+renderBundleEncoder24.setIndexBuffer(buffer36, 'uint16', 178, 664);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+renderBundleEncoder42.pushDebugGroup('\u536a');
+} catch {}
+let textureView94 = texture36.createView({label: '\u0b4e\u115c\u1f2a\u481f\u173b\u074a\u479f\u4e95\ue897\u0031\uaa62', baseMipLevel: 2});
+try {
+renderPassEncoder26.setScissorRect(238, 5, 48, 6);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer90, 0, 2_114);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.submit([commandBuffer179]);
+} catch {}
+let video9 = await videoWithData();
+let computePassEncoder86 = commandEncoder343.beginComputePass();
+try {
+commandEncoder285.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 7, y: 1369, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 163, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1076, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer140, 'uint32', 7_536, 243);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(5, undefined, 0, 62_850_439);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let buffer143 = device2.createBuffer({
+  label: '\u037e\u2ec2\u7ae0\u0e85\u{1f886}\u6dc5\u6a83',
+  size: 3722,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder361 = device2.createCommandEncoder({label: '\u{1fa4f}\u0810\u0d13\u084e\u{1ffec}'});
+let commandBuffer237 = commandEncoder361.finish({label: '\uf5c2\u0078\ub532\u1ef5\ud5a7\u{1f822}\u2eb2\u{1f735}'});
+document.body.prepend(img5);
+let textureView95 = texture36.createView({
+  label: '\u29f4\ucd99\u042a\u0c51\u0f89\u93b6\u{1fe0f}\u{1fafc}\ufb20\u8e35',
+  aspect: 'all',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder76.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer64, 0, 4_642);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 104, y: 18, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(227), /* required buffer size: 227 */
+{offset: 227, bytesPerRow: 1058, rowsPerImage: 54}, {width: 109, height: 37, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+  await promise49;
+} catch {}
+let commandEncoder362 = device3.createCommandEncoder({label: '\u0086\u0fa5'});
+let sampler24 = device3.createSampler({
+  label: '\ue3bb\ub44d\uf83b\u00ec\u0bca\u{1faf6}\ubf81\u0dae\u5581\ufab2\u050c',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 91.14,
+  lodMaxClamp: 96.15,
+});
+try {
+buffer136.unmap();
+} catch {}
+let commandEncoder363 = device4.createCommandEncoder({});
+let commandBuffer238 = commandEncoder363.finish({label: '\u1927\u0790\u25bf\u0134\u0db2\ubde7\u0384\u5470'});
+let commandEncoder364 = device1.createCommandEncoder();
+try {
+computePassEncoder69.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+buffer139.unmap();
+} catch {}
+try {
+computePassEncoder80.insertDebugMarker('\u4ed1');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(335), /* required buffer size: 335 */
+{offset: 335}, {width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext14 = canvas9.getContext('webgpu');
+await gc();
+try {
+computePassEncoder73.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+let commandEncoder365 = device5.createCommandEncoder({label: '\u01ce\u{1f843}\u23f8\u2870\u{1fcea}\u0db7\u{1fed7}\u060f\u0bc1\u092e'});
+let computePassEncoder87 = commandEncoder357.beginComputePass();
+let commandEncoder366 = device5.createCommandEncoder({});
+let renderBundle220 = renderBundleEncoder38.finish({label: '\u{1ff0c}\u6d40'});
+let imageData34 = new ImageData(4, 8);
+let commandEncoder367 = device0.createCommandEncoder();
+try {
+renderBundleEncoder24.setIndexBuffer(buffer69, 'uint16', 1_186, 890);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 332, new Int16Array(2822), 1998, 504);
+} catch {}
+await gc();
+let commandEncoder368 = device4.createCommandEncoder();
+let commandBuffer239 = commandEncoder368.finish();
+let renderBundle221 = renderBundleEncoder40.finish({label: '\u3197\u3c8e\u2f11\u0596\u{1fed7}\u83c9\u0ca0\ud82a\u6eb0'});
+try {
+renderBundleEncoder42.setIndexBuffer(buffer140, 'uint16', 8_206, 88);
+} catch {}
+try {
+adapter4.label = '\u{1ff6d}\u4aa5\ub265\ue8d8\u{1fab9}';
+} catch {}
+let commandEncoder369 = device5.createCommandEncoder({label: '\u{1fb8f}\u{1fce2}\u0dd3\uce0f\ub327\u0d76\ue089\u{1f85f}\u18f3'});
+let buffer144 = device5.createBuffer({size: 228, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandBuffer240 = commandEncoder369.finish({label: '\uab39\u01e6\u{1f9a1}\u7f4b\ua127\ubec7'});
+try {
+  await promise50;
+} catch {}
+await gc();
+try {
+renderPassEncoder51.setVertexBuffer(1, buffer139, 204, 69);
+} catch {}
+let commandEncoder370 = device1.createCommandEncoder({label: '\ua8a8\u2065\u15f6'});
+let renderPassEncoder79 = commandEncoder353.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 6,
+  clearValue: { r: 108.1, g: 740.5, b: 920.1, a: -917.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder364.copyBufferToBuffer(buffer128, 3344, buffer91, 664, 12);
+} catch {}
+let promise53 = device5.queue.onSubmittedWorkDone();
+let commandEncoder371 = device3.createCommandEncoder({label: '\uacc6\u{1f739}\u{1f6bf}\u04ca\u6f9c\uef61\u04be\u89f2\u916a'});
+let computePassEncoder88 = commandEncoder339.beginComputePass({label: '\u6cc9\u3900\u54bc\u{1fee0}\u60c8\u0b38\u75b2\u09ca\u{1f768}'});
+let renderBundleEncoder43 = device3.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: false});
+let promise54 = device3.queue.onSubmittedWorkDone();
+let texture125 = device3.createTexture({
+  label: '\u{1f8ed}\u6802\u9be9',
+  size: [36, 1, 10],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder89 = commandEncoder285.beginComputePass({label: '\u{1fb39}\u05bc\u0800\u78cd\uf098\u4e59\u2801\u9523'});
+let renderBundle222 = renderBundleEncoder29.finish({label: '\u0223\u5ece\u76c0\u0816\u2262'});
+try {
+renderBundleEncoder43.setVertexBuffer(7, buffer136, 108, 74);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageBitmap8 = await createImageBitmap(offscreenCanvas4);
+let imageData35 = new ImageData(60, 4);
+let commandBuffer241 = commandEncoder370.finish({});
+let renderPassEncoder80 = commandEncoder364.beginRenderPass({
+  label: '\ua208\uc33d\u03a6\u6fee\uc589\ud3fe\u0fe8\u{1f90c}\ufce2\u24e1',
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 771.4, g: 129.7, b: -626.5, a: -657.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder53.setVertexBuffer(7, buffer139, 0, 1_098);
+} catch {}
+try {
+  await promise53;
+} catch {}
+let commandEncoder372 = device2.createCommandEncoder({label: '\ucc0d\u9b9f\u01b3\ue51c\u{1f696}\u6f99\u{1fa62}\u8aa5\u6f87'});
+let computePassEncoder90 = commandEncoder372.beginComputePass({label: '\ub3e8\u04e5\u8184\u848c\ub590\u6ce8\u1786\u0663\ue2be\u0df1'});
+try {
+buffer100.unmap();
+} catch {}
+let commandBuffer242 = commandEncoder362.finish({});
+videoFrame0.close();
+videoFrame4.close();
+videoFrame5.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -106,10 +106,14 @@ void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIn
         return completion(nullptr);
 
     RefPtr<NativeImage> displayImage;
+    bool isIOSurfaceSupportedFormat = false;
     if (auto* presentationContextPtr = m_presentationContext.get())
-        displayImage = presentationContextPtr->getMetalTextureAsNativeImage(bufferIndex);
+        displayImage = presentationContextPtr->getMetalTextureAsNativeImage(bufferIndex, isIOSurfaceSupportedFormat);
 
     if (!displayImage) {
+        if (!isIOSurfaceSupportedFormat)
+            return completion(nullptr);
+
         auto& renderBuffer = m_renderBuffers[bufferIndex];
         RetainPtr<CGContextRef> cgContext = renderBuffer->createPlatformContext();
         if (cgContext)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -133,10 +133,10 @@ void PresentationContextImpl::present(bool)
     m_currentTexture = nullptr;
 }
 
-RefPtr<WebCore::NativeImage> PresentationContextImpl::getMetalTextureAsNativeImage(uint32_t bufferIndex)
+RefPtr<WebCore::NativeImage> PresentationContextImpl::getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat)
 {
     if (auto* surface = m_swapChain.get())
-        return WebCore::NativeImage::create(wgpuSwapChainGetTextureAsNativeImage(surface, bufferIndex));
+        return WebCore::NativeImage::create(wgpuSwapChainGetTextureAsNativeImage(surface, bufferIndex, isIOSurfaceSupportedFormat));
 
     return nullptr;
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
@@ -55,7 +55,7 @@ public:
     void present(bool = false);
 
     WGPUSurface backing() const { return m_backing.get(); }
-    RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex) final;
+    RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) final;
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
@@ -52,7 +52,7 @@ public:
     virtual void present(bool = false) = 0;
 
     virtual RefPtr<Texture> getCurrentTexture() = 0;
-    virtual RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex) = 0;
+    virtual RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) = 0;
 
 protected:
     PresentationContext() = default;

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -66,7 +66,7 @@ public:
     void setBufferMapCount(int);
     int bufferMapCount() const;
     NSString* lastError() const;
-    void waitForCompletion();
+    bool waitForCompletion();
 
 private:
     CommandBuffer(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -89,12 +89,14 @@ int CommandBuffer::bufferMapCount() const
     return m_bufferMapCount;
 }
 
-void CommandBuffer::waitForCompletion()
+bool CommandBuffer::waitForCompletion()
 {
     auto status = [m_cachedCommandBuffer status];
-    constexpr auto commandBufferSubmissionTimeout = 5000_ms;
+    constexpr auto commandBufferSubmissionTimeout = 500_ms;
     if (status == MTLCommandBufferStatusCommitted || status == MTLCommandBufferStatusScheduled)
-        m_commandBufferComplete.waitFor(commandBufferSubmissionTimeout);
+        return m_commandBufferComplete.waitFor(commandBufferSubmissionTimeout);
+
+    return true;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -103,7 +103,7 @@ public:
     void decrementBufferMapCount();
     void endEncoding(id<MTLCommandEncoder>);
     void setLastError(NSString*);
-    void waitForCommandBufferCompletion();
+    bool waitForCommandBufferCompletion();
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
     bool submitWillBeInvalid() const;
     void addBuffer(id<MTLBuffer>);

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1130,10 +1130,12 @@ void CommandEncoder::clearTextureIfNeeded(const WGPUImageCopyTexture& destinatio
     CommandEncoder::clearTextureIfNeeded(texture, mipLevel, slice, device, blitCommandEncoder);
 }
 
-void CommandEncoder::waitForCommandBufferCompletion()
+bool CommandEncoder::waitForCommandBufferCompletion()
 {
     if (m_cachedCommandBuffer)
-        m_cachedCommandBuffer.get()->waitForCompletion();
+        return m_cachedCommandBuffer.get()->waitForCompletion();
+
+    return true;
 }
 
 bool CommandEncoder::encoderIsCurrent(id<MTLCommandEncoder> commandEncoder) const

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -68,7 +68,7 @@ public:
 
     virtual bool isPresentationContextIOSurface() const { return false; }
     virtual bool isPresentationContextCoreAnimation() const { return false; }
-    virtual RetainPtr<CGImageRef> getTextureAsNativeImage(uint32_t) { return nullptr; }
+    virtual RetainPtr<CGImageRef> getTextureAsNativeImage(uint32_t, bool&) { return nullptr; }
 
     virtual bool isValid() { return false; }
 protected:

--- a/Source/WebGPU/WebGPU/PresentationContext.mm
+++ b/Source/WebGPU/WebGPU/PresentationContext.mm
@@ -132,7 +132,7 @@ void wgpuSwapChainPresent(WGPUSwapChain swapChain)
     WebGPU::fromAPI(swapChain).present();
 }
 
-RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex)
+RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat)
 {
-    return WebGPU::fromAPI(swapChain).getTextureAsNativeImage(bufferIndex);
+    return WebGPU::fromAPI(swapChain).getTextureAsNativeImage(bufferIndex, isIOSurfaceSupportedFormat);
 }

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -58,7 +58,7 @@ private:
 
     void renderBuffersWereRecreated(NSArray<IOSurface *> *renderBuffers);
     void onSubmittedWorkScheduled(Function<void()>&&);
-    RetainPtr<CGImageRef> getTextureAsNativeImage(uint32_t bufferIndex) final;
+    RetainPtr<CGImageRef> getTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) final;
 
     NSArray<IOSurface *> *m_ioSurfaces { nil };
     struct RenderBuffer {

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -45,7 +45,7 @@ class Device;
 class TextureView;
 
 // https://gpuweb.github.io/gpuweb/#gputexture
-class Texture : public WGPUTextureImpl, public RefCounted<Texture> {
+class Texture : public WGPUTextureImpl, public RefCounted<Texture>, public CanMakeWeakPtr<Texture> {
     WTF_MAKE_TZONE_ALLOCATED(Texture);
 public:
     static Ref<Texture> create(id<MTLTexture> texture, const WGPUTextureDescriptor& descriptor, Vector<WGPUTextureFormat>&& viewFormats, Device& device)
@@ -124,7 +124,7 @@ public:
     void setCommandEncoder(CommandEncoder&) const;
     static ASCIILiteral formatToString(WGPUTextureFormat);
     bool isCanvasBacking() const;
-    void waitForCommandBufferCompletion();
+    bool waitForCommandBufferCompletion();
 
 private:
     Texture(id<MTLTexture>, const WGPUTextureDescriptor&, Vector<WGPUTextureFormat>&& viewFormats, Device&);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2992,10 +2992,13 @@ void Texture::makeCanvasBacking()
     m_canvasBacking = true;
 }
 
-void Texture::waitForCommandBufferCompletion()
+bool Texture::waitForCommandBufferCompletion()
 {
+    bool result = true;
     for (auto& commandEncoder : m_commandEncoders)
-        commandEncoder.waitForCommandBufferCompletion();
+        result = commandEncoder.waitForCommandBufferCompletion() && result;
+
+    return result;
 }
 
 void Texture::setCommandEncoder(CommandEncoder& commandEncoder) const

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -149,7 +149,7 @@ WGPU_EXPORT WGPUXRSubImage wgpuBindingGetViewSubImage(WGPUXRBinding binding, WGP
 WGPU_EXPORT WGPUBool wgpuAdapterXRCompatible(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
 
 #ifdef __cplusplus
-WGPU_EXPORT RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex);
+WGPU_EXPORT RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat);
 #endif
 WGPU_EXPORT WGPUBool wgpuExternalTextureIsValid(WGPUExternalTexture externalTexture) WGPU_FUNCTION_ATTRIBUTE;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -87,7 +87,7 @@ void RemotePresentationContextProxy::present(bool presentToGPUProcess)
     }
 }
 
-RefPtr<WebCore::NativeImage> RemotePresentationContextProxy::getMetalTextureAsNativeImage(uint32_t)
+RefPtr<WebCore::NativeImage> RemotePresentationContextProxy::getMetalTextureAsNativeImage(uint32_t, bool&)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -68,7 +68,7 @@ private:
     RemotePresentationContextProxy& operator=(RemotePresentationContextProxy&&) = delete;
 
     WebGPUIdentifier backing() const { return m_backing; }
-    RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t) final;
+    RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t, bool& isIOSurfaceSupportedFormat) final;
 
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)


### PR DESCRIPTION
#### df309938f9794af725883822f477336fa36993f0
<pre>
[WebGPU] GPUCanvasContext.surfaceBufferToImageBuffer doesn&apos;t handle failure when work is not submitted correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=278545">https://bugs.webkit.org/show_bug.cgi?id=278545</a>
<a href="https://rdar.apple.com/133539413">rdar://133539413</a>

Reviewed by Dan Glastonbury.

Removing the semaphore is problematic because we never return to the offscreen canvas call
if the work is never submitted to the WebGPU::Queue. A prior attempt to do that in 281449@main
was reverted due to causing a regression when work was never submitted.

Instead, if the semaphore times out, we can signal to the offscreen canvas that the call failed.

We were not previously handling the semaphore timeout which seems like the potential cause of
this issue.

* LayoutTests/fast/webgpu/nocrash/fuzz-278545-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-278545.html: Added.
Add regression test.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::withDisplayBufferAsNativeImage):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::PresentationContextImpl::getMetalTextureAsNativeImage):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h:
* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::waitForCompletion):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::waitForCommandBufferCompletion):
* Source/WebGPU/WebGPU/PresentationContext.h:
(WebGPU::PresentationContext::getTextureAsNativeImage):
* Source/WebGPU/WebGPU/PresentationContext.mm:
(wgpuSwapChainGetTextureAsNativeImage):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::getTextureAsNativeImage):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::waitForCommandBufferCompletion):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
(WebKit::WebGPU::RemotePresentationContextProxy::getMetalTextureAsNativeImage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/282683@main">https://commits.webkit.org/282683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72d6a46729c7242f78428411dd0c5e6a09a2a3bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14543 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14823 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10050 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55349 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13416 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7882 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55445 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6548 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->