### PR TITLE
Remove Frame::setOpener

### DIFF
--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -286,12 +286,13 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
 
     bool created;
     WindowFeatures features;
-    RefPtr frame = dynamicDowncast<LocalFrame>(WebCore::createWindow(mainFrame, mainFrame, WTFMove(frameLoadRequest), features, created));
+    RefPtr frame = dynamicDowncast<LocalFrame>(WebCore::createWindow(mainFrame, WTFMove(frameLoadRequest), features, created));
     if (!frame)
         return;
 
-    frame->setOpener(mainFrame.ptr());
+    ASSERT(frame->opener() == mainFrame.ptr());
     frame->page()->setOpenedByDOM();
+    frame->page()->setOpenedByDOMWithOpener(true);
 
     // FIXME: Why do we compute the absolute URL with respect to |frame| instead of |mainFrame|?
     ResourceRequest resourceRequest { frame->document()->completeURL(url) };

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -549,6 +549,6 @@ private:
 //
 // FIXME: Consider making this function part of an appropriate class (not FrameLoader)
 // and moving it to a more appropriate location.
-RefPtr<Frame> createWindow(LocalFrame& openerFrame, LocalFrame& lookupFrame, FrameLoadRequest&&, WindowFeatures&, bool& created);
+RefPtr<Frame> createWindow(LocalFrame& openerFrame, FrameLoadRequest&&, WindowFeatures&, bool& created);
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -73,10 +73,11 @@ public:
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() const { return m_mainFrame.get(); }
     bool isMainFrame() const { return this == m_mainFrame.ptr(); }
-    WEBCORE_EXPORT void setOpener(Frame*);
+    WEBCORE_EXPORT void disownOpener();
+    void updateOpener(Frame&);
+    WEBCORE_EXPORT void setOpenerForWebKitLegacy(Frame*);
     const Frame* opener() const { return m_opener.get(); }
     Frame* opener() { return m_opener.get(); }
-    WEBCORE_EXPORT Vector<Ref<Frame>> openedFrames();
     bool hasOpenedFrames() const;
     WEBCORE_EXPORT void detachFromAllOpenedFrames();
     virtual bool isRootFrame() const = 0;
@@ -93,7 +94,7 @@ public:
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
     CheckedRef<NavigationScheduler> checkedNavigationScheduler() const;
-    WEBCORE_EXPORT void takeWindowProxyFrom(Frame&);
+    WEBCORE_EXPORT void takeWindowProxyAndOpenerFrom(Frame&);
 
     HistoryController& history() const { return m_history.get(); }
     WEBCORE_EXPORT CheckedRef<HistoryController> checkedHistory() const;

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -93,12 +93,6 @@ unsigned RemoteDOMWindow::length() const
     return m_frame->tree().childCount();
 }
 
-void RemoteDOMWindow::setOpener(WindowProxy*)
-{
-    // FIXME: <rdar://118263373> Implement.
-    // JSDOMWindow::setOpener has some security checks. Are they needed here?
-}
-
 ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&& options)
 {
     RefPtr sourceDocument = incumbentWindow.document();

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -63,7 +63,6 @@ public:
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
     unsigned length() const;
-    void setOpener(WindowProxy*);
     void frameDetached();
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&&);
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -149,7 +149,7 @@ WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 void WKBundleFrameClearOpener(WKBundleFrameRef frameRef)
 {
     if (auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame())
-        coreFrame->setOpener(nullptr);
+        coreFrame->disownOpener();
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -372,11 +372,7 @@ void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHosting
         : parent ? WebCore::RemoteFrame::createSubframe(*corePage, WTFMove(clientCreator), m_frameID, *parent) : WebCore::RemoteFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, localFrame->opener());
     if (!parent)
         corePage->setMainFrame(newFrame.copyRef());
-    newFrame->takeWindowProxyFrom(*localFrame);
-
-    newFrame->setOpener(localFrame->opener());
-    for (auto& frame : localFrame->openedFrames())
-        frame->setOpener(newFrame.ptr());
+    newFrame->takeWindowProxyAndOpenerFrom(*localFrame);
 
     newFrame->tree().setSpecifiedName(localFrame->tree().specifiedName());
     if (ownerRenderer)
@@ -468,11 +464,7 @@ void WebFrame::commitProvisionalFrame()
     localFrame->setOwnerElement(ownerElement.get());
     if (remoteFrame->isMainFrame())
         corePage->setMainFrame(*localFrame);
-    localFrame->takeWindowProxyFrom(*remoteFrame);
-
-    localFrame->setOpener(remoteFrame->opener());
-    for (auto& frame : remoteFrame->openedFrames())
-        frame->setOpener(localFrame.get());
+    localFrame->takeWindowProxyAndOpenerFrom(*remoteFrame);
 
     if (corePage->focusController().focusedFrame() == remoteFrame.get())
         corePage->focusController().setFocusedFrame(localFrame.get(), FocusController::BroadcastFocusedFrame::No);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -304,8 +304,10 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& fea
         newWebView = CallUIDelegate(m_webView, @selector(webView:createWebViewWithRequest:), nil);
 
     auto* newPage = core(newWebView);
