### PR TITLE
Fix [super init] antipatterns

### DIFF
--- a/Source/WebCore/platform/ios/wak/WAKClipView.m
+++ b/Source/WebCore/platform/ios/wak/WAKClipView.m
@@ -36,10 +36,10 @@
 @synthesize documentView = _documentView;
 @synthesize copiesOnScroll = _copiesOnScroll;
 
-- (id)initWithFrame:(CGRect)rect
+- (instancetype)initWithFrame:(CGRect)rect
 {
     WKViewRef view = WKViewCreateWithFrame(rect, &viewContext);
-    self = [self _initWithViewRef:view];
+    self = [super _initWithViewRef:view];
     WAKRelease(view);
     return self;
 }

--- a/Source/WebCore/platform/ios/wak/WAKView.h
+++ b/Source/WebCore/platform/ios/wak/WAKView.h
@@ -57,7 +57,7 @@ WEBCORE_EXPORT @interface WAKView : WAKResponder
 
 + (WAKView *)focusView;
 
-- (id)initWithFrame:(CGRect)rect;
+- (instancetype)initWithFrame:(CGRect)rect;
 
 - (WAKWindow *)window;
 

--- a/Source/WebCore/platform/ios/wak/WAKView.mm
+++ b/Source/WebCore/platform/ios/wak/WAKView.mm
@@ -70,7 +70,7 @@ static WAKScrollView *enclosingScrollView(WAKView *view)
 @end
 
 @interface WAKView (WAKInternal)
-- (id)_initWithViewRef:(WKViewRef)viewRef;
+- (instancetype)_initWithViewRef:(WKViewRef)viewRef;
 @end
 
 @implementation WAKView
@@ -204,7 +204,7 @@ static void invalidateGStateCallback(WKViewRef view)
     return nil;
 }
 
-- (id)_initWithViewRef:(WKViewRef)viewR
+- (instancetype)_initWithViewRef:(WKViewRef)viewR
 {
     self = [super init];
     if (!self)
@@ -216,12 +216,12 @@ static void invalidateGStateCallback(WKViewRef view)
     return self;
 }
 
-- (id)init
+- (instancetype)init
 {
     return [self initWithFrame:CGRectZero];
 }
 
