### PR TITLE
Build fails with “'CGWindowListCreateImage' is unavailable: obsoleted in macOS 15.0”

### DIFF
--- a/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.cpp
@@ -39,4 +39,8 @@ SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, CGContextSetOwnerIdentity, void, (CGContextRef context, task_id_token_t owner), (context, owner), PAL_EXPORT)
 #endif
 
+#if USE(CG) && PLATFORM(MAC)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, CGWindowListCreateImage, CGImageRef, (CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption), (screenBounds, listOption, windowID, imageOption), PAL_EXPORT)
+#endif
+
 #endif

--- a/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h
+++ b/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h
@@ -40,4 +40,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreGraphics, CGContextSetOwnerIdentity, void
 #define CGContextSetOwnerIdentity PAL::softLink_CoreGraphics_CGContextSetOwnerIdentity
 #endif
 
+#if USE(CG) && PLATFORM(MAC)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, CoreGraphics, CGWindowListCreateImage, CGImageRef, (CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption), (screenBounds, listOption, windowID, imageOption))
+#endif
+
 #endif

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -398,6 +398,7 @@ platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
 platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 platform/graphics/ca/cocoa/WebVideoContainerLayer.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
+platform/graphics/cg/CGWindowUtilities.cpp
 platform/graphics/cg/ColorCG.cpp
 platform/graphics/cg/ColorSpaceCG.cpp
 platform/graphics/cg/FloatPointCG.cpp

--- a/Source/WebCore/platform/graphics/cg/CGWindowUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cg/CGWindowUtilities.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "CGWindowUtilities.h"
+
+#if USE(CG) && PLATFORM(MAC)
+
+#import <pal/cg/CoreGraphicsSoftLink.h>
+
+namespace WebCore {
+
+CGImageRef cgWindowListCreateImage(CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption)
+{
+    if (PAL::canLoad_CoreGraphics_CGWindowListCreateImage())
+        return PAL::softLink_CoreGraphics_CGWindowListCreateImage(screenBounds, listOption, windowID, imageOption);
+
+    return nullptr;
+}
+
+}
+
+#endif // USE(CG) && PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/cg/CGWindowUtilities.h
+++ b/Source/WebCore/platform/graphics/cg/CGWindowUtilities.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CG) && PLATFORM(MAC)
+
+#include "FloatRect.h"
+#include "GraphicsTypes.h"
+#include "IntRect.h"
+#include <CoreGraphics/CoreGraphics.h>
+#include <math.h>
+
+namespace WebCore {
+
+WEBCORE_EXPORT CGImageRef cgWindowListCreateImage(CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
+
+}
+
+#endif // USE(CG) && PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -833,4 +833,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 @end
 
+@interface WKWebView (WKWindowSnapshot)
+- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options;
+@end
+
 #endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -32,7 +32,6 @@
 #import "WKTextAnimationType.h"
 #import "WKTextFinderClient.h"
 #import "WKWebViewConfigurationPrivate.h"
-#import <WebKit/WKUIDelegatePrivate.h>
 #import "WebBackForwardList.h"
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
@@ -41,6 +40,8 @@
 #import "_WKFrameHandleInternal.h"
 #import "_WKHitTestResultInternal.h"
 #import "_WKWarningView.h"
+#import <WebCore/CGWindowUtilities.h>
+#import <WebKit/WKUIDelegatePrivate.h>
 #import <pal/spi/mac/NSTextFinderSPI.h>
 #import <pal/spi/mac/NSTextInputContextSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
@@ -1793,5 +1794,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 @end // WKWebView (WKPrivateMac)
+
+@implementation WKWebView (WKWindowSnapshot)
+- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options
+{
+    RetainPtr snapshot = WebCore::cgWindowListCreateImage(rect, kCGWindowListOptionIncludingWindow, (CGSWindowID)[[self window] windowNumber], options);
+    if (!snapshot)
+        return nil;
+
+    return [[NSImage alloc] initWithCGImage:snapshot.get() size:NSZeroSize];
+}
+@end
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -38,6 +38,7 @@
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
 #import <QuartzCore/QuartzCore.h>
+#import <WebCore/CGWindowUtilities.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/IntRect.h>
@@ -236,9 +237,7 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
 
     CGWindowID windowID = [[_webView window] windowNumber];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr<CGImageRef> webViewContents = adoptCF(CGWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque));
-ALLOW_DEPRECATED_DECLARATIONS_END
+    RetainPtr<CGImageRef> webViewContents = adoptCF(WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque));
 
     // Using the returned CGImage directly would result in calls to the WindowServer every time
     // the image was painted. Instead, copy the image data into our own process to eliminate that
