### PR TITLE
Refactor noise injection policy types to be an OptionSet

### DIFF
--- a/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
@@ -61,7 +61,7 @@ ExceptionOr<Ref<AnalyserNode>> AnalyserNode::create(BaseAudioContext& context, c
 
 AnalyserNode::AnalyserNode(BaseAudioContext& context)
     : AudioBasicInspectorNode(context, NodeTypeAnalyser)
-    , m_analyser { context.noiseInjectionPolicy() }
+    , m_analyser { context.noiseInjectionPolicies() }
 {
     addOutput(1);
     

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -737,9 +737,9 @@ const BaseAudioContext& AudioNode::context() const
     });
 }
 
-NoiseInjectionPolicy AudioNode::noiseInjectionPolicy() const
+OptionSet<NoiseInjectionPolicy> AudioNode::noiseInjectionPolicies() const
 {
-    return context().noiseInjectionPolicy();
+    return context().noiseInjectionPolicies();
 }
 
 #if DEBUG_AUDIONODE_REFERENCES

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -43,7 +43,7 @@ class AudioNodeOutput;
 class AudioParam;
 class BaseAudioContext;
 
-enum class NoiseInjectionPolicy : bool;
+enum class NoiseInjectionPolicy : uint8_t;
 
 // An AudioNode is the basic building block for handling audio within an AudioContext.
 // It may be an audio source, an intermediate processing module, or an audio destination.
@@ -197,7 +197,7 @@ public:
     bool isTailProcessing() const { return m_isTailProcessing; }
     void setIsTailProcessing(bool isTailProcessing) { m_isTailProcessing = isTailProcessing; }
 
-    NoiseInjectionPolicy noiseInjectionPolicy() const;
+    OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const;
     virtual float noiseInjectionMultiplier() const { return 0; }
 
 protected:

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -216,7 +216,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
     for (unsigned i = 0; i < numberOfOutputs(); ++i)
         m_outputs[i] = *output(i)->bus();
 
