### PR TITLE
Update DateTimeEditBuilder::m_editElement to use a smart pointer

### DIFF
--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -64,7 +64,7 @@ private:
     void visitField(DateTimeFormat::FieldType, int);
     void visitLiteral(String&&);
 
-    DateTimeEditElement& m_editElement;
+    Ref<DateTimeEditElement> m_editElement;
     const DateTimeEditElement::LayoutParameters& m_parameters;
 };
 
@@ -76,47 +76,47 @@ DateTimeEditBuilder::DateTimeEditBuilder(DateTimeEditElement& element, const Dat
 
 bool DateTimeEditBuilder::build(const String& formatString)
 {
-    m_editElement.resetFields();
+    m_editElement->resetFields();
     return DateTimeFormat::parse(formatString, *this);
 }
 
 void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int count)
 {
-    Document& document = m_editElement.document();
+    Document& document = m_editElement->document();
 
     switch (fieldType) {
     case DateTimeFormat::FieldTypeDayOfMonth: {
-        m_editElement.addField(DateTimeDayFieldElement::create(document, m_editElement));
+        m_editElement->addField(DateTimeDayFieldElement::create(document, m_editElement));
         return;
     }
 
     case DateTimeFormat::FieldTypeFractionalSecond: {
-        m_editElement.addField(DateTimeMillisecondFieldElement::create(document, m_editElement));
+        m_editElement->addField(DateTimeMillisecondFieldElement::create(document, m_editElement));
         return;
     }
 
     case DateTimeFormat::FieldTypeHour11: {
-        m_editElement.addField(DateTimeHourFieldElement::create(document, m_editElement, 0, 11));
+        m_editElement->addField(DateTimeHourFieldElement::create(document, m_editElement, 0, 11));
         return;
     }
 
     case DateTimeFormat::FieldTypeHour12: {
-        m_editElement.addField(DateTimeHourFieldElement::create(document, m_editElement, 1, 12));
+        m_editElement->addField(DateTimeHourFieldElement::create(document, m_editElement, 1, 12));
         return;
     }
 
     case DateTimeFormat::FieldTypeHour23: {
-        m_editElement.addField(DateTimeHourFieldElement::create(document, m_editElement, 0, 23));
+        m_editElement->addField(DateTimeHourFieldElement::create(document, m_editElement, 0, 23));
         return;
     }
 
     case DateTimeFormat::FieldTypeHour24: {
-        m_editElement.addField(DateTimeHourFieldElement::create(document, m_editElement, 1, 24));
+        m_editElement->addField(DateTimeHourFieldElement::create(document, m_editElement, 1, 24));
         return;
     }
 
     case DateTimeFormat::FieldTypeMinute: {
-        m_editElement.addField(DateTimeMinuteFieldElement::create(document, m_editElement));
+        m_editElement->addField(DateTimeMinuteFieldElement::create(document, m_editElement));
         return;
     }
 
@@ -130,27 +130,27 @@ void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int co
         case countForNarrowMonth:
         case countForAbbreviatedMonth: {
             auto field = DateTimeSymbolicMonthFieldElement::create(document, m_editElement, fieldType == DateTimeFormat::FieldTypeMonth ? m_parameters.locale.shortMonthLabels() : m_parameters.locale.shortStandAloneMonthLabels());
-            m_editElement.addField(field);
+            m_editElement->addField(field);
             return;
         }
         case countForFullMonth: {
             auto field = DateTimeSymbolicMonthFieldElement::create(document, m_editElement, fieldType == DateTimeFormat::FieldTypeMonth ? m_parameters.locale.monthLabels() : m_parameters.locale.standAloneMonthLabels());
-            m_editElement.addField(field);
+            m_editElement->addField(field);
             return;
         }
         default:
-            m_editElement.addField(DateTimeMonthFieldElement::create(document, m_editElement));
+            m_editElement->addField(DateTimeMonthFieldElement::create(document, m_editElement));
             return;
         }
     }
 
     case DateTimeFormat::FieldTypePeriod: {
-        m_editElement.addField(DateTimeMeridiemFieldElement::create(document, m_editElement, m_parameters.locale.timeAMPMLabels()));
+        m_editElement->addField(DateTimeMeridiemFieldElement::create(document, m_editElement, m_parameters.locale.timeAMPMLabels()));
         return;
     }
 
     case DateTimeFormat::FieldTypeSecond: {
-        m_editElement.addField(DateTimeSecondFieldElement::create(document, m_editElement));
+        m_editElement->addField(DateTimeSecondFieldElement::create(document, m_editElement));
 
         if (m_parameters.shouldHaveMillisecondField) {
             visitLiteral(m_parameters.locale.localizedDecimalSeparator());
@@ -160,7 +160,7 @@ void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int co
     }
 
     case DateTimeFormat::FieldTypeYear: {
-        m_editElement.addField(DateTimeYearFieldElement::create(document, m_editElement));
+        m_editElement->addField(DateTimeYearFieldElement::create(document, m_editElement));
         return;
     }
 
@@ -173,7 +173,7 @@ void DateTimeEditBuilder::visitLiteral(String&& text)
 {
     ASSERT(text.length());
 
-    auto element = HTMLDivElement::create(m_editElement.document());
+    auto element = HTMLDivElement::create(m_editElement->document());
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setUserAgentPart(UserAgentParts::webkitDatetimeEditText());
 
@@ -187,8 +187,8 @@ void DateTimeEditBuilder::visitLiteral(String&& text)
     if (text.endsWith(' '))
         element->setInlineStyleProperty(CSSPropertyMarginInlineEnd, -1, CSSUnitType::CSS_PX);
 
-    element->appendChild(Text::create(m_editElement.document(), WTFMove(text)));
-    m_editElement.fieldsWrapperElement().appendChild(element);
+    element->appendChild(Text::create(m_editElement->document(), WTFMove(text)));
+    m_editElement->fieldsWrapperElement().appendChild(element);
 }
 
 DateTimeEditElementEditControlOwner::~DateTimeEditElementEditControlOwner() = default;


### PR DESCRIPTION
#### 5db594221738ee6c0f873b9b7992e90f3b20e436
<pre>
Update DateTimeEditBuilder::m_editElement to use a smart pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=278600">https://bugs.webkit.org/show_bug.cgi?id=278600</a>

Reviewed by Darin Adler.

* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditBuilder::build):
(WebCore::DateTimeEditBuilder::visitField):
(WebCore::DateTimeEditBuilder::visitLiteral):

Canonical link: <a href="https://commits.webkit.org/282702@main">https://commits.webkit.org/282702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2026949ee0436142f812526cf4a3467335b598f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51524 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10073 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13460 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69700 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58845 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58991 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6578 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9681 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39156 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->