### PR TITLE
Initial implementation of WebExtensionSidebar external API

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2224,6 +2224,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionSidebar {
+    header "_WKWebExtensionSidebar.h"
+    export *
+  }
+
   explicit module _WKWebExtensionCommand {
     header "_WKWebExtensionCommand.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3126,6 +3126,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionSidebar {
+    header "_WKWebExtensionSidebar.h"
+    export *
+  }
+
   explicit module _WKWebExtensionCommand {
     header "_WKWebExtensionCommand.h"
     export *

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -112,6 +112,7 @@
 #import "WKWebExtensionInternal.h"
 #import "WKWebExtensionMatchPatternInternal.h"
 #import "WKWebExtensionMessagePortInternal.h"
+#import "_WKWebExtensionSidebarInternal.h"
 #endif
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -437,7 +438,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     case Type::WebExtensionMessagePort:
         wrapper = [WKWebExtensionMessagePort alloc];
         break;
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    case Type::WebExtensionSidebar:
+        wrapper = [_WKWebExtensionSidebar alloc];
+        break;
 #endif
+#endif // ENABLE(WK_WEB_EXTENSIONS)
 
     case Type::WebsiteDataRecord:
         wrapper = [WKWebsiteDataRecord alloc];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -309,6 +309,18 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     return _webExtension->backgroundContentUsesModules();
 }
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+- (BOOL)_hasSidebar
+{
+    return _webExtension->hasSidebar();
+}
+#else // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+- (BOOL)_hasSidebar
+{
+    return NO;
+}
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -503,6 +515,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 }
 
 - (BOOL)_hasModularBackgroundContent
