### PR TITLE
Update git-webkit conflict to support additional integration/ branches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
@@ -22,26 +22,54 @@
 
 import sys
 
+from webkitbugspy import Tracker, radar
 from .command import Command
 from .. import local
+from ..commit import Commit
 
 
 class Conflict(Command):
     name = 'conflict'
     help = "Given the representative Radar ID of a conflicting merge, checkout the branch."
+    INTEGRATION_BRANCH_PREFIX = 'integration'
 
     @classmethod
     def parser(cls, parser, loggers=None):
         parser.add_argument(
-            'radar_id',
-            type=int, default=None,
-            help='Radar ID that caused a merge conflict.',
+            'radar',
+            type=str, default=None,
+            help='Radar ID that caused a merge conflict. Ex. rdar://problem/123, rdar://123, 123',
         )
 
     @classmethod
-    def find_conflict_pr(cls, remote, branch):
-        for pr in remote.pull_requests.find(head=branch, opened=True):
-            return pr
+    def find_conflict_pr(cls, remote, radar_id):
+        """
+        Because we don't know what the target branch was just given the radar id,
+        we need to search for PRs with branches that start with the integration prefix
+        and have the first and last sha.
+        """
+        radar_obj = Tracker.from_string(f'rdar://{radar_id}')
+        assert radar_obj, 'Could not fetch radar object for id {}'.format(radar_id)
+        shas = []
+
+        repo_name = remote.name if '/' not in remote.name else remote.name.split('/', 1)[-1]
+        for entry in radar_obj.source_changes:
+            repo, action, sha = entry.split(', ')
+            if repo == repo_name:
+                shas.append(sha)
+
+        integration_branches = []
+        for prefix in ('ci', 'conflict'):
+            integration_branches.append("{}/{}/{}_{}".format(cls.INTEGRATION_BRANCH_PREFIX, prefix, shas[0][:Commit.HASH_LABEL_SIZE], shas[-1][:Commit.HASH_LABEL_SIZE]))
+
+        for pr in cls.get_open_integration_prs(remote):
+            for branch in integration_branches:
+                if pr.head.startswith(branch):
+                    return pr
+
+    @classmethod
+    def get_open_integration_prs(cls, remote):
+        return remote.pull_requests.find(head=cls.INTEGRATION_BRANCH_PREFIX, opened=True)
 
     @classmethod
     def main(cls, args, repository, **kwargs):
@@ -52,11 +80,13 @@ class Conflict(Command):
             sys.stderr.write('Cannot checkout conflict, must be in a local git repository\n')
             return 1
 
-        expected_branch = 'integration/conflict/{}'.format(args.radar_id)
+        # This is to remove any extra inputs like rdar://problem/
+        radar_id = ''.join(i for i in args.radar if i.isdigit())
+        radar_obj = Tracker.from_string(f'rdar://{radar_id}')
+        expected_branch = 'integration/conflict/{}'.format(radar_obj.id)
         for source_remote in repository.source_remotes():
             rmt = repository.remote(name=source_remote)
-
-            conflict_pr = cls.find_conflict_pr(rmt, expected_branch)
+            conflict_pr = cls.find_conflict_pr(rmt, radar_obj.id)
             if conflict_pr:
                 return repository.checkout('{}:{}'.format(conflict_pr._metadata['full_name'], conflict_pr.head))
 


### PR DESCRIPTION
#### c2e76f6579ddf2b7c0424c7b23405c1a5c1aff38
<pre>
Update git-webkit conflict to support additional integration/ branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=278562">https://bugs.webkit.org/show_bug.cgi?id=278562</a>
<a href="https://rdar.apple.com/129681381">rdar://129681381</a>

Reviewed by Ryan Haddad.

This will now search for updated integration branches when running git-webkit conflict.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py:
(Conflict):
(Conflict.parser):
(Conflict.find_conflict_pr):
(Conflict.get_open_integration_prs):
(Conflict.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py:
(TestConflict._mock_radar_response):
(TestConflict.test_conflict_not_found):
(TestConflict.test_conflict_found):

Canonical link: <a href="https://commits.webkit.org/283569@main">https://commits.webkit.org/283569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c6076a1e6e265e993266becf51c643e2f5e12ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19298 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/17809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17575 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/70710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/17809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69743 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/57700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/66188 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/15091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/15432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72412 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10633 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/66356 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10665 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/57756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/8753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10114 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->