### PR TITLE
Pack CSSSelectorParser bits.

### DIFF
--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -105,13 +105,13 @@ private:
     CSSParserEnum::IsNestedContext m_isNestedContext { CSSParserEnum::IsNestedContext::No };
 
     // FIXME: This m_failedParsing is ugly and confusing, we should look into removing it (the return value of each function already convey this information).
-    bool m_failedParsing { false };
+    bool m_failedParsing : 1 { false };
 
-    bool m_disallowPseudoElements { false };
-    bool m_disallowHasPseudoClass { false };
-    bool m_resistDefaultNamespace { false };
-    bool m_ignoreDefaultNamespace { false };
-    bool m_disableForgivingParsing { false };
+    bool m_disallowPseudoElements : 1 { false };
+    bool m_disallowHasPseudoClass : 1 { false };
+    bool m_resistDefaultNamespace : 1 { false };
+    bool m_ignoreDefaultNamespace : 1 { false };
+    bool m_disableForgivingParsing : 1 { false };
     std::optional<CSSSelector::PseudoElement> m_precedingPseudoElement;
 };
 


### PR DESCRIPTION
#### 8ea68a79c477f3a9a5f90aefd5adb9f029bada69
<pre>
Pack CSSSelectorParser bits.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278580">https://bugs.webkit.org/show_bug.cgi?id=278580</a>

Reviewed by NOBODY (OOPS!).

Pack CSSSelectorParser bits.

* Source/WebCore/css/parser/CSSSelectorParser.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ea68a79c477f3a9a5f90aefd5adb9f029bada69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63916 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43273 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16513 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67938 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14524 "Hash 8ea68a79 for PR 32646 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66036 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50971 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14804 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/67938 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/14524 "Hash 8ea68a79 for PR 32646 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66985 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/50971 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/16513 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/67938 "Hash 8ea68a79 for PR 32646 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/50971 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/16513 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13397 "Hash 8ea68a79 for PR 32646 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/50971 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/16513 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69634 "Hash 8ea68a79 for PR 32646 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7863 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/14804 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/69634 "Hash 8ea68a79 for PR 32646 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7896 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/16513 "Hash 8ea68a79 for PR 32646 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/69634 "Hash 8ea68a79 for PR 32646 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39093 "Hash 8ea68a79 for PR 32646 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40172 "Hash 8ea68a79 for PR 32646 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41355 "Hash 8ea68a79 for PR 32646 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39915 "Hash 8ea68a79 for PR 32646 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->