### PR TITLE
Web Inspector: Timelines: Unable to load more instances of a type in JavaScript Allocations view

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotContentView.js
@@ -72,7 +72,11 @@ WI.HeapSnapshotContentView = class HeapSnapshotContentView extends WI.ContentVie
     dataGridMatchNodeAgainstCustomFilters(node)
     {
         console.assert(node);
-        if (node instanceof WI.HeapSnapshotInstanceFetchMoreDataGridNode)
+
+        if (!this._dataGrid.filterText)
+            return true;
+
+        if (node instanceof WI.HeapSnapshotInstanceFetchMoreDataGridNode && !node.hasVisibleSiblingNodes())
             return false;
         return true;
     }

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceFetchMoreDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceFetchMoreDataGridNode.js
@@ -39,6 +39,19 @@ WI.HeapSnapshotInstanceFetchMoreDataGridNode = class HeapSnapshotInstanceFetchMo
         this._fetchCallback = fetchCallback;
     }
 
+    // Public
+
+    hasVisibleSiblingNodes()
+    {
+        let node = this;
+        while (node = node.previousSibling) {
+            if (!node.hidden)
+                return true;
+        }
+
+        return false;
+    }
+
     // Protected
 
     createCellContent(columnIdentifier)


### PR DESCRIPTION
#### 41ae46049e57b0879803ec62b8e814023f5b9e36
<pre>
Web Inspector: Timelines: Unable to load more instances of a type in JavaScript Allocations view
<a href="https://bugs.webkit.org/show_bug.cgi?id=278667">https://bugs.webkit.org/show_bug.cgi?id=278667</a>
<a href="https://rdar.apple.com/133810318">rdar://133810318</a>

Reviewed by BJ Burg.

For heap snapshot trees with many entries, instances are rendered batched in groups of 100.

A `WI.HeapSnapshotInstanceFetchMoreDataGridNode` with controls to generate the DOM for
the next batch or the full list is created, but it marked as `hidden` as a side-effect of
<a href="https://bugs.webkit.org/show_bug.cgi?id=157582.">https://bugs.webkit.org/show_bug.cgi?id=157582.</a>

A `WI.DataGrid` is virtualized to only display the limited number of data grid nodes
that are visible in the viewport. Any `WI.DataGridNode` marked as `hidden` is skipped
in `WI.DataGrid.updateVisibleRows()`:

```
let revealedRows = this._rows.filter((row) =&gt; row.revealed &amp;&amp; !row.hidden);
```

`WI.HeapSnapshotInstanceFetchMoreDataGridNode` gets marked as hidden when inserted inserted:

`WI.DataGrid.insertChild(node)` -&gt; `WI.DataGrid._applyFiltersToNodeAndDispatchEvent(node)`
-&gt; `WI.DataGrid._applyFiltersToNode(node)` where a delegate filtering method is called:
`WI.HeapSnapshotContentView.dataGridMatchNodeAgainstCustomFilters()`.

This delegate filter explicitly skips `WI.HeapSnapshotInstanceFetchMoreDataGridNode` nodes:

```
dataGridMatchNodeAgainstCustomFilters(node)
{
    console.assert(node);
    if (node instanceof WI.HeapSnapshotInstanceFetchMoreDataGridNode)
        return false;
    return true;
}
```

Combined with the virtualization logic from `WI.DataGrid.updateVisibleRows()` this results
in always hiding the controls to load more entries.

The intent was likely to skip showing these controls when there are no matches for a filter query.

This patch ensures that the delegate filter checks for visible sibling data grid nodes when deciding
whether to show the controls to load more entries.

The filter query matches against the top-level instance type, so the number of matched individual instances
of that type will not vary. Therefore, the controls to load more entries don&apos;t have to update their counts.

* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotContentView.js:
(WI.HeapSnapshotContentView.prototype.dataGridMatchNodeAgainstCustomFilters.hasVisibleSiblingNodes):
(WI.HeapSnapshotContentView.prototype.dataGridMatchNodeAgainstCustomFilters):

Canonical link: <a href="https://commits.webkit.org/283215@main">https://commits.webkit.org/283215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c94eaf4ed63c14eed2a73a11802718356d207b1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15835 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52404 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10963 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37894 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13834 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70958 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9181 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13651 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-activesourcebuffers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59729 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56524 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60004 "Found 2 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/basic-hierarchy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1263 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40408 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41485 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->