### PR TITLE
Port more identifiers from LegacyNullableObjectIdentifier to ObjectIdentifier

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchIdentifier.h
+++ b/Source/WebCore/Modules/fetch/FetchIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class FetchIdentifierType { };
-using FetchIdentifier = LegacyNullableObjectIdentifier<FetchIdentifierType>;
+using FetchIdentifier = ObjectIdentifier<FetchIdentifierType>;
 
 }

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -247,7 +247,7 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
         auto fillResult = init.headers ? m_headers->fill(*init.headers) : m_headers->fill(input.headers());
         if (fillResult.hasException())
             return fillResult;
-        m_navigationPreloadIdentifier = { };
+        m_navigationPreloadIdentifier = std::nullopt;
     } else {
         m_headers->setInternalHeaders(HTTPHeaderMap { input.headers().internalHeaders() });
         m_navigationPreloadIdentifier = input.m_navigationPreloadIdentifier;

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -84,8 +84,8 @@ public:
     const URL& url() const { return m_request.url(); }
 
     ResourceRequest resourceRequest() const;
-    FetchIdentifier navigationPreloadIdentifier() const { return m_navigationPreloadIdentifier; }
-    void setNavigationPreloadIdentifier(FetchIdentifier identifier) { m_navigationPreloadIdentifier = identifier; }
+    std::optional<FetchIdentifier> navigationPreloadIdentifier() const { return m_navigationPreloadIdentifier.asOptional(); }
+    void setNavigationPreloadIdentifier(std::optional<FetchIdentifier> identifier) { m_navigationPreloadIdentifier = identifier; }
 
     RequestPriority fetchPriorityHint() const { return m_fetchPriorityHint; }
 
@@ -111,7 +111,7 @@ private:
     RequestPriority m_fetchPriorityHint { RequestPriority::Auto };
     String m_referrer;
     Ref<AbortSignal> m_signal;
-    FetchIdentifier m_navigationPreloadIdentifier;
+    Markable<FetchIdentifier> m_navigationPreloadIdentifier;
     bool m_enableContentExtensionsCheck { true };
 };
 

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -253,7 +253,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     RequestPriority fetchPriorityHint : bitWidthOfFetchPriorityHint;
     ShouldEnableContentExtensionsCheck shouldEnableContentExtensionsCheck : bitWidthOfShouldEnableContentExtensionsCheck;
 
-    FetchIdentifier navigationPreloadIdentifier;
+    Markable<FetchIdentifier> navigationPreloadIdentifier;
     String nonce;
 };
 

--- a/Source/WebCore/platform/graphics/LayerHostingContextIdentifier.h
+++ b/Source/WebCore/platform/graphics/LayerHostingContextIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class LayerHostingContextIdentifierType { };
-using LayerHostingContextIdentifier = LegacyNullableObjectIdentifier<LayerHostingContextIdentifierType>;
+using LayerHostingContextIdentifier = ObjectIdentifier<LayerHostingContextIdentifierType>;
 
 }

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -101,14 +101,13 @@ private:
 
     ResponseCallback m_onResponse;
 
-    FetchIdentifier m_navigationPreloadIdentifier;
+    Markable<FetchIdentifier> m_navigationPreloadIdentifier;
     std::unique_ptr<PreloadResponsePromise> m_preloadResponsePromise;
 };
 
 inline void FetchEvent::setNavigationPreloadIdentifier(FetchIdentifier identifier)
 {
     ASSERT(!m_navigationPreloadIdentifier);
-    ASSERT(identifier);
     m_navigationPreloadIdentifier = identifier;
 }
 

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -129,7 +129,7 @@ public:
     WEBCORE_EXPORT void registerServiceWorkerClients();
     bool isClosed() const { return m_isClosed; }
 