+{
+    return NO;
+}
+
+- (BOOL)_hasSidebar
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -842,6 +842,23 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
     return _webExtensionContext->backgroundContentURL();
 }
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+- (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
+{
+    if (tab)
+        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+
+    if (RefPtr maybeSidebar = _webExtensionContext->getOrCreateSidebar(toImplNullable(tab, *_webExtensionContext)))
+        return maybeSidebar->wrapper();
+    return nil;
+}
+#else
+- (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
+{
+    return nil;
+}
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -1234,6 +1251,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 }
 
 - (NSURL *)_backgroundContentURL
+{
+    return nil;
+}
+
+- (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -25,6 +25,8 @@
 
 #import <WebKit/WKWebExtensionControllerDelegate.h>
 
+@class _WKWebExtensionSidebar;
+
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -66,6 +68,35 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  @discussion The app can use this to setup additional properties on the web view before it is loaded. Default implementation does nothing.
  */
 - (void)_webExtensionController:(WKWebExtensionController *)controller didCreateBackgroundWebView:(WKWebView *)webView forExtensionContext:(WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when a sidebar is requested to be opened.
+ @param controller The web extension controller initiating the request.
+ @param sidebar The sidebar which should be displayed.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block to be called once the sidebar has been opened.
+ @discussion This method is called in response to the extension's scripts programmatically requesting the sidebar to open. Implementing this method
+ is needed if the app intends to support programmatically showing the sidebar from the extension.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller presentSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called when a sidebar is requested to be closed.
+ @param controller The web extension controller initiating the request.
+ @param sidebar The sidebar which should be closed.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block to be called once the sidebar has been closed.
+ @discussion This method is called in response to the extension's scripts programmatically requesting the sidebar to close. Implementing this method is needed if the app intends to support programmatically closing the sidebar from the extension.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller closeSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called when a sidebar's properties must be re-queried by the browser.
+ @param controller The web extension controller initiating the request.
+ @param sidebar The sidebar whose properties must be re-queried.
+ @param context The context within which the web extension is running.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller didUpdateSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
@@ -82,6 +82,9 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 /*! @abstract A Boolean value indicating whether the extension use modules for the background content. */
 @property (readonly, nonatomic) BOOL _hasModularBackgroundContent;
 
+/*! @abstract A Boolean value indicating whether the extension has a sidebar. */
+@property (readonly, nonatomic) BOOL _hasSidebar;
+
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
+
+@class WKWebExtensionContext;
+@class WKWebView;
+@protocol WKWebExtensionTab;
+@protocol WKWebExtension;
+
+#if TARGET_OS_IPHONE
+@class UIImage;
+@class UIViewController;
+#else
+@class NSImage;
+@class NSViewController;
+#endif
+
+WK_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+/*!
+ @abstract A `_WKWebExtensionSidebar` object encapsulates the properties for a specific web extension sidebar.
+ @discussion When this property is `nil`, it indicates that the action is the default action and not associated with a specific tab.
+ */
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+NS_SWIFT_NAME(WKWebExtension.Sidebar)
+@interface _WKWebExtensionSidebar : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)new NS_UNAVAILABLE;
+
+/*! @abstract The extension context to which this sidebar is related. */
+@property (nonatomic, nullable, readonly, weak) WKWebExtensionContext *webExtensionContext;
+
+/*! @abstract The tab that this sidebar is associated with, or `nil` if it is the default sidebar */
+@property (nonatomic, nullable, readonly, weak) id <WKWebExtensionTab> associatedTab;
+
+/*! @abstract The title of this sidebar. */
+@property (nonatomic, readonly, copy) NSString *title;
+
+/*!
+ @abstract Get the sidebar icon of the given size.
+ @param size The size to use when looking up the sidebar icon.
+ @result The sidebar icon, or the action icon if the sidebar specifies no icon, or `nil` if the action icon was unable to be loaded.
+ */
+#if TARGET_OS_IPHONE
+- (nullable UIImage *)iconForSize:(CGSize)size;
+#else
+- (nullable NSImage *)iconForSize:(CGSize)size;
+#endif
+
+/*! @abstract Whether this sidebar is enabled or not. */
+@property (nonatomic, readonly, getter=isEnabled) BOOL enabled;
+
+/*! @abstract The web view which should be displayed when this sidebar is opened, or `nil` if this sidebar is not a tab-specific sidebar. */
+@property (nonatomic, nullable, readonly) WKWebView *webView;
+
+#if TARGET_OS_IPHONE
+/*!
+ @abstract A view controller that presents a web view which will load the sidebar page for this sidebar, or `nil` if this sidebar
+ is not a tab-specific sidebar.
+ */
+@property (nonatomic, nullable, readonly) UIViewController *viewController;
+#endif
+
+#if TARGET_OS_OSX
+/*!
+ @abstract The view controller that presents a web view which will load the sidebar page for this sidebar, or `nil` if this sidebar
+ is not a tab-specific sidebar.
+ */
+@property (nonatomic, nullable, readonly) NSViewController *viewController;
+#endif
+
+/*!
+ @abstract Indicate that the sidebar will be opened
+ @discussion This method should be invoked by the browser when this sidebar will be opened -- i.e., its associated ``WKWebView`` will be
+ displayed. If this method is not called before the sidebar is opened, then the ``WKWebView`` associated with this sidebar may not have a
+ document loaded.
+ */
+- (void)willOpenSidebar;
+
+/*!
+ @abstract Indicate that the sidebar will be closed
+ @discussion This method should be invoked by the browser when the sidebar will be closed -- i.e., its associated ``WKWebView`` will cease
+ to be displayed. If this method is not called when the sidebar is closed, then the sidebar's associated ``WKWebView`` may remain active longer than
+ necessary. Note that calling this method does not guarantee that the ``WKWebView`` associated with a particular sidebar will be deallocated, as the
+ web view may be shared between mutliple sidebars.
+ */
+- (void)willCloseSidebar;
+
+@end // interface _WKWebExtensionSidebar
+
+WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionSidebarInternal.h"
+
+#import "WebExtensionContext.h"
+#import "WebExtensionSidebar.h"
+#import "WebExtensionTab.h"
+#import <wtf/BlockPtr.h>
+#import <wtf/CompletionHandler.h>
+
+@implementation _WKWebExtensionSidebar
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSidebar, _webExtensionSidebar);
+
+- (WKWebExtensionContext *)webExtensionContext
+{
+    return _webExtensionSidebar->extensionContext()
+        .transform([](auto const& context) { return context->wrapper(); })
+        .value_or(nil);
+}
+
+- (NSString *)title
+{
+    return _webExtensionSidebar->title();
+}
+
+#if PLATFORM(MAC)
+- (NSImage *)iconForSize:(CGSize)size
+{
+    return _webExtensionSidebar->icon(size).get();
+}
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+- (UIImage *)iconForSize:(CGSize)size
+{
+    return _webExtensionSidebar->icon(size).get();
+}
+#endif
+
+- (SidebarViewControllerType *)viewController
+{
+    return _webExtensionSidebar->viewController().get();
+}
+
+- (BOOL)isEnabled
+{
+    return _webExtensionSidebar->isEnabled();
+}
+
+- (WKWebView *)webView
+{
+    return _webExtensionSidebar->webView();
+}
+
+- (void)willOpenSidebar
+{
+    _webExtensionSidebar->willOpenSidebar();
+}
+
+- (void)willCloseSidebar
+{
+    _webExtensionSidebar->willCloseSidebar();
+}
+
+- (id<WKWebExtensionTab>)associatedTab
+{
+    if (auto tab = _webExtensionSidebar->tab())
+        return tab.value()->delegate();
+    return nil;
+}
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionSidebar;
+}
+
+- (WebKit::WebExtensionSidebar&) _webExtensionSidebar
+{
+    return *_webExtensionSidebar;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+- (WKWebExtensionContext *)webExtensionContext
+{
+    return nil;
+}
+
+- (NSString *)title
+{
+    return nil;
+}
+
+#if PLATFORM(MAC)
+- (NSImage *)iconForSize:(CGSize)size
+{
+    return nil;
+}
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+- (UIImage *)iconForSize:(CGSize)size
+{
+    return nil;
+}
+#endif
+
+- (SidebarViewControllerType *)viewController
+{
+    return nil;
+}
+
+- (BOOL)isEnabled
+{
+    return false;
+}
+
+- (WKWebView *)webView
+{
+    return nil;
+}
+
+- (void)willOpenSidebar
+{
+}
+
+- (void)willCloseSidebar
+{
+}
+
+- (id<WKWebExtensionTab>)associatedTab
+{
+    return nil;
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebarInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebarInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKWebExtensionContext.h>
+#import "_WKWebExtensionSidebar.h"
 
-@class _WKWebExtensionSidebar;
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
-WK_HEADER_AUDIT_BEGIN(nullability, sendability)
+#import "WKObject.h"
+#import "WebExtensionSidebar.h"
 
-@interface WKWebExtensionContext ()
+namespace WebKit {
+template<> struct WrapperTraits<WebExtensionSidebar> {
+    using WrapperClass = _WKWebExtensionSidebar;
+};
+}
 
-/*! @abstract The extension background view used for the extension, or `nil` if the extension does not have background content or it is currently unloaded. */
-@property (nonatomic, nullable, readonly) WKWebView *_backgroundWebView;
+@interface _WKWebExtensionSidebar () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionSidebar> _webExtensionSidebar;
+}
 
-/*! @abstract The extension background content URL for the extension, or `nil` if the extension does not have background content. */
-@property (nonatomic, nullable, readonly) NSURL *_backgroundContentURL;
-
-/*!
- @abstract Retrieves the extension sidebar for a given tab, or the default sidebar if `nil` is passed.
- @param tab The tab for which to retrieve the extension sidebar, or `nil` to get the default sidebar.
- @discussion The returned object represents the sidebar specific to the tab when provided; otherwise, it returns the default sidebar.
- The default sidebar should not be directly displayed. When possible, specify the tab to get the most context-relevant sidebar.
- */
-- (nullable _WKWebExtensionSidebar *)sidebarForTab:(nullable id <WKWebExtensionTab>)tab NS_SWIFT_NAME(sidebar(for:));
+@property (nonatomic, readonly) WebKit::WebExtensionSidebar& _webExtensionSidebar;
 
 @end
 
-WK_HEADER_AUDIT_END(nullability, sendability)
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1109,6 +1109,11 @@ void WebExtension::populateActionPropertiesIfNeeded()
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+bool WebExtension::hasSidebar()
+{
+    return objectForKey<NSDictionary>(m_manifest, sidebarActionManifestKey) || hasRequestedPermission(WKWebExtensionPermissionSidePanel);
+}
+
 CocoaImage *WebExtension::sidebarIcon(CGSize idealSize)
 {
     // FIXME: <https://webkit.org/b/276833> implement this
@@ -1165,7 +1170,7 @@ void WebExtension::populateSidePanelProperties(RetainPtr<NSDictionary> sidePanel
     m_sidebarTitle = nil;
     m_sidebarDocumentPath = objectForKey<NSString>(sidePanelDictionary, sidePanelPathManifestKey);
 }
-#endif
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 CocoaImage *WebExtension::imageForPath(NSString *imagePath, NSError **outError)
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2733,6 +2733,9 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getSidebar(WebExten
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(WebExtensionWindow& window)
 {
+    if (!extension().hasSidebar())
+        return std::nullopt;
+
     return m_sidebarWindowMap.ensure(window, [&] {
         return WebExtensionSidebar::create(*this, window);
     }).iterator->value;
@@ -2740,9 +2743,24 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(WebExtensionTab& tab)
 {
+    if (!extension().hasSidebar())
+        return std::nullopt;
+
     return m_sidebarTabMap.ensure(tab, [&] {
         return WebExtensionSidebar::create(*this, tab);
     }).iterator->value;
+}
+
+RefPtr<WebExtensionSidebar> WebExtensionContext::getOrCreateSidebar(RefPtr<WebExtensionTab> tab)
+{
+    if (!extension().hasSidebar())
+        return nil;
+    if (!tab)
+        return &defaultSidebar();
+
+    return getOrCreateSidebar(*tab.get())
+        .and_then([](auto const& sidebar) { return std::optional(RefPtr<WebExtensionSidebar>(&sidebar.get())); })
+        .value_or(nil);
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -235,6 +235,7 @@ public:
     bool hasPageAction();
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    bool hasSidebar();
     CocoaImage *sidebarIcon(CGSize idealSize);
     NSString *sidebarDocumentPath();
     NSString *sidebarTitle();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -452,6 +452,7 @@ public:
     std::optional<Ref<WebExtensionSidebar>> getSidebar(WebExtensionTab const&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionWindow&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionTab&);
+    RefPtr<WebExtensionSidebar> getOrCreateSidebar(RefPtr<WebExtensionTab>);
     void openSidebarForTab(WebExtensionTab&, UserTriggered = UserTriggered::No);
     void closeSidebarForTab(WebExtensionTab&, UserTriggered = UserTriggered::No);
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -125,9 +125,12 @@
 		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
 		02660A7C2C4099370074EDC5 /* WebExtensionAPISidebarActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		02660A7E2C4099B50074EDC5 /* WebExtensionAPISidePanelCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		02673A312C583239002878FB /* WebExtensionSidebarCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02673A302C583232002878FB /* WebExtensionSidebarCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		028648C62C3F5A3A00E474D4 /* WebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 028648C52C3F5A2E00E474D4 /* WebExtensionAPISidePanel.h */; };
 		028D30772C616E8A004F4FC6 /* WebExtensionSidebar.h in Headers */ = {isa = PBXBuildFile; fileRef = 028D30762C616E8A004F4FC6 /* WebExtensionSidebar.h */; };
+		028D30882C63DEE1004F4FC6 /* _WKWebExtensionSidebar.h in Headers */ = {isa = PBXBuildFile; fileRef = 028D30862C62FA8A004F4FC6 /* _WKWebExtensionSidebar.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		028D308A2C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm in Sources */ = {isa = PBXBuildFile; fileRef = 028D30892C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		028D308C2C63E214004F4FC6 /* WebExtensionSidebarCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 028D308B2C63E214004F4FC6 /* WebExtensionSidebarCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		028D308E2C63E764004F4FC6 /* _WKWebExtensionSidebarInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 028D308D2C63E3B3004F4FC6 /* _WKWebExtensionSidebarInternal.h */; };
 		029D6BAC2C40609D0068CF99 /* WebExtensionAPISidebarAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAB2C4060920068CF99 /* WebExtensionAPISidebarAction.h */; };
 		029D6BB12C407AA30068CF99 /* JSWebExtensionAPISidePanel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 029D6BB02C407AA30068CF99 /* JSWebExtensionAPISidePanel.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		029D6BB22C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 029D6BAE2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3096,7 +3099,6 @@
 		0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindStringCallbackAggregator.h; sourceTree = "<group>"; };
 		02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPISidebarActionCocoa.mm; sourceTree = "<group>"; };
 		02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPISidePanelCocoa.mm; sourceTree = "<group>"; };
-		02673A302C583232002878FB /* WebExtensionSidebarCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionSidebarCocoa.mm; sourceTree = "<group>"; };
 		02789EF628D3FC3200F77E40 /* WebGPUBufferBindingLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUBufferBindingLayout.serialization.in; sourceTree = "<group>"; };
 		02789EF728D3FF4800F77E40 /* WebGPUCanvasConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUCanvasConfiguration.serialization.in; sourceTree = "<group>"; };
 		02789EF828D4026000F77E40 /* WebGPUColor.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUColor.serialization.in; sourceTree = "<group>"; };
@@ -3113,6 +3115,10 @@
 		02789F0528D44ED800F77E40 /* WebGPUVertexBufferLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUVertexBufferLayout.serialization.in; sourceTree = "<group>"; };
 		028648C52C3F5A2E00E474D4 /* WebExtensionAPISidePanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPISidePanel.h; sourceTree = "<group>"; };
 		028D30762C616E8A004F4FC6 /* WebExtensionSidebar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSidebar.h; sourceTree = "<group>"; };
+		028D30862C62FA8A004F4FC6 /* _WKWebExtensionSidebar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSidebar.h; sourceTree = "<group>"; };
+		028D30892C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSidebar.mm; sourceTree = "<group>"; };
+		028D308B2C63E214004F4FC6 /* WebExtensionSidebarCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionSidebarCocoa.mm; sourceTree = "<group>"; };
+		028D308D2C63E3B3004F4FC6 /* _WKWebExtensionSidebarInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSidebarInternal.h; sourceTree = "<group>"; };
 		029D6BAB2C4060920068CF99 /* WebExtensionAPISidebarAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPISidebarAction.h; sourceTree = "<group>"; };
 		029D6BAD2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPISidebarAction.h; sourceTree = "<group>"; };
 		029D6BAE2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPISidebarAction.mm; sourceTree = "<group>"; };
@@ -9910,7 +9916,7 @@
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 				1CC1A36D2B0DCEC900373759 /* WebExtensionMenuItemCocoa.mm */,
 				1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */,
-				02673A302C583232002878FB /* WebExtensionSidebarCocoa.mm */,
+				028D308B2C63E214004F4FC6 /* WebExtensionSidebarCocoa.mm */,
 				1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */,
 				1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */,
 				1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */,
@@ -11550,6 +11556,9 @@
 				574728D023456E98001700AF /* _WKWebAuthenticationPanel.mm */,
 				5790A6512565DE6A0077C5A7 /* _WKWebAuthenticationPanelForTesting.h */,
 				574728D3234570AE001700AF /* _WKWebAuthenticationPanelInternal.h */,
+				028D30862C62FA8A004F4FC6 /* _WKWebExtensionSidebar.h */,
+				028D30892C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm */,
+				028D308D2C63E3B3004F4FC6 /* _WKWebExtensionSidebarInternal.h */,
 				51E0BD9B2C7471110048411B /* _WKWebPushAction.h */,
 				51E0BD9C2C7471110048411B /* _WKWebPushAction.mm */,
 				1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */,
@@ -16096,6 +16105,8 @@
 				1CC5CA8E2C5ACCC600DF3B94 /* _WKWebExtensionMessagePortPrivate.h in Headers */,
 				1CC5CA782C5ACB8500DF3B94 /* _WKWebExtensionPrivate.h in Headers */,
 				B6D75B1E2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h in Headers */,
+				028D30882C63DEE1004F4FC6 /* _WKWebExtensionSidebar.h in Headers */,
+				028D308E2C63E764004F4FC6 /* _WKWebExtensionSidebarInternal.h in Headers */,
 				B6A2923D2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.h in Headers */,
 				B6BF18422B1A8F8B00FA39D3 /* _WKWebExtensionSQLiteDatatypeTraits.h in Headers */,
 				B6BF18402B1A8C3600FA39D3 /* _WKWebExtensionSQLiteHelpers.h in Headers */,
@@ -19465,6 +19476,7 @@
 				3326F2682B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.mm in Sources */,
 				B62C01BC2A8E7AF600D6A941 /* _WKWebExtensionLocalization.mm in Sources */,
 				B6D75B1D2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.mm in Sources */,
+				028D308A2C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm in Sources */,
 				B6A2923E2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.mm in Sources */,
 				B6BF18392B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm in Sources */,
 				B6BF18352B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.mm in Sources */,
@@ -19930,7 +19942,7 @@
 				1CC1A36C2B0D9A0900373759 /* WebExtensionMenuItem.cpp in Sources */,
 				1CC1A36E2B0DCEC900373759 /* WebExtensionMenuItemCocoa.mm in Sources */,
 				1C73167F2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm in Sources */,
-				02673A312C583239002878FB /* WebExtensionSidebarCocoa.mm in Sources */,
+				028D308C2C63E214004F4FC6 /* WebExtensionSidebarCocoa.mm in Sources */,
 				1C66BDE22A8C2830009D4452 /* WebExtensionTabCocoa.mm in Sources */,
 				1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */,
 				337822482947FBA5002106BB /* WebExtensionUtilities.mm in Sources */,


### PR DESCRIPTION
#### aa35126f4291babb0cac50a4a3683dd5cfbc33b0
<pre>
Initial implementation of WebExtensionSidebar external API
<a href="https://webkit.org/b/277575">https://webkit.org/b/277575</a>
<a href="https://rdar.apple.com/133073385">rdar://133073385</a>

Reviewed by Timothy Hatcher.

This patch introduces an initial external API for the
WebExtensionSidebar object.

* Source/WebKit/Modules/OSX_Private.modulemap: Add
  _WKWebExtensionSidebar module
* Source/WebKit/Modules/iOS_Private.modulemap: Add
  _WKWebExtensionSidebar module
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject): Add case for Type::WebExtensionSidebar which
allocates a new _WKWebExtensionSidebar object
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext sidebarForTab:]): Added method implementation
to retrieve the sidebar for the given tab from the appropriate
WebExtensionContext
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h: Add
  prototype for [WKWebExtensionContext sidebarForTab:]
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
Add _webExtensionController presentSidebar to
WKWebExtensionControllerDelegatePrivate protocol.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm: Added.
(-[_WKWebExtensionSidebar webExtensionContext]): External getter for a
sidebar&apos;s context
(-[_WKWebExtensionSidebar title]): External getter for a sidebar&apos;s title
(-[_WKWebExtensionSidebar iconForSize:]): External getter for a
sidebar&apos;s icon
(-[_WKWebExtensionSidebar isEnabled]): External getter for a sidebar&apos;s
enablement state
(-[_WKWebExtensionSidebar webView]): External getter for a sidebar&apos;s web
view
(-[_WKWebExtensionSidebar willOpenSidebar]): Method to indicate the
sidebar will be opened
(-[_WKWebExtensionSidebar willCloseSidebar]): Method to indicate the
sidebar will be closed
(-[_WKWebExtensionSidebar associatedTab]): External getter for a
sidebar&apos;s tab
(-[_WKWebExtensionSidebar _apiObject]): Internal getter for the
sidebar&apos;s implementation object as a API::Object
(-[_WKWebExtensionSidebar _webExtensionSidebar]): Internal getter for
the sidebar&apos;s implementation object
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebarInternal.h:
  Added
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::hasSidebar): Utility method to check if the
extension uses either sidebar API
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(toOptionalRef): Utility method to convert a RefPtr&lt;T&gt; to a
std::optional&lt;Ref&lt;T&gt;&gt;
(-[_WKWebExtensionSidebarWebViewDelegate initWithWebExtensionSidebar:]):
Initializer
(-[_WKWebExtensionSidebarWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
Delegate method implementation which handles deciding the navigation
policy for navigation actions within a sidebar&apos;s WKWebView
(WebKit::WebExtensionSidebar::setTitle): Notify delegate of title change
when necessary
(WebKit::WebExtensionSidebar::setSidebarPath): Notify delegate of
webView change when necessary
(WebKit::WebExtensionSidebar::willOpenSidebar): Assert that this sidebar
(or parent) has a web view
(WebKit::WebExtensionSidebar::willCloseSidebar): If this sidebar is a
tab-specific sidebar, and if this sidebar has its own web view, set the
web view to nil
(WebKit::WebExtensionSidebar::reloadWebView): Helper method to load the
current sidebar path in the sidebar&apos;s web view, if present
(WebKit::WebExtensionSidebar::webView): Use parent web view if no path
is set, properly configure web view before returning
(WebKit::WebExtensionSidebar::webViewWasUpdated): Helper method to
notify delegate to re-query this sidebar&apos;s web view
* Source/WebKit/UIProcess/Extensions/WebExtension.h: Add prototype for
  hasSidebar
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Add wrapper
  method, sidebar API wrapper prototypes, add declarations for
  willOpenSidebar and willCloseSidebar
(WebKit::WebExtensionSidebar::wrapper const): Added
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Add new files to
  project

Canonical link: <a href="https://commits.webkit.org/282878@main">https://commits.webkit.org/282878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e31e85295fddb2a9de9acd3947f8bded918a4801

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64547 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68568 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15153 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15432 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10454 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37289 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55945 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/699 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9788 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39723 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->