### PR TITLE
[WebXR] Fix spelling of createPresentationSession

### DIFF
--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -130,7 +130,7 @@ void ARKitCoordinator::startSession(WebPageProxy& page, WeakPtr<SessionEventClie
             auto presentationSessionDesc = adoptNS([WKARPresentationSessionDescriptor new]);
             [presentationSessionDesc setPresentingViewController:presentingViewController];
 
-            auto presentationSession = adoptNS(createPresesentationSession(m_session.get(), presentationSessionDesc.get()));
+            auto presentationSession = adoptNS(createPresentationSession(m_session.get(), presentationSessionDesc.get()));
 
             auto renderState = Box<RenderState>::create();
             renderState->presentationSession = WTFMove(presentationSession);

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)terminate;
 @end
 
-id<WKARPresentationSession> createPresesentationSession(ARSession *, WKARPresentationSessionDescriptor *);
+id<WKARPresentationSession> createPresentationSession(ARSession *, WKARPresentationSessionDescriptor *);
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -352,7 +352,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 @end
 
-id<WKARPresentationSession> createPresesentationSession(ARSession *session, WKARPresentationSessionDescriptor *descriptor)
+id<WKARPresentationSession> createPresentationSession(ARSession *session, WKARPresentationSessionDescriptor *descriptor)
 {
     return [[_WKARPresentationSession alloc] initWithSession:session descriptor:descriptor];
 }


### PR DESCRIPTION
#### 7891d75648002155650c1b1598f43b88884029e6
<pre>
[WebXR] Fix spelling of createPresentationSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=278555">https://bugs.webkit.org/show_bug.cgi?id=278555</a>
<a href="https://rdar.apple.com/134549156">rdar://134549156</a>

Reviewed by Cameron McCormack and Ada Chan.

createPresesentationSession -&gt; createPresentationSession.

* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(createPresentationSession):
(createPresesentationSession): Deleted.

Canonical link: <a href="https://commits.webkit.org/282724@main">https://commits.webkit.org/282724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a441f31525e6652e8c36772c5b32a05bd391b951

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14435 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51432 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9982 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32049 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36679 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69544 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7774 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12509 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58901 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6468 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9694 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39004 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40083 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->