@@ -475,9 +474,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     CGWindowImageOption imageOptions = kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
     if (captureAtNominalResolution)
         imageOptions |= kCGWindowImageNominalResolution;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
-ALLOW_DEPRECATED_DECLARATIONS_END
+    return adoptCF(WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
 }
 
 - (void)finishedExitFullScreenAnimationAndExitImmediately:(bool)immediately

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -91,6 +91,7 @@
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/ActivityState.h>
 #import <WebCore/AttributedString.h>
+#import <WebCore/CGWindowUtilities.h>
 #import <WebCore/CaretRectComputation.h>
 #import <WebCore/CharacterRange.h>
 #import <WebCore/ColorMac.h>
@@ -4553,9 +4554,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     CGWindowImageOption imageOptions = kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
     if (captureAtNominalResolution)
         imageOptions |= kCGWindowImageNominalResolution;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
-ALLOW_DEPRECATED_DECLARATIONS_END
+    return adoptCF(WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
 }
 
 RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot()

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -31,6 +31,7 @@
 #import "WebPreferencesPrivate.h"
 #import "WebViewInternal.h"
 #import "WebWindowAnimation.h"
+#import <WebCore/CGWindowUtilities.h>
 #import <WebCore/Document.h>
 #import <WebCore/DocumentInlines.h>
 #import <WebCore/Element.h>
@@ -205,7 +206,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     
     CGWindowID windowID = [[_webView window] windowNumber];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr<CGImageRef> webViewContents = adoptCF(CGWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque));
+    RetainPtr<CGImageRef> webViewContents = adoptCF(WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque));
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Screen updates to be re-enabled in beganEnterFullScreenWithInitialFrame:finalFrame:

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -137,6 +137,7 @@
 #import <WebCore/BackForwardCache.h>
 #import <WebCore/BackForwardController.h>
 #import <WebCore/BroadcastChannelRegistry.h>
+#import <WebCore/CGWindowUtilities.h>
 #import <WebCore/CacheStorageProvider.h>
 #import <WebCore/Chrome.h>
 #import <WebCore/ColorMac.h>
@@ -9838,3 +9839,16 @@ void WebInstallMemoryPressureHandler(void)
         });
     }
 }
+
+#if !TARGET_OS_IPHONE
+@implementation WebView (WKWindowSnapshot)
+- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options
+{
+    RetainPtr snapshot = WebCore::cgWindowListCreateImage(rect, kCGWindowListOptionIncludingWindow, (CGSWindowID)[[self window] windowNumber], options);
+    if (!snapshot)
+        return nil;
+
+    return [[NSImage alloc] initWithCGImage:snapshot.get() size:NSZeroSize];
+}
+@end
+#endif

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -1053,6 +1053,12 @@ typedef struct WebEdgeInsets {
 - (NSCachedURLResponse *)webView:(WebView *)sender resource:(id)identifier willCacheResponse:(NSCachedURLResponse *)response fromDataSource:(WebDataSource *)dataSource;
 @end
 
+#if !TARGET_OS_IPHONE
+@interface WebView (WKWindowSnapshot)
+- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options;
+@end
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm
+++ b/Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm
@@ -30,21 +30,21 @@
 
 #import "config.h"
 #import "PixelDumpSupport.h"
-#import "PixelDumpSupportCG.h"
 
-#import "DumpRenderTree.h" 
+#import "DumpRenderTree.h"
+#import "PixelDumpSupportCG.h"
 #import "TestRunner.h"
 #import <CoreGraphics/CGBitmapContext.h>
 #import <QuartzCore/QuartzCore.h>
-#import <pal/spi/cg/CoreGraphicsSPI.h>
-#import <pal/spi/cocoa/QuartzCoreSPI.h>
-#import <wtf/Assertions.h>
-#import <wtf/RefPtr.h>
-
+#import <WebCore/CGWindowUtilities.h>
 #import <WebKit/WebCoreStatistics.h>
 #import <WebKit/WebDocumentPrivate.h>
 #import <WebKit/WebHTMLViewPrivate.h>
 #import <WebKit/WebViewPrivate.h>
+#import <pal/spi/cg/CoreGraphicsSPI.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/Assertions.h>
+#import <wtf/RefPtr.h>
 
 @interface WebView ()
 - (BOOL)_flushCompositingChanges;
@@ -82,7 +82,7 @@ static void paintRepaintRectOverlay(WebView* webView, CGContextRef context)
 static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, CGWindowImageOption imageOptions)
 {
     imageOptions |= kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
-    return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
+    return adoptCF(WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
 }
 
 RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool incrementalRepaint, bool sweepHorizontally, bool drawSelectionRect)

--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -94,6 +94,8 @@
 - (NSURL *)currentURL;
 - (NSView *)mainContentView;
 
