### PR TITLE
Fix -Wthread-safety-reference-return warnings in WebCore with upstream clang

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h
@@ -40,13 +40,17 @@ inline JSC::Structure* JSDOMGlobalObject::createStructure(JSC::VM& vm, JSC::JSVa
 inline JSDOMStructureMap& JSDOMGlobalObject::structures(NoLockingNecessaryTag)
 {
     ASSERT(!vm().heap.mutatorShouldBeFenced());
+    IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
     return m_structures;
+    IGNORE_CLANG_WARNINGS_END
 }
 
 inline DOMGuardedObjectSet& JSDOMGlobalObject::guardedObjects(NoLockingNecessaryTag)
 {
     ASSERT(!vm().heap.mutatorShouldBeFenced());
+    IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
     return m_guardedObjects;
+    IGNORE_CLANG_WARNINGS_END
 }
 
 template<class ConstructorClass, DOMConstructorID constructorID>

--- a/Source/WebCore/dom/MessageEvent.h
+++ b/Source/WebCore/dom/MessageEvent.h
@@ -75,7 +75,12 @@ public:
     const std::optional<MessageEventSource>& source() const { return m_source; }
     const Vector<Ref<MessagePort>>& ports() const { return m_ports; }
 
-    const DataType& data() const { return m_data; }
+    const DataType& data() const
+    {
+        IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
+        return m_data;
+        IGNORE_CLANG_WARNINGS_END
+    }
 
     JSValueInWrappedObject& jsData() { return m_jsData; }
     JSValueInWrappedObject& cachedData() { return m_cachedData; }

--- a/Source/WebCore/dom/TrustedTypePolicy.h
+++ b/Source/WebCore/dom/TrustedTypePolicy.h
@@ -57,7 +57,12 @@ public:
     ExceptionOr<String> getPolicyValue(TrustedType trustedTypeName, const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&, IfMissing = IfMissing::Throw);
     const String name() const { return m_name; }
 
-    const TrustedTypePolicyOptions& options() const { return m_options; }
+    const TrustedTypePolicyOptions& options() const
+    {
+        IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
+        return m_options;
+        IGNORE_CLANG_WARNINGS_END
+    }
     Lock& lock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
 
 private:

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -170,8 +170,9 @@ RefPtr<Document> MediaResourceLoader::protectedDocument()
 const String& MediaResourceLoader::crossOriginMode() const
 {
     assertIsMainThread();
-
+    IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
     return m_crossOriginMode;
+    IGNORE_CLANG_WARNINGS_END
 }
 
 Vector<ResourceResponse> MediaResourceLoader::responsesForTesting() const

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -262,7 +262,9 @@ const PlatformTimeRanges& MediaSourcePrivate::liveSeekableRange() const
 {
     Locker locker { m_lock };
 
+    IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
     return m_liveSeekable;
+    IGNORE_CLANG_WARNINGS_END
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -98,7 +98,9 @@ RangeResponseGenerator::~RangeResponseGenerator() = default;
 HashMap<String, std::unique_ptr<RangeResponseGenerator::Data>>& RangeResponseGenerator::map()
 {
     assertIsCurrent(m_targetDispatcher.get());
+    IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
     return m_map;
+    IGNORE_CLANG_WARNINGS_END
 }
 
 static ResourceResponse synthesizedResponseForRange(const ResourceResponse& originalResponse, const ParsedRequestRange& parsedRequestRange, std::optional<size_t> totalContentLength)


### PR DESCRIPTION
#### 1baa85fefb7e9c527fb24afadba91168e5e33f05
<pre>
Fix -Wthread-safety-reference-return warnings in WebCore with upstream clang
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278625">https://bugs.webkit.org/show_bug.cgi?id=278625</a>&gt;
&lt;<a href="https://rdar.apple.com/134653057">rdar://134653057</a>&gt;

Reviewed by Chris Dumez.

Use IGNORE_CLANG_WARNINGS_BEGIN/IGNORE_CLANG_WARNINGS_END to ignore
-Wthread-safety-reference-return warnings.

* Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h:
(WebCore::JSDOMGlobalObject::structures):
(WebCore::JSDOMGlobalObject::guardedObjects):
* Source/WebCore/dom/MessageEvent.h:
* Source/WebCore/dom/TrustedTypePolicy.h:
(WebCore::TrustedTypePolicy::options const):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::crossOriginMode const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::liveSeekableRange const):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::map):

Canonical link: <a href="https://commits.webkit.org/282816@main">https://commits.webkit.org/282816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d127f089a878676ccfd68907d2ca4109395133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51591 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10131 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58910 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59060 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/331 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39242 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->