### PR TITLE
Replace NetworkCache::Data's m_data / m_size with a span

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -73,10 +73,10 @@ public:
     Data(Vector<uint8_t>&& data) : Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData> { WTFMove(data) }) { }
 #endif
     bool isNull() const;
-    bool isEmpty() const { return !m_size; }
+    bool isEmpty() const { return !size(); }
 
     std::span<const uint8_t> span() const;
-    size_t size() const { return m_size; }
+    size_t size() const;
     bool isMap() const { return m_isMap; }
     RefPtr<WebCore::SharedMemory> tryCreateSharedMemory() const;
 
@@ -96,6 +96,7 @@ public:
 private:
 #if PLATFORM(COCOA)
     mutable OSObjectPtr<dispatch_data_t> m_dispatchData;
+    mutable std::span<const uint8_t> m_data;
 #endif
 #if USE(GLIB)
     mutable GRefPtr<GBytes> m_buffer;
@@ -104,8 +105,6 @@ private:
 #if USE(CURL)
     Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>> m_buffer;
 #endif
-    mutable const uint8_t* m_data { nullptr };
-    size_t m_size { 0 };
     bool m_isMap { false };
 };
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -34,7 +34,6 @@ namespace NetworkCache {
 
 Data::Data(std::span<const uint8_t> data)
     : m_buffer(Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(Vector<uint8_t>(data.size())))
-    , m_size(data.size())
 {
     memcpy(std::get<Vector<uint8_t>>(*m_buffer).data(), data.data(), data.size());
 }
@@ -43,10 +42,6 @@ Data::Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData>&& data)
     : m_buffer(Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(WTFMove(data)))
     , m_isMap(std::holds_alternative<FileSystem::MappedFileData>(*m_buffer))
 {
-    m_size = WTF::switchOn(*m_buffer,
-        [](const Vector<uint8_t>& buffer) -> size_t { return buffer.size(); },
-        [](const FileSystem::MappedFileData& mappedFile) -> size_t { return mappedFile.size(); }
-    );
 }
 
 Data Data::empty()
@@ -63,6 +58,16 @@ std::span<const uint8_t> Data::span() const
     return WTF::switchOn(*m_buffer,
         [](const Vector<uint8_t>& buffer) { return buffer.span(); },
         [](const FileSystem::MappedFileData& mappedFile) { return mappedFile.span(); }
+    );
+}
+
+size_t Data::size() const
+{
+    if (!m_buffer)
+        return 0;
+    return WTF::switchOn(*m_buffer,
+        [](const Vector<uint8_t>& buffer) -> size_t { return buffer.size(); },
+        [](const FileSystem::MappedFileData& mappedFile) -> size_t { return mappedFile.size(); }
     );
 }
 
@@ -118,7 +123,7 @@ RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const
     if (!newHandle)
         return nullptr;
 
-    return WebCore::SharedMemory::map({ WTFMove(newHandle), m_size }, WebCore::SharedMemory::Protection::ReadOnly);
+    return WebCore::SharedMemory::map({ WTFMove(newHandle), size() }, WebCore::SharedMemory::Protection::ReadOnly);
 }
 #endif
 


### PR DESCRIPTION
#### f5eee56fb7777a4bdd45c418dd9e56122bc64b12
<pre>
Replace NetworkCache::Data&apos;s m_data / m_size with a span
<a href="https://bugs.webkit.org/show_bug.cgi?id=278601">https://bugs.webkit.org/show_bug.cgi?id=278601</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
(WebKit::NetworkCache::Data::isEmpty const):
(WebKit::NetworkCache::Data::size const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::Data):
(WebKit::NetworkCache::Data::span const):
(WebKit::NetworkCache::Data::size const):
(WebKit::NetworkCache::Data::apply const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp:
(WebKit::NetworkCache::Data::Data):
(WebKit::NetworkCache::Data::size const):
(WebKit::NetworkCache::Data::tryCreateSharedMemory const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::Data):
(WebKit::NetworkCache::Data::span const):
(WebKit::NetworkCache::Data::size const):
(WebKit::NetworkCache::Data::apply const):

Canonical link: <a href="https://commits.webkit.org/282703@main">https://commits.webkit.org/282703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/884cc0bc6862f324e71557290038f7e64285154c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14590 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51529 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36796 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69703 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58849 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58995 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6582 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9680 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39159 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->