### PR TITLE
[JSC] Disallow yield/await expressions in class field initializers

### DIFF
--- a/JSTests/stress/yield-await-class-field-initializer-expr.js
+++ b/JSTests/stress/yield-await-class-field-initializer-expr.js
@@ -1,0 +1,117 @@
+// Tests for 'yield' and 'await' inside class field initializers, where the class is declared inside
+// async and generator functions.
+const verbose = false;
+
+const wrappers = ['none', 'generator', 'async'];
+const fieldModifiers = ['', 'static'];
+const fieldInitExprs = ['yield', 'yield 42', 'function() { yield 21; }', 'await', 'await 3', '() => await 7', 'function() { await 9; }'];
+
+function genTestCases() {
+    let cases = [];
+    for (const wrapper of wrappers) {
+        for (const fieldModifier of fieldModifiers) {
+            for (const fieldInitExpr of fieldInitExprs) {
+                cases.push({ wrapper, fieldModifier, fieldInitExpr });
+            }
+        }
+    }
+    return cases;
+}
+
+function genTestScript(c) {
+    let tabs = 0;
+    let script = "";
+
+    function append(line) {
+        for (t = 0; t < tabs; t++)
+            script += '  ';
+        script += line + '\n';
+    }
+
+    switch (c.wrapper) {
+        case 'generator':
+            append('function * g() {');
+            break;
+        case 'async':
+            append('async function f() {');
+            break;
+        case 'none':
+            break;
+    }
+    tabs++;
+    append('class C {');
+    tabs++;
+    append(`${c.fieldModifier} f = ${c.fieldInitExpr};`);
+    tabs--;
+    append('}');
+    tabs--;
+    if (c.wrapper !== 'none') append('}');
+    return script;
+}
+
+function expected(c, result, error) {
+    if (c.fieldInitExpr === 'await') {
+        // 'await' will parse as an identifier.
+        if (c.wrapper === 'none' && c.fieldModifier === 'static') {
+            // In this case, 'await' as identifier produces a ReferenceError.
+            return result === null && error instanceof ReferenceError;
+        }
+        // In these cases, 'await' as identifier has value 'undefined').
+        return result === undefined && error === null;
+    }
+    // All other cases should result in a SyntaxError.
+    return result === null && error instanceof SyntaxError;
+}
+
+// Verify that 'await' and 'yield' do not parse as keywords (directly) inside class field initializers.
+function testNegativeCases() {
+    cases = genTestCases();
+
+    for (const c of cases) {
+        let script = genTestScript(c);
+        let result = null;
+        let error = null;
+        try {
+            result = eval(script);
+        } catch (e) {
+            error = e;
+        }
+
+        if (verbose || !expected(c, result, error)) {
+            print(`Case: ${c.wrapper}:${c.fieldModifier}:${c.fieldInitExpr}`);
+            print(`Script:\n${script}`);
+            print(`Result: ${result}`);
+            print(`Error: ${error}\n`);
+        }
+    }
+}
+
+// Verify that 'await' and 'yield' work inside anonymous async / generator functions
+// used as class field initializers.
+function testPositiveCases() {
+    function assertEq(got, expected) {
+        if (got !== expected) {
+            throw Error(`Got: ${got}, Expected: ${expected}`);
+        }
+    }
+
+    class C {
+        asyncFn0 = async y => await y;
+        asyncFn1 = async () => { return await 5 };
+        asyncFn2 = async function(x) { return await x; };
+
+        yieldFn0 = function* () { yield 9; };
+        yieldFn1 = async function* () { yield await 11; };
+    };
+    let c = new C();
+
+    c.asyncFn0(3).then(x => assertEq(x, 3));
+    c.asyncFn1().then(x => assertEq(x, 5));
+    c.asyncFn2(7).then(x => assertEq(x, 7));
+
+    assertEq(c.yieldFn0().next().value, 9);
+    c.yieldFn1().next().then(x => assertEq(x.value, 11));
+}
+
+testNegativeCases();
+testPositiveCases();

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -2018,6 +2018,7 @@ private:
         const Identifier* lastPrivateName { nullptr };
         bool allowAwait { true };
         bool isParsingClassFieldInitializer { false };
+        bool classFieldInitMasksAsync { false };
     };
 
     // If you're using this directly, you probably should be using


### PR DESCRIPTION
#### 83c375677006369e1f00216b5640eaf3e6850d01
<pre>
[JSC] Disallow yield/await expressions in class field initializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=278589">https://bugs.webkit.org/show_bug.cgi?id=278589</a>
<a href="https://rdar.apple.com/132338331">rdar://132338331</a>

Reviewed by Yusuke Suzuki.

The language spec doesn&apos;t explictly disallow yield and await expressions
in class field initializers, however it implicitly does given that
the expression is effectively evaluated as if it&apos;s inside a method.
Additionally, the consensus seems to be that these expressions
should not be allowed, see:

<a href="https://github.com/tc39/ecma262/issues/3333">https://github.com/tc39/ecma262/issues/3333</a>

The yield and await expressions are now handled differently, but
similar to how they are each handled in other contexts. This also
seems to be the least disruptive way to handle existing scripts,
as well as consistent with other engines:

yield: raise syntax error
await: parse as an identifier

However, if the field initializer expression is an async function
expression, then &apos;await&apos; is allowed within that expression.

Also adding a new test that generates and verifies scripts containing
a class with a field initializer containing yield and await, where the
class is either not nested or nested inside generator or async functions
to verify the behavior of various combinations.

* JSTests/stress/yield-await-class-field-initializer-expr.js: Added.
(genTestCases):
(genTestScript.append):
(genTestScript):
(expected):
(testNegativeCases):
(testPositiveCases.assertEq):
(testPositiveCases.yieldFn0):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionBody):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseYieldExpression):
(JSC::Parser&lt;LexerType&gt;::parseAwaitExpression):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/282819@main">https://commits.webkit.org/282819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/246c2c4c99fef49582e31fff6ac6e810c8a95bee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14796 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51673 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12924 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13670 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57300 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69909 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63433 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8135 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59151 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/419 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85194 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9753 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15024 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40444 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->