### PR TITLE
Fix WTF::HashSet<Class> and WTF::HashSet<RetainPtr<>> to work with ARC and upstream clang

### DIFF
--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -46,7 +46,7 @@ public:
 
     WEBCORE_EXPORT SerializedPlatformDataCueValue encodableValue() const final;
 
-    WEBCORE_EXPORT static const HashSet<Class>& allowedClassesForNativeValues();
+    WEBCORE_EXPORT static const HashSet<RetainPtr<Class>>& allowedClassesForNativeValues();
 
 private:
     SerializedPlatformDataCueValue m_value;

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -101,9 +101,9 @@ const SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(const Seriali
     return static_cast<const SerializedPlatformDataCueMac*>(rep);
 }
 
-const HashSet<Class>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
+const HashSet<RetainPtr<Class>>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
 {
-    static NeverDestroyed<HashSet<Class>> allowedClasses(HashSet<Class> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
+    static NeverDestroyed<HashSet<RetainPtr<Class>>> allowedClasses(HashSet<RetainPtr<Class>> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
     return allowedClasses;
 }
 

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -65,6 +65,10 @@ template<typename T, typename = IsObjCObject<T>> Class getClass()
 }
 #endif
 
+#if PLATFORM(COCOA)
+using AllowedClassHashSet = HashSet<RetainPtr<ClassStructPtr>>;
+#endif
+
 class Decoder {
     WTF_MAKE_TZONE_ALLOCATED(Decoder);
 public:
@@ -138,22 +142,20 @@ public:
 
 #ifdef __OBJC__
     template<typename T, typename = IsObjCObject<T>>
-    std::optional<RetainPtr<T>> decodeWithAllowedClasses(const HashSet<ClassStructPtr>& allowedClasses = { getClass<T>() })
+    std::optional<RetainPtr<T>> decodeWithAllowedClasses(const AllowedClassHashSet& allowedClasses = { getClass<T>() })
     {
         m_allowedClasses = allowedClasses;
         return IPC::decodeRequiringAllowedClasses<T>(*this);
     }
 
     template<typename T, typename = IsNotObjCObject<T>>
-    std::optional<T> decodeWithAllowedClasses(const HashSet<ClassStructPtr>& allowedClasses)
+    std::optional<T> decodeWithAllowedClasses(const AllowedClassHashSet& allowedClasses)
     {
         m_allowedClasses = allowedClasses;
         return decode<T>();
     }
-#endif
 
-#if PLATFORM(COCOA)
-    HashSet<ClassStructPtr>& allowedClasses() { return m_allowedClasses; }
+    AllowedClassHashSet& allowedClasses() { return m_allowedClasses; }
 #endif
 
     std::optional<Attachment> takeLastAttachment();
@@ -182,7 +184,7 @@ private:
     ImportanceAssertion m_importanceAssertion;
 #endif
 #if PLATFORM(COCOA)
-    HashSet<ClassStructPtr> m_allowedClasses;
+    AllowedClassHashSet m_allowedClasses;
 #endif
 
     uint64_t m_destinationID;

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -151,10 +151,10 @@ template<typename T, typename = IsObjCObject<T>> void encode(Encoder&, T *);
 
 #if ASSERT_ENABLED
 
-static inline bool isObjectClassAllowed(id object, const HashSet<Class>& allowedClasses)
+static inline bool isObjectClassAllowed(id object, const AllowedClassHashSet& allowedClasses)
 {
-    for (Class allowedClass : allowedClasses) {
-        if ([object isKindOfClass:allowedClass])
+    for (auto& allowedClass : allowedClasses) {
+        if ([object isKindOfClass:allowedClass.get()])
             return true;
     }
     return false;

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -454,7 +454,7 @@ template<> void encodeObjectDirectly<NSObject<NSSecureCoding>>(Encoder& encoder,
     encoder << (__bridge CFDataRef)[archiver encodedData];
 }
 
-static bool shouldEnableStrictMode(Decoder& decoder, const HashSet<Class>& allowedClasses)
+static bool shouldEnableStrictMode(Decoder& decoder, const AllowedClassHashSet& allowedClasses)
 {
 #if HAVE(STRICT_DECODABLE_NSTEXTTABLE) \
     && HAVE(STRICT_DECODABLE_PKCONTACT) \
@@ -562,8 +562,8 @@ static constexpr bool haveSecureActionContext = false;
     // If you want to serialize something new, extract its contents into a
     // struct and use a *.serialization.in file to serialize its contents.
     RetainPtr<NSMutableArray> nsAllowedClasses = adoptNS([[NSMutableArray alloc] initWithCapacity:allowedClasses.size()]);
-    for (auto classPtr : allowedClasses)
-        [nsAllowedClasses addObject:classPtr];
+    for (auto& classPtr : allowedClasses)
+        [nsAllowedClasses addObject:classPtr.get()];
     RELEASE_LOG_FAULT(SecureCoding, "Strict mode check found unknown classes %@", nsAllowedClasses.get());
     ASSERT_NOT_REACHED();
     return true;
@@ -614,8 +614,8 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
 #endif
 
     auto allowedClassSet = adoptNS([[NSMutableSet alloc] initWithCapacity:allowedClasses.size()]);
-    for (auto allowedClass : allowedClasses)
-        [allowedClassSet addObject:allowedClass];
+    for (auto& allowedClass : allowedClasses)
+        [allowedClassSet addObject:allowedClass.get()];
 
     if (shouldEnableStrictMode(decoder, allowedClasses))
         [unarchiver _enableStrictSecureDecodingMode];

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 		44D3F8402BE1A74200BE0218 /* XMLParsing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D3F8382BE1A6BE00BE0218 /* XMLParsing.mm */; };
 		44D3F8432BE1DB0000BE0218 /* test.xml in Copy Resources */ = {isa = PBXBuildFile; fileRef = 44D3F8422BE1DAD800BE0218 /* test.xml */; };
 		44D5008E26FE9ED6000EB12F /* RetainPtrARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D5008D26FE9ED6000EB12F /* RetainPtrARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		44FBAEFF2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44FBAEFD2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm */; };
+		44FBAF002C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44FBAEFE2C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4628C8E92367ABD100B073F0 /* WKSecurityOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4628C8E82367ABBC00B073F0 /* WKSecurityOrigin.cpp */; };
 		462B4E8028E7B0E400653230 /* fragment-navigation-before-load-event.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 462B4E7828E7B0AF00653230 /* fragment-navigation-before-load-event.html */; };
 		46397B951DC2C850009A78AE /* DOMNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46397B941DC2C850009A78AE /* DOMNode.mm */; };
