### PR TITLE
Regression(282064@main): WebContent processes suspend when shared by multiple web pages

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -567,56 +567,56 @@ Ref<WebPageProxy> WebPageProxy::create(PageClient& pageClient, WebProcessProxy& 
 
 void WebPageProxy::takeVisibleActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().takeVisibleActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().takeVisibleActivity(pageID);
     });
 }
 void WebPageProxy::takeAudibleActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().takeAudibleActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().takeAudibleActivity(pageID);
     });
 }
 void WebPageProxy::takeCapturingActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().takeCapturingActivity();
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.activityState().takeCapturingActivity(pageID);
     });
 }
 
 void WebPageProxy::resetActivityState()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().reset();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().reset(pageID);
     });
 }
 
 void WebPageProxy::dropVisibleActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().dropVisibleActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().dropVisibleActivity(pageID);
     });
 }
 
 void WebPageProxy::dropAudibleActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().takeAudibleActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().takeAudibleActivity(pageID);
     });
 }
 
 void WebPageProxy::dropCapturingActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().takeCapturingActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().takeCapturingActivity(pageID);
     });
 }
 
 bool WebPageProxy::hasValidVisibleActivity() const
 {
     bool hasValidVisibleActivity = true;
-    forEachWebContentProcess([&](auto& webProcess, auto) {
-        hasValidVisibleActivity &= webProcess.activityState().hasValidVisibleActivity();
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        hasValidVisibleActivity &= webProcess.activityState().hasValidVisibleActivity(pageID);
     });
     return hasValidVisibleActivity;
 }
@@ -624,8 +624,8 @@ bool WebPageProxy::hasValidVisibleActivity() const
 bool WebPageProxy::hasValidAudibleActivity() const
 {
     bool hasValidAudibleActivity = true;
-    forEachWebContentProcess([&](auto& webProcess, auto) {
-        hasValidAudibleActivity &= webProcess.activityState().hasValidAudibleActivity();
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        hasValidAudibleActivity &= webProcess.activityState().hasValidAudibleActivity(pageID);
     });
     return hasValidAudibleActivity;
 }
@@ -633,8 +633,8 @@ bool WebPageProxy::hasValidAudibleActivity() const
 bool WebPageProxy::hasValidCapturingActivity() const
 {
     bool hasValidCapturingActivity = true;
-    forEachWebContentProcess([&](auto& webProcess, auto) {
-        hasValidCapturingActivity &= webProcess.activityState().hasValidCapturingActivity();
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        hasValidCapturingActivity &= webProcess.activityState().hasValidCapturingActivity(pageID);
     });
     return hasValidCapturingActivity;
 }
@@ -642,23 +642,23 @@ bool WebPageProxy::hasValidCapturingActivity() const
 #if PLATFORM(IOS_FAMILY)
 void WebPageProxy::takeOpeningAppLinkActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().takeOpeningAppLinkActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().takeOpeningAppLinkActivity(pageID);
     });
 }
 
 void WebPageProxy::dropOpeningAppLinkActivity()
 {
-    forEachWebContentProcess([](auto& webProcess, auto) {
-        webProcess.activityState().dropOpeningAppLinkActivity();
+    forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.activityState().dropOpeningAppLinkActivity(pageID);
     });
 }
 
 bool WebPageProxy::hasValidOpeningAppLinkActivity() const
 {
     bool hasValidOpeningAppLinkActivity = true;
-    forEachWebContentProcess([&](auto& webProcess, auto) {
-        hasValidOpeningAppLinkActivity &= webProcess.activityState().hasValidOpeningAppLinkActivity();
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        hasValidOpeningAppLinkActivity &= webProcess.activityState().hasValidOpeningAppLinkActivity(pageID);
     });
     return hasValidOpeningAppLinkActivity;
 }
@@ -829,6 +829,11 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->sendCachedLinkDecorationFilteringData();
     });
+#endif
+
+#if PLATFORM(MAC)
+    // FIXME: If this activity state is needed for iframe processes, it should be taken for them as well.
+    m_legacyMainFrameProcess->activityState().takeWasRecentlyVisibleActivity(internals().webPageID);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -27,45 +27,55 @@
 
 #include <wtf/WeakRef.h>
 
