### PR TITLE
[LegacySVG] Margin collapsing should not occur at the foreignObject boundary

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/containing-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/containing-block-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL position assert_equals: offsetTop expected 5 but got 0
+PASS position
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/getboundingclientrect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/getboundingclientrect-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL foreignObject: Element.prototype.getBoundingClientRect() assert_equals: top expected 24 but got 18
+PASS foreignObject: Element.prototype.getBoundingClientRect()
 

--- a/LayoutTests/platform/glib/svg/custom/dominant-baseline-hanging-expected.txt
+++ b/LayoutTests/platform/glib/svg/custom/dominant-baseline-hanging-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 400x400
         RenderSVGInlineText {#text} at (0,0) size 323x22
           chunk 1 text run 1 at (2.00,14.40) startOffset 0 endOffset 40 width 323.00: "This is hanging from the top-left corner"
     RenderSVGForeignObject {foreignObject} at (10,45) size 380x150
-      RenderBlock {html} at (0,0) size 380x124
+      RenderBlock {html} at (0,16) size 380x124
         RenderBody {body} at (8,0) size 364x124
           RenderBlock {p} at (0,0) size 364x90
             RenderText {#text} at (0,0) size 347x35

--- a/LayoutTests/platform/ios/svg/custom/dominant-baseline-hanging-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/dominant-baseline-hanging-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 400x400
         RenderSVGInlineText {#text} at (0,0) size 317x23
           chunk 1 text run 1 at (2.00,14.40) startOffset 0 endOffset 40 width 316.58: "This is hanging from the top-left corner"
     RenderSVGForeignObject {foreignObject} at (10,45) size 380x150
-      RenderBlock {html} at (0,0) size 380x136
+      RenderBlock {html} at (0,16) size 380x136
         RenderBody {body} at (8,0) size 364x136
           RenderBlock {p} at (0,0) size 364x100
             RenderText {#text} at (0,0) size 353x39

--- a/LayoutTests/platform/mac/svg/custom/dominant-baseline-hanging-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/dominant-baseline-hanging-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 400x400
         RenderSVGInlineText {#text} at (0,0) size 317x23
           chunk 1 text run 1 at (2.00,14.40) startOffset 0 endOffset 40 width 316.58: "This is hanging from the top-left corner"
     RenderSVGForeignObject {foreignObject} at (10,45) size 380x150
-      RenderBlock {html} at (0,0) size 380x124
+      RenderBlock {html} at (0,16) size 380x124
         RenderBody {body} at (8,0) size 364x124
           RenderBlock {p} at (0,0) size 364x90
             RenderText {#text} at (0,0) size 353x36

--- a/LayoutTests/platform/win/svg/custom/dominant-baseline-hanging-expected.txt
+++ b/LayoutTests/platform/win/svg/custom/dominant-baseline-hanging-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 400x400
         RenderSVGInlineText {#text} at (0,0) size 308x22
           chunk 1 text run 1 at (2.00,13.60) startOffset 0 endOffset 40 width 308.00: "This is hanging from the top-left corner"
     RenderSVGForeignObject {foreignObject} at (10,45) size 380x150
-      RenderBlock {html} at (0,0) size 380x136
+      RenderBlock {html} at (0,16) size 380x136
         RenderBody {body} at (8,0) size 364x136
           RenderBlock {p} at (0,0) size 364x100
             RenderText {#text} at (0,0) size 349x39

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1355,7 +1355,7 @@ bool RenderBlock::createsNewFormattingContext() const
         || isFieldset()
         || isDocumentElementRenderer()
         || isRenderFragmentedFlow()
-        || isRenderSVGForeignObject()
+        || isRenderOrLegacyRenderSVGForeignObject()
         || style.specifiesColumns()
         || style.columnSpan() == ColumnSpan::All
         || style.display() == DisplayType::FlowRoot


### PR DESCRIPTION
#### 45d2ff003832f2f675276fc272a058934a0669d0
<pre>
[LegacySVG] Margin collapsing should not occur at the foreignObject boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=23963">https://bugs.webkit.org/show_bug.cgi?id=23963</a>
<a href="https://rdar.apple.com/97208795">rdar://97208795</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/eb26f063d73fce4d8a2cf64541667e0863cb6421">https://chromium.googlesource.com/chromium/src.git/+/eb26f063d73fce4d8a2cf64541667e0863cb6421</a>

This patch makes foreignObject a block formatting context (BFC) which
prevents margin collapsing across the foreignObject boundary. This
function (createsNewFormattingContext) is limited to BFC context nowadays.

<a href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement">https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement</a>

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::createsNewFormattingContext const):
* LayoutTests/platform/glib/svg/custom/dominant-baseline-hanging-expected.txt:
* LayoutTests/platform/ios/svg/custom/dominant-baseline-hanging-expected.txt:
* LayoutTests/platform/mac/svg/custom/dominant-baseline-hanging-expected.txt:
* LayoutTests/platform/win/svg/custom/dominant-baseline-hanging-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/containing-block-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/getboundingclientrect-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/304916@main">https://commits.webkit.org/304916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/945b6ac321d0ab107e44e2c71970ca159a3ef5db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89838 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b36d374-2442-40c6-936a-d0309ee65ac4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104655 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29d86d1d-eebb-4deb-97dd-0567ca8b953f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe47279d-34e3-4184-a4fa-ce32567bb298) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6904 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4595 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5189 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147358 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28794 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6821 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63097 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8956 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36959 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->