@@ -2454,6 +2456,8 @@
 		44D3F8422BE1DAD800BE0218 /* test.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = test.xml; sourceTree = "<group>"; };
 		44D5008D26FE9ED6000EB12F /* RetainPtrARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RetainPtrARC.mm; path = ns/RetainPtrARC.mm; sourceTree = "<group>"; };
 		44DBE9512BD2272900307F65 /* TextPlaceholderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextPlaceholderTests.mm; sourceTree = "<group>"; };
+		44FBAEFD2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RetainPtrHashingCocoa.mm; sourceTree = "<group>"; };
+		44FBAEFE2C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RetainPtrHashingCocoaARC.mm; sourceTree = "<group>"; };
 		46061545275824B400AB613D /* WebLocks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebLocks.mm; sourceTree = "<group>"; };
 		460C2FC827039D7D0047EF11 /* ServiceWorkerPageProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerPageProtocol.h; sourceTree = "<group>"; };
 		4612C2B8210A6ABF00B788A6 /* LoadFileThenReload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadFileThenReload.mm; sourceTree = "<group>"; };
@@ -6000,6 +6004,8 @@
 			children = (
 				1CA6FBAC2A1D818C001D4402 /* ContextualizedNSString.mm */,
 				A1C7D7D22AB817A90055AD62 /* LoggerCocoa.mm */,
