### PR TITLE
[JSC] Return written bytes in JSStringGetUTF8CString when it encounters invalid source

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -104,9 +104,6 @@ size_t JSStringGetUTF8CString(JSStringRef string, char* buffer, size_t bufferSiz
         result = WTF::Unicode::convert(string->span8(), target);
     else
         result = WTF::Unicode::convert(string->span16(), target);
-    if (result.code == WTF::Unicode::ConversionResultCode::SourceInvalid)
-        return 0;
-
     buffer[result.buffer.size()] = '\0';
     return result.buffer.size() + 1;
 }

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1303,6 +1303,31 @@ static void checkJSStringOOB(void)
     printf("PASS: checkJSStringOOB\n");
 }
 
+static void checkJSStringInvalid(void)
+{
+    printf("Test: checkJSStringInvalid\n");
+    JSChar* source = (JSChar*)malloc(sizeof(JSChar) * 4);
+    source[0] = 'a';
+    source[1] = 'b';
+    source[2] = 'c';
+    source[3] = 0xD800;
+    JSStringRef string = JSStringCreateWithCharacters(source, 4);
+
+    char* out = (char*)malloc(sizeof(char) * 32);
+    memset(out, 1, sizeof(char) * 32);
+    size_t bytesWritten = JSStringGetUTF8CString(string, out, sizeof(char) * 32);
+
+    assertTrue(bytesWritten == 4, "we report 4 bytes written precisely");
+    assertTrue(out[0] == 'a', "a");
+    assertTrue(out[1] == 'b', "b");
+    assertTrue(out[2] == 'c', "c");
+    assertTrue(out[3] == '\0', "string terminated");
+
+    JSStringRelease(string);
+    free(out);
+    free(source);
+}
+
 static const unsigned numWeakRefs = 10000;
 
 static void markingConstraint(JSMarkerRef marker, void *userData)
@@ -1888,6 +1913,7 @@ int main(int argc, char* argv[])
     assertEqualsAsUTF8String(jsOneString, "1");
 
     checkJSStringOOB();
+    checkJSStringInvalid();
 
     checkConstnessInJSObjectNames();
 


### PR DESCRIPTION
#### 698815c7917c7ce54e8d8613c1f0f159cc3bfef3
<pre>
[JSC] Return written bytes in JSStringGetUTF8CString when it encounters invalid source
<a href="https://bugs.webkit.org/show_bug.cgi?id=278587">https://bugs.webkit.org/show_bug.cgi?id=278587</a>
<a href="https://rdar.apple.com/133747399">rdar://133747399</a>

Reviewed by Yijia Huang.

As API document describes, we should return written bytes even when we encountered the invalid source (like, unpaired surrogate) and stopped
conversion in the middle of the string.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringGetUTF8CString):
* Source/JavaScriptCore/API/tests/testapi.c:
(checkJSStringInvalid):
(main):

Canonical link: <a href="https://commits.webkit.org/282689@main">https://commits.webkit.org/282689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/068cba1db0e7ec6ac1e92ccc887309c25b276b74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63940 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14548 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13421 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/57052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63185 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7887 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55444 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6552 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84946 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9672 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14982 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->