-    if (noiseInjectionPolicy() == NoiseInjectionPolicy::Minimal) {
+    if (noiseInjectionPolicies().contains(NoiseInjectionPolicy::Minimal)) {
         for (unsigned inputIndex = 0; inputIndex < numberOfInputs(); ++inputIndex) {
             if (auto& input = m_inputs[inputIndex]) {
                 for (unsigned channelIndex = 0; channelIndex < input->numberOfChannels(); ++channelIndex) {

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -129,7 +129,7 @@ BaseAudioContext::BaseAudioContext(Document& document)
     , m_contextID(generateContextID())
     , m_worklet(AudioWorklet::create(*this))
     , m_listener(AudioListener::create(*this))
-    , m_noiseInjectionPolicy(document.noiseInjectionPolicy())
+    , m_noiseInjectionPolicies(document.noiseInjectionPolicies())
 {
     liveAudioContexts().add(m_contextID);
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -235,7 +235,7 @@ public:
     void addAudioParamDescriptors(const String& processorName, Vector<AudioParamDescriptor>&&);
     const MemoryCompactRobinHoodHashMap<String, Vector<AudioParamDescriptor>>& parameterDescriptorMap() const { return m_parameterDescriptorMap; }
 
-    NoiseInjectionPolicy noiseInjectionPolicy() const { return m_noiseInjectionPolicy; }
+    OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const { return m_noiseInjectionPolicies; }
 
 protected:
     explicit BaseAudioContext(Document&);
@@ -378,7 +378,7 @@ private:
     bool m_isAudioThreadFinished { false };
     bool m_automaticPullNodesNeedUpdating { false };
     bool m_hasFinishedAudioSourceNodes { false };
-    NoiseInjectionPolicy m_noiseInjectionPolicy { NoiseInjectionPolicy::None };
+    OptionSet<NoiseInjectionPolicy> m_noiseInjectionPolicies;
 };
 
 } // WebCore

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -52,7 +52,7 @@ OfflineAudioContext::OfflineAudioContext(Document& document, const OfflineAudioC
 {
     if (!renderTarget())
         document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Failed to construct internal AudioBuffer with "_s, options.numberOfChannels, " channel(s), a sample rate of "_s, options.sampleRate, " and a length of "_s, options.length, '.'));
-    else if (noiseInjectionPolicy() == NoiseInjectionPolicy::Minimal)
+    else if (noiseInjectionPolicies().contains(NoiseInjectionPolicy::Minimal))
         renderTarget()->increaseNoiseInjectionMultiplier();
 }
 
@@ -87,7 +87,7 @@ void OfflineAudioContext::lazyInitialize()
 
 void OfflineAudioContext::increaseNoiseMultiplierIfNeeded()
 {
-    if (noiseInjectionPolicy() == NoiseInjectionPolicy::None)
+    if (!noiseInjectionPolicies())
         return;
 
     Locker locker { graphLock() };

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -45,10 +45,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RealtimeAnalyser);
 
-RealtimeAnalyser::RealtimeAnalyser(NoiseInjectionPolicy policy)
+RealtimeAnalyser::RealtimeAnalyser(OptionSet<NoiseInjectionPolicy> policies)
     : m_inputBuffer(InputBufferSize)
     , m_downmixBus(AudioBus::create(1, AudioUtilities::renderQuantumSize))
-    , m_noiseInjectionPolicy(policy)
+    , m_noiseInjectionPolicies(policies)
 {
     m_analysisFrame = makeUnique<FFTFrame>(DefaultFFTSize);
 }
@@ -181,7 +181,7 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
         destination[i] = static_cast<float>(k * destination[i] + (1 - k) * scalarMagnitude);
     }
 
-    if (m_noiseInjectionPolicy == NoiseInjectionPolicy::Minimal)
+    if (m_noiseInjectionPolicies.contains(NoiseInjectionPolicy::Minimal))
         AudioUtilities::applyNoise(destination, n, 0.25);
 }
 

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
@@ -41,7 +41,7 @@ class RealtimeAnalyser {
     WTF_MAKE_TZONE_ALLOCATED(RealtimeAnalyser);
     WTF_MAKE_NONCOPYABLE(RealtimeAnalyser);
 public:
-    explicit RealtimeAnalyser(NoiseInjectionPolicy);
+    explicit RealtimeAnalyser(OptionSet<NoiseInjectionPolicy>);
     virtual ~RealtimeAnalyser();
 
     size_t fftSize() const { return m_fftSize; }
@@ -101,7 +101,7 @@ private:
 
     // We should only do the FFT analysis once per render quantum.
     bool m_shouldDoFFTAnalysis { true };
-    NoiseInjectionPolicy m_noiseInjectionPolicy { NoiseInjectionPolicy::None };
+    OptionSet<NoiseInjectionPolicy> m_noiseInjectionPolicies;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10704,11 +10704,12 @@ void Document::resetObservationSizeForContainIntrinsicSize(Element& target)
         resizeObserverForContainIntrinsicSize->resetObservationSize(target);
 }
 
-NoiseInjectionPolicy Document::noiseInjectionPolicy() const
+OptionSet<NoiseInjectionPolicy> Document::noiseInjectionPolicies() const
 {
+    OptionSet<NoiseInjectionPolicy> policies;
     if (advancedPrivacyProtections().contains(AdvancedPrivacyProtections::FingerprintingProtections))
-        return NoiseInjectionPolicy::Minimal;
-    return NoiseInjectionPolicy::None;
+        policies.add(NoiseInjectionPolicy::Minimal);
+    return policies;
 }
 
 OptionSet<AdvancedPrivacyProtections> Document::advancedPrivacyProtections() const
@@ -10720,7 +10721,7 @@ OptionSet<AdvancedPrivacyProtections> Document::advancedPrivacyProtections() con
 
 std::optional<uint64_t> Document::noiseInjectionHashSalt() const
 {
-    if (!page() || noiseInjectionPolicy() == NoiseInjectionPolicy::None)
+    if (!page() || !noiseInjectionPolicies())
         return std::nullopt;
     return protectedPage()->noiseInjectionHashSaltForDomain(RegistrableDomain { m_url });
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -310,7 +310,7 @@ enum class FocusTrigger : uint8_t;
 enum class MediaProducerMediaState : uint32_t;
 enum class MediaProducerMediaCaptureKind : uint8_t;
 enum class MediaProducerMutedState : uint8_t;
-enum class NoiseInjectionPolicy : bool;
+enum class NoiseInjectionPolicy : uint8_t;
 enum class ParserContentPolicy : uint8_t;
 enum class PlatformEventType : uint8_t;
 enum class ReferrerPolicySource : uint8_t;
@@ -1423,7 +1423,7 @@ public:
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
 
     std::optional<uint64_t> noiseInjectionHashSalt() const final;
-    NoiseInjectionPolicy noiseInjectionPolicy() const;
+    OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const final;
 
     // Used to allow element that loads data without going through a FrameLoader to delay the 'load' event.
     void incrementLoadEventDelayCount() { ++m_loadEventDelayCount; }

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -73,6 +73,7 @@ public:
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final { return { }; }
     std::optional<uint64_t> noiseInjectionHashSalt() const { return std::nullopt; }
+    OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const { return { }; }
 
     void postTask(Task&&) final { ASSERT_NOT_REACHED(); }
     EventTarget* errorEventTarget() final { return nullptr; };

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -88,6 +88,7 @@ class SocketProvider;
 class WebCoreOpaqueRoot;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class LoadedFromOpaqueSource : bool;
+enum class NoiseInjectionPolicy : uint8_t;
 enum class TaskSource : uint8_t;
 
 #if ENABLE(NOTIFICATIONS)
@@ -147,6 +148,7 @@ public:
 
     virtual OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const = 0;
     virtual std::optional<uint64_t> noiseInjectionHashSalt() const = 0;
+    virtual OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const = 0;
 
     virtual RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection();
 

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -38,8 +38,9 @@
 #include "ImageBuffer.h"
 #include "InspectorInstrumentation.h"
 #include "IntRect.h"
-#include "StyleCanvasImage.h"
+#include "NoiseInjectionPolicy.h"
 #include "RenderElement.h"
+#include "StyleCanvasImage.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
@@ -54,9 +55,9 @@ namespace WebCore {
 constexpr InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Low;
 static std::optional<size_t> maxCanvasAreaForTesting;
 
-CanvasBase::CanvasBase(IntSize size, const std::optional<NoiseInjectionHashSalt>& noiseHashSalt)
+CanvasBase::CanvasBase(IntSize size, const ScriptExecutionContext& context)
     : m_size(size)
-    , m_canvasNoiseHashSalt(noiseHashSalt)
+    , m_canvasNoiseHashSalt(context.noiseInjectionPolicies().contains(NoiseInjectionPolicy::Minimal) ? context.noiseInjectionHashSalt() : std::nullopt)
 {
 }
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -155,7 +155,7 @@ public:
     bool hasCreatedImageBuffer() const { return m_hasCreatedImageBuffer; }
 
 protected:
-    explicit CanvasBase(IntSize, const std::optional<NoiseInjectionHashSalt>&);
+    explicit CanvasBase(IntSize, const ScriptExecutionContext&);
 
     virtual ScriptExecutionContext* canvasBaseScriptExecutionContext() const = 0;
 

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -41,7 +41,7 @@ Ref<CustomPaintCanvas> CustomPaintCanvas::create(ScriptExecutionContext& context
 }
 
 CustomPaintCanvas::CustomPaintCanvas(ScriptExecutionContext& context, unsigned width, unsigned height)
-    : CanvasBase(IntSize(width, height), context.noiseInjectionHashSalt())
+    : CanvasBase(IntSize(width, height), context)
     , ContextDestructionObserver(&context)
 {
 }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -122,7 +122,7 @@ const int defaultHeight = 150;
 
 HTMLCanvasElement::HTMLCanvasElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
-    , CanvasBase(IntSize(defaultWidth, defaultHeight), document.noiseInjectionHashSalt())
+    , CanvasBase(IntSize(defaultWidth, defaultHeight), document)
     , ActiveDOMObject(document)
 {
     ASSERT(hasTagName(canvasTag));

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -119,7 +119,7 @@ Ref<OffscreenCanvas> OffscreenCanvas::create(ScriptExecutionContext& scriptExecu
 
 OffscreenCanvas::OffscreenCanvas(ScriptExecutionContext& scriptExecutionContext, IntSize size, RefPtr<PlaceholderRenderingContextSource>&& placeholderSource)
     : ActiveDOMObject(&scriptExecutionContext)
-    , CanvasBase(WTFMove(size), scriptExecutionContext.noiseInjectionHashSalt())
+    , CanvasBase(WTFMove(size), scriptExecutionContext)
     , m_placeholderSource(WTFMove(placeholderSource))
 {
 }

--- a/Source/WebCore/platform/NoiseInjectionPolicy.h
+++ b/Source/WebCore/platform/NoiseInjectionPolicy.h
@@ -25,11 +25,13 @@
 
 #pragma once
 
+#include <wtf/OptionSet.h>
+
 namespace WebCore {
 
-enum class NoiseInjectionPolicy : bool {
-    None,
-    Minimal
+enum class NoiseInjectionPolicy : uint8_t {
+    Minimal     = 1 << 0,
+    Enhanced    = 1 << 1,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3900,7 +3900,7 @@ void Internals::setMockVideoPresentationModeEnabled(bool enabled)
 
 void Internals::setCanvasNoiseInjectionSalt(HTMLCanvasElement& element, unsigned long long salt)
 {
-    return element.setNoiseInjectionSalt(salt);
+    element.setNoiseInjectionSalt(salt);
 }
 
 bool Internals::doesCanvasHavePendingCanvasNoiseInjection(HTMLCanvasElement& element) const

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WorkerOrWorkletGlobalScope.h"
 
+#include "NoiseInjectionPolicy.h"
 #include "ScriptModuleLoader.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "WorkerEventLoop.h"
@@ -135,6 +136,14 @@ void WorkerOrWorkletGlobalScope::postTaskForMode(Task&& task, const String& mode
 {
     ASSERT(workerOrWorkletThread());
     workerOrWorkletThread()->runLoop().postTaskForMode(WTFMove(task), mode);
+}
+
+OptionSet<NoiseInjectionPolicy> WorkerOrWorkletGlobalScope::noiseInjectionPolicies() const
+{
+    OptionSet<NoiseInjectionPolicy> policies;
+    if (m_advancedPrivacyProtections.contains(AdvancedPrivacyProtections::FingerprintingProtections))
+        policies.add(NoiseInjectionPolicy::Minimal);
+    return policies;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -40,6 +40,7 @@ class WorkerOrWorkletScriptController;
 class WorkerOrWorkletThread;
 
 enum class AdvancedPrivacyProtections : uint16_t;
+enum class NoiseInjectionPolicy : uint8_t;
 
 class WorkerOrWorkletGlobalScope : public RefCounted<WorkerOrWorkletGlobalScope>, public ScriptExecutionContext, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WorkerOrWorkletGlobalScope);
@@ -85,6 +86,7 @@ public:
     virtual FetchOptions::Destination destination() const = 0;
     ReferrerPolicy referrerPolicy() const final { return m_referrerPolicy; }
     std::optional<uint64_t> noiseInjectionHashSalt() const final { return m_noiseInjectionHashSalt; }
+    OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const final;
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final { return m_advancedPrivacyProtections; }
 
 protected:


### PR DESCRIPTION
#### cf6c75850aaa8928a7d37e4fff79b278277047f3
<pre>
Refactor noise injection policy types to be an OptionSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=278628">https://bugs.webkit.org/show_bug.cgi?id=278628</a>

Reviewed by Abrar Rahman Protyasha.

Refactor the `NoiseInjectionPolicy` enum type, such that it can hold up to 2 different types (the
existing `Minimal` type and a new `Enhanced` type) in a single option set. Populate the `OptionSet`
in `Document` and propagate it to the relevant web audio and canvas noise injection codepaths.

No change in behavior.

* Source/WebCore/Modules/webaudio/AnalyserNode.cpp:
(WebCore::AnalyserNode::AnalyserNode):
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::noiseInjectionPolicies const):
(WebCore::AudioNode::noiseInjectionPolicy const): Deleted.
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::BaseAudioContext):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::noiseInjectionPolicies const):
(WebCore::BaseAudioContext::noiseInjectionPolicy const): Deleted.
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::OfflineAudioContext):
(WebCore::OfflineAudioContext::increaseNoiseMultiplierIfNeeded):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::RealtimeAnalyser):
(WebCore::RealtimeAnalyser::doFFTAnalysisIfNecessary):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::noiseInjectionPolicies const):
(WebCore::Document::noiseInjectionHashSalt const):
(WebCore::Document::noiseInjectionPolicy const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::CanvasBase):
* Source/WebCore/html/CanvasBase.h:

Pass the `ScriptExecutionContext` into the constructor to avoid duplicating code for extracting the
hash salt for minimal noise injection.

* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::CustomPaintCanvas):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::HTMLCanvasElement):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::OffscreenCanvas):
* Source/WebCore/platform/NoiseInjectionPolicy.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setCanvasNoiseInjectionSalt):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::noiseInjectionPolicies const):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/282742@main">https://commits.webkit.org/282742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3d19e9ce00990771150c86fc76150dc691feb26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51608 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12840 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14167 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6653 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39259 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->