-    using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(ExceptionOr<BackgroundFetchInformation>&&)>;
+    using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(ExceptionOr<std::optional<BackgroundFetchInformation>>&&)>;
     virtual void startBackgroundFetch(ServiceWorkerRegistrationIdentifier, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, ExceptionOrBackgroundFetchInformationCallback&&) = 0;
     virtual void backgroundFetchInformation(ServiceWorkerRegistrationIdentifier, const String&, ExceptionOrBackgroundFetchInformationCallback&&) = 0;
     using BackgroundFetchIdentifiersCallback = CompletionHandler<void(Vector<String>&&)>;

--- a/Source/WebCore/workers/service/ServiceWorkerJobData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJobData.cpp
@@ -30,23 +30,14 @@
 
 namespace WebCore {
 
-static inline ServiceWorkerOrClientIdentifier serviceWorkerOrClientIdentifier(const ServiceWorkerOrClientIdentifier& localSourceContext)
-{
-    return WTF::switchOn(localSourceContext, [&](ScriptExecutionContextIdentifier contextIdentifier) -> ServiceWorkerOrClientIdentifier {
-        return contextIdentifier;
-    }, [&](ServiceWorkerIdentifier serviceWorkerIdentifier) -> ServiceWorkerOrClientIdentifier {
-        return serviceWorkerIdentifier;
-    });
-}
-
 ServiceWorkerJobData::ServiceWorkerJobData(SWServerConnectionIdentifier connectionIdentifier, const ServiceWorkerOrClientIdentifier& localSourceContext)
-    : sourceContext(serviceWorkerOrClientIdentifier(localSourceContext))
+    : sourceContext(localSourceContext)
     , m_identifier { connectionIdentifier, ServiceWorkerJobIdentifier::generate() }
 {
 }
 
 ServiceWorkerJobData::ServiceWorkerJobData(Identifier identifier, const ServiceWorkerOrClientIdentifier& localSourceContext)
-    : sourceContext(serviceWorkerOrClientIdentifier(localSourceContext))
+    : sourceContext(localSourceContext)
     , m_identifier { identifier }
 {
 }
@@ -82,9 +73,7 @@ std::optional<ScriptExecutionContextIdentifier> ServiceWorkerJobData::serviceWor
 
 ServiceWorkerJobData ServiceWorkerJobData::isolatedCopy() const
 {
-    ServiceWorkerJobData result;
-    result.m_identifier = identifier();
-    result.sourceContext = sourceContext;
+    ServiceWorkerJobData result { identifier(), sourceContext };
     result.workerType = workerType;
     result.type = type;
     result.isFromServiceWorkerPage = isFromServiceWorkerPage;

--- a/Source/WebCore/workers/service/ServiceWorkerJobData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJobData.h
@@ -64,8 +64,6 @@ struct ServiceWorkerJobData {
     ServiceWorkerJobData isolatedCopy() const;
 
 private:
-    ServiceWorkerJobData() = default;
-
     Identifier m_identifier;
 };
 

--- a/Source/WebCore/workers/service/ServiceWorkerTypes.h
+++ b/Source/WebCore/workers/service/ServiceWorkerTypes.h
@@ -66,13 +66,13 @@ enum class ServiceWorkerIsInspectable : bool { No, Yes };
 enum class ShouldNotifyWhenResolved : bool { No, Yes };
 
 enum class ServiceWorkerRegistrationIdentifierType { };
-using ServiceWorkerRegistrationIdentifier = LegacyNullableAtomicObjectIdentifier<ServiceWorkerRegistrationIdentifierType>;
+using ServiceWorkerRegistrationIdentifier = AtomicObjectIdentifier<ServiceWorkerRegistrationIdentifierType>;
 
 enum class ServiceWorkerJobIdentifierType { };
-using ServiceWorkerJobIdentifier = LegacyNullableAtomicObjectIdentifier<ServiceWorkerJobIdentifierType>;
+using ServiceWorkerJobIdentifier = AtomicObjectIdentifier<ServiceWorkerJobIdentifierType>;
 
 enum class SWServerToContextConnectionIdentifierType { };
-using SWServerToContextConnectionIdentifier = LegacyNullableObjectIdentifier<SWServerToContextConnectionIdentifierType>;
+using SWServerToContextConnectionIdentifier = ObjectIdentifier<SWServerToContextConnectionIdentifierType>;
 
 using SWServerConnectionIdentifierType = ProcessIdentifierType;
 using SWServerConnectionIdentifier = LegacyNullableObjectIdentifier<SWServerConnectionIdentifierType>;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
@@ -90,7 +90,7 @@ void BackgroundFetchEngine::startBackgroundFetch(SWServerRegistration& registrat
                     return server ? server->createBackgroundFetchRecordLoader(client, request, responseDataSize, origin) : nullptr;
                 });
             }
