### PR TITLE
[Cocoa] AV1 codec strings specifying 4:2:0 Colocated subsampling incorrectly fail

### DIFF
--- a/LayoutTests/media/av1-codec-validate-configuration-record-expected.txt
+++ b/LayoutTests/media/av1-codec-validate-configuration-record-expected.txt
@@ -1,0 +1,52 @@
+* Main Profile
+Only 8 or 10 bit color is supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.08") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.10") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.12") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.09") == 'false') OK
+Only 4:2:0 subsampling is supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.000.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.100.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.110.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.111.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.112.1.1.1.0") == 'true') OK
+
+* High Profile
+Only 8 or 10 bit color is supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.10.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.12.0.000.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.09.0.000.1.1.1.0") == 'false') OK
+Only 4:4:4 subsampling is supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.100.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.110.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.111.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.112.1.1.1.0") == 'false') OK
+Monochrome is not supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.1.00M.08.1.000.1.1.1.0") == 'false') OK
+
+* Professional Profile
+Only 8, 10, or 12 bit color is supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.10.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.09.0.000.1.1.1.0") == 'false') OK
+For 8 and 10 bit color, only 4:4:4 subsampling is supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.100.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.110.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.111.1.1.1.0") == 'false') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.112.1.1.1.0") == 'false') OK
+For 12 bit color, only all subsampling values are supported:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.100.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.110.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.111.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.112.1.1.1.0") == 'true') OK
+Monochrome is supported for 12 bit color:
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.000.1.1.1.0") == 'true') OK
+EXPECTED (internals.validateAV1ConfigurationRecord("av01.2.00M.12.1.110.1.1.1.0") == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/av1-codec-validate-configuration-record.html
+++ b/LayoutTests/media/av1-codec-validate-configuration-record.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="video-test.js"></script>
+    <script>
+    window.addEventListener('load', event => {
+        consoleWrite('* Main Profile');
+        consoleWrite('Only 8 or 10 bit color is supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.08")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.10")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.12")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.09")`, false);
+        consoleWrite('Only 4:2:0 subsampling is supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.000.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.100.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.110.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.111.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.0.00M.08.0.112.1.1.1.0")`, true);
+
+        consoleWrite('');
+        consoleWrite('* High Profile');
+        consoleWrite('Only 8 or 10 bit color is supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.10.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.12.0.000.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.09.0.000.1.1.1.0")`, false);
+        consoleWrite('Only 4:4:4 subsampling is supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.100.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.110.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.111.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.112.1.1.1.0")`, false);
+        consoleWrite('Monochrome is not supported:');
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.1.00M.08.1.000.1.1.1.0")`, false);
+
+        consoleWrite('');
+        consoleWrite('* Professional Profile');
+        consoleWrite('Only 8, 10, or 12 bit color is supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.10.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.09.0.000.1.1.1.0")`, false);
+        consoleWrite('For 8 and 10 bit color, only 4:4:4 subsampling is supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.100.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.110.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.111.1.1.1.0")`, false);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.08.0.112.1.1.1.0")`, false);
+        consoleWrite('For 12 bit color, only all subsampling values are supported:')
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.100.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.110.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.111.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.112.1.1.1.0")`, true);
+        consoleWrite('Monochrome is supported for 12 bit color:');
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.0.000.1.1.1.0")`, true);
+        testExpected(`internals.validateAV1ConfigurationRecord("av01.2.00M.12.1.110.1.1.1.0")`, true);
+        endTest();
+    }, { once: true });
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/AV1Utilities.h
+++ b/Source/WebCore/platform/graphics/AV1Utilities.h
@@ -172,6 +172,7 @@ struct VideoInfo;
 WEBCORE_EXPORT std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView codecString);
 WEBCORE_EXPORT String createAV1CodecParametersString(const AV1CodecConfigurationRecord&);
 
+WEBCORE_EXPORT bool validateAV1ConfigurationRecord(const AV1CodecConfigurationRecord&);
 WEBCORE_EXPORT bool validateAV1PerLevelConstraints(const AV1CodecConfigurationRecord&, const VideoConfiguration&);
 
 std::optional<AV1CodecConfigurationRecord> parseAV1DecoderConfigurationRecord(const SharedBuffer&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6736,6 +6736,13 @@ bool Internals::validateAV1PerLevelConstraints(const String& parameters, const V
     return false;
 }
 
+bool Internals::validateAV1ConfigurationRecord(const String& parameters)
+{
+    if (auto record = WebCore::parseAV1CodecParameters(parameters))
+        return WebCore::validateAV1ConfigurationRecord(*record);
+    return false;
+}
+
 auto Internals::getCookies() const -> Vector<CookieData>
 {
     auto* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1247,6 +1247,7 @@ public:
     using AV1CodecConfigurationRecord = WebCore::AV1CodecConfigurationRecord;
     std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(const String&);
     String createAV1CodecParametersString(const AV1CodecConfigurationRecord&);
+    bool validateAV1ConfigurationRecord(const String&);
     bool validateAV1PerLevelConstraints(const String&, const VideoConfiguration&);
 
     struct CookieData {

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1270,6 +1270,7 @@ enum RenderingMode {
     VPCodecConfigurationRecord? parseVPCodecParameters(DOMString codecParameters);
     AV1CodecConfigurationRecord? parseAV1CodecParameters(DOMString codecParameters);
     DOMString createAV1CodecParametersString(AV1CodecConfigurationRecord parameters);
+    boolean validateAV1ConfigurationRecord(DOMString codecParameters);
     boolean validateAV1PerLevelConstraints(DOMString codecParameters, VideoConfiguration configuration);
 
     sequence<CookieData> getCookies();


### PR DESCRIPTION
#### 4a952c137807148a4bb342f1ae4d0ac6414e3446
<pre>
[Cocoa] AV1 codec strings specifying 4:2:0 Colocated subsampling incorrectly fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=278676">https://bugs.webkit.org/show_bug.cgi?id=278676</a>
<a href="https://rdar.apple.com/134375956">rdar://134375956</a>

Reviewed by Eric Carlson.

Correct a mismatch between CoreMedia&apos;s definition of the ChromaSubsampling parameter
and the definition used by the AV1 ISO-BMFF bindings specification. CoreMedia uses
a definition whose low-order digit specifies monochrome support, and AV1 uses chroma
sample position in that same digit.

Construct a query paratemer which matches CoreMedia&apos;s definition from the codecs
string provided. Also, do more validation of combinations of monochrome and subsampling
coordinates.

* LayoutTests/media/av1-codec-validate-configuration-record-expected.txt: Added.
* LayoutTests/media/av1-codec-validate-configuration-record.html: Added.
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
(WebCore::validateAV1ConfigurationRecord):
* Source/WebCore/platform/graphics/AV1Utilities.h:
* Source/WebCore/platform/graphics/cocoa/AV1UtilitiesCocoa.mm:
(WebCore::validateAV1Parameters):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::validateAV1ConfigurationRecord):

Canonical link: <a href="https://commits.webkit.org/282806@main">https://commits.webkit.org/282806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beaa53bd710c24dea7605397264b80fc59649ec5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51692 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10229 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12954 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13716 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59173 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/445 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39411 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->