### PR TITLE
[JSC] Fix memory leaks for AbstractHeap in OMGIRGenerator

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -327,6 +327,7 @@ public:
     enum class CastKind { Cast, Test };
 
     struct AbstractHeap {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AbstractHeap);
         Vector<AbstractHeap*> m_children;
         bool hasAnyUnindexed = false;
         unsigned minBeginIndex = 0xffffffffu;
@@ -383,14 +384,14 @@ public:
 
 private:
 #define DEFINE_VARIABLE(parent, name) \
-    AbstractHeap* m_heap ## name;
+    std::unique_ptr<AbstractHeap> m_heap ## name;
     FOR_EACH_OMG_ABSTRACT_HEAP(DEFINE_VARIABLE)
 #undef DEFINE_VARIABLE
 
 #define INITIALIZE_HEAP(parent, name) \
-    m_heap ## name = new AbstractHeap(); \
+    m_heap ## name = makeUnique<AbstractHeap>(); \
     if (m_heap ## name != m_heap ## parent) \
-        m_heap ## parent ->addChild(m_heap ## name);
+        m_heap ## parent ->addChild(m_heap ## name.get());
     void initializeHeaps()
     {
         FOR_EACH_OMG_ABSTRACT_HEAP(INITIALIZE_HEAP)
@@ -399,7 +400,7 @@ private:
 
 public:
 #define DEFINE_GETTER(parent, name) \
-    AbstractHeap* heap ## name () { return m_heap ## name ; }
+    AbstractHeap* heap ## name () { return m_heap ## name.get() ; }
     FOR_EACH_OMG_ABSTRACT_HEAP(DEFINE_GETTER)
 #undef DEFINE_GETTER
 


### PR DESCRIPTION
#### bfe0238da5a9fee33568d685bfc09010f695dec5
<pre>
[JSC] Fix memory leaks for AbstractHeap in OMGIRGenerator
<a href="https://bugs.webkit.org/show_bug.cgi?id=278594">https://bugs.webkit.org/show_bug.cgi?id=278594</a>
<a href="https://rdar.apple.com/134598934">rdar://134598934</a>

Reviewed by Yusuke Suzuki.

Use unique_ptr for the AbstractHeap fields defined in
OMGIRGenerator to avoid memory leaks.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:

Canonical link: <a href="https://commits.webkit.org/282707@main">https://commits.webkit.org/282707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed14922979aac543f913b8ed907f4e71c8c5a722

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51516 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12751 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13442 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57073 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69682 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63206 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7908 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12606 "Found 1 new test failure: media/modern-media-controls/tracks-support/show-contextmenu-then-double-click-on-tracks-button.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58979 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6569 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84967 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9685 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39138 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14984 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->