### PR TITLE
Use BorderShape to render outset box-shadows

### DIFF
--- a/LayoutTests/fast/box-shadow/box-shadow-with-zero-radius.html
+++ b/LayoutTests/fast/box-shadow/box-shadow-with-zero-radius.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-626" />
+<meta name="fuzzy" content="maxDifference=0-170; totalPixels=0-626" />
 <style type="text/css">
 .greenSquare-shadow {
     position: absolute;

--- a/Source/WebCore/platform/graphics/RoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/RoundedRect.cpp
@@ -64,7 +64,7 @@ void RoundedRect::Radii::scale(float factor)
         m_bottomRight = LayoutSize();
 }
 
-void RoundedRect::Radii::expand(const LayoutUnit& topWidth, const LayoutUnit& bottomWidth, const LayoutUnit& leftWidth, const LayoutUnit& rightWidth)
+void RoundedRect::Radii::expand(LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth)
 {
     if (m_topLeft.width() > 0 && m_topLeft.height() > 0) {
         m_topLeft.setWidth(std::max<LayoutUnit>(0, m_topLeft.width() + leftWidth));
@@ -84,17 +84,22 @@ void RoundedRect::Radii::expand(const LayoutUnit& topWidth, const LayoutUnit& bo
     }
 }
 
-void RoundedRect::inflateWithRadii(const LayoutUnit& size)
+void RoundedRect::inflateWithRadii(LayoutUnit amount)
 {
     LayoutRect old = m_rect;
 
-    m_rect.inflate(size);
+    if (amount < 0) {
+        m_rect.inflateX(std::max(-m_rect.width() / 2, amount));
+        m_rect.inflateY(std::max(-m_rect.height() / 2, amount));
+    } else
+        m_rect.inflate(amount);
+
     // Considering the inflation factor of shorter size to scale the radii seems appropriate here
     float factor;
     if (m_rect.width() < m_rect.height())
-        factor = old.width() ? (float)m_rect.width() / old.width() : int(0);
+        factor = old.width() ? (float)m_rect.width() / old.width() : 0.0f;
     else
-        factor = old.height() ? (float)m_rect.height() / old.height() : int(0);
+        factor = old.height() ? (float)m_rect.height() / old.height() : 0.0f;
 
     m_radii.scale(factor);
 }
@@ -165,7 +170,7 @@ void RoundedRect::Radii::makeRenderableInRect(const LayoutRect& rect)
 
 }
 
-RoundedRect::RoundedRect(const LayoutUnit& x, const LayoutUnit& y, const LayoutUnit& width, const LayoutUnit& height)
+RoundedRect::RoundedRect(LayoutUnit x, LayoutUnit y, LayoutUnit width, LayoutUnit height)
     : m_rect(x, y, width, height)
 {
 }

--- a/Source/WebCore/platform/graphics/RoundedRect.h
+++ b/Source/WebCore/platform/graphics/RoundedRect.h
@@ -62,10 +62,10 @@ public:
     void excludeLogicalEdges(bool isHorizontal, bool excludeLogicalLeftEdge, bool excludeLogicalRightEdge);
 
     void scale(float factor);
-    void expand(const LayoutUnit& topWidth, const LayoutUnit& bottomWidth, const LayoutUnit& leftWidth, const LayoutUnit& rightWidth);
-    void expand(const LayoutUnit& size) { expand(size, size, size, size); }
-    void shrink(const LayoutUnit& topWidth, const LayoutUnit& bottomWidth, const LayoutUnit& leftWidth, const LayoutUnit& rightWidth) { expand(-topWidth, -bottomWidth, -leftWidth, -rightWidth); }
-    void shrink(const LayoutUnit& size) { shrink(size, size, size, size); }
+    void expand(LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth);
+    void expand(LayoutUnit size) { expand(size, size, size, size); }
+    void shrink(LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth) { expand(-topWidth, -bottomWidth, -leftWidth, -rightWidth); }
+    void shrink(LayoutUnit size) { shrink(size, size, size, size); }
 
     RoundedRectRadii transposedRadii() const { return { m_topLeft.transposedSize(), m_topRight.transposedSize(), m_bottomLeft.transposedSize(), m_bottomRight.transposedSize() }; }
 
