### PR TITLE
[WPE] Set WPEMonitor's width and height at the same time

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
@@ -377,7 +377,7 @@ int wpe_monitor_get_height(WPEMonitor* monitor)
  * wpe_monitor_set_size:
  * @monitor: a #WPEMonitor
  * @width: the width, or -1
- * @height: the height, o -1
+ * @height: the height, or -1
  *
  * Set the size of @monitor in logical coordinates.
  */
@@ -387,6 +387,7 @@ void wpe_monitor_set_size(WPEMonitor* monitor, int width, int height)
     g_return_if_fail(width == -1 || width >= 0);
     g_return_if_fail(height == -1 || height >= 0);
 
+    g_object_freeze_notify(G_OBJECT(monitor));
     if (width != -1 && width != monitor->priv->width) {
         monitor->priv->width = width;
         g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_WIDTH]);
@@ -396,6 +397,7 @@ void wpe_monitor_set_size(WPEMonitor* monitor, int width, int height)
         monitor->priv->height = height;
         g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_HEIGHT]);
     }
+    g_object_thaw_notify(G_OBJECT(monitor));
 }
 
 /**


### PR DESCRIPTION
#### 8b4645f9b063d455693ac6b6097119db0971b364
<pre>
[WPE] Set WPEMonitor&apos;s width and height at the same time
<a href="https://bugs.webkit.org/show_bug.cgi?id=278660">https://bugs.webkit.org/show_bug.cgi?id=278660</a>

Reviewed by Adrian Perez de Castro.

Setting WPEMonitor&apos;s width and height at the same time by freezing
the notify signal before emitting and thawing it afterwards.

* Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp:
(wpe_monitor_set_size):

Canonical link: <a href="https://commits.webkit.org/282785@main">https://commits.webkit.org/282785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7a2a5d426403f92b4b6da1bf052026335f0b41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14765 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51665 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10197 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36930 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13639 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58984 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59147 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/403 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9736 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40413 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->