### PR TITLE
Take a background assertion for processes having muted capture

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3116,15 +3116,18 @@ private:
         void takeVisibleActivity();
         void takeAudibleActivity();
         void takeCapturingActivity();
+        void takeMutedCaptureActivity();
 
         void reset();
         void dropVisibleActivity();
         void dropAudibleActivity();
         void dropCapturingActivity();
+        void dropMutedCaptureActivity();
 
         bool hasValidVisibleActivity() const;
         bool hasValidAudibleActivity() const;
         bool hasValidCapturingActivity() const;
+        bool hasValidMutedCaptureActivity() const;
 
 #if PLATFORM(IOS_FAMILY)
         void takeOpeningAppLinkActivity();
@@ -3141,6 +3144,7 @@ private:
 #endif
         std::unique_ptr<ProcessThrottlerActivity> m_isAudibleActivity;
         std::unique_ptr<ProcessThrottlerActivity> m_isCapturingActivity;
+        std::unique_ptr<ProcessThrottlerActivity> m_isMutedCaptureActivity;
 #if PLATFORM(IOS_FAMILY)
         std::unique_ptr<ProcessThrottlerActivity> m_openingAppLinkActivity;
 #endif


### PR DESCRIPTION
#### 760a765e8b6f0e1f976fe48b6bfa4fe63f6e5576
<pre>
Take a background assertion for processes having muted capture
<a href="https://rdar.apple.com/130691389">rdar://130691389</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278560">https://bugs.webkit.org/show_bug.cgi?id=278560</a>

Reviewed by Chris Dumez.

To allow web application doing WebRTC streaming to quickly recover ts camera streaming when moving in the foreground after being backgrounded,
a background assertion is being taken in case a process is doing muted capture.

Manually tested by observing that a WebRTC connection continues sending black frames in a backgrounded tab on iOS.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateThrottleState):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/282757@main">https://commits.webkit.org/282757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cebd62d3f0de18297d09a1dbc91897d20f407d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14726 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51637 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32256 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36898 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58954 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14172 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6683 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39295 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40374 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->