@@ -86,7 +86,7 @@ public:
     using Radii = RoundedRectRadii;
 
     WEBCORE_EXPORT explicit RoundedRect(const LayoutRect&, const Radii& = Radii());
-    RoundedRect(const LayoutUnit&, const LayoutUnit&, const LayoutUnit& width, const LayoutUnit& height);
+    RoundedRect(LayoutUnit, LayoutUnit, LayoutUnit width, LayoutUnit height);
     WEBCORE_EXPORT RoundedRect(const LayoutRect&, const LayoutSize& topLeft, const LayoutSize& topRight, const LayoutSize& bottomLeft, const LayoutSize& bottomRight);
 
     const LayoutRect& rect() const { return m_rect; }
@@ -99,10 +99,10 @@ public:
 
     void move(const LayoutSize& size) { m_rect.move(size); }
     void moveBy(const LayoutPoint& offset) { m_rect.moveBy(offset); }
-    void inflate(const LayoutUnit& size) { m_rect.inflate(size);  }
-    void inflateWithRadii(const LayoutUnit& size);
-    void expandRadii(const LayoutUnit& size) { m_radii.expand(size); }
-    void shrinkRadii(const LayoutUnit& size) { m_radii.shrink(size); }
+    void inflate(LayoutUnit size) { m_rect.inflate(size);  }
+    void inflateWithRadii(LayoutUnit size);
+    void expandRadii(LayoutUnit size) { m_radii.expand(size); }
+    void shrinkRadii(LayoutUnit size) { m_radii.shrink(size); }
 
     void includeLogicalEdges(const Radii& edges, bool isHorizontal, bool includeLogicalLeftEdge, bool includeLogicalRightEdge);
     void excludeLogicalEdges(bool isHorizontal, bool excludeLogicalLeftEdge, bool excludeLogicalRightEdge);

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -154,6 +154,21 @@ bool BorderShape::innerShapeContains(const LayoutRect& rect) const
     return innerEdgeRoundedRect().contains(rect);
 }
 
+bool BorderShape::outerShapeContains(const LayoutRect& rect) const
+{
+    return m_borderRect.contains(rect);
+}
+
+void BorderShape::move(LayoutSize offset)
+{
+    m_borderRect.move(offset);
+}
+
+void BorderShape::inflate(LayoutUnit amount)
+{
+    m_borderRect.inflateWithRadii(amount);
+}
+
 static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path)
 {
     if (roundedRect.isRounded())
@@ -212,9 +227,24 @@ void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFa
         context.clip(pixelSnappedRect.rect());
 }
 
+void BorderShape::clipOutOuterShape(GraphicsContext& context, float deviceScaleFactor)
+{
+    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (pixelSnappedRect.isEmpty())
+        return;
+
+    if (pixelSnappedRect.isRounded())
+        context.clipOutRoundedRect(pixelSnappedRect);
+    else
+        context.clipOut(pixelSnappedRect.rect());
+}
+
 void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleFactor)
 {
     auto pixelSnappedRect = innerEdgeRoundedRect().pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (pixelSnappedRect.isEmpty())
+        return;
+
     if (pixelSnappedRect.isRounded())
         context.clipOutRoundedRect(pixelSnappedRect);
     else

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -54,6 +54,14 @@ public:
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const RoundedRectRadii&);
 
+    BorderShape(const BorderShape& other)
+        : m_borderRect(other.m_borderRect)
+        , m_borderWidths(other.m_borderWidths)
+    {
+    }
+
+    LayoutRect borderRect() const { return m_borderRect.rect(); }
+
     RoundedRect deprecatedRoundedRect() const;
     RoundedRect deprecatedInnerRoundedRect() const;
     FloatRoundedRect deprecatedPixelSnappedRoundedRect(float deviceScaleFactor) const;
