### PR TITLE
Pack CSSSelectorParserContext bits

### DIFF
--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -36,21 +36,21 @@ class Document;
 
 struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
-    bool cssNestingEnabled { false };
-    bool customStateSetEnabled { false };
-    bool grammarAndSpellingPseudoElementsEnabled { false };
-    bool highlightAPIEnabled { false };
+    bool cssNestingEnabled : 1 { false };
+    bool customStateSetEnabled : 1 { false };
+    bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
+    bool highlightAPIEnabled : 1 { false };
 #if ENABLE(SERVICE_CONTROLS)
-    bool imageControlsEnabled { false };
+    bool imageControlsEnabled : 1 { false };
 #endif
-    bool popoverAttributeEnabled { false };
-    bool targetTextPseudoElementEnabled { false };
-    bool thumbAndTrackPseudoElementsEnabled { false };
-    bool viewTransitionsEnabled { false };
-    bool viewTransitionClassesEnabled { false };
-    bool viewTransitionTypesEnabled { false };
+    bool popoverAttributeEnabled : 1 { false };
+    bool targetTextPseudoElementEnabled : 1 { false };
+    bool thumbAndTrackPseudoElementsEnabled : 1 { false };
+    bool viewTransitionsEnabled : 1 { false };
+    bool viewTransitionClassesEnabled : 1 { false };
+    bool viewTransitionTypesEnabled : 1 { false };
 
-    bool isHashTableDeletedValue { false };
+    bool isHashTableDeletedValue : 1 { false };
 
     CSSSelectorParserContext() = default;
     CSSSelectorParserContext(const CSSParserContext&);


### PR DESCRIPTION
#### c1cb1d89cd7ee1c0362372728cf12fef484d6bb1
<pre>
Pack CSSSelectorParserContext bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=278241">https://bugs.webkit.org/show_bug.cgi?id=278241</a>
<a href="https://rdar.apple.com/problem/134517018">rdar://problem/134517018</a>

Reviewed by Tim Nguyen.

We tell the compile to only use 1 bit per bool in
CSSSelectorParserContext so that it can pack the bools together into less bytes.

* Source/WebCore/css/parser/CSSSelectorParserContext.h:

Canonical link: <a href="https://commits.webkit.org/282749@main">https://commits.webkit.org/282749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/889fe107373a90357c92e6bc43faa4c1b9f6aae8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51477 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10027 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12697 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14170 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6513 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39070 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->