### PR TITLE
Move WebCore/WebKitLegacy/WebKit destructors to source files for upstream clang

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -36,6 +36,8 @@ FetchBodySource::FetchBodySource(FetchBodyOwner& bodyOwner)
 {
 }
 
+FetchBodySource::~FetchBodySource() = default;
+
 void FetchBodySource::setActive()
 {
     ASSERT(m_bodyOwner);

--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -40,6 +40,7 @@ class FetchBodyOwner;
 class FetchBodySource final : public RefCountedReadableStreamSource {
 public:
     FetchBodySource(FetchBodyOwner&);
+    virtual ~FetchBodySource();
 
     bool enqueue(RefPtr<JSC::ArrayBuffer>&& chunk) { return controller().enqueue(WTFMove(chunk)); }
     void close();

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -50,6 +50,8 @@ static inline bool isNullBodyStatus(int status)
     return status == 101 || status == 204 || status == 205 || status == 304;
 }
 
+FetchResponse::~FetchResponse() = default;
+
 Ref<FetchResponse> FetchResponse::create(ScriptExecutionContext* context, std::optional<FetchBody>&& body, FetchHeaders::Guard guard, ResourceResponse&& response)
 {
     bool isSynthetic = response.type() == ResourceResponse::Type::Default || response.type() == ResourceResponse::Type::Error;

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -60,6 +60,8 @@ public:
         std::optional<FetchHeaders::Init> headers;
     };
 
+    virtual ~FetchResponse();
+
     WEBCORE_EXPORT static Ref<FetchResponse> create(ScriptExecutionContext*, std::optional<FetchBody>&&, FetchHeaders::Guard, ResourceResponse&&);
 
     static ExceptionOr<Ref<FetchResponse>> create(ScriptExecutionContext&, std::optional<FetchBody::Init>&&, Init&&);

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -67,6 +67,8 @@ YouTubePluginReplacement::YouTubePluginReplacement(HTMLPlugInElement& plugin, co
         m_attributes.add(paramNames[i], paramValues[i]);
 }
 
+YouTubePluginReplacement::~YouTubePluginReplacement() = default;
+
 RenderPtr<RenderElement> YouTubePluginReplacement::createElementRenderer(HTMLPlugInElement& plugin, RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
     ASSERT_UNUSED(plugin, m_parentElement == &plugin);

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
@@ -43,7 +43,10 @@ public:
 
 private:
     YouTubePluginReplacement(HTMLPlugInElement&, const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues);
+    virtual ~YouTubePluginReplacement();
+
     static Ref<PluginReplacement> create(HTMLPlugInElement&, const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues);
+
     static bool supportsMIMEType(const String&);
     static bool supportsFileExtension(StringView);
     static bool supportsURL(const URL&);

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
@@ -57,4 +57,6 @@ SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, uint64_t 
 {
 }
 
+SpeechRecognitionEvent::~SpeechRecognitionEvent() = default;
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.h
@@ -42,6 +42,8 @@ public:
     static Ref<SpeechRecognitionEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     static Ref<SpeechRecognitionEvent> create(const AtomString&, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&&);
 
+    virtual ~SpeechRecognitionEvent();
+
     uint64_t resultIndex() const { return m_resultIndex; }
     SpeechRecognitionResultList* results() const { return m_results.get(); }
 

--- a/Source/WebCore/Modules/storage/StorageConnection.h
+++ b/Source/WebCore/Modules/storage/StorageConnection.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "FileSystemHandleIdentifier.h"
+#include "StorageEstimate.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -34,7 +35,6 @@ namespace WebCore {
 class FileSystemStorageConnection;
 template<typename> class ExceptionOr;
 struct ClientOrigin;
-struct StorageEstimate;
 
 class StorageConnection : public ThreadSafeRefCounted<StorageConnection> {
 public:

--- a/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp
@@ -48,6 +48,8 @@ AudioBasicProcessorNode::AudioBasicProcessorNode(BaseAudioContext& context, Node
     // The subclass must create m_processor.
 }
 
+AudioBasicProcessorNode::~AudioBasicProcessorNode() = default;
+
 void AudioBasicProcessorNode::initialize()
 {
     if (isInitialized())

--- a/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h
@@ -38,6 +38,7 @@ class AudioBasicProcessorNode : public AudioNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioBasicProcessorNode);
 public:
     AudioBasicProcessorNode(BaseAudioContext&, NodeType);
+    virtual ~AudioBasicProcessorNode();
 
     // AudioNode
     void process(size_t framesToProcess) override;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -61,6 +61,8 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
 {
 }
 
+CSSTransition::~CSSTransition() = default;
+
 OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
 {
     auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, startTime);

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -43,7 +43,8 @@ class CSSTransition final : public StyleOriginatedAnimation {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSTransition);
 public:
     static Ref<CSSTransition> create(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double);
-    ~CSSTransition() = default;
+
+    virtual ~CSSTransition();
 
     const AtomString transitionProperty() const;
     AnimatableCSSProperty property() const { return m_property; }

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -72,6 +72,8 @@ DocumentTimeline::DocumentTimeline(Document& document, Seconds originTime)
     document.ensureTimelinesController().addTimeline(*this);
 }
 
+DocumentTimeline::~DocumentTimeline() = default;
+
 DocumentTimelinesController* DocumentTimeline::controller() const
 {
     if (m_document)

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -53,6 +53,8 @@ public:
     static Ref<DocumentTimeline> create(Document&);
     static Ref<DocumentTimeline> create(Document&, DocumentTimelineOptions&&);
 
+    virtual ~DocumentTimeline();
+
     Document* document() const { return m_document.get(); }
 
     std::optional<Seconds> currentTime() override;

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -60,6 +60,8 @@ CryptoKeyEC::CryptoKeyEC(CryptoAlgorithmIdentifier identifier, NamedCurve curve,
     ASSERT(platformSupportedCurve(curve));
 }
 
+CryptoKeyEC::~CryptoKeyEC() = default;
+
 ExceptionOr<CryptoKeyPair> CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier identifier, const String& curve, bool extractable, CryptoKeyUsageBitmap usages)
 {
     auto namedCurve = toNamedCurve(curve);

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -79,7 +79,7 @@ public:
     {
         return adoptRef(*new CryptoKeyEC(identifier, curve, type, WTFMove(platformKey), extractable, usages));
     }
-    virtual ~CryptoKeyEC() = default;
+    virtual ~CryptoKeyEC();
 
     WEBCORE_EXPORT static ExceptionOr<CryptoKeyPair> generatePair(CryptoAlgorithmIdentifier, const String& curve, bool extractable, CryptoKeyUsageBitmap);
     WEBCORE_EXPORT static RefPtr<CryptoKeyEC> importRaw(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -120,6 +120,8 @@ CSSUnparsedValue::CSSUnparsedValue(Vector<CSSUnparsedSegment>&& segments)
 {
 }
 
+CSSUnparsedValue::~CSSUnparsedValue() = default;
+
 void CSSUnparsedValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments> arguments) const
 {
     for (auto& segment : m_segments) {

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.h
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.h
@@ -42,6 +42,8 @@ public:
     static Ref<CSSUnparsedValue> create(Vector<CSSUnparsedSegment>&&);
     static Ref<CSSUnparsedValue> create(CSSParserTokenRange);
 
+    virtual ~CSSUnparsedValue();
+
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const final;
     size_t length() const { return m_segments.size(); }
     

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -102,6 +102,8 @@ CSSPerspective::CSSPerspective(CSSPerspectiveValue length)
 {
 }
 
+CSSPerspective::~CSSPerspective() = default;
+
 ExceptionOr<void> CSSPerspective::setLength(CSSPerspectiveValue length)
 {
     auto checkedLength = checkLength(WTFMove(length));

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.h
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.h
@@ -41,6 +41,8 @@ public:
     static ExceptionOr<Ref<CSSPerspective>> create(CSSPerspectiveValue);
     static ExceptionOr<Ref<CSSPerspective>> create(CSSFunctionValue&);
 
+    virtual ~CSSPerspective();
+
     const CSSPerspectiveValue& length() const { return m_length; }
     ExceptionOr<void> setLength(CSSPerspectiveValue);
 

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -168,6 +168,8 @@ CSSTransformValue::CSSTransformValue(Vector<Ref<CSSTransformComponent>>&& transf
 {
 }
 
+CSSTransformValue::~CSSTransformValue() = default;
+
 void CSSTransformValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-csstransformvalue

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -42,6 +42,8 @@ public:
     static ExceptionOr<Ref<CSSTransformValue>> create(const CSSTransformListValue&);
     static ExceptionOr<Ref<CSSTransformValue>> create(Vector<Ref<CSSTransformComponent>>&&);
 
+    virtual ~CSSTransformValue();
+
     size_t length() const { return m_components.size(); }
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_components.size(); }
     RefPtr<CSSTransformComponent> item(size_t);

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -72,4 +72,6 @@ DragEvent::DragEvent()
 {
 }
 
+DragEvent::~DragEvent() = default;
+
 } // namespace WebCore

--- a/Source/WebCore/dom/DragEvent.h
+++ b/Source/WebCore/dom/DragEvent.h
@@ -49,6 +49,7 @@ public:
         const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         EventTarget* relatedTarget, double force, SyntheticClickType, DataTransfer* = nullptr, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
 
+    virtual ~DragEvent();
 
     DataTransfer* dataTransfer() const { return m_dataTransfer.get(); }
 

--- a/Source/WebCore/dom/InputEvent.cpp
+++ b/Source/WebCore/dom/InputEvent.cpp
@@ -61,6 +61,8 @@ InputEvent::InputEvent(const AtomString& eventType, const Init& initializer)
 {
 }
 
+InputEvent::~InputEvent() = default;
+
 RefPtr<DataTransfer> InputEvent::dataTransfer() const
 {
     return m_dataTransfer;

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -44,6 +44,8 @@ public:
         String inputType;
     };
 
+    virtual ~InputEvent();
+
     static Ref<InputEvent> create(const AtomString& eventType, const String& inputType, IsCancelable, RefPtr<WindowProxy>&& view,
         const String& data, RefPtr<DataTransfer>&&, const Vector<RefPtr<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -233,6 +233,8 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
     }
 }
 
+ReplaceSelectionCommand::~ReplaceSelectionCommand() = default;
+
 void ReplacementFragment::removeContentsWithSideEffects()
 {
     Vector<Ref<Element>> elementsToRemove;

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -52,6 +52,8 @@ public:
         return adoptRef(*new ReplaceSelectionCommand(WTFMove(document), WTFMove(fragment), options, editingAction));
     }
 
+    virtual ~ReplaceSelectionCommand();
+
     VisibleSelection visibleSelectionForInsertedText() const { return m_visibleSelectionForInsertedText; }
     String documentFragmentPlainText() const { return m_documentFragmentPlainText; }
 

--- a/Source/WebCore/html/CollectionTraversalInlines.h
+++ b/Source/WebCore/html/CollectionTraversalInlines.h
@@ -27,6 +27,7 @@
 
 #include "CollectionTraversal.h"
 #include "ElementChildIteratorInlines.h"
+#include "HTMLOptionsCollectionInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/html/GenericCachedHTMLCollection.cpp
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.cpp
@@ -51,6 +51,11 @@ template GenericCachedHTMLCollection<CollectionTraversalType::Descendants>::Gene
 template GenericCachedHTMLCollection<CollectionTraversalType::ChildrenOnly>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
 
 template <CollectionTraversalType traversalType>
+GenericCachedHTMLCollection<traversalType>::~GenericCachedHTMLCollection() = default;
+template GenericCachedHTMLCollection<CollectionTraversalType::Descendants>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionTraversalType::ChildrenOnly>::~GenericCachedHTMLCollection();
+
+template <CollectionTraversalType traversalType>
 bool GenericCachedHTMLCollection<traversalType>::elementMatches(Element& element) const
 {
     switch (this->type()) {

--- a/Source/WebCore/html/GenericCachedHTMLCollection.h
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.h
@@ -39,6 +39,8 @@ public:
         return adoptRef(*new GenericCachedHTMLCollection(base, collectionType));
     }
 
+    virtual ~GenericCachedHTMLCollection();
+
     bool elementMatches(Element&) const;
 
 private:

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -166,6 +166,8 @@ PluginDocument::PluginDocument(LocalFrame& frame, const URL& url)
     lockCompatibilityMode();
 }
 
+PluginDocument::~PluginDocument() = default;
+
 Ref<DocumentParser> PluginDocument::createParser()
 {
     return PluginDocumentParser::create(*this);

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -41,6 +41,8 @@ public:
         return document;
     }
 
+    virtual ~PluginDocument();
+
     WEBCORE_EXPORT PluginViewBase* pluginWidget();
     HTMLPlugInElement* pluginElement() { return m_pluginElement.get(); }
 

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -57,6 +57,8 @@ CachedSVGFont::CachedSVGFont(CachedResourceRequest&& request, CachedSVGFont& res
 {
 }
 
+CachedSVGFont::~CachedSVGFont() = default;
+
 RefPtr<Font> CachedSVGFont::createFont(const FontDescription& fontDescription, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
 {
     ASSERT(firstFontFace());

--- a/Source/WebCore/loader/cache/CachedSVGFont.h
+++ b/Source/WebCore/loader/cache/CachedSVGFont.h
@@ -38,6 +38,7 @@ class CachedSVGFont final : public CachedFont {
 public:
     CachedSVGFont(CachedResourceRequest&&, PAL::SessionID, const CookieJar*, const Settings&);
     CachedSVGFont(CachedResourceRequest&&, CachedSVGFont&);
+    virtual ~CachedSVGFont();
 
     bool ensureCustomFontData() final;
     RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) final;

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -46,6 +46,8 @@ WorkerNavigator::WorkerNavigator(ScriptExecutionContext& context, const String& 
 {
 }
 
+WorkerNavigator::~WorkerNavigator() = default;
+
 const String& WorkerNavigator::userAgent() const
 {
     return m_userAgent;

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -38,6 +38,8 @@ class WorkerNavigator final : public NavigatorBase, public Supplementable<Worker
 public:
     static Ref<WorkerNavigator> create(ScriptExecutionContext& context, const String& userAgent, bool isOnline) { return adoptRef(*new WorkerNavigator(context, userAgent, isOnline)); }
 
+    virtual ~WorkerNavigator();
+
     const String& userAgent() const final;
     bool onLine() const final;
     void setIsOnline(bool isOnline) { m_isOnline = isOnline; }

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
@@ -44,6 +44,8 @@ AudioDSPKernelProcessor::AudioDSPKernelProcessor(float sampleRate, unsigned numb
 {
 }
 
+AudioDSPKernelProcessor::~AudioDSPKernelProcessor() = default;
+
 void AudioDSPKernelProcessor::initialize()
 {
     if (isInitialized())

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
@@ -49,6 +49,7 @@ class AudioDSPKernelProcessor : public AudioProcessor {
 public:
     // numberOfChannels may be later changed if object is not yet in an "initialized" state
     AudioDSPKernelProcessor(float sampleRate, unsigned numberOfChannels);
+    virtual ~AudioDSPKernelProcessor();
 
     // Subclasses create the appropriate type of processing kernel here.
     // We'll call this to create a kernel for each channel.

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -59,6 +59,8 @@ WebAudioBufferList::WebAudioBufferList(const CAAudioStreamDescription& format, s
     setSampleCount(sampleCount);
 }
 
+WebAudioBufferList::~WebAudioBufferList() = default;
+
 static inline std::optional<std::pair<size_t, size_t>> computeBufferSizes(uint32_t numberOfInterleavedChannels, uint32_t bytesPerFrame, uint32_t numberOfChannelStreams, size_t sampleCount)
 {
     size_t totalSampleCount;

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -44,6 +44,7 @@ public:
     WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&);
     WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&, size_t sampleCount);
     WebAudioBufferList(const CAAudioStreamDescription&, CMSampleBufferRef);
+    WEBCORE_EXPORT virtual ~WebAudioBufferList();
 
     void reset();
     WEBCORE_EXPORT void setSampleCount(size_t);

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -68,6 +68,7 @@ public:
 
 private:
     GameControllerGamepadProvider();
+    virtual ~GameControllerGamepadProvider();
 
     enum class ConnectionVisibility {
         Visible,

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -95,6 +95,8 @@ GameControllerGamepadProvider::GameControllerGamepadProvider()
 {
 }
 
+GameControllerGamepadProvider::~GameControllerGamepadProvider() = default;
+
 void GameControllerGamepadProvider::controllerDidConnect(GCController *controller, ConnectionVisibility visibility)
 {
     LOG(Gamepad, "GameControllerGamepadProvider controller %p added", controller);

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -50,6 +50,8 @@ BitmapImageSource::BitmapImageSource(BitmapImage& bitmapImage, AlphaOption alpha
 {
 }
 
+BitmapImageSource::~BitmapImageSource() = default;
+
 ImageDecoder* BitmapImageSource::decoder(FragmentedSharedBuffer* data) const
 {
     if (m_decoder)

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -42,6 +42,8 @@ class BitmapImageSource : public ImageSource {
 public:
     static Ref<BitmapImageSource> create(BitmapImage&, AlphaOption, GammaAndColorProfileOption);
 
+    virtual ~BitmapImageSource();
+
     // State
     ImageDecoder* decoder(FragmentedSharedBuffer* = nullptr) const;
     ImageDecoder* decoderIfExists() const { return m_decoder.get(); }

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -70,6 +70,8 @@ NativeImage::NativeImage(UniqueRef<NativeImageBackend> backend, RenderingResourc
 {
 }
 
+NativeImage::~NativeImage() = default;
+
 const PlatformImagePtr& NativeImage::platformImage() const
 {
     return m_backend->platformImage();

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -47,6 +47,8 @@ public:
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
     static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
+    virtual ~NativeImage();
+
     WEBCORE_EXPORT const PlatformImagePtr& platformImage() const;
 
     WEBCORE_EXPORT IntSize size() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -60,6 +60,8 @@ public:
         return adoptRef(new AudioTrackPrivateAVFObjC(option));
     }
 
+    virtual ~AudioTrackPrivateAVFObjC();
+
     virtual void setEnabled(bool);
 
     void setPlayerItemTrack(AVPlayerItemTrack*);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -55,6 +55,7 @@ AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(std::unique_ptr<AVTrackPrivat
     resetPropertiesFromTrack();
 }
 
+AudioTrackPrivateAVFObjC::~AudioTrackPrivateAVFObjC() = default;
 
 void AudioTrackPrivateAVFObjC::resetPropertiesFromTrack()
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -38,6 +38,8 @@ AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC(AVAsset
     resetPropertiesFromTrack();
 }
 
+AudioTrackPrivateMediaSourceAVFObjC::~AudioTrackPrivateMediaSourceAVFObjC() = default;
+
 void AudioTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
 {
     setKind(m_impl->audioKind());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
@@ -44,6 +44,8 @@ public:
         return adoptRef(*new AudioTrackPrivateMediaSourceAVFObjC(track));
     }
 
+    virtual ~AudioTrackPrivateMediaSourceAVFObjC();
+
     void setEnabled(bool) final;
 
     void setAssetTrack(AVAssetTrack*);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -187,7 +187,7 @@ public:
     using AVContentKeySessionDelegateClient::WeakPtrImplType;
 
     CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
-    virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC() = default;
+    virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC();
 
     // CDMInstanceSession
     void requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -729,6 +729,8 @@ CDMInstanceSessionFairPlayStreamingAVFObjC::CDMInstanceSessionFairPlayStreamingA
 {
 }
 
+CDMInstanceSessionFairPlayStreamingAVFObjC::~CDMInstanceSessionFairPlayStreamingAVFObjC() = default;
+
 using Keys = CDMInstanceSessionFairPlayStreamingAVFObjC::Keys;
 using Request = CDMInstanceSessionFairPlayStreamingAVFObjC::Request;
 static Keys keyIDsForRequest(const Request& requests)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
@@ -47,6 +47,8 @@ public:
         return adoptRef(*new VideoTrackPrivateMediaSourceAVFObjC(track));
     }
 
+    virtual ~VideoTrackPrivateMediaSourceAVFObjC();
+
     void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack() const;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -40,6 +40,8 @@ VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC(AVAsset
     resetPropertiesFromTrack();
 }
 
+VideoTrackPrivateMediaSourceAVFObjC::~VideoTrackPrivateMediaSourceAVFObjC() = default;
+
 void VideoTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
 {
     setTrackIndex(m_impl->index());

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -49,6 +49,8 @@ CoreAudioCaptureDeviceManager& CoreAudioCaptureDeviceManager::singleton()
     return manager;
 }
 
+CoreAudioCaptureDeviceManager::~CoreAudioCaptureDeviceManager() = default;
+
 const Vector<CaptureDevice>& CoreAudioCaptureDeviceManager::captureDevices()
 {
     coreAudioCaptureDevices();

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.h
@@ -50,8 +50,8 @@ public:
 
 private:
     CoreAudioCaptureDeviceManager() = default;
-    ~CoreAudioCaptureDeviceManager() = default;
-    
+    virtual ~CoreAudioCaptureDeviceManager();
+
     Vector<CoreAudioCaptureDevice>& coreAudioCaptureDevices();
 
     enum class NotifyIfDevicesHaveChanged { Notify, DoNotNotify };

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
@@ -49,7 +49,7 @@ class MockRealtimeVideoSourceMac final : public MockRealtimeVideoSource {
 public:
     static Ref<MockRealtimeVideoSource> createForMockDisplayCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, PageIdentifier);
 
-    ~MockRealtimeVideoSourceMac() = default;
+    virtual ~MockRealtimeVideoSourceMac();
 
 private:
     friend class MockRealtimeVideoSource;

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -82,6 +82,8 @@ MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(String&& deviceID, AtomSt
 {
 }
 
+MockRealtimeVideoSourceMac::~MockRealtimeVideoSourceMac() = default;
+
 void MockRealtimeVideoSourceMac::updateSampleBuffer()
 {
     RefPtr imageBuffer = this->imageBufferInternal();

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp
@@ -63,6 +63,8 @@ RealtimeOutgoingVideoSourceCocoa::RealtimeOutgoingVideoSourceCocoa(Ref<MediaStre
 {
 }
 
+RealtimeOutgoingVideoSourceCocoa::~RealtimeOutgoingVideoSourceCocoa() = default;
+
 void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata)
 {
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.h
@@ -41,6 +41,8 @@ class RealtimeOutgoingVideoSourceCocoa final : public RealtimeOutgoingVideoSourc
 public:
     static Ref<RealtimeOutgoingVideoSourceCocoa> create(Ref<MediaStreamTrackPrivate>&&);
 
+    virtual ~RealtimeOutgoingVideoSourceCocoa();
+
 private:
     explicit RealtimeOutgoingVideoSourceCocoa(Ref<MediaStreamTrackPrivate>&&);
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -51,7 +51,7 @@ enum class VideoFrameRotation : uint16_t;
 class MockRealtimeVideoSource : public RealtimeVideoCaptureSource, private OrientationNotifier::Observer {
 public:
     static CaptureSourceOrError create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
-    ~MockRealtimeVideoSource();
+    virtual ~MockRealtimeVideoSource();
 
     static void setIsInterrupted(bool);
 

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -667,6 +667,8 @@ BasicShapePath::BasicShapePath(std::unique_ptr<SVGPathByteStream>&& byteStream, 
 {
 }
 
+BasicShapePath::~BasicShapePath() = default;
+
 Ref<BasicShape> BasicShapePath::clone() const
 {
     std::unique_ptr<SVGPathByteStream> byteStream;

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -315,6 +315,8 @@ public:
 
     WEBCORE_EXPORT static Ref<BasicShapePath> create(std::unique_ptr<SVGPathByteStream>&&, float zoom, WindRule);
 
+    virtual ~BasicShapePath();
+
     Ref<BasicShape> clone() const final;
 
     void setWindRule(WindRule windRule) { m_windRule = windRule; }

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -65,6 +65,8 @@ PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, std::
     m_networkLoad->convertTaskToDownload(*this, request, response, WTFMove(completionHandler));
 }
 
+PendingDownload::~PendingDownload() = default;
+
 void PendingDownload::willSendRedirectedRequest(WebCore::ResourceRequest&&, WebCore::ResourceRequest&& redirectRequest, WebCore::ResourceResponse&& redirectResponse, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::DownloadProxy::WillSendRequest(WTFMove(redirectRequest), WTFMove(redirectResponse)), WTFMove(completionHandler));

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -60,6 +60,7 @@ class PendingDownload : public NetworkLoadClient, public IPC::MessageSender, pub
 public:
     PendingDownload(IPC::Connection*, NetworkLoadParameters&&, DownloadID, NetworkSession&, const String& suggestedName);
     PendingDownload(IPC::Connection*, std::unique_ptr<NetworkLoad>&&, ResponseCompletionHandler&&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
+    virtual ~PendingDownload();
 
     void cancel(CompletionHandler<void(std::span<const uint8_t>)>&&);
 

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -92,6 +92,8 @@ WebImage::WebImage(RefPtr<ImageBuffer>&& buffer)
 {
 }
 
+WebImage::~WebImage() = default;
+
 IntSize WebImage::size() const
 {
     if (!m_buffer)

--- a/Source/WebKit/Shared/WebImage.h
+++ b/Source/WebKit/Shared/WebImage.h
@@ -43,7 +43,7 @@ namespace WebKit {
 
 // WebImage - An image type suitable for vending to an API.
 
-class WebImage : public API::ObjectImpl<API::Object::Type::Image> {
+class WebImage final : public API::ObjectImpl<API::Object::Type::Image> {
 public:
     using ParametersAndHandle = std::pair<WebCore::ImageBufferParameters, WebCore::ShareableBitmap::Handle>;
 
@@ -51,6 +51,8 @@ public:
     static Ref<WebImage> create(std::optional<ParametersAndHandle>&&);
     static Ref<WebImage> create(Ref<WebCore::ImageBuffer>&&);
     static Ref<WebImage> createEmpty();
+
+    virtual ~WebImage();
 
     WebCore::IntSize size() const;
     const WebCore::ImageBufferParameters* parameters() const;

--- a/Source/WebKit/UIProcess/API/APIInspectorConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIInspectorConfiguration.cpp
@@ -36,6 +36,8 @@ Ref<InspectorConfiguration> InspectorConfiguration::create()
     return adoptRef(*new InspectorConfiguration);
 }
 
+InspectorConfiguration::~InspectorConfiguration() = default;
+
 void InspectorConfiguration::addURLSchemeHandler(Ref<WebKit::WebURLSchemeHandler>&& urlSchemeHandler, const WTF::String& urlScheme)
 {
     m_customURLSchemes.append(std::make_pair(WTFMove(urlSchemeHandler), urlScheme));

--- a/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
@@ -41,7 +41,10 @@ using URLSchemeHandlerPair = std::pair<Ref<WebKit::WebURLSchemeHandler>, WTF::St
 class InspectorConfiguration final : public API::ObjectImpl<Object::Type::InspectorConfiguration> {
 public:
     static Ref<InspectorConfiguration> create();
-    
+
+    InspectorConfiguration() = default;
+    virtual ~InspectorConfiguration();
+
     void addURLSchemeHandler(Ref<WebKit::WebURLSchemeHandler>&&, const WTF::String& urlScheme);
     const Vector<URLSchemeHandlerPair>& urlSchemeHandlers() { return m_customURLSchemes; }
     

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
@@ -59,6 +59,8 @@ AuthenticationChallengeProxy::AuthenticationChallengeProxy(WebCore::Authenticati
     ASSERT(challengeID);
 }
 
+AuthenticationChallengeProxy::~AuthenticationChallengeProxy() = default;
+
 WebCredential* AuthenticationChallengeProxy::proposedCredential() const
 {
     if (!m_webCredential)

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
@@ -54,6 +54,8 @@ public:
         return adoptRef(*new AuthenticationChallengeProxy(WTFMove(authenticationChallenge), challengeID, WTFMove(connection), WTFMove(secKeyProxyStore)));
     }
 
+    virtual ~AuthenticationChallengeProxy();
+
     WebCredential* proposedCredential() const;
     WebProtectionSpace* protectionSpace() const;
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -38,7 +38,11 @@
 #import "InsertTextOptions.h"
 #import "LoadParameters.h"
 #import "MessageSenderInlines.h"
+#import "NativeWebGestureEvent.h"
+#import "NativeWebKeyboardEvent.h"
+#import "NativeWebMouseEvent.h"
 #import "PageClient.h"
+#import "PlatformXRSystem.h"
 #import "PlaybackSessionManagerProxy.h"
 #import "QuickLookThumbnailLoader.h"
 #import "RemoteLayerTreeTransaction.h"
@@ -75,6 +79,7 @@
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/RunLoopObserver.h>
 #import <WebCore/SearchPopupMenuCocoa.h>
+#import <WebCore/SleepDisabler.h>
 #import <WebCore/TextAlternativeWithRange.h>
 #import <WebCore/TextAnimationTypes.h>
 #import <WebCore/ValidationBubble.h>
@@ -448,6 +453,8 @@ ResourceError WebPageProxy::errorForUnpermittedAppBoundDomainNavigation(const UR
 {
     return { WKErrorDomain, WKErrorNavigationAppBoundDomain, url, localizedDescriptionForErrorCode(WKErrorNavigationAppBoundDomain) };
 }
+
+WebPageProxy::Internals::~Internals() = default;
 
 #if ENABLE(APPLE_PAY)
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -66,6 +66,8 @@ WebNotificationManagerProxy::WebNotificationManagerProxy(WebProcessPool* process
 {
 }
 
+WebNotificationManagerProxy::~WebNotificationManagerProxy() = default;
+
 void WebNotificationManagerProxy::setProvider(std::unique_ptr<API::NotificationProvider>&& provider)
 {
     if (!provider) {

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -64,6 +64,8 @@ public:
 
     static WebNotificationManagerProxy& sharedServiceWorkerManager();
 
+    virtual ~WebNotificationManagerProxy();
+
     void setProvider(std::unique_ptr<API::NotificationProvider>&&);
     HashMap<String, bool> notificationPermissions();
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -101,7 +101,53 @@
 
 namespace WebKit {
 
-class WebPageProxyFrameLoadStateObserver;
+#if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
+class WebPageProxyFrameLoadStateObserver final : public FrameLoadStateObserver {
+    WTF_MAKE_NONCOPYABLE(WebPageProxyFrameLoadStateObserver);
+    WTF_MAKE_TZONE_ALLOCATED(WebPageProxyFrameLoadStateObserver);
+public:
+    static constexpr size_t maxVisitedDomainsSize = 6;
+
+    WebPageProxyFrameLoadStateObserver();
+    virtual ~WebPageProxyFrameLoadStateObserver();
+
+    void didReceiveProvisionalURL(const URL& url) override
+    {
+        m_provisionalURLs.append(url);
+    }
+
+    void didCancelProvisionalLoad() override
+    {
+        m_provisionalURLs.clear();
+    }
+
+    void didCommitProvisionalLoad() override
+    {
+        for (auto& url : m_provisionalURLs)
+            didVisitDomain(WebCore::RegistrableDomain(url));
+    }
+
+    const ListHashSet<WebCore::RegistrableDomain>& visitedDomains() const
+    {
+        return m_visitedDomains;
+    }
+
+private:
+    void didVisitDomain(WebCore::RegistrableDomain&& domain)
+    {
+        if (domain.isEmpty())
+            return;
+
+        m_visitedDomains.prependOrMoveToFirst(WTFMove(domain));
+
+        if (m_visitedDomains.size() > maxVisitedDomainsSize)
+            m_visitedDomains.removeLast();
+    }
+
+    Vector<URL> m_provisionalURLs;
+    ListHashSet<WebCore::RegistrableDomain> m_visitedDomains;
+};
+#endif
 
 struct PrivateClickMeasurementAndMetadata {
     WebCore::PrivateClickMeasurement pcm;
@@ -173,6 +219,9 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 #endif
 {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+public:
+    virtual ~Internals();
 
     WebPageProxy& page;
     OptionSet<WebCore::ActivityState> activityState;

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -110,6 +110,8 @@ ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const Param
     m_context->applyDeviceScaleFactor(resolutionScale());
 }
 
+ImageBufferShareableBitmapBackend::~ImageBufferShareableBitmapBackend() = default;
+
 bool ImageBufferShareableBitmapBackend::canMapBackingStore() const
 {
     return true;

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -65,6 +65,7 @@ public:
     static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const Parameters&, WebCore::ShareableBitmap::Handle);
 
     ImageBufferShareableBitmapBackend(const Parameters&, Ref<WebCore::ShareableBitmap>&&, std::unique_ptr<WebCore::GraphicsContext>&&);
+    virtual ~ImageBufferShareableBitmapBackend();
 
     bool canMapBackingStore() const final;
     WebCore::GraphicsContext& context() final { return *m_context; }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -68,6 +68,8 @@ RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy(RemoteRenderingBa
 {
 }
 
+RemoteDisplayListRecorderProxy::~RemoteDisplayListRecorderProxy() = default;
+
 template<typename T>
 ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -48,7 +48,7 @@ class RemoteDisplayListRecorderProxy : public WebCore::DisplayList::Recorder {
 public:
     RemoteDisplayListRecorderProxy(RemoteImageBufferProxy&, RemoteRenderingBackendProxy&, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&);
     RemoteDisplayListRecorderProxy(RemoteRenderingBackendProxy& , WebCore::RenderingResourceIdentifier, const WebCore::DestinationColorSpace&, WebCore::RenderingMode, const WebCore::FloatRect&, const WebCore::AffineTransform&);
-    ~RemoteDisplayListRecorderProxy() = default;
+    virtual ~RemoteDisplayListRecorderProxy();
 
     void disconnect();
 

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
@@ -44,6 +44,8 @@ WebPageInspectorTarget::WebPageInspectorTarget(WebPage& page)
 {
 }
 
+WebPageInspectorTarget::~WebPageInspectorTarget() = default;
+
 String WebPageInspectorTarget::identifier() const
 {
     return toTargetID(m_page.identifier());

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
@@ -40,7 +40,7 @@ class WebPageInspectorTarget final : public Inspector::InspectorTarget {
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTarget);
 public:
     explicit WebPageInspectorTarget(WebPage&);
-    ~WebPageInspectorTarget() = default;
+    virtual ~WebPageInspectorTarget();
 
     Inspector::InspectorTargetType type() const final { return Inspector::InspectorTargetType::Page; }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -51,6 +51,8 @@ WebServiceWorkerFetchTaskClient::WebServiceWorkerFetchTaskClient(Ref<IPC::Connec
 {
 }
 
+WebServiceWorkerFetchTaskClient::~WebServiceWorkerFetchTaskClient() = default;
+
 void WebServiceWorkerFetchTaskClient::didReceiveRedirection(const WebCore::ResourceResponse& response)
 {
     Locker lock(m_connectionLock);

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -45,6 +45,8 @@ public:
         return adoptRef(*new WebServiceWorkerFetchTaskClient(WTFMove(connection), serviceWorkerIdentifier, serverConnectionIdentifier, fetchTaskIdentifier, needsContinueDidReceiveResponseMessage));
     }
 
+    virtual ~WebServiceWorkerFetchTaskClient();
+
     void continueDidReceiveResponse();
     void convertFetchToDownload();
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
@@ -36,6 +36,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WebCookieCache::~WebCookieCache() = default;
+
 bool WebCookieCache::isSupported()
 {
 #if HAVE(COOKIE_CHANGE_LISTENER_API)

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -43,9 +43,10 @@ namespace WebKit {
 enum PendingCookieUpdateCounterType { };
 using PendingCookieUpdateCounter = RefCounter<PendingCookieUpdateCounterType>;
 
-class WebCookieCache : public WebCore::CookieChangeListener {
+class WebCookieCache final : public WebCore::CookieChangeListener {
 public:
     WebCookieCache() = default;
+    virtual ~WebCookieCache();
 
     bool isSupported();
 

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
@@ -66,6 +66,8 @@ StorageNamespaceImpl::StorageNamespaceImpl(WebCore::StorageType storageType, con
     ASSERT(storageType == StorageType::Session || !m_sessionPageID);
 }
 
+StorageNamespaceImpl::~StorageNamespaceImpl() = default;
+
 PAL::SessionID StorageNamespaceImpl::sessionID() const
 {
     return WebProcess::singleton().sessionID();

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
@@ -49,7 +49,7 @@ public:
     static Ref<StorageNamespaceImpl> createLocalStorageNamespace(unsigned quotaInBytes);
     static Ref<StorageNamespaceImpl> createTransientLocalStorageNamespace(WebCore::SecurityOrigin& topLevelOrigin, uint64_t quotaInBytes);
 
-    virtual ~StorageNamespaceImpl() = default;
+    virtual ~StorageNamespaceImpl();
 
     WebCore::StorageType storageType() const { return m_storageType; }
     std::optional<Identifier> storageNamespaceID() const { return m_storageNamespaceID; }

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
@@ -50,6 +50,8 @@ WebInspectorClient::WebInspectorClient(WebView* inspectedWebView)
 {
 }
 
+WebInspectorClient::~WebInspectorClient() = default;
+
 void WebInspectorClient::inspectedPageDestroyed()
 {
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -58,6 +58,7 @@ class WebInspectorClient final : public WebCore::InspectorClient, public Inspect
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WebInspectorClient);
 public:
     explicit WebInspectorClient(WebView *inspectedWebView);
+    virtual ~WebInspectorClient();
 
     void inspectedPageDestroyed() override;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -101,6 +101,8 @@ WebInspectorClient::WebInspectorClient(WebView* inspectedWebView)
 {
 }
 
+WebInspectorClient::~WebInspectorClient() = default;
+
 void WebInspectorClient::inspectedPageDestroyed()
 {
 }


### PR DESCRIPTION
#### b2f4995bd76966615fbf9ff6bb9b9761981b610f
<pre>
Move WebCore/WebKitLegacy/WebKit destructors to source files for upstream clang
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278630">https://bugs.webkit.org/show_bug.cgi?id=278630</a>&gt;
&lt;<a href="https://rdar.apple.com/134660411">rdar://134660411</a>&gt;

Reviewed by Darin Adler.

In upstream clang, destructors require full class definitions for any
instance variable that is destructed.  In most cases, moving the
destructor out of the header fixes this build failure without
increasing header parsing time.  Alternate fixes are noted below.

* Source/WebCore/Modules/fetch/FetchBodySource.cpp:
* Source/WebCore/Modules/fetch/FetchBodySource.h:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.h:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.h:
* Source/WebCore/Modules/storage/StorageConnection.h:
- Replace struct StorageEstimate predeclaration by including
  StorageEstimate.h since it&apos;s a small struct.
* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp:
* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h:
* Source/WebCore/animation/CSSTransition.cpp:
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
* Source/WebCore/css/typedom/CSSUnparsedValue.h:
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
* Source/WebCore/css/typedom/transform/CSSPerspective.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/dom/DragEvent.cpp:
* Source/WebCore/dom/DragEvent.h:
* Source/WebCore/dom/InputEvent.cpp:
* Source/WebCore/dom/InputEvent.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/ReplaceSelectionCommand.h:
* Source/WebCore/html/CollectionTraversalInlines.h:
- Include HTMLOptionsCollectionInlines.h since this is needed in some
  source files.
* Source/WebCore/html/GenericCachedHTMLCollection.cpp:
* Source/WebCore/html/GenericCachedHTMLCollection.h:
* Source/WebCore/html/PluginDocument.cpp:
* Source/WebCore/html/PluginDocument.h:
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
* Source/WebCore/loader/cache/CachedSVGFont.h:
* Source/WebCore/page/WorkerNavigator.cpp:
* Source/WebCore/page/WorkerNavigator.h:
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp:
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.h:
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/NativeImage.cpp:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h:
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.h:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebCore/rendering/style/BasicShapes.cpp:
* Source/WebCore/rendering/style/BasicShapes.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/Shared/WebImage.cpp:
* Source/WebKit/Shared/WebImage.h:
- Also mark WebImage class as final.
* Source/WebKit/UIProcess/API/APIInspectorConfiguration.cpp:
* Source/WebKit/UIProcess/API/APIInspectorConfiguration.h:
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp:
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
- Include headers require for WebPageProxy::Internals destructor.
- Declare WebPageProxy::Internals destructor for Cocoa platforms.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
- Move class definition of WebPageProxyFrameLoadStateObserver to
  WebPageProxyInternals.h, leaving constructor and destructor here.
- Declare WebPageProxy::Internals destructor for non-Cocoa platforms.
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
- Move class definition of WebPageProxyFrameLoadStateObserver to here
  from WebPageProxy.cpp.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h:
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
- Also mark WebCookieCache class as final.
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp:
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h:
* Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:

Canonical link: <a href="https://commits.webkit.org/282753@main">https://commits.webkit.org/282753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/999595dfddb7ebf2cdff6365907af5baa398e808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14700 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51617 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12850 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13573 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58942 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59099 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6668 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9711 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39269 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->