### PR TITLE
Adopt checkedPtr for WebPopupMenuProxyClient

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitPopupMenu.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPopupMenu.cpp
@@ -40,7 +40,7 @@ static void menuCloseCallback(WebKitPopupMenu* popupMenu)
 void WebKitPopupMenu::showPopupMenu(const IntRect& rect, TextDirection direction, double pageScaleFactor, const Vector<WebPopupItem>& items, const PlatformPopupMenuData& platformData, int32_t selectedIndex)
 {
     GRefPtr<WebKitOptionMenu> menu = adoptGRef(webkitOptionMenuCreate(*this, items, selectedIndex));
-    const GdkEvent* event = m_client->currentlyProcessedMouseDownEvent() ? m_client->currentlyProcessedMouseDownEvent()->nativeEvent() : nullptr;
+    const GdkEvent* event = client()->currentlyProcessedMouseDownEvent() ? client()->currentlyProcessedMouseDownEvent()->nativeEvent() : nullptr;
     webkitOptionMenuSetEvent(menu.get(), const_cast<GdkEvent*>(event));
     if (webkitWebViewShowOptionMenu(WEBKIT_WEB_VIEW(m_webView), rect, menu.get())) {
         m_menu = WTFMove(menu);

--- a/Source/WebKit/UIProcess/API/wpe/WebKitPopupMenu.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitPopupMenu.cpp
@@ -70,15 +70,15 @@ void WebKitPopupMenu::cancelTracking()
 
 void WebKitPopupMenu::selectItem(unsigned itemIndex)
 {
-    if (m_client)
-        m_client->setTextFromItemForPopupMenu(this, itemIndex);
+    if (CheckedPtr client = this->client())
+        client->setTextFromItemForPopupMenu(this, itemIndex);
     m_selectedItem = itemIndex;
 }
 
 void WebKitPopupMenu::activateItem(std::optional<unsigned> itemIndex)
 {
-    if (m_client)
-        m_client->valueChangedForPopupMenu(this, itemIndex.value_or(m_selectedItem.value_or(-1)));
+    if (CheckedPtr client = this->client())
+        client->valueChangedForPopupMenu(this, itemIndex.value_or(m_selectedItem.value_or(-1)));
     if (m_menu) {
         g_signal_handlers_disconnect_matched(m_menu.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
         m_menu = nullptr;

--- a/Source/WebKit/UIProcess/WebPopupMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebPopupMenuProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 
@@ -42,7 +43,9 @@ struct WebPopupItem;
 
 class WebPopupMenuProxy;
 
-class WebPopupMenuProxyClient {
+class WebPopupMenuProxyClient : public CanMakeCheckedPtr<WebPopupMenuProxyClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPopupMenuProxyClient);
 protected:
     virtual ~WebPopupMenuProxyClient() = default;
 
@@ -65,7 +68,7 @@ public:
     virtual void hidePopupMenu() = 0;
     virtual void cancelTracking() { }
 
-    void invalidate() { m_client = 0; }
+    void invalidate() { m_client = nullptr; }
 
 protected:
     explicit WebPopupMenuProxy(Client& client)
@@ -73,7 +76,10 @@ protected:
     {
     }
 
-    Client* m_client;
+    Client* client() const { return m_client.get(); }
+
+private:
+    CheckedPtr<Client> m_client;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
@@ -62,15 +62,15 @@ WebPopupMenuProxyGtk::~WebPopupMenuProxyGtk()
 
 void WebPopupMenuProxyGtk::selectItem(unsigned itemIndex)
 {
-    if (m_client)
-        m_client->setTextFromItemForPopupMenu(this, itemIndex);
+    if (CheckedPtr client = this->client())
+        client->setTextFromItemForPopupMenu(this, itemIndex);
     m_selectedItem = itemIndex;
 }
 
 void WebPopupMenuProxyGtk::activateItem(std::optional<unsigned> itemIndex)
 {
-    if (m_client)
-        m_client->valueChangedForPopupMenu(this, itemIndex.value_or(m_selectedItem.value_or(-1)));
+    if (CheckedPtr client = this->client())
+        client->valueChangedForPopupMenu(this, itemIndex.value_or(m_selectedItem.value_or(-1)));
 }
 
 bool WebPopupMenuProxyGtk::activateItemAtPath(GtkTreePath* path)
@@ -363,7 +363,7 @@ void WebPopupMenuProxyGtk::showPopupMenu(const IntRect& rect, TextDirection, dou
     gtk_window_move(GTK_WINDOW(m_popup), menuPosition.x(), menuPosition.y());
 #endif
 
-    const GdkEvent* event = m_client->currentlyProcessedMouseDownEvent() ? m_client->currentlyProcessedMouseDownEvent()->nativeEvent() : nullptr;
+    const GdkEvent* event = client()->currentlyProcessedMouseDownEvent() ? client()->currentlyProcessedMouseDownEvent()->nativeEvent() : nullptr;
     m_device = event ? gdk_event_get_device(event) : nullptr;
     if (!m_device)
         m_device = gtk_get_current_event_device();
@@ -383,8 +383,8 @@ void WebPopupMenuProxyGtk::showPopupMenu(const IntRect& rect, TextDirection, dou
     // PopupMenu can fail to open when there is no mouse grab.
     // Ensure WebCore does not go into some pesky state.
     if (grabResult != GDK_GRAB_SUCCESS) {
-       m_client->failedToShowPopupMenu();
-       return;
+        client()->failedToShowPopupMenu();
+        return;
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -178,16 +178,17 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
     [m_popup dismissPopUp];
     [dummyView removeFromSuperview];
     
-    if (!m_client || m_wasCanceled)
+    CheckedPtr client = this->client();
+    if (!client || m_wasCanceled)
         return;
     
-    m_client->valueChangedForPopupMenu(this, [m_popup indexOfSelectedItem]);
+    client->valueChangedForPopupMenu(this, [m_popup indexOfSelectedItem]);
     
     // <https://bugs.webkit.org/show_bug.cgi?id=57904> This code is adopted from EventHandler::sendFakeEventsAfterWidgetTracking().
-    if (!m_client->currentlyProcessedMouseDownEvent())
+    if (!client->currentlyProcessedMouseDownEvent())
         return;
     
-    NSEvent* initiatingNSEvent = m_client->currentlyProcessedMouseDownEvent()->nativeEvent();
+    NSEvent* initiatingNSEvent = client->currentlyProcessedMouseDownEvent()->nativeEvent();
     if ([initiatingNSEvent type] != NSEventTypeLeftMouseDown)
         return;
 

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -317,10 +317,11 @@ void WebPopupMenuProxyWin::showPopupMenu(const IntRect& rect, TextDirection, dou
     m_showPopup = false;
     ::ShowWindow(m_popup, SW_HIDE);
 
-    if (!WebPopupMenuProxy::m_client)
+    CheckedPtr client = this->client();
+    if (!client)
         return;
 
-    WebPopupMenuProxy::m_client->valueChangedForPopupMenu(this, m_newSelectedIndex);
+    client->valueChangedForPopupMenu(this, m_newSelectedIndex);
 
     // <https://bugs.webkit.org/show_bug.cgi?id=57904> In order to properly call the onClick()
     // handler on a <select> element, we need to fake a mouse up event in the main window.
@@ -330,10 +331,10 @@ void WebPopupMenuProxyWin::showPopupMenu(const IntRect& rect, TextDirection, dou
     // Thus, we are virtually clicking at the
     // same location where the mouse down event occurred. This allows the hit test to select
     // the correct element, and thereby call the onClick() JS handler.
-    if (!WebPopupMenuProxy::m_client->currentlyProcessedMouseDownEvent())
+    if (!client->currentlyProcessedMouseDownEvent())
         return;
 
-    const MSG* initiatingWinEvent = WebPopupMenuProxy::m_client->currentlyProcessedMouseDownEvent()->nativeEvent();
+    const MSG* initiatingWinEvent = client->currentlyProcessedMouseDownEvent()->nativeEvent();
     MSG fakeEvent = *initiatingWinEvent;
     fakeEvent.message = WM_LBUTTONUP;
     ::PostMessage(fakeEvent.hwnd, fakeEvent.message, fakeEvent.wParam, fakeEvent.lParam);
@@ -934,8 +935,8 @@ bool WebPopupMenuProxyWin::setFocusedIndex(int i, bool hotTracking)
     m_focusedIndex = i;
 
     if (!hotTracking) {
-        if (WebPopupMenuProxy::m_client)
-            WebPopupMenuProxy::m_client->setTextFromItemForPopupMenu(this, i);
+        if (CheckedPtr client = this->client())
+            client->setTextFromItemForPopupMenu(this, i);
     }
 
     scrollToRevealSelection();


### PR DESCRIPTION
#### f75d480496b38c7c12503b97d711a54bf53a6d63
<pre>
Adopt checkedPtr for WebPopupMenuProxyClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=278632">https://bugs.webkit.org/show_bug.cgi?id=278632</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/API/gtk/WebKitPopupMenu.cpp:
(WebKit::WebKitPopupMenu::showPopupMenu):
* Source/WebKit/UIProcess/API/wpe/WebKitPopupMenu.cpp:
(WebKit::WebKitPopupMenu::selectItem):
(WebKit::WebKitPopupMenu::activateItem):
* Source/WebKit/UIProcess/WebPopupMenuProxy.h:
(WebKit::WebPopupMenuProxy::invalidate):
(WebKit::WebPopupMenuProxy::client const):
* Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp:
(WebKit::WebPopupMenuProxyGtk::selectItem):
(WebKit::WebPopupMenuProxyGtk::activateItem):
(WebKit::WebPopupMenuProxyGtk::showPopupMenu):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::showPopupMenu):
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
(WebKit::WebPopupMenuProxyWin::showPopupMenu):
(WebKit::WebPopupMenuProxyWin::setFocusedIndex):

Canonical link: <a href="https://commits.webkit.org/282730@main">https://commits.webkit.org/282730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7485b81ded6d9660d19f72fcc1e05b1fcb119ebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51609 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36869 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69806 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58928 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59082 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6655 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9695 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39262 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->