### PR TITLE
Adopt CheckedRef in ElementDescendantIterator

### DIFF
--- a/Source/WebCore/dom/TypedElementDescendantIterator.h
+++ b/Source/WebCore/dom/TypedElementDescendantIterator.h
@@ -73,7 +73,7 @@ public:
     inline ElementType* last() const;
 
 private:
-    const ContainerNode& m_root;
+    CheckedRef<const ContainerNode> m_root;
 };
 
 template<typename ElementType> class InclusiveElementDescendantRange {
@@ -88,7 +88,7 @@ public:
     inline ElementType* last() const;
 
 private:
-    const ContainerNode& m_root;
+    CheckedRef<const ContainerNode> m_root;
 };
 
 template<typename ElementType> class DoubleElementDescendantRange {
@@ -135,7 +135,7 @@ public:
     inline ElementType* first() const;
 
 private:
-    const ContainerNode& m_root;
+    CheckedRef<const ContainerNode> m_root;
 };
 
 // ElementDescendantIterator

--- a/Source/WebCore/dom/TypedElementDescendantIteratorInlines.h
+++ b/Source/WebCore/dom/TypedElementDescendantIteratorInlines.h
@@ -62,7 +62,7 @@ template<typename ElementType> ElementDescendantIterator<ElementType> ElementDes
     ASSERT(descendant.isDescendantOf(m_root));
     if (auto descendantElement = dynamicDowncast<ElementType>(descendant))
         return ElementDescendantIterator<ElementType>(m_root, descendantElement);
-    ElementType* next = Traversal<ElementType>::next(descendant, &m_root);
+    ElementType* next = Traversal<ElementType>::next(descendant, m_root.ptr());
     return ElementDescendantIterator<ElementType>(m_root, next);
 }
 
@@ -80,7 +80,7 @@ template<typename ElementType> ElementType* ElementDescendantRange<ElementType>:
 
 template<typename ElementType> ElementDescendantIterator<ElementType> InclusiveElementDescendantRange<ElementType>::begin() const
 {
-    return ElementDescendantIterator<ElementType>(m_root, Traversal<ElementType>::inclusiveFirstWithin(const_cast<ContainerNode&>(m_root)));
+    return ElementDescendantIterator<ElementType>(m_root, Traversal<ElementType>::inclusiveFirstWithin(const_cast<ContainerNode&>(m_root.get())));
 }
 
 template<typename ElementType> ElementDescendantIterator<ElementType> InclusiveElementDescendantRange<ElementType>::beginAt(ElementType& descendant) const
@@ -154,7 +154,7 @@ template<typename ElementType, bool filter(const ElementType&)> auto FilteredEle
 
 template<typename ElementType, bool filter(const ElementType&)> ElementType* FilteredElementDescendantRange<ElementType, filter>::first() const
 {
-    for (auto* element = Traversal<ElementType>::firstWithin(m_root); element; element = Traversal<ElementType>::next(*element, &m_root)) {
+    for (auto* element = Traversal<ElementType>::firstWithin(m_root.get()); element; element = Traversal<ElementType>::next(*element, m_root.ptr())) {
         if (filter(*element))
             return element;
     }


### PR DESCRIPTION
#### ea5e6616e81855e267f03f68cad298292e201972
<pre>
Adopt CheckedRef in ElementDescendantIterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=278584">https://bugs.webkit.org/show_bug.cgi?id=278584</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer.

* Source/WebCore/dom/TypedElementDescendantIterator.h:
(WebCore::filter):
* Source/WebCore/dom/TypedElementDescendantIteratorInlines.h:
(WebCore::ElementDescendantRange&lt;ElementType&gt;::from const):
(WebCore::InclusiveElementDescendantRange&lt;ElementType&gt;::begin const):
(WebCore::filter const):

Canonical link: <a href="https://commits.webkit.org/282688@main">https://commits.webkit.org/282688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/873689ad4371a986b42f22f7dd667560c906086e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14817 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13410 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7876 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55433 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6545 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9671 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->