-            callback(fetch->information());
+            callback(std::optional { fetch->information() });
             break;
         };
     });
@@ -139,10 +139,10 @@ void BackgroundFetchEngine::backgroundFetchInformation(SWServerRegistration& reg
     auto& map = iterator->value;
     auto fetchIterator = map.find(backgroundFetchIdentifier);
     if (fetchIterator == map.end()) {
-        callback(BackgroundFetchInformation { });
+        callback(std::optional<BackgroundFetchInformation> { });
         return;
     }
-    callback(fetchIterator->value->information());
+    callback(std::optional { fetchIterator->value->information() });
 }
 
 // https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-getids

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
@@ -48,7 +48,7 @@ class BackgroundFetchEngine : public CanMakeWeakPtr<BackgroundFetchEngine> {
 public:
     explicit BackgroundFetchEngine(SWServer&);
 
-    using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(Expected<BackgroundFetchInformation, ExceptionData>&&)>;
+    using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(Expected<std::optional<BackgroundFetchInformation>, ExceptionData>&&)>;
     void startBackgroundFetch(SWServerRegistration&, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, ExceptionOrBackgroundFetchInformationCallback&&);
     void backgroundFetchInformation(SWServerRegistration&, const String&, ExceptionOrBackgroundFetchInformationCallback&&);
     using BackgroundFetchIdentifiersCallback = CompletionHandler<void(Vector<String>&&)>;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -98,7 +98,7 @@ public:
         WEBCORE_EXPORT RefPtr<SWServerRegistration> doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL);
         void resolveRegistrationReadyRequests(SWServerRegistration&);
 