+- (NSImage *)windowSnapshotInRect:(CGRect)rect;
+
 - (CGFloat)pageScaleForMenuItemTag:(NSInteger)tag;
 
 - (void)updateTitleForBadgeChange;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -308,6 +308,12 @@
     return !!_mainThreadStallTimer;
 }
 
+- (NSImage *)windowSnapshotInRect:(CGRect)rect
+{
+    [self doesNotRecognizeSelector:_cmd];
+    return nil;
+}
+
 #pragma mark -
 #pragma mark NSSharingServicePickerDelegate
 
@@ -344,20 +350,8 @@ static CGRect coreGraphicsScreenRectForAppKitScreenRect(NSRect rect)
 - (NSImage *)sharingService:(NSSharingService *)sharingService transitionImageForShareItem:(id)item contentRect:(NSRect *)contentRect
 {
     NSRect contentFrame = [self.window convertRectToScreen:self.mainContentView.bounds];
-
     CGRect frame = coreGraphicsScreenRectForAppKitScreenRect(contentFrame);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    CGImageRef imageRef = CGWindowListCreateImage(frame, kCGWindowListOptionIncludingWindow, (CGWindowID)[self.window windowNumber], kCGWindowImageBoundsIgnoreFraming);
-#pragma clang diagnostic pop
-
-    if (!imageRef)
-        return nil;
-    
-    NSImage *image = [[NSImage alloc] initWithCGImage:imageRef size:NSZeroSize];
-    CGImageRelease(imageRef);
-
-    return image;
+    return [self windowSnapshotInRect:frame];
 }
 
 - (NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope

--- a/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
@@ -475,4 +475,9 @@ static BOOL areEssentiallyEqual(double a, double b)
     return WebDragDestinationActionAny;
 }
 
+- (NSImage *)windowSnapshotInRect:(CGRect)rect
+{
+    return [_webView _windowSnapshotInRect:rect withOptions:kCGWindowImageBoundsIgnoreFraming];
+}
+
 @end

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -1076,4 +1076,9 @@ static BOOL isJavaScriptURL(NSURL *url)
     [webView _setHeaderBannerLayer:nil];
 }
 
+- (NSImage *)windowSnapshotInRect:(CGRect)rect
+{
+    return [_webView _windowSnapshotInRect:rect withOptions:kCGWindowImageBoundsIgnoreFraming];
+}
+
 @end

--- a/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
+++ b/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
@@ -222,7 +222,8 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
     if ([m_window backingScaleFactor] == 1)
         options |= kCGWindowImageNominalResolution;
 
-    return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, [m_window windowNumber], options));
+    RetainPtr image = adoptNS([platformView() _windowSnapshotInRect:CGRectNull withOptions:options]);
+    return adoptCF([image CGImageForProposedRect:nil context:nil hints:nil]);
 }
 
 void PlatformWebView::changeWindowScaleIfNeeded(float newScale)


### PR DESCRIPTION
#### ea20b8a718cd18f88b5ba0fd7536c9f13c55f89e
<pre>
Build fails with “&apos;CGWindowListCreateImage&apos; is unavailable: obsoleted in macOS 15.0”
<a href="https://bugs.webkit.org/show_bug.cgi?id=277564">https://bugs.webkit.org/show_bug.cgi?id=277564</a>
<a href="https://rdar.apple.com/133237307">rdar://133237307</a>

Reviewed by Jean-Yves Avenard.

Softlink `CGWindowListCreateImage` so we can call it in PAL to avoid the obsolete error
when building. Ultimately we should replace it by using ScreenCaptureKit, but doing so
causes a 2% Speedometer regression so do this for now.

* Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.cpp:
* Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cg/CGWindowUtilities.cpp: Added.
(WebCore::cgWindowListCreateImage):
* Source/WebCore/platform/graphics/cg/CGWindowUtilities.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _windowSnapshotInRect:withOptions:]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(takeWindowSnapshot):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::takeWindowSnapshot):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(-[WebFullScreenController enterFullScreen:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _windowSnapshotInRect:withOptions:]):
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:
* Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm:
(takeWindowSnapshot):
* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController windowSnapshotInRect:]):
(-[BrowserWindowController sharingService:transitionImageForShareItem:contentRect:]):
* Tools/MiniBrowser/mac/WK1BrowserWindowController.m:
(-[WK1BrowserWindowController windowSnapshotInRect:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController windowSnapshotInRect:]):
* Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm:
(WTR::PlatformWebView::windowSnapshotImage):

Canonical link: <a href="https://commits.webkit.org/282791@main">https://commits.webkit.org/282791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a099967dd5c6034fec582ae4c133cec7d33c84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51715 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10252 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12978 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69982 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59036 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55691 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59197 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14189 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/467 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39438 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->