-    if (newPage && !features.wantsNoOpener())
+    if (newPage && !features.wantsNoOpener()) {
         m_webView.page->protectedStorageNamespaceProvider()->cloneSessionStorageNamespaceForPage(*m_webView.page, *newPage);
+        newPage->mainFrame().setOpenerForWebKitLegacy(&frame);
+    }
 
     return newPage;
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -813,13 +813,15 @@ void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::La
     }
 }
 
-WebCore::LocalFrame* WebFrameLoaderClient::dispatchCreatePage(const WebCore::NavigationAction&, WebCore::NewFrameOpenerPolicy)
+WebCore::LocalFrame* WebFrameLoaderClient::dispatchCreatePage(const WebCore::NavigationAction&, WebCore::NewFrameOpenerPolicy policy)
 {
     WebView *currentWebView = getWebView(m_webFrame.get());
     auto features = adoptNS([[NSDictionary alloc] init]);
     WebView *newWebView = [[currentWebView _UIDelegateForwarder] webView:currentWebView 
                                                 createWebViewWithRequest:nil
                                                           windowFeatures:features.get()];
+    if (newWebView && policy == WebCore::NewFrameOpenerPolicy::Allow)
+        core([newWebView mainFrame])->setOpenerForWebKitLegacy(core(m_webFrame.get()));
     return core([newWebView mainFrame]);
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2201,7 +2201,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_clearOpener
 {
     if (auto coreFrame = _private->coreFrame)
-        coreFrame->setOpener(nullptr);
+        coreFrame->disownOpener();
 }
 
 - (BOOL)hasRichlyEditableDragCaret

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1516,7 +1516,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
             return makeUniqueRef<WebFrameLoaderClient>();
         } },
         WebCore::FrameIdentifier::generate(),
-        nullptr,
+        nullptr, // Opener may be set by setOpenerForWebKitLegacy.
         makeUniqueRef<WebCore::DummySpeechRecognitionProvider>(),
         makeUniqueRef<WebCore::MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),
@@ -1779,7 +1779,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
             return makeUniqueRef<WebFrameLoaderClient>();
         } },
         WebCore::FrameIdentifier::generate(),
-        nullptr,
+        nullptr, // Opener may be set by setOpenerForWebKitLegacy.
         makeUniqueRef<WebCore::DummySpeechRecognitionProvider>(),
         makeUniqueRef<WebCore::MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),