+				44FBAEFD2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm */,
+				44FBAEFE2C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm */,
 				1C4616A626BB172F00F8C9F6 /* TextStreamCocoa.cpp */,
 				1C46169E26BA510700F8C9F6 /* TextStreamCocoa.mm */,
 				44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */,
@@ -6489,6 +6495,8 @@
 				7C83DF241D0A590C00FEBCF3 /* RetainPtr.mm in Sources */,
 				44D5008E26FE9ED6000EB12F /* RetainPtrARC.mm in Sources */,
 				44B28A0528D18AD20010172C /* RetainPtrHashing.cpp in Sources */,
+				44FBAEFF2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm in Sources */,
+				44FBAF002C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm in Sources */,
 				E355A6322615718F001C1129 /* RobinHoodHashMap.cpp in Sources */,
 				E355A63026157174001C1129 /* RobinHoodHashSet.cpp in Sources */,
 				7C83DF051D0A590C00FEBCF3 /* RunLoop.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtrHashingCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtrHashingCocoa.mm
@@ -34,17 +34,17 @@
 
 namespace TestWebKitAPI {
 
-TEST(RetainPtrHashing, HashSet)
+TEST(RetainPtrHashingCocoa, HashSet)
 {
-    HashSet<RetainPtr<CFArrayRef>> set;
+    HashSet<RetainPtr<NSObject>> set;
 
-    RetainPtr<CFArrayRef> foo = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainPtr<NSObject> foo = adoptNS([NSObject new]);
 
     EXPECT_FALSE(set.contains(foo));
     set.add(foo);
     EXPECT_TRUE(set.contains(foo));
 
-    RetainPtr<CFArrayRef> foo2 = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainPtr<NSObject> foo2 = adoptNS([NSObject new]);
     EXPECT_FALSE(set.contains(foo2));
     set.add(foo2);
     EXPECT_TRUE(set.contains(foo));
@@ -55,17 +55,17 @@ TEST(RetainPtrHashing, HashSet)
     EXPECT_TRUE(set.contains(foo2));
 }
 
-TEST(RetainPtrHashing, HashMapKey)
+TEST(RetainPtrHashingCocoa, HashMapKey)
 {
-    HashMap<RetainPtr<CFArrayRef>, int> map;
+    HashMap<RetainPtr<NSObject>, int> map;
 
-    RetainPtr<CFArrayRef> foo = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainPtr<NSObject> foo = adoptNS([NSObject new]);
 
     EXPECT_FALSE(map.contains(foo));
     map.add(foo, 1);
     EXPECT_EQ(1, map.get(foo));
 
-    RetainPtr<CFArrayRef> foo2 = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainPtr<NSObject> foo2 = adoptNS([NSObject new]);
     EXPECT_TRUE(map.contains(foo));
     EXPECT_FALSE(map.contains(foo2));
     map.add(foo2, 2);
@@ -77,17 +77,17 @@ TEST(RetainPtrHashing, HashMapKey)
     EXPECT_TRUE(map.contains(foo2));
 }
 
-TEST(RetainPtrHashing, HashMapValue)
+TEST(RetainPtrHashingCocoa, HashMapValue)
 {
-    HashMap<int, RetainPtr<CFArrayRef>> map;
+    HashMap<int, RetainPtr<NSObject>> map;
 
-    RetainPtr<CFArrayRef> foo = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainPtr<NSObject> foo = adoptNS([NSObject new]);
 
     EXPECT_FALSE(map.contains(1));
     map.add(1, foo);
     EXPECT_EQ(foo, map.get(1));
 
-    RetainPtr<CFArrayRef> foo2 = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainPtr<NSObject> foo2 = adoptNS([NSObject new]);
     EXPECT_FALSE(map.contains(2));
     map.add(2, foo2);
     EXPECT_EQ(foo, map.get(1));

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtrHashingCocoaARC.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtrHashingCocoaARC.mm
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This tests HashMap.h+HashSet.h+RetainPtr.h with ARC enabled.
+#endif
+
+#define RetainPtrHashingCocoa RetainPtrHashingCocoaARC
+#include "RetainPtrHashingCocoa.mm"
+#undef RetainPtrHashingCocoa


### PR DESCRIPTION
#### f61eefa7dc8c4fa3576a0d10d06f523b7e907e9b
<pre>
Fix WTF::HashSet&lt;Class&gt; and WTF::HashSet&lt;RetainPtr&lt;&gt;&gt; to work with ARC and upstream clang
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278624">https://bugs.webkit.org/show_bug.cgi?id=278624</a>&gt;
&lt;<a href="https://rdar.apple.com/134591290">rdar://134591290</a>&gt;

Reviewed by Darin Adler.

Upstream clang makes Class objects participate in ARC, so
WTF::HashSet&lt;Class&gt; must be changed to WTF::HashSet&lt;RetainPtr&lt;Class&gt;&gt;.

However, WTF::HashSet&lt;RetainPtr&lt;&gt;&gt; doesn&apos;t currently work with ARC, so
that had to be fixed with casting changes to WTF::RetainPtr&lt;&gt;.

Also introduce IPC::AllowedClassHashSet to use a consistent type
everywhere (except WebCore::SerializedPlatformDataCueMac).

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::RetainPtr):
(WTF::RetainPtr::isHashTableDeletedValue const):
- Use toStorageType() to fix compilation with ARC.
(WTF::RetainPtr::hashTableDeletedValue):
- Use fromStorageType() with reinterpret_cast&lt;CFTypeRef&gt;() to create the
  deleted value.
(WTF::RetainPtr::fromStorageTypeHelper):
(WTF::RetainPtr::fromStorageType):
(WTF::RetainPtr::toStorageType):
- Change to static so they can be used from hashTableDeletedValue().

* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues):
- Switch from WTF::HashSet&lt;Class&gt; to WTF::HashSet&lt;RetainPtr&lt;Class&gt;&gt; for
  future ARC conversion and to eliminate raw pointer use.

* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::AllowedClassHashSet): Add.
- Define common type for HashSet&lt;RetainPtr&lt;Class&gt;&gt; and use in WebKit.
  This replaces HashSet&lt;Class&gt; since that no longer works with ARC.
(IPC::Decoder::decodeWithAllowedClasses):
(IPC::Decoder::allowedClasses):
- Make use of AllowedClassHashSet type.
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::isObjectClassAllowed):
- Make use of AllowedClassHashSet type, and update for loop to work with
  the new type.
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
- Make use of AllowedClassHashSet type, and update for loop to work with
  the new type.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add RetainPtrHashingCocoa[ARC].mm to the project.
* Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtrHashing.cpp:
(TestWebKitAPI::TEST(RetainPtrHashing, HashSet)):
(TestWebKitAPI::TEST(RetainPtrHashing, HashMapKey)):
(TestWebKitAPI::TEST(RetainPtrHashing, HashMapValue)):
- Add more expectations to tests and fix header sort order.
* Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtrHashingCocoa.mm: Copied from Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtrHashing.cpp.
(TestWebKitAPI::TEST(RetainPtrHashingCocoa, HashSet)):
(TestWebKitAPI::TEST(RetainPtrHashingCocoa, HashMapKey)):
(TestWebKitAPI::TEST(RetainPtrHashingCocoa, HashMapValue)):
- Add tests for HashMap&lt;RetainPtr&lt;&gt;&gt; and HashSet&lt;RetainPtr&lt;&gt;&gt;.
* Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtrHashingCocoaARC.mm: Add.
- Add tests for HashMap&lt;RetainPtr&lt;&gt;&gt; and HashSet&lt;RetainPtr&lt;&gt;&gt; under ARC.

Canonical link: <a href="https://commits.webkit.org/283028@main">https://commits.webkit.org/283028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/917cef58a07025fe90ab1c0ed9abc3c6b0d18e3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64960 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52187 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14442 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58073 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70689 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64203 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13409 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59727 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1026 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85969 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9851 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40139 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15154 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->