### PR TITLE
Convert new scrollbar-gutter-root* tests from LayoutTests to wpts

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges-expected.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: scrollbar-gutter on the root element</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+
+<style>
+    html {
+        background-color: blue;
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid black;
+    }
+
+    body{
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid green;
+    }
+
+    #abspos {
+        position:absolute;
+        top:150px;
+        left: 15px;
+        background-color: green;
+        width: 80px;
+        height: 100px;
+        transform: translateZ(0);
+    }
+
+p {
+    background-color: purple;
+    color: white;
+}
+
+</style>
+
+<div id="outer" style="width: 100px; height: 100px; overflow: scroll; left: -200px; position: absolute;">
+    <div id="inner" style="width: 100%; height: 200%;"></div>
+</div>
+
+ <script>
+    var outer = document.getElementById("outer");
+    var inner = document.getElementById("inner");
+    // Compute scrollbar gutter size and add it as margin to the root element
+    var scrollbarWidthPlusMargin = String((outer.offsetWidth - inner.offsetWidth) + 10) + "px";
+    document.documentElement.style.marginRight = scrollbarWidthPlusMargin;
+    document.documentElement.style.marginLeft = scrollbarWidthPlusMargin;
+ </script>
+
+<p id="content">Should not have space around me in the inline axis.</p> 
+<div id="abspos"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges-ref.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: scrollbar-gutter on the root element</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+
+<style>
+    html {
+        background-color: blue;
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid black;
+    }
+
+    body{
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid green;
+    }
+
+    #abspos {
+        position:absolute;
+        top:150px;
+        left: 15px;
+        background-color: green;
+        width: 80px;
+        height: 100px;
+        transform: translateZ(0);
+    }
+
+p {
+    background-color: purple;
+    color: white;
+}
+
+</style>
+
+<div id="outer" style="width: 100px; height: 100px; overflow: scroll; left: -200px; position: absolute;">
+    <div id="inner" style="width: 100%; height: 200%;"></div>
+</div>
+
+ <script>
+    var outer = document.getElementById("outer");
+    var inner = document.getElementById("inner");
+    // Compute scrollbar gutter size and add it as margin to the root element
+    var scrollbarWidthPlusMargin = String((outer.offsetWidth - inner.offsetWidth) + 10) + "px";
+    document.documentElement.style.marginRight = scrollbarWidthPlusMargin;
+    document.documentElement.style.marginLeft = scrollbarWidthPlusMargin;
+ </script>
+
+<p id="content">Should not have space around me in the inline axis.</p> 
+<div id="abspos"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Overflow: scrollbar-gutter on the root element</title>
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
-<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1874093">
+<link rel="match" href="scrollbar-gutter-root-both-edges-ref.html">
 
 <style>
     body,html {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-expected.html
@@ -8,8 +8,6 @@
     html {
         background-color: blue;
         margin: 10px;
-        margin-right: 25px;
-        margin-left: 25px;
         padding: 10px;
         border: 5px solid black;
     }
@@ -20,10 +18,10 @@
         border: 5px solid green;
     }
 
-    div {
+    #abspos {
         position:absolute;
         top:150px;
-        left: 15px;
+        left: 0px;
         background-color: green;
         width: 80px;
         height: 100px;
@@ -31,9 +29,19 @@
     }
 
 p {
-  background-color: purple;
-  color: white;
+    background-color: purple;
+    color: white;
 }
 </style>
+<div id="outer" style="width: 100px; height: 100px; overflow: scroll; left: -200px; position: absolute;">
+    <div id="inner" style="width: 100%; height: 200%;"></div>
+</div>
+<script>
+    var outer = document.getElementById("outer");
+    var inner = document.getElementById("inner");
+    // Compute scrollbar gutter size and add it as margin to the root element
+    document.documentElement.style.marginRight = String((outer.offsetWidth - inner.offsetWidth) + 10) + "px";
+</script>
+
 <p id="content">Should not have space around me in the inline axis.</p> 
-<div></div>
+<div id="abspos"> </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-ref.html
@@ -6,10 +6,8 @@
 
 <style>
     html {
-
         background-color: blue;
         margin: 10px;
-        margin-right: 25px;
         padding: 10px;
         border: 5px solid black;
     }
@@ -20,7 +18,7 @@
         border: 5px solid green;
     }
 
-    div {
+    #abspos {
         position:absolute;
         top:150px;
         left: 0px;
@@ -31,9 +29,19 @@
     }
 
 p {
-  background-color: purple;
-  color: white;
+    background-color: purple;
+    color: white;
 }
 </style>
+<div id="outer" style="width: 100px; height: 100px; overflow: scroll; left: -200px; position: absolute;">
+    <div id="inner" style="width: 100%; height: 200%;"></div>
+</div>
+<script>
+    var outer = document.getElementById("outer");
+    var inner = document.getElementById("inner");
+    // Compute scrollbar gutter size and add it as margin to the root element
+    document.documentElement.style.marginRight = String((outer.offsetWidth - inner.offsetWidth) + 10) + "px";
+</script>
+
 <p id="content">Should not have space around me in the inline axis.</p> 
-<div></div>
+<div id="abspos"> </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Overflow: scrollbar-gutter on the root element</title>
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
-<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1874093">
+<link rel="match" href="scrollbar-gutter-root-ref.html">
 
 <style>
     body,html {

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1908,6 +1908,9 @@ imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-
 
 http/tests/login-status/login-status-api-getter-setter-functions.html [ Failure ]
 
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure ]
+
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1280,6 +1280,9 @@ fast/scrolling/v-rl-scrollbars-initial-position-dynamic.html [ Skip ]
 fast/scrolling/v-rl-scrollbars-initial-position.html [ Skip ]
 fast/scrolling/vertical-scrollbar-position.html [ Skip ]
 
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure ]
+
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1521,6 +1521,9 @@ scrollbars/scrolling-by-page-ignoring-hidden-fixed-elements-on-keyboard-spacebar
 scrollbars/scrolling-by-page-ignoring-transparent-fixed-elements-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-by-page-on-keyboard-spacebar.html [ Skip ]
 
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure ]
+
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-005.html [ ImageOnlyFailure ]
 # This test times out.

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1601,6 +1601,9 @@ imported/w3c/web-platform-tests/uievents/interface/keyboard-accesskey-click-even
 
 http/tests/login-status/login-status-api-getter-setter-functions.html [ Failure ]
 
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure ]
+
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-003.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 85032ed8b983d4ccc2bae7c51788ce4032105955
<pre>
Convert new scrollbar-gutter-root* tests from LayoutTests to wpts
<a href="https://bugs.webkit.org/show_bug.cgi?id=278568">https://bugs.webkit.org/show_bug.cgi?id=278568</a>
<a href="https://rdar.apple.com/134580767">rdar://134580767</a>

Reviewed by Tim Nguyen.

Convert new scrollbar-gutter-root* tests from LayoutTests to wpts by computing scrolbar
gutter size.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges-expected.html: Renamed from LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-both-edges-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html: Renamed from LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-both-edges.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-expected.html: Renamed from LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html: Renamed from LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root.html.

Canonical link: <a href="https://commits.webkit.org/283140@main">https://commits.webkit.org/283140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75baf78480b2bcf95ec6d20acaeeabd970d2a4c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14578 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51517 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10064 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12755 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58838 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58984 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/264 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9910 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->