--- a/Tools/TestWebKitAPI/Tests/WebKit/CloseFromWithinCreatePage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/CloseFromWithinCreatePage.cpp
@@ -36,22 +36,23 @@ namespace TestWebKitAPI {
 static bool testDone;
 static std::unique_ptr<PlatformWebView> openedWebView;
 
-static void runJavaScriptAlert(WKPageRef page, WKStringRef alertText, WKFrameRef frame, WKSecurityOriginRef, const void* clientInfo)
+static void runJavaScriptAlert(WKPageRef page, WKStringRef alertText, WKFrameRef frame, WKSecurityOriginRef, WKPageRunJavaScriptAlertResultListenerRef listener, const void* clientInfo)
 {
     // FIXME: Check that the alert text matches the storage.
     testDone = true;
+    WKPageRunJavaScriptAlertResultListenerCall(listener);
 }
 
-static WKPageRef createNewPageThenClose(WKPageRef page, WKURLRequestRef urlRequest, WKDictionaryRef features, WKEventModifiers modifiers, WKEventMouseButton mouseButton, const void *clientInfo)
+static WKPageRef createNewPageThenClose(WKPageRef page, WKPageConfigurationRef configuration, WKNavigationActionRef navigationAction, WKWindowFeaturesRef windowFeatures, const void *clientInfo)
 {
     EXPECT_TRUE(openedWebView == nullptr);
 
-    openedWebView = makeUnique<PlatformWebView>(page);
+    openedWebView = makeUnique<PlatformWebView>(configuration);
 
-    WKPageUIClientV5 uiClient;
+    WKPageUIClientV6 uiClient;
     memset(&uiClient, 0, sizeof(uiClient));
 
-    uiClient.base.version = 5;
+    uiClient.base.version = 6;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
     WKPageSetPageUIClient(openedWebView->page(), &uiClient.base);
 
@@ -67,10 +68,10 @@ TEST(WebKit, CloseFromWithinCreatePage)
 
     PlatformWebView webView(context.get());
 
-    WKPageUIClientV5 uiClient;
+    WKPageUIClientV6 uiClient;
     memset(&uiClient, 0, sizeof(uiClient));
 
-    uiClient.base.version = 5;
+    uiClient.base.version = 6;
     uiClient.createNewPage = createNewPageThenClose;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
     WKPageSetPageUIClient(webView.page(), &uiClient.base);
@@ -88,16 +89,16 @@ TEST(WebKit, CloseFromWithinCreatePage)
     openedWebView = nullptr;
 }
 
-static WKPageRef createNewPage(WKPageRef page, WKURLRequestRef urlRequest, WKDictionaryRef features, WKEventModifiers modifiers, WKEventMouseButton mouseButton, const void *clientInfo)
+static WKPageRef createNewPage(WKPageRef page, WKPageConfigurationRef configuration, WKNavigationActionRef navigationAction, WKWindowFeaturesRef windowFeatures, const void *clientInfo)
 {
     EXPECT_TRUE(openedWebView == nullptr);
 
-    openedWebView = makeUnique<PlatformWebView>(page);
+    openedWebView = makeUnique<PlatformWebView>(configuration);
 
-    WKPageUIClientV5 uiClient;
+    WKPageUIClientV6 uiClient;
     memset(&uiClient, 0, sizeof(uiClient));
 
-    uiClient.base.version = 5;
+    uiClient.base.version = 6;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
     WKPageSetPageUIClient(openedWebView->page(), &uiClient.base);
 
@@ -111,10 +112,10 @@ TEST(WebKit, CreatePageThenDocumentOpenMIMEType)
 
     PlatformWebView webView(context.get());
 
-    WKPageUIClientV5 uiClient;
+    WKPageUIClientV6 uiClient;
     memset(&uiClient, 0, sizeof(uiClient));
 
-    uiClient.base.version = 5;
+    uiClient.base.version = 6;
     uiClient.createNewPage = createNewPage;
     uiClient.runJavaScriptAlert = runJavaScriptAlert;
     WKPageSetPageUIClient(webView.page(), &uiClient.base);


### PR DESCRIPTION
#### b87d18215a73f63b17fc05ca68ad57d8a04646e4
<pre>
Remove Frame::setOpener
<a href="https://bugs.webkit.org/show_bug.cgi?id=278592">https://bugs.webkit.org/show_bug.cgi?id=278592</a>
<a href="https://rdar.apple.com/134596394">rdar://134596394</a>

Reviewed by Charlie Wolfe.

This PR untangles the different cases where we need to set
the opener of a frame.  Most commonly we only want to remove
the opener.  A frame can usually only get an opener if it is
created with one, which I moved to the UI process in
274396@main but it can also be given an opener later if
window.open is called with an existing frame as the target.
We also need a setter upon Page construction in
WebKitLegacy because the delegate callback doesn&apos;t have a
configuration object and when switching between a LocalFrame
and RemoteFrame.

This is step 1 of turning FrameLoaderClient::dispatchCreatePage
inside out and making it send the request and other parameters
for the UI process to decide to make a page in whatever process
it decides to.  This is needed for implementing window.open
with noopener with site isolation enabled.

In order for this new way of setting the opener to work,
users of WKPageSetPageUIClient need to be updated to v6
to get the createNewPage callback with a configuration where
we can preserve the opener info like we do with WKUIDelegate.
I&apos;ve gone through the users of WKPageSetPageUIClient and made
sure this won&apos;t break any current use.  There is one current
use and it always returns nil, so there is no compatibility
concern there.

WebCore::createWindow had an issue that had been covered up for
many years.  It takes two LocalFrame parameters, but when it is
called from LocalDOMWindow::createWindow the parameter order was
switched, and we used to just call Frame::setOpener to cover it
up and make sure the frame had the correct opener when we were
done.  With this new flow of giving the Frame the correct opener
in its constructor then never changing it unless we call open
with a named existing frame, we need to use the correct frame as
the opener.  Since we were already using the opener as the lookup
frame, I simplified it to only take one frame as a parameter,
the correct opener frame.

* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::openURLExternally):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::~FrameLoader):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::switchBrowsingContextsGroup):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::takeWindowProxyAndOpenerFrom):
(WebCore::Frame::disownOpener):
(WebCore::Frame::setOpenerForWebKitLegacy):
(WebCore::Frame::detachFromAllOpenedFrames):
(WebCore::Frame::takeWindowProxyFrom): Deleted.
(WebCore::Frame::setOpener): Deleted.
(WebCore::Frame::openedFrames): Deleted.
* Source/WebCore/page/Frame.h:
(WebCore::Frame::opener):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::disownOpener):
(WebCore::LocalDOMWindow::createWindow):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setOpener): Deleted.
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameClearOpener):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):
(WebKit::WebFrame::commitProvisionalFrame):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchCreatePage):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _clearOpener]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView initSimpleHTMLDocumentWithStyle:frame:preferences:groupName:]):

Canonical link: <a href="https://commits.webkit.org/282987@main">https://commits.webkit.org/282987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b642607f4e4189654c7866a37711e60c98d2471c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52062 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10602 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37484 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59388 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59587 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7186 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/858 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9833 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39937 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->