@@ -61,6 +69,7 @@ public:
 
     // Returns true if the given rect is entirely inside the shape, without impinging on any of the corners.
     bool innerShapeContains(const LayoutRect&) const;
+    bool outerShapeContains(const LayoutRect&) const;
 
     const RoundedRectRadii& radii() const { return m_borderRect.radii(); }
     void setRadii(const RoundedRectRadii& radii) { m_borderRect.setRadii(radii); }
@@ -69,6 +78,12 @@ public:
     FloatRect snappedInnerRect(float deviceScaleFactor) const;
 
     bool isRounded() const { return m_borderRect.isRounded(); }
+    bool isEmpty() const { return m_borderRect.rect().isEmpty(); }
+
+    void move(LayoutSize);
+
+    // This will inflate the m_borderRect, and scale the radii up accordingly. Note that this changes the meaning of "inner shape" which will no longer correspond to the padding box.
+    void inflate(LayoutUnit);
 
     Path pathForOuterShape(float deviceScaleFactor) const;
     Path pathForInnerShape(float deviceScaleFactor) const;
@@ -77,6 +92,8 @@ public:
 
     void clipToOuterShape(GraphicsContext&, float deviceScaleFactor);
     void clipToInnerShape(GraphicsContext&, float deviceScaleFactor);
+
+    void clipOutOuterShape(GraphicsContext&, float deviceScaleFactor);
     void clipOutInnerShape(GraphicsContext&, float deviceScaleFactor);
 
     void fillOuterShape(GraphicsContext&, const Color&, float deviceScaleFactor);


### PR DESCRIPTION
#### 0cb414c8ee44853f705400dad8e1a9ae7de8cb7f
<pre>
Use BorderShape to render outset box-shadows
<a href="https://bugs.webkit.org/show_bug.cgi?id=278626">https://bugs.webkit.org/show_bug.cgi?id=278626</a>
<a href="https://rdar.apple.com/134654586">rdar://134654586</a>

Reviewed by Antti Koivisto.

Adopt BorderShape in `BackgroundPainter::paintBoxShadow()` for outset shadows.

Since BorderShape knows about inside and outside shapes, we create one for both inset
and outset shadows, then later fill the inner or outer shape as appropriate.

Add `BorderShape::inflate()` which is needed by shadow code.

* LayoutTests/fast/box-shadow/box-shadow-with-zero-radius.html:
* Source/WebCore/platform/graphics/RoundedRect.cpp:
(WebCore::RoundedRect::Radii::expand):
(WebCore::RoundedRect::inflateWithRadii):
(WebCore::RoundedRect::RoundedRect):
* Source/WebCore/platform/graphics/RoundedRect.h:
(WebCore::RoundedRectRadii::expand):
(WebCore::RoundedRectRadii::shrink):
(WebCore::RoundedRect::inflate): Ensure we don&apos;t shrink below zero with negative amounts.
(WebCore::RoundedRect::expandRadii):
(WebCore::RoundedRect::shrinkRadii):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBoxShadow const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::outerShapeContains const):
(WebCore::BorderShape::move):
(WebCore::BorderShape::inflate):
(WebCore::BorderShape::clipOutOuterShape): Don&apos;t clip out empty rects.
(WebCore::BorderShape::clipOutInnerShape): Don&apos;t clip out empty rects.
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::BorderShape):
(WebCore::BorderShape::borderRect const):
(WebCore::BorderShape::isEmpty const):

Canonical link: <a href="https://commits.webkit.org/283714@main">https://commits.webkit.org/283714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e42e868af30415e2805db8f93212a6d5badcdd06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53761 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72769 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61230 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9028 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2634 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-border-radius-001.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42215 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->