### PR TITLE
Port more identifier types from LegacyNullableObjectIdentifier to ObjectIdentifier

### DIFF
--- a/Source/WebCore/page/GlobalWindowIdentifier.h
+++ b/Source/WebCore/page/GlobalWindowIdentifier.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 enum class WindowIdentifierType { };
-using WindowIdentifier = LegacyNullableObjectIdentifier<WindowIdentifierType>;
+using WindowIdentifier = ObjectIdentifier<WindowIdentifierType>;
 
 // Window identifier that is unique across all WebContent processes.
 struct GlobalWindowIdentifier {
@@ -59,7 +59,7 @@ struct GlobalWindowIdentifierHash {
 };
 
 template<> struct HashTraits<WebCore::GlobalWindowIdentifier> : GenericHashTraits<WebCore::GlobalWindowIdentifier> {
-    static WebCore::GlobalWindowIdentifier emptyValue() { return { }; }
+    static WebCore::GlobalWindowIdentifier emptyValue() { return { { }, HashTraits<WebCore::WindowIdentifier>::emptyValue() }; }
 
     static void constructDeletedValue(WebCore::GlobalWindowIdentifier& slot)
     {

--- a/Source/WebCore/workers/shared/SharedWorkerIdentifier.h
+++ b/Source/WebCore/workers/shared/SharedWorkerIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class SharedWorkerIdentifierType { };
-using SharedWorkerIdentifier = LegacyNullableObjectIdentifier<SharedWorkerIdentifierType>;
+using SharedWorkerIdentifier = ObjectIdentifier<SharedWorkerIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -49,7 +49,7 @@ class WorkerScriptLoader;
 struct WorkletParameters;
 
 enum class WorkletGlobalScopeIdentifierType { };
-using WorkletGlobalScopeIdentifier = LegacyNullableObjectIdentifier<WorkletGlobalScopeIdentifierType>;
+using WorkletGlobalScopeIdentifier = ObjectIdentifier<WorkletGlobalScopeIdentifierType>;
 
 class WorkletGlobalScope : public WorkerOrWorkletGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WorkletGlobalScope);

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -66,13 +66,10 @@ template: enum class WebCore::MediaUniqueIdentifierType
 template: enum class WebCore::ProcessIdentifierType
 template: enum class WebCore::PushSubscriptionIdentifierType
 template: enum class WebCore::RealtimeMediaSourceIdentifierType
-template: enum class WebCore::SharedWorkerIdentifierType
 template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
 template: enum class WebCore::TextCheckingRequestIdentifierType
 template: enum class WebCore::TextManipulationItemIdentifierType
 template: enum class WebCore::TextManipulationTokenIdentifierType
-template: enum class WebCore::WindowIdentifierType
-template: enum class WebCore::WorkletGlobalScopeIdentifierType
 template: enum class WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
 template: enum class WebKit::ContentWorldIdentifierType
 template: enum class WebKit::DownloadIdentifierType
@@ -160,6 +157,9 @@ template: enum class WebCore::ImageOverlayDataDetectionResultIdentifierType
 template: enum class WebCore::InbandGenericCueIdentifierType
 template: enum class WebCore::LayerHostingContextIdentifierType
 template: enum class WebCore::SWServerToContextConnectionIdentifierType
+template: enum class WebCore::SharedWorkerIdentifierType
+template: enum class WebCore::WindowIdentifierType
+template: enum class WebCore::WorkletGlobalScopeIdentifierType
 template: struct WebCore::NavigationIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()


### PR DESCRIPTION
#### c878607b4a50f89a6f2ea417dca4c3c1d9235fc9
<pre>
Port more identifier types from LegacyNullableObjectIdentifier to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=278637">https://bugs.webkit.org/show_bug.cgi?id=278637</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/page/GlobalWindowIdentifier.h:
(WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;::emptyValue):
* Source/WebCore/workers/shared/SharedWorkerIdentifier.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/282733@main">https://commits.webkit.org/282733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cc1824b66d9f7ef9408e5c6b40d4339abe07de1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51629 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12862 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58946 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59102 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6674 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9698 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39282 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->