### PR TITLE
Fix PlayStation build following 282670@main

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
@@ -189,13 +189,17 @@ auto evaluateCalcNoConversionDataRequired(const std::variant<Ts...>& component, 
 template<typename... Ts>
 auto evaluateCalc(const std::optional<std::variant<Ts...>>& component, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> std::optional<TypesMinusUnevaluatedCalcType<Ts...>>
 {
-    return component.transform([&](auto component) { return evaluateCalc(component, conversionData, symbolTable); });
+    if (!component)
+        return std::nullopt;
+    return evaluateCalc(component.value(), conversionData, symbolTable);
 }
 
 template<typename... Ts>
 auto evaluateCalcNoConversionDataRequired(const std::optional<std::variant<Ts...>>& component, const CSSCalcSymbolTable& symbolTable) -> std::optional<TypesMinusUnevaluatedCalcType<Ts...>>
 {
-    return component.transform([&](auto component) { return evaluateCalcNoConversionDataRequired(component, symbolTable); });
+    if (!component)
+        return std::nullopt;
+    return evaluateCalcNoConversionDataRequired(component.value(), symbolTable);
 }
 
 // MARK: Simplify
@@ -224,7 +228,9 @@ auto simplify(const std::variant<Ts...>& component, const CSSToLengthConversionD
 template<typename... Ts>
 auto simplify(const std::optional<std::variant<Ts...>>& component, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> std::optional<std::variant<Ts...>>
 {
-    return component.transform([&](auto component) { return simplify(component, conversionData, symbolTable); });
+    if (!component)
+        return std::nullopt;
+    return simplify(component.value(), conversionData, symbolTable);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### c3689e15b7b1cac386d26bbd260a1f8e265df3ae
<pre>
Fix PlayStation build following 282670@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=278641">https://bugs.webkit.org/show_bug.cgi?id=278641</a>

Unreviewed build fix.

std::optional::transform is a C++23 feature and, at least in the context of this patch, is not pulling its own weight;
it suffices to write an explicit early-out for nullopt.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h:
(WebCore::evaluateCalc):
(WebCore::evaluateCalcNoConversionDataRequired):
(WebCore::simplify):

Canonical link: <a href="https://commits.webkit.org/282722@main">https://commits.webkit.org/282722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c24aeb8ae7d21ac663b817b8436087bc951173f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14999 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67180 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32252 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12720 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55578 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6678 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->