### PR TITLE
[ MacOS x86_64 wk2 ] fast/webgpu/regression/repro_275111b.html is a constant failure

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_275111b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275111b.html
@@ -18,6 +18,7 @@ struct VertexOutput {
 @vertex
 fn v(@location(0) fromVertexBuffer: u32) -> VertexOutput {
   var v = VertexOutput();
+  v.position = vec4f(0, 0, 0, 1);
   v.something = fromVertexBuffer;
   return v;
 }

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1756,8 +1756,6 @@ webkit.org/b/274852 imported/w3c/web-platform-tests/css/css-view-transitions/new
 
 webkit.org/b/273613 [ Ventura ] imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html [ Skip ]
 
-webkit.org/b/275758 [ x86_64 ] fast/webgpu/regression/repro_275111b.html [ Failure ]
-
 webkit.org/b/275913 [ Debug ] imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html [ Pass Crash ]
 
 # webkit.org/b/275928 (REGRESSION(280114@main): [ macOS wk2 ] 2 tests in css-view-transitions are constant failure

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -142,6 +142,9 @@ private:
 
     const Ref<Device> m_device;
     mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+#if CPU(X86_64)
+    bool m_mappedAtCreation { false };
+#endif
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -151,6 +151,9 @@ Buffer::Buffer(id<MTLBuffer> buffer, uint64_t initialSize, WGPUBufferUsageFlags 
     , m_state(initialState)
     , m_mappingRange(initialMappingRange)
     , m_device(device)
+#if CPU(X86_64)
+    , m_mappedAtCreation(m_state == State::MappedAtCreation)
+#endif
 {
     if (m_usage & WGPUBufferUsage_Indirect)
         m_indirectBuffer = device.safeCreateBuffer(sizeof(MTLDrawPrimitivesIndirectArguments), MTLStorageModePrivate);
@@ -375,10 +378,14 @@ void Buffer::unmap()
     decrementBufferMapCount();
     indirectBufferInvalidated();
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if CPU(X86_64)
     if (m_buffer.storageMode == MTLStorageModeManaged) {
-        for (const auto& mappedRange : m_mappedRanges)
-            [m_buffer didModifyRange:NSMakeRange(static_cast<NSUInteger>(mappedRange.begin()), static_cast<NSUInteger>(mappedRange.end() - mappedRange.begin()))];
+        if (m_mappedAtCreation)
+            [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
+        else {
+            for (const auto& mappedRange : m_mappedRanges)
+                [m_buffer didModifyRange:NSMakeRange(static_cast<NSUInteger>(mappedRange.begin()), static_cast<NSUInteger>(mappedRange.end() - mappedRange.begin()))];
+        }
     }
 #endif
 

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -43,9 +43,9 @@ class Device;
 class CommandBuffer : public WGPUCommandBufferImpl, public RefCounted<CommandBuffer>, public CanMakeWeakPtr<CommandBuffer> {
     WTF_MAKE_TZONE_ALLOCATED(CommandBuffer);
 public:
-    static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
+    static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, Device& device)
     {
-        return adoptRef(*new CommandBuffer(commandBuffer, event, device));
+        return adoptRef(*new CommandBuffer(commandBuffer, device));
     }
     static Ref<CommandBuffer> createInvalid(Device& device)
     {
@@ -69,11 +69,10 @@ public:
     bool waitForCompletion();
 
 private:
-    CommandBuffer(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);
+    CommandBuffer(id<MTLCommandBuffer>, Device&);
     CommandBuffer(Device&);
 
     id<MTLCommandBuffer> m_commandBuffer { nil };
-    id<MTLSharedEvent> m_abortEvent { nil };
     id<MTLCommandBuffer> m_cachedCommandBuffer { nil };
     int m_bufferMapCount { 0 };
 

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -33,9 +33,8 @@ namespace WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CommandBuffer);
 
-CommandBuffer::CommandBuffer(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
+CommandBuffer::CommandBuffer(id<MTLCommandBuffer> commandBuffer, Device& device)
     : m_commandBuffer(commandBuffer)
-    , m_abortEvent(event)
     , m_device(device)
 {
 }
@@ -45,7 +44,10 @@ CommandBuffer::CommandBuffer(Device& device)
 {
 }
 
-CommandBuffer::~CommandBuffer() = default;
+CommandBuffer::~CommandBuffer()
+{
+    m_device->getQueue().removeMTLCommandBuffer(m_commandBuffer);
+}
 
 void CommandBuffer::setLabel(String&& label)
 {
@@ -57,9 +59,8 @@ void CommandBuffer::makeInvalid(NSString* lastError)
     if (!m_commandBuffer || m_commandBuffer.status >= MTLCommandBufferStatusCommitted)
         return;
 
-    [m_abortEvent setSignaledValue:1];
     m_lastErrorString = lastError;
-    m_device->getQueue().commitMTLCommandBuffer(m_commandBuffer);
+    m_device->getQueue().removeMTLCommandBuffer(m_commandBuffer);
     m_commandBuffer = nil;
 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -58,9 +58,9 @@ class Texture;
 class CommandEncoder : public WGPUCommandEncoderImpl, public RefCounted<CommandEncoder>, public CommandsMixin, public CanMakeWeakPtr<CommandEncoder> {
     WTF_MAKE_TZONE_ALLOCATED(CommandEncoder);
 public:
-    static Ref<CommandEncoder> create(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
+    static Ref<CommandEncoder> create(id<MTLCommandBuffer> commandBuffer, Device& device)
     {
-        return adoptRef(*new CommandEncoder(commandBuffer, event, device));
+        return adoptRef(*new CommandEncoder(commandBuffer, device));
     }
     static Ref<CommandEncoder> createInvalid(Device& device)
     {
@@ -112,7 +112,7 @@ public:
     void setExistingEncoder(id<MTLCommandEncoder>);
 
 private:
-    CommandEncoder(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);
+    CommandEncoder(id<MTLCommandBuffer>, Device&);
     CommandEncoder(Device&);
 
     NSString* errorValidatingCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -42,6 +42,7 @@ namespace WebGPU {
 #define RETURN_IF_FINISHED() \
 if (!m_parentEncoder->isLocked() || m_parentEncoder->isFinished()) { \
     m_device->generateAValidationError([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]); \
+    m_computeCommandEncoder = nil; \
     return; \
 } \
 if (!m_computeCommandEncoder || !m_parentEncoder->isValid() || !m_parentEncoder->encoderIsCurrent(m_computeCommandEncoder)) { \
@@ -70,7 +71,7 @@ ComputePassEncoder::ComputePassEncoder(CommandEncoder& parentEncoder, Device& de
 ComputePassEncoder::~ComputePassEncoder()
 {
     if (m_computeCommandEncoder)
-        m_parentEncoder->endEncoding(m_computeCommandEncoder);
+        m_parentEncoder->makeInvalid(@"GPUComputePassEncoder.finish was never called");
     m_computeCommandEncoder = nil;
 }
 

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -177,7 +177,7 @@ private:
 
     bool validateRenderPipeline(const WGPURenderPipelineDescriptor&);
 
-    void makeInvalid() { m_device = nil; }
+    void makeInvalid();
     NSString* addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>&, const std::optional<WGSL::PipelineLayout>&);
     Ref<PipelineLayout> generatePipelineLayout(const Vector<Vector<WGPUBindGroupLayoutEntry>> &bindGroupEntries);
 

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -139,7 +139,7 @@ bool Device::isDestroyed() const
 
 Ref<Device> Device::create(id<MTLDevice> device, String&& deviceLabel, HardwareCapabilities&& capabilities, Adapter& adapter)
 {
-    id<MTLCommandQueue> commandQueue = [device newCommandQueueWithMaxCommandBufferCount:2048];
+    id<MTLCommandQueue> commandQueue = [device newCommandQueueWithMaxCommandBufferCount:4096];
     if (!commandQueue)
         return Device::createInvalid(adapter);
 
@@ -239,13 +239,17 @@ RefPtr<XRSubImage> Device::getXRViewSubImage(WGPUXREye eye)
     return eye == WGPUXREye_Right ? m_xrSubImages[1] : m_xrSubImages[0];
 }
 
+void Device::makeInvalid()
+{
+    m_device = nil;
+    m_defaultQueue->makeInvalid();
+}
+
 void Device::loseTheDevice(WGPUDeviceLostReason reason)
 {
     m_device = nil;
 
     m_adapter->makeInvalid();
-
-    makeInvalid();
 
     if (m_deviceLostCallback) {
         m_deviceLostCallback(reason, "Device lost."_s);

--- a/Source/WebGPU/WebGPU/MetalSPI.h
+++ b/Source/WebGPU/WebGPU/MetalSPI.h
@@ -35,7 +35,4 @@ constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P_PACKED = static_cast<MTLPi
 @optional
 - (kern_return_t)setOwnerWithIdentity:(mach_port_t)task_id_token;
 @end
-@protocol MTLCommandBufferSPI <MTLCommandBuffer>
-- (void)encodeConditionalAbortEvent:(id <MTLSharedEvent>)event;
-@end
 #endif

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -322,7 +322,7 @@ void PresentationContextIOSurface::present()
     if (Texture* texturePtr = textureRefPtr.get(); texturePtr && m_computePipelineState) {
         MTLCommandBufferDescriptor *descriptor = [MTLCommandBufferDescriptor new];
         descriptor.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
-        id<MTLCommandBuffer> commandBuffer = devicePtr->getQueue().commandBufferWithDescriptor(descriptor).first;
+        id<MTLCommandBuffer> commandBuffer = devicePtr->getQueue().commandBufferWithDescriptor(descriptor);
         MTLComputePassDescriptor* computeDescriptor = [MTLComputePassDescriptor new];
         computeDescriptor.dispatchType = MTLDispatchTypeSerial;
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -76,8 +76,9 @@ public:
 
     const Device& device() const;
     void clearTextureIfNeeded(const WGPUImageCopyTexture&, NSUInteger);
-    std::pair<id<MTLCommandBuffer>, id<MTLSharedEvent>> commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
+    id<MTLCommandBuffer> commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
     void commitMTLCommandBuffer(id<MTLCommandBuffer>);
+    void removeMTLCommandBuffer(id<MTLCommandBuffer>);
     void setEncoderForBuffer(id<MTLCommandBuffer>, id<MTLCommandEncoder>);
     id<MTLCommandEncoder> encoderForBuffer(id<MTLCommandBuffer>) const;
     void clearTextureViewIfNeeded(TextureView&);
@@ -96,6 +97,7 @@ private:
 
     bool isIdle() const;
     bool isSchedulingIdle() const { return m_submittedCommandBufferCount == m_scheduledCommandBufferCount; }
+    void removeMTLCommandBufferInternal(id<MTLCommandBuffer>);
 
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
@@ -103,7 +105,6 @@ private:
 
     id<MTLCommandQueue> m_commandQueue { nil };
     id<MTLCommandBuffer> m_commandBuffer { nil };
-    id<MTLSharedEvent> m_commandBufferEvent { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
     ThreadSafeWeakPtr<Device> m_device; // The only kind of queues that exist right now are default queues, which are owned by Devices.
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -46,6 +46,7 @@ namespace WebGPU {
 #define RETURN_IF_FINISHED() \
 if (!m_parentEncoder->isLocked() || m_parentEncoder->isFinished()) { \
     m_device->generateAValidationError([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]); \
+    m_renderCommandEncoder = nil; \
     return; \
 } \
 if (!m_renderCommandEncoder || !m_parentEncoder->isValid() || !m_parentEncoder->encoderIsCurrent(m_renderCommandEncoder)) { \
@@ -184,7 +185,8 @@ RenderPassEncoder::RenderPassEncoder(CommandEncoder& parentEncoder, Device& devi
 RenderPassEncoder::~RenderPassEncoder()
 {
     if (m_renderCommandEncoder)
-        m_parentEncoder->endEncoding(m_renderCommandEncoder);
+        m_parentEncoder->makeInvalid(@"GPURenderPassEncoder.finish was never called");
+
     m_renderCommandEncoder = nil;
 }
 


### PR DESCRIPTION
#### 7662fa7cb93963ffe4e0ab9fda31ad5614f80d43
<pre>
[ MacOS x86_64 wk2 ] fast/webgpu/regression/repro_275111b.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=275758">https://bugs.webkit.org/show_bug.cgi?id=275758</a>
radar://130302752

Reviewed by Tadeu Zagallo.

Command buffers were collecting because we didn&apos;t remove
them in WebGPU::CommandBuffer&apos;s destructor.

With this change, we don&apos;t need the abort event which was
Apple Silicon only so we no longer sumbit invalid command buffers
on Intel Macs.

* LayoutTests/platform/mac-wk2/TestExpectations:
Remove failing test expectation.

* Source/WebGPU/WebGPU/CommandBuffer.h:
(WebGPU::CommandBuffer::create):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::CommandBuffer):
(WebGPU::CommandBuffer::~CommandBuffer):
(WebGPU::CommandBuffer::makeInvalid):
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::create):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::Device::createCommandEncoder):
(WebGPU::CommandEncoder::CommandEncoder):
(WebGPU::CommandEncoder::~CommandEncoder):
(WebGPU::CommandEncoder::discardCommandBuffer):
(WebGPU::CommandEncoder::endEncoding):
(WebGPU::CommandEncoder::makeInvalid):
(WebGPU::CommandEncoder::finish):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::~ComputePassEncoder):
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::makeInvalid): Deleted.
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::create):
Increase the limit since sometimes it takes time for the GC to
run.

(WebGPU::Device::makeInvalid):
(WebGPU::Device::loseTheDevice):
* Source/WebGPU/WebGPU/MetalSPI.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::ensureBlitCommandEncoder):
(WebGPU::Queue::commandBufferWithDescriptor):
(WebGPU::Queue::makeInvalid):
(WebGPU::Queue::removeMTLCommandBuffer):
(WebGPU::Queue::removeMTLCommandBufferInternal):
(WebGPU::Queue::commitMTLCommandBuffer):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::~RenderPassEncoder):

Canonical link: <a href="https://commits.webkit.org/283015@main">https://commits.webkit.org/283015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a5d64e96241c22909552b59509ae452c9788cc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15486 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52135 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10688 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32755 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13511 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14362 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59477 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/953 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40057 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->