-- (id)initWithFrame:(CGRect)rect
+- (instancetype)initWithFrame:(CGRect)rect
 {
     WKViewRef view = WKViewCreateWithFrame(rect, &viewContext);
     self = [self _initWithViewRef:view];

--- a/Source/WebCore/platform/ios/wak/WAKViewInternal.h
+++ b/Source/WebCore/platform/ios/wak/WAKViewInternal.h
@@ -44,7 +44,7 @@
 
 - (WKViewRef)_viewRef;
 + (WAKView *)_wrapperForViewRef:(WKViewRef)_viewRef;
-- (id)_initWithViewRef:(WKViewRef)view;
+- (instancetype)_initWithViewRef:(WKViewRef)view;
 - (BOOL)_handleResponderCall:(WKViewResponderCallbackType)type;
 - (NSMutableSet *)_subviewReferences;
 - (BOOL)_selfHandleEvent:(WebEvent *)event;

--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
@@ -43,7 +43,7 @@ SOFT_LINK_CLASS_OPTIONAL(SpringBoardServices, SBSStatusBarStyleOverridesCoordina
 using namespace WebCore;
 
 @interface WebCoreMediaCaptureStatusBarHandler : NSObject<SBSStatusBarStyleOverridesCoordinatorDelegate>
--(id)initWithManager:(MediaCaptureStatusBarManager*)manager;
+-(instancetype)initWithManager:(MediaCaptureStatusBarManager*)manager;
 -(void)validateIsStopped;
 @end
 
@@ -53,9 +53,9 @@ using namespace WebCore;
     RetainPtr<SBSStatusBarStyleOverridesCoordinator> m_coordinator;
 }
 
-- (id)initWithManager:(MediaCaptureStatusBarManager*)manager
+- (instancetype)initWithManager:(MediaCaptureStatusBarManager*)manager
 {
-    self = [self init];
+    self = [super init];
     if (!self)
         return nil;
 

--- a/Source/WebCore/platform/network/mac/AuthenticationMac.mm
+++ b/Source/WebCore/platform/network/mac/AuthenticationMac.mm
@@ -37,16 +37,16 @@ using namespace WebCore;
 {
     AuthenticationClient* m_client;
 }
-- (id)initWithAuthenticationClient:(AuthenticationClient*)client;
+- (instancetype)initWithAuthenticationClient:(AuthenticationClient*)client;
 - (AuthenticationClient*)client;
 - (void)detachClient;
 @end
 
 @implementation WebCoreAuthenticationClientAsChallengeSender
 
-- (id)initWithAuthenticationClient:(AuthenticationClient*)client
+- (instancetype)initWithAuthenticationClient:(AuthenticationClient*)client
 {
-    self = [self init];
+    self = [super init];
     if (!self)
         return nil;
     m_client = client;

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h
@@ -53,7 +53,7 @@ class SynchronousLoaderMessageQueue;
 }
 
 - (void)detachHandle;
-- (id)initWithHandle:(WebCore::ResourceHandle*)handle messageQueue:(RefPtr<WebCore::SynchronousLoaderMessageQueue>&&)messageQueue;
+- (instancetype)initWithHandle:(WebCore::ResourceHandle*)handle messageQueue:(RefPtr<WebCore::SynchronousLoaderMessageQueue>&&)messageQueue;
 @end
 
 @interface WebCoreResourceHandleWithCredentialStorageAsOperationQueueDelegate : WebCoreResourceHandleAsOperationQueueDelegate

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -82,9 +82,9 @@ static bool scheduledWithCustomRunLoopMode(const std::optional<SchedulePairHashS
         CFRunLoopPerformBlock(pair->runLoop(), pair->mode(), block.get());
 }
 
-- (id)initWithHandle:(WebCore::ResourceHandle*)handle messageQueue:(RefPtr<WebCore::SynchronousLoaderMessageQueue>&&)messageQueue
+- (instancetype)initWithHandle:(WebCore::ResourceHandle*)handle messageQueue:(RefPtr<WebCore::SynchronousLoaderMessageQueue>&&)messageQueue
 {
-    self = [self init];
+    self = [super init];
     if (!self)
         return nil;
 

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -57,7 +57,7 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
 
 - (instancetype)initWithDownloadTask:(NSURLSessionDownloadTask *)task download:(WebKit::Download&)download URL:(NSURL *)fileURL sandboxExtension:(RefPtr<WebKit::SandboxExtension>)sandboxExtension
 {
-    if (!(self = [self initWithParent:nil userInfo:nil]))
+    if (!(self = [super initWithParent:nil userInfo:nil]))
         return nil;
 
     m_task = task;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.mm
@@ -34,7 +34,8 @@
 
 - (instancetype)_init
 {
-    return [super init];
+    self = [super init];
+    return self;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.mm
@@ -34,7 +34,8 @@
 
 - (instancetype)_init
 {
-    return [super init];
+    self = [super init];
+    return self;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -102,7 +102,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    if (!(self = [self init]))
+    if (!(self = [super init]))
         return nil;
 
     _src = adoptNS([[coder decodeObjectOfClass:[NSURL class] forKey:@"src"] copy]);
@@ -181,7 +181,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    if (!(self = [self init]))
+    if (!(self = [super init]))
         return nil;
 
     _name = adoptNS([[coder decodeObjectOfClass:[NSString class] forKey:@"name"] copy]);

--- a/Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm
@@ -38,7 +38,7 @@
 
 - (instancetype)initWithElementContext:(const WebCore::ElementContext&)context
 {
-    if (!(self = [self init]))
+    if (!(self = [super init]))
         return nil;
     _elementContext = context;
     return self;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -131,7 +131,7 @@ inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonIte
 
 - (instancetype)initWithInputAssistantItem:(UITextInputAssistantItem *)inputAssistant delegate:(id<WKFormAccessoryViewDelegate>)delegate
 {
-    self = [self init];
+    self = [super init];
     if (!self)
         return nil;
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm
@@ -55,7 +55,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVBackgroundView)
 - (instancetype)init
 {
     CGRect frame = CGRectMake(0, 0, 100, 100);
-    self = [self initWithFrame:frame];
+    self = [super initWithFrame:frame];
 
     if (!self)
         return nil;

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -246,7 +246,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     [self _setRealDelegate:delegate];
-    return [super initWithRequest:request delegate:_webInternal];
+    self = [super initWithRequest:request delegate:_webInternal];
+    return self;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
@@ -258,7 +259,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 IGNORE_WARNINGS_END
 {
     [self _setRealDelegate:delegate];
-    return [super _initWithLoadingConnection:connection request:request response:response delegate:_webInternal proxy:proxy];
+    self = [super _initWithLoadingConnection:connection request:request response:response delegate:_webInternal proxy:proxy];
+    return self;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
@@ -268,7 +270,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 IGNORE_WARNINGS_END
 {
     [self _setRealDelegate:delegate];
-    return [super _initWithRequest:request delegate:_webInternal directory:directory];
+    self = [super _initWithRequest:request delegate:_webInternal directory:directory];
+    return self;
 }
 
 @end

--- a/Source/WebKitLegacy/mac/Panels/WebAuthenticationPanel.m
+++ b/Source/WebKitLegacy/mac/Panels/WebAuthenticationPanel.m
@@ -46,7 +46,7 @@
 
 -(id)initWithCallback:(id)cb selector:(SEL)sel
 {
-    self = [self init];
+    self = [super init];
     if (self != nil) {
         callback = [cb retain];
         selector = sel;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -2102,7 +2102,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
 
 - (id)initWithFrame:(NakedPtr<WebCore::LocalFrame>)frame policyFunction:(WebCore::FramePolicyFunction&&)policyFunction defaultPolicy:(WebCore::PolicyAction)defaultPolicy
 {
-    self = [self init];
+    self = [super init];
     if (!self)
         return nil;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
@@ -42,7 +42,7 @@
 
 - (id)initWithPrompt:(NSString *)p text:(NSString *)t
 {
-    self = [self initWithWindowNibName:@"WebJavaScriptTextInputPanel"];
+    self = [super initWithWindowNibName:@"WebJavaScriptTextInputPanel"];
     if (!self)
         return nil;
     NSWindow *window = [self window];

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
@@ -56,7 +56,7 @@ using namespace WebCore;
 
 - (id)initWithWebNodeHighlight:(WebNodeHighlight *)webNodeHighlight
 {
-    self = [self initWithFrame:NSZeroRect];
+    self = [super initWithFrame:NSZeroRect];
     if (!self)
         return nil;
 

--- a/Tools/MiniBrowser/mac/ExtensionManagerWindowController.m
+++ b/Tools/MiniBrowser/mac/ExtensionManagerWindowController.m
@@ -33,7 +33,7 @@
 
 - (instancetype)init
 {
-    self = [self initWithWindowNibName:@"ExtensionManagerWindowController"];
+    self = [super initWithWindowNibName:@"ExtensionManagerWindowController"];
     if (self) {
         NSArray *installedContentExtensions = [[NSUserDefaults standardUserDefaults] arrayForKey:@"InstalledContentExtensions"];
         if (installedContentExtensions) {


### PR DESCRIPTION
<pre>Fix [super init] antipatterns
https://bugs.webkit.org/show_bug.cgi?id=278651

Reviewed by NOBODY (OOPS!).

There are cases where we call self init, when the self version does not
exist but the super version does, and places where [super init] is not
assigned to self. These are especially important in ARC code.
Luckily these are trivial fixes.

* Source/WebCore/platform/ios/wak/WAKClipView.m:
(-[WAKClipView initWithFrame:]):
* Source/WebCore/platform/ios/wak/WAKView.h:
* Source/WebCore/platform/ios/wak/WAKView.mm:
(-[WAKView _initWithViewRef:]):
(-[WAKView init]):
(-[WAKView initWithFrame:]):
* Source/WebCore/platform/ios/wak/WAKViewInternal.h:
* Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm:
(-[WebCoreMediaCaptureStatusBarHandler initWithManager:]):
* Source/WebCore/platform/network/mac/AuthenticationMac.mm:
(-[WebCoreAuthenticationClientAsChallengeSender initWithAuthenticationClient:]):
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h:
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate initWithHandle:messageQueue:]):
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm:
(-[WKDownloadProgress initWithDownloadTask:download:URL:sandboxExtension:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.mm:
(-[WKWebExtensionTabConfiguration _init]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.mm:
(-[WKWebExtensionWindowConfiguration _init]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifestIcon initWithCoder:]):
(-[_WKApplicationManifestShortcut initWithCoder:]):
* Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm:
(-[WKTextPlaceholder initWithElementContext:]):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(+[WKDataListTextSuggestion textSuggestionWithInputText:]):
* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm:
(-[WKFormAccessoryView initWithInputAssistantItem:delegate:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm:
(-[WKFullscreenStackView init]):
* Source/WebKitLegacy/mac/Panels/WebAuthenticationPanel.m:
(-[WebAuthenticationPanel initWithCallback:selector:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(-[WebFramePolicyListener initWithFrame:policyFunction:defaultPolicy:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebJavaScriptTextInputPanel.m:
(-[WebJavaScriptTextInputPanel initWithPrompt:text:]):
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm:
(-[WebNodeHighlightView initWithWebNodeHighlight:]):
* Tools/MiniBrowser/mac/ExtensionManagerWindowController.m:
(-[ExtensionManagerWindowController init]):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9360de9ed167411f825acd20d28250d13c78922c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70199 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53093 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15653 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71901 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60417 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1994 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41348 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->