### PR TITLE
[JSC] Add sources, line, column information to SamplingProfiler output

### DIFF
--- a/JSTests/stress/sampling-profiler-line-column.js
+++ b/JSTests/stress/sampling-profiler-line-column.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+(function () {
+    if (!platformSupportsSamplingProfiler())
+        return;
+
+    load("./sampling-profiler/samplingProfiler.js", "caller relative");
+
+    function test() {
+        var res = 0;
+        for (let i = 0; i < 1000; ++i)
+            res += Math.tan(i);
+        return res;
+    }
+    noInline(test);
+
+    const timeToFail = 50000;
+    let startTime = Date.now();
+    do {
+        test();
+        let data = samplingProfilerStackTraces();
+        for (let trace of data.traces) {
+            for (let frame of trace.frames) {
+                if (frame.name === 'test' && (frame.line >= 11 && frame.line <= 16) && (frame.column >= 5 && frame.line <= 38))
+                    return;
+            }
+        }
+    } while (Date.now() - startTime < timeToFail);
+    let stacktraces = samplingProfilerStackTraces();
+    throw new Error(`Bad stack trace ${JSON.stringify(stacktraces)}`);
+}());

--- a/JSTests/stress/sampling-profiler-url-directives.js
+++ b/JSTests/stress/sampling-profiler-url-directives.js
@@ -1,0 +1,28 @@
+//# sourceMappingURL=faster-than-light.js.map
+//# sourceURL=faster-than-light.js
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + " expected: " + expected);
+}
+(function () {
+    if (!platformSupportsSamplingProfiler())
+        return;
+
+    load("./sampling-profiler/samplingProfiler.js", "caller relative");
+
+    const timeToFail = 50000;
+    let startTime = Date.now();
+    do {
+        let data = samplingProfilerStackTraces();
+        for (let source of data.sources) {
+            if (source.sourceURL && source.sourceMappingURL) {
+                shouldBe(source.sourceURL, `faster-than-light.js`);
+                shouldBe(source.sourceMappingURL, `faster-than-light.js.map`);
+                return;
+            }
+        }
+    } while (Date.now() - startTime < timeToFail);
+    let stacktraces = samplingProfilerStackTraces();
+    throw new Error(`Bad stack trace ${JSON.stringify(stacktraces)}`);
+}());

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
@@ -178,7 +178,7 @@ static Ref<Protocol::ScriptProfiler::Samples> buildSamples(VM& vm, Vector<Sampli
         auto frames = JSON::ArrayOf<Protocol::ScriptProfiler::StackFrame>::create();
         for (SamplingProfiler::StackFrame& stackFrame : stackTrace.frames) {
             auto frameObject = Protocol::ScriptProfiler::StackFrame::create()
-                .setSourceID(String::number(stackFrame.sourceID()))
+                .setSourceID(String::number(std::get<1>(stackFrame.sourceProviderAndID())))
                 .setName(stackFrame.displayName(vm))
                 .setLine(stackFrame.functionStartLine())
                 .setColumn(stackFrame.functionStartColumn())

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2419,7 +2419,7 @@ ALWAYS_INLINE void CachedCodeBlock<CodeBlockType>::encode(Encoder& encoder, cons
     m_rareData.encode(encoder, codeBlock.m_rareData.get());
 
     m_sourceURLDirective.encode(encoder, codeBlock.m_sourceURLDirective.get());
-    m_sourceMappingURLDirective.encode(encoder, codeBlock.m_sourceURLDirective.get());
+    m_sourceMappingURLDirective.encode(encoder, codeBlock.m_sourceMappingURLDirective.get());
 
     m_instructions.encode(encoder, codeBlock.m_instructions.get());
     m_constantRegisters.encode(encoder, codeBlock.m_constantRegisters);

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -153,7 +153,7 @@ public:
         String displayName(VM&);
         int functionStartLine();
         unsigned functionStartColumn();
-        SourceID sourceID();
+        std::tuple<SourceProvider*, SourceID> sourceProviderAndID();
         String url();
     };
 


### PR DESCRIPTION
#### 010b05aed8971c55f5fb8d40dc5f9e8a4dea80b3
<pre>
[JSC] Add sources, line, column information to SamplingProfiler output
<a href="https://bugs.webkit.org/show_bug.cgi?id=278585">https://bugs.webkit.org/show_bug.cgi?id=278585</a>
<a href="https://rdar.apple.com/125935249">rdar://125935249</a>

Reviewed by Keith Miller and Mark Lam.

This patch extends sampling profiler output as followings.

1. We add `sources` section. It is array of source, and each one may have url, sourceURL, and sourceMappingURL.

    {
        sourceID: &lt;integer source id&gt;,
        url: &lt;url string from WebKit / JavaScriptCore. optional&gt;,
        sourceURL: &lt;sourceURL string specified via comment directive. optional&gt;,
        sourceMappingURL: &lt;sourceMappingURL string specified via comment directive. optional&gt;
    }

2. Add line and column information. If they are not found, it is UINT32_MAX (0xffffffff).

* JSTests/stress/sampling-profiler-line-column.js: Added.
(shouldBe):
(test):
* JSTests/stress/sampling-profiler-url-directives.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::StackFrame::sourceID):
(JSC::SamplingProfiler::StackFrame::sourceProvider):
(JSC::SamplingProfiler::stackTracesAsJSON):
* Source/JavaScriptCore/runtime/SamplingProfiler.h:

Canonical link: <a href="https://commits.webkit.org/282692@main">https://commits.webkit.org/282692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbdd2cedf2d5acc4b779f7d41b07346cbdaa9dd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16569 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67994 "Hash fbdd2ced for PR 32651 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14580 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14860 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/67994 "Hash fbdd2ced for PR 32651 does not build (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40113 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/67994 "Hash fbdd2ced for PR 32651 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36785 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13453 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/57084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69693 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63217 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7919 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7952 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/55471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6572 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84978 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9675 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14986 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->