+namespace WebCore {
+struct PageIdentifierType;
+using PageIdentifier = LegacyNullableObjectIdentifier<PageIdentifierType>;
+}
+
 namespace WebKit {
 
 class ProcessThrottlerActivity;
+class ProcessThrottlerTimedActivity;
 class WebProcessProxy;
 
 class WebProcessActivityState {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WebProcessActivityState(WebProcessProxy&);
-    void takeVisibleActivity();
-    void takeAudibleActivity();
-    void takeCapturingActivity();
+    void takeVisibleActivity(WebCore::PageIdentifier);
+    void takeAudibleActivity(WebCore::PageIdentifier);
+    void takeCapturingActivity(WebCore::PageIdentifier);
 
-    void reset();
-    void dropVisibleActivity();
-    void dropAudibleActivity();
-    void dropCapturingActivity();
+    void reset(WebCore::PageIdentifier);
+    void dropVisibleActivity(WebCore::PageIdentifier);
+    void dropAudibleActivity(WebCore::PageIdentifier);
+    void dropCapturingActivity(WebCore::PageIdentifier);
 
-    bool hasValidVisibleActivity() const;
-    bool hasValidAudibleActivity() const;
-    bool hasValidCapturingActivity() const;
+    bool hasValidVisibleActivity(WebCore::PageIdentifier) const;
+    bool hasValidAudibleActivity(WebCore::PageIdentifier) const;
+    bool hasValidCapturingActivity(WebCore::PageIdentifier) const;
 
 #if PLATFORM(IOS_FAMILY)
-    void takeOpeningAppLinkActivity();
-    void dropOpeningAppLinkActivity();
-    bool hasValidOpeningAppLinkActivity() const;
+    void takeOpeningAppLinkActivity(WebCore::PageIdentifier);
+    void dropOpeningAppLinkActivity(WebCore::PageIdentifier);
+    bool hasValidOpeningAppLinkActivity(WebCore::PageIdentifier) const;
+#endif
+
+#if PLATFORM(MAC)
+    void takeWasRecentlyVisibleActivity(WebCore::PageIdentifier);
 #endif
 
 private:
     WeakRef<WebProcessProxy> m_process;
 
-    std::unique_ptr<ProcessThrottlerActivity> m_isVisibleActivity;
+    HashMap<WebCore::PageIdentifier, UniqueRef<ProcessThrottlerActivity>> m_isVisibleActivity;
 #if PLATFORM(MAC)
-    UniqueRef<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
+    HashMap<WebCore::PageIdentifier, UniqueRef<ProcessThrottlerTimedActivity>> m_wasRecentlyVisibleActivity;
 #endif
-    std::unique_ptr<ProcessThrottlerActivity> m_isAudibleActivity;
-    std::unique_ptr<ProcessThrottlerActivity> m_isCapturingActivity;
+    HashMap<WebCore::PageIdentifier, UniqueRef<ProcessThrottlerActivity>> m_isAudibleActivity;
+    HashMap<WebCore::PageIdentifier, UniqueRef<ProcessThrottlerActivity>> m_isCapturingActivity;
 #if PLATFORM(IOS_FAMILY)
-    std::unique_ptr<ProcessThrottlerActivity> m_openingAppLinkActivity;
+    HashMap<WebCore::PageIdentifier, UniqueRef<ProcessThrottlerActivity>> m_openingAppLinkActivity;
 #endif
 };
 


### PR DESCRIPTION
#### ce02f802a636e2317b02a12048159f109197f2f1
<pre>
Regression(282064@main): WebContent processes suspend when shared by multiple web pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=278636">https://bugs.webkit.org/show_bug.cgi?id=278636</a>
<a href="https://rdar.apple.com/134619952">rdar://134619952</a>

Reviewed by NOBODY (OOPS!).

282064@main moved the ownership of `WebProcessActivityState` from `WebPageProxy` to `WebProcessProxy`.
Since multiple web pages can share a web process, there was an issue where one page could release an
assertion that was taken by another page. To fix this, `WebProcessActivityState` should track which pages
have taken an assertion for a web process and avoid releasing an assertion that is still in use by
another page.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeVisibleActivity):
(WebKit::WebPageProxy::takeAudibleActivity):
(WebKit::WebPageProxy::takeCapturingActivity):
(WebKit::WebPageProxy::resetActivityState):
(WebKit::WebPageProxy::dropVisibleActivity):
(WebKit::WebPageProxy::dropAudibleActivity):
(WebKit::WebPageProxy::dropCapturingActivity):
(WebKit::WebPageProxy::hasValidVisibleActivity const):
(WebKit::WebPageProxy::hasValidAudibleActivity const):
(WebKit::WebPageProxy::hasValidCapturingActivity const):
(WebKit::WebPageProxy::takeOpeningAppLinkActivity):
(WebKit::WebPageProxy::dropOpeningAppLinkActivity):
(WebKit::WebPageProxy::hasValidOpeningAppLinkActivity const):
(WebKit::m_pageForTesting):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::WebProcessActivityState):
(WebKit::WebProcessActivityState::takeVisibleActivity):
(WebKit::WebProcessActivityState::takeAudibleActivity):
(WebKit::WebProcessActivityState::takeCapturingActivity):
(WebKit::WebProcessActivityState::reset):
(WebKit::WebProcessActivityState::dropVisibleActivity):
(WebKit::WebProcessActivityState::dropAudibleActivity):
(WebKit::WebProcessActivityState::dropCapturingActivity):
(WebKit::WebProcessActivityState::hasValidVisibleActivity const):
(WebKit::WebProcessActivityState::hasValidAudibleActivity const):
(WebKit::WebProcessActivityState::hasValidCapturingActivity const):
(WebKit::WebProcessActivityState::takeOpeningAppLinkActivity):
(WebKit::WebProcessActivityState::dropOpeningAppLinkActivity):
(WebKit::WebProcessActivityState::hasValidOpeningAppLinkActivity const):
(WebKit::WebProcessActivityState::takeWasRecentlyVisibleActivity):
* Source/WebKit/UIProcess/WebProcessActivityState.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce02f802a636e2317b02a12048159f109197f2f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14714 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51627 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32246 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36887 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69827 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58945 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55569 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59101 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6671 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39283 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->