### PR TITLE
[SVG2] getPointAtLength should throw exception when "path" is empty and renderable display type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGPathElement assert_throws_dom: function "function() { pathElement.getPointAtLength(700) }" did not throw
+PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGPathElement
 PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGRectElement
 PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGCircleElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
@@ -1,7 +1,7 @@
 
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: default
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style assert_approx_equals: expected 50 +/- 0.00001 but got 0
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style The element's path is empty.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: default
 FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: default

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: default and an empty path
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: none and an empty path
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, circle with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw

--- a/LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html
+++ b/LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html
@@ -6,8 +6,8 @@ if (window.testRunner)
 
 function go() {
     var oSVGPolygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-    var oSVGPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    var oSVGPoint1 = oSVGPath.getPointAtLength(0);
+    var svgRoot = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    var oSVGPoint1 = svgRoot.createSVGPoint();
     oSVGPolygon.points.initialize(oSVGPoint1);
     oSVGPolygon.points.removeItem(-9223372036854775802);
     alert("Accessing old oSVGPoint1.x: " + oSVGPoint1.x);

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -189,6 +189,10 @@ ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) cons
 {
     protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
+    // Spec: If it is not able to compute the total length of path, then throw.
+    if (pathByteStream().isEmpty())
+        return Exception { ExceptionCode::InvalidStateError, "The element's path is empty."_s };
+
     // Spec: Clamp distance to [0, length].
     distance = clampTo<float>(distance, 0, getTotalLength());
 


### PR DESCRIPTION
#### 6b8f14839b0719d27956f717e132e9055dad7510
<pre>
[SVG2] getPointAtLength should throw exception when &quot;path&quot; is empty and renderable display type

<a href="https://bugs.webkit.org/show_bug.cgi?id=268594">https://bugs.webkit.org/show_bug.cgi?id=268594</a>
<a href="https://rdar.apple.com/122574451">rdar://122574451</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement</a>

NOTE: SVGPathElement interface with SVGGeometryElement.

This patch aligns WebKit to throw exception in case of &quot;path&quot; being empty
(not being able to compute the total length of the path).

&quot;If current element is a non-rendered element, and the UA is not able to compute the total length
of the path, then throw an InvalidStateError.&quot;

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt:
* LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::getPointAtLength const):

Canonical link: <a href="https://commits.webkit.org/282665@main">https://commits.webkit.org/282665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5298e7324c631d3fb723eb23943c952f8a2c92a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16462 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/14473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65985 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/50920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14753 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/14473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66934 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/50920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/50920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/13346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/50920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/7812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/7845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/55384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9655 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->