### PR TITLE
Use CheckedPtr for WebColorPickerClient

### DIFF
--- a/Source/WebKit/UIProcess/WebColorPicker.cpp
+++ b/Source/WebKit/UIProcess/WebColorPicker.cpp
@@ -42,19 +42,14 @@ WebColorPicker::~WebColorPicker()
 
 void WebColorPicker::endPicker()
 {
-    if (!m_client)
-        return;
-
-    if (auto client = std::exchange(m_client, nullptr))
+    if (CheckedPtr client = std::exchange(m_client, nullptr))
         client->didEndColorPicker();
 }
 
 void WebColorPicker::setSelectedColor(const WebCore::Color& color)
 {
-    if (!m_client)
-        return;
-
-    m_client->didChooseColor(color);
+    if (CheckedPtr client = m_client)
+        client->didChooseColor(color);
 }
 
 void WebColorPicker::showColorPicker(const WebCore::Color&)

--- a/Source/WebKit/UIProcess/WebColorPicker.h
+++ b/Source/WebKit/UIProcess/WebColorPicker.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -38,13 +39,15 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class WebColorPickerClient {
-protected:
-    virtual ~WebColorPickerClient() = default;
-
+class WebColorPickerClient : public CanMakeCheckedPtr<WebColorPickerClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebColorPickerClient);
 public:
     virtual void didChooseColor(const WebCore::Color&) = 0;
     virtual void didEndColorPicker() = 0;
+
+protected:
+    virtual ~WebColorPickerClient() = default;
 };
 
 class WebColorPicker : public RefCounted<WebColorPicker> {
@@ -65,7 +68,10 @@ public:
 protected:
     explicit WebColorPicker(Client*);
 
-    Client* m_client;
+    Client* client() const { return m_client.get(); }
+
+private:
+    CheckedPtr<Client> m_client;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
@@ -71,10 +71,8 @@ void WebColorPickerGtk::endPicker()
 
 void WebColorPickerGtk::didChooseColor(const Color& color)
 {
-    if (!m_client)
-        return;
-
-    m_client->didChooseColor(color);
+    if (CheckedPtr client = this->client())
+        client->didChooseColor(color);
 }
 
 void WebColorPickerGtk::colorChooserDialogRGBAChangedCallback(GtkColorChooser* colorChooser, GParamSpec*, WebColorPickerGtk* colorPicker)
@@ -93,7 +91,7 @@ void WebColorPickerGtk::colorChooserDialogResponseCallback(GtkColorChooser*, int
 
 void WebColorPickerGtk::showColorPicker(const Color& color)
 {
-    if (!m_client)
+    if (!client())
         return;
 
     m_initialColor = color;

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -104,7 +104,7 @@ void WebColorPickerMac::endPicker()
 
 void WebColorPickerMac::setSelectedColor(const WebCore::Color& color)
 {
-    if (!m_client || !m_colorPickerUI)
+    if (!client() || !m_colorPickerUI)
         return;
     
     [m_colorPickerUI setColor:cocoaColor(color).get()];
@@ -112,15 +112,13 @@ void WebColorPickerMac::setSelectedColor(const WebCore::Color& color)
 
 void WebColorPickerMac::didChooseColor(const WebCore::Color& color)
 {
-    if (!m_client)
-        return;
-    
-    m_client->didChooseColor(color);
+    if (CheckedPtr client = this->client())
+        client->didChooseColor(color);
 }
 
 void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
 {
-    if (!m_client)
+    if (!client())
         return;
 
     [m_colorPickerUI setAndShowPicker:this withColor:cocoaColor(color).get() suggestions:WTFMove(m_suggestions)];


### PR DESCRIPTION
#### 3d5700be9db6a159cafcf289037a2ba0a51d0f5e
<pre>
Use CheckedPtr for WebColorPickerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=278634">https://bugs.webkit.org/show_bug.cgi?id=278634</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/WebColorPicker.cpp:
(WebKit::WebColorPicker::endPicker):
(WebKit::WebColorPicker::setSelectedColor):
* Source/WebKit/UIProcess/WebColorPicker.h:
(WebKit::WebColorPicker::client const):
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp:
(WebKit::WebColorPickerGtk::didChooseColor):
(WebKit::WebColorPickerGtk::showColorPicker):
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(WebKit::WebColorPickerMac::setSelectedColor):
(WebKit::WebColorPickerMac::didChooseColor):
(WebKit::WebColorPickerMac::showColorPicker):

Canonical link: <a href="https://commits.webkit.org/282732@main">https://commits.webkit.org/282732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/077f0932baf3dcebbb990e48fbb1c0cbd9e47895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14696 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51611 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10146 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36872 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58930 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59084 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6656 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9697 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39265 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->