### PR TITLE
[resultsdbpy] Speed up disabled slow tests and selenium

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/flask_support/flask_testcase.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/flask_support/flask_testcase.py
@@ -41,7 +41,7 @@ class FlaskTestCase(unittest.TestCase):
 
     @classmethod
     def driver(cls):
-        if cls._cached_driver:
+        if not int(os.environ.get('selenium', '0')) or cls._cached_driver:
             return cls._driver
 
         try:

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/wait_for_docker_test_case.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/wait_for_docker_test_case.py
@@ -32,7 +32,7 @@ from resultsdbpy.model.docker import Docker
 class WaitForDockerTestCase(unittest.TestCase):
 
     def setUp(self):
-        if Docker.is_running() and int(os.environ.get('slow_tests', '0')):
+        if int(os.environ.get('slow_tests', '0')) and Docker.is_running():
             with Docker.instance():
                 StrictRedis().flushdb()
         FakeStrictRedis().flushdb()

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py
@@ -116,6 +116,7 @@ class WebSiteUnittest(WebSiteTestCase):
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
     def test_constants(self, client, **kwargs):
+        self.maxDiff = None
         response = client.get(f'{self.URL}/assets/js/constants.js')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -147,6 +148,10 @@ const XCODE_CLOUD_SUITES = [
     'Build',
 ];
 const DEFAULT_ARCHITECTURE = null;
+const TESTS_LIMITS = JSON.parse('{"max": 50000, "default": 5000}');
+const SUITES_LIMITS = JSON.parse('{"max": 10000, "default": 1000}');
+const COMMITS_LIMITS = JSON.parse('{"max": 10000, "default": 1000}');
+const DASHBOARD_QUERY = JSON.parse('[]');
 
-export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE}''',
+export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE, TESTS_LIMITS, SUITES_LIMITS, COMMITS_LIMITS, DASHBOARD_QUERY}''',
         )


### PR DESCRIPTION
#### 991722dac1c1ca01082889372a48e54626ef7de6
<pre>
[resultsdbpy] Speed up disabled slow tests and selenium
<a href="https://bugs.webkit.org/show_bug.cgi?id=278677">https://bugs.webkit.org/show_bug.cgi?id=278677</a>
<a href="https://rdar.apple.com/134731012">rdar://134731012</a>

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/flask_support/flask_testcase.py:
(FlaskTestCase.driver): Only return a Selenium driver if it will be used.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/wait_for_docker_test_case.py:
(WaitForDockerTestCase.setUp): Only check if docker exists if docker will be needed.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py:
(WebSiteUnittest.test_constants): Rebaseline test.

Canonical link: <a href="https://commits.webkit.org/282968@main">https://commits.webkit.org/282968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a3e6667546d58584c6911f76c1698f59387079c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51911 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32531 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/64034 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14002 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70243 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59239 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/64202 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59411 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/681 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9825 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->