### PR TITLE
Adopt more smart pointers in DOMTokenList

### DIFF
--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -205,18 +205,18 @@ ExceptionOr<bool> DOMTokenList::supports(StringView token)
 {
     if (!m_isSupportedToken)
         return Exception { ExceptionCode::TypeError };
-    return m_isSupportedToken(m_element.document(), token);
+    return m_isSupportedToken(m_element->document(), token);
 }
 
 // https://dom.spec.whatwg.org/#dom-domtokenlist-value
 const AtomString& DOMTokenList::value() const
 {
-    return m_element.getAttribute(m_attributeName);
+    return protectedElement()->getAttribute(m_attributeName);
 }
 
 void DOMTokenList::setValue(const AtomString& value)
 {
-    m_element.setAttribute(m_attributeName, value);
+    protectedElement()->setAttribute(m_attributeName, value);
 }
 
 void DOMTokenList::updateTokensFromAttributeValue(const AtomString& value)
@@ -259,18 +259,19 @@ void DOMTokenList::updateAssociatedAttributeFromTokens()
 {
     ASSERT(!m_tokensNeedUpdating);
 
-    if (m_tokens.isEmpty() && !m_element.hasAttribute(m_attributeName))
+    Ref element = m_element.get();
+    if (m_tokens.isEmpty() && !element->hasAttribute(m_attributeName))
         return;
 
     if (m_tokens.isEmpty()) {
-        m_element.setAttribute(m_attributeName, emptyAtom());
+        element->setAttribute(m_attributeName, emptyAtom());
         return;
     }
 
     bool wholeAttributeIsSingleToken = m_tokens.size() == 1;
     if (wholeAttributeIsSingleToken) {
         SetForScope inAttributeUpdate(m_inUpdateAssociatedAttributeFromTokens, true);
-        m_element.setAttribute(m_attributeName, m_tokens[0]);
+        element->setAttribute(m_attributeName, m_tokens[0]);
         return;
     }
 
@@ -284,13 +285,13 @@ void DOMTokenList::updateAssociatedAttributeFromTokens()
     AtomString serializedValue = builder.toAtomString();
 
     SetForScope inAttributeUpdate(m_inUpdateAssociatedAttributeFromTokens, true);
-    m_element.setAttribute(m_attributeName, serializedValue);
+    element->setAttribute(m_attributeName, serializedValue);
 }
 
 Vector<AtomString, 1>& DOMTokenList::tokens()
 {
     if (m_tokensNeedUpdating)
-        updateTokensFromAttributeValue(m_element.getAttribute(m_attributeName));
+        updateTokensFromAttributeValue(protectedElement()->getAttribute(m_attributeName));
     ASSERT(!m_tokensNeedUpdating);
     return m_tokens;
 }

--- a/Source/WebCore/html/DOMTokenList.h
+++ b/Source/WebCore/html/DOMTokenList.h
@@ -38,8 +38,8 @@ public:
 
     inline void associatedAttributeValueChanged();
 
-    void ref() { m_element.ref(); }
-    void deref() { m_element.deref(); }
+    void ref() { m_element->ref(); }
+    void deref() { m_element->deref(); }
 
     unsigned length() const;
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
@@ -54,7 +54,8 @@ public:
     ExceptionOr<bool> replace(const AtomString& token, const AtomString& newToken);
     ExceptionOr<bool> supports(StringView token);
 
-    Element& element() const { return m_element; }
+    Element& element() const { return m_element.get(); }
+    Ref<Element> protectedElement() const { return m_element.get(); }
 
     WEBCORE_EXPORT void setValue(const AtomString&);
     WEBCORE_EXPORT const AtomString& value() const;
@@ -71,7 +72,7 @@ private:
     ExceptionOr<void> addInternal(std::span<const AtomString> tokens);
     ExceptionOr<void> removeInternal(std::span<const AtomString> tokens);
 
-    Element& m_element;
+    CheckedRef<Element> m_element;
     const WebCore::QualifiedName& m_attributeName;
     bool m_inUpdateAssociatedAttributeFromTokens { false };
     bool m_tokensNeedUpdating { true };


### PR DESCRIPTION
#### edbb46ca39e489104642a39744a335aa512fc793
<pre>
Adopt more smart pointers in DOMTokenList
<a href="https://bugs.webkit.org/show_bug.cgi?id=278610">https://bugs.webkit.org/show_bug.cgi?id=278610</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer.

* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::DOMTokenList::supports):
(WebCore::DOMTokenList::value const):
(WebCore::DOMTokenList::setValue):
(WebCore::DOMTokenList::updateAssociatedAttributeFromTokens):
(WebCore::DOMTokenList::tokens):
* Source/WebCore/html/DOMTokenList.h:

Canonical link: <a href="https://commits.webkit.org/282706@main">https://commits.webkit.org/282706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd6b33c1053e80d37bf0a9837a947af371c4691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51552 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10097 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69732 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55497 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59018 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6602 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9684 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->