-        using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(Expected<BackgroundFetchInformation, ExceptionData>&&)>;
+        using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(Expected<std::optional<BackgroundFetchInformation>, ExceptionData>&&)>;
         WEBCORE_EXPORT void startBackgroundFetch(ServiceWorkerRegistrationIdentifier, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, ExceptionOrBackgroundFetchInformationCallback&&);
         WEBCORE_EXPORT void backgroundFetchInformation(ServiceWorkerRegistrationIdentifier, const String&, ExceptionOrBackgroundFetchInformationCallback&&);
         using BackgroundFetchIdentifiersCallback = CompletionHandler<void(Vector<String>&&)>;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -102,7 +102,7 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
     , m_serviceWorkerRegistrationIdentifier(registration.identifier())
     , m_shouldSoftUpdate(registration.shouldSoftUpdate(loader.parameters().options))
 {
-    SWFETCH_RELEASE_LOG("ServiceWorkerFetchTask: (serverConnectionIdentifier=%" PRIu64 ", serviceWorkerRegistrationIdentifier=%" PRIu64 ", serviceWorkerIdentifier=%" PRIu64 ", %d)", m_serverConnectionIdentifier.toUInt64(), m_serviceWorkerRegistrationIdentifier.toUInt64(), m_serviceWorkerIdentifier.toUInt64(), isWorkerReady);
+    SWFETCH_RELEASE_LOG("ServiceWorkerFetchTask: (serverConnectionIdentifier=%" PRIu64 ", serviceWorkerRegistrationIdentifier=%" PRIu64 ", serviceWorkerIdentifier=%" PRIu64 ", %d)", m_serverConnectionIdentifier.toUInt64(), m_serviceWorkerRegistrationIdentifier->toUInt64(), m_serviceWorkerIdentifier.toUInt64(), isWorkerReady);
 
     // We only do the timeout logic for main document navigations because it is not Web-compatible to do so for subresources.
     if (loader.parameters().request.requester() == WebCore::ResourceRequestRequester::Main) {
@@ -456,7 +456,7 @@ void ServiceWorkerFetchTask::softUpdateIfNeeded()
     CheckedPtr swConnection = loader->connectionToWebProcess().swConnection();
     if (!swConnection)
         return;
-    if (RefPtr registration = swConnection->server().getRegistration(m_serviceWorkerRegistrationIdentifier))
+    if (RefPtr registration = swConnection->server().getRegistration(*m_serviceWorkerRegistrationIdentifier))
         registration->scheduleSoftUpdate(loader->isAppInitiated() ? WebCore::IsAppInitiated::Yes : WebCore::IsAppInitiated::No);
 }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -133,7 +133,7 @@ private:
     WebCore::ServiceWorkerIdentifier m_serviceWorkerIdentifier;
     WebCore::ResourceRequest m_currentRequest;
     std::unique_ptr<WebCore::Timer> m_timeoutTimer;
-    WebCore::ServiceWorkerRegistrationIdentifier m_serviceWorkerRegistrationIdentifier;
+    Markable<WebCore::ServiceWorkerRegistrationIdentifier> m_serviceWorkerRegistrationIdentifier;
     std::unique_ptr<ServiceWorkerNavigationPreloader> m_preloader;
     bool m_wasHandled { false };
     bool m_isDone { false };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -55,8 +55,8 @@ messages -> WebSWServerConnection NotRefCounted {
     SetNavigationPreloadHeaderValue(WebCore::ServiceWorkerRegistrationIdentifier identifier, String value) -> (std::optional<WebCore::ExceptionData> result)
     GetNavigationPreloadState(WebCore::ServiceWorkerRegistrationIdentifier identifier) -> (Expected<WebCore::NavigationPreloadState, WebCore::ExceptionData> result)
 
-    StartBackgroundFetch(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String backgroundFetchIdentifier, Vector<WebCore::BackgroundFetchRequest> requests, struct WebCore::BackgroundFetchOptions options) -> (Expected<WebCore::BackgroundFetchInformation, WebCore::ExceptionData> result)
-    BackgroundFetchInformation(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String backgroundFetchIdentifier) -> (Expected<WebCore::BackgroundFetchInformation, WebCore::ExceptionData> result)
+    StartBackgroundFetch(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String backgroundFetchIdentifier, Vector<WebCore::BackgroundFetchRequest> requests, struct WebCore::BackgroundFetchOptions options) -> (Expected<std::optional<WebCore::BackgroundFetchInformation>, WebCore::ExceptionData> result)
+    BackgroundFetchInformation(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String backgroundFetchIdentifier) -> (Expected<std::optional<WebCore::BackgroundFetchInformation>, WebCore::ExceptionData> result)
     BackgroundFetchIdentifiers(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier) -> (Vector<String> result)
 
     AbortBackgroundFetch(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String backgroundFetchIdentifier) -> (bool result)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -340,7 +340,7 @@ void WebSWServerToContextConnection::startFetch(ServiceWorkerFetchTask& task)
 
 void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto iterator = m_ongoingFetches.find(LegacyNullableObjectIdentifier<FetchIdentifierType>(decoder.destinationID()));
+    auto iterator = m_ongoingFetches.find(ObjectIdentifier<FetchIdentifierType>(decoder.destinationID()));
     if (iterator == m_ongoingFetches.end())
         return;
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -61,14 +61,11 @@ header: <wtf/text/AtomString.h>
 
 header: <wtf/ObjectIdentifier.h>
 template: enum class WebCore::AXIDType
-template: enum class WebCore::FetchIdentifierType
-template: enum class WebCore::LayerHostingContextIdentifierType
 template: enum class WebCore::MediaSessionGroupIdentifierType
 template: enum class WebCore::MediaUniqueIdentifierType
 template: enum class WebCore::ProcessIdentifierType
 template: enum class WebCore::PushSubscriptionIdentifierType
 template: enum class WebCore::RealtimeMediaSourceIdentifierType
-template: enum class WebCore::SWServerToContextConnectionIdentifierType
 template: enum class WebCore::SharedWorkerIdentifierType
 template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
 template: enum class WebCore::TextCheckingRequestIdentifierType
@@ -157,9 +154,12 @@ template: struct WebKit::WebTransportStreamIdentifierType
 template: class WebKit::WebURLSchemeHandler
 template: enum class WebCore::BackgroundFetchRecordIdentifierType
 template: enum class WebCore::ElementIdentifierType
+template: enum class WebCore::FetchIdentifierType
 template: enum class WebCore::ImageDecoderIdentifierType
 template: enum class WebCore::ImageOverlayDataDetectionResultIdentifierType
 template: enum class WebCore::InbandGenericCueIdentifierType
+template: enum class WebCore::LayerHostingContextIdentifierType
+template: enum class WebCore::SWServerToContextConnectionIdentifierType
 template: struct WebCore::NavigationIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
@@ -185,8 +185,6 @@ template: enum class WebCore::RTCDataChannelLocalIdentifierType
 template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
 template: enum class WebCore::RenderingResourceIdentifierType
 template: enum class WebCore::ServiceWorkerIdentifierType
-template: enum class WebCore::ServiceWorkerJobIdentifierType
-template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
 template: enum class WebCore::IDBDatabaseConnectionIdentifierType
 template: enum class WebCore::WebLockIdentifierType
 template: enum class WebCore::WebSocketIdentifierType
@@ -208,6 +206,13 @@ template: struct WebCore::WebSocketFrame
 template: struct WebKit::ConnectionAsyncReplyHandler
 template: struct WebKit::StorageAreaIdentifierType
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::LegacyNullableAtomicObjectIdentifier {
+    [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
+}
+
+header: <wtf/ObjectIdentifier.h>
+template: enum class WebCore::ServiceWorkerJobIdentifierType
+template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::AtomicObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
 


### PR DESCRIPTION
#### 08bd5d5785ce1bdfe052fe1c83a925f10496c360
<pre>
Port more identifiers from LegacyNullableObjectIdentifier to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=278616">https://bugs.webkit.org/show_bug.cgi?id=278616</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/Modules/fetch/FetchIdentifier.h:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/platform/graphics/LayerHostingContextIdentifier.h:
* Source/WebCore/workers/service/FetchEvent.h:
(WebCore::FetchEvent::setNavigationPreloadIdentifier):
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/ServiceWorkerJobData.cpp:
(WebCore::ServiceWorkerJobData::ServiceWorkerJobData):
(WebCore::ServiceWorkerJobData::isolatedCopy const):
(WebCore::serviceWorkerOrClientIdentifier): Deleted.
* Source/WebCore/workers/service/ServiceWorkerJobData.h:
* Source/WebCore/workers/service/ServiceWorkerTypes.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
(WebCore::BackgroundFetchEngine::backgroundFetchInformation):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp:
(WebCore::BackgroundFetchManager::fetch):
(WebCore::BackgroundFetchManager::get):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::softUpdateIfNeeded):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::didReceiveFetchTaskMessage):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/282717@main">https://commits.webkit.org/282717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f298456aa5436ee3fe32e0856d48a1ca18ce3bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51604 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10139 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12837 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13560 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58923 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59076 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6652 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->