### PR TITLE
REGRESSION: WebContent process terminates due to invalid RemoteLayerTreeDrawingAreaProxy_CommitLayerTree message.

### DIFF
--- a/LayoutTests/compositing/visibility/omitted-nested-hidden-layers-crash-expected.txt
+++ b/LayoutTests/compositing/visibility/omitted-nested-hidden-layers-crash-expected.txt
@@ -1,0 +1,3 @@
+This test should not crash.
+
+

--- a/LayoutTests/compositing/visibility/omitted-nested-hidden-layers-crash.html
+++ b/LayoutTests/compositing/visibility/omitted-nested-hidden-layers-crash.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html lang="en">
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+    .header {
+        padding: .1rem .1rem;
+        position: relative;
+        width: 100%;
+    }
+
+    li {
+        position: relative;
+        line-height: 100rem;
+    }
+
+    .overlap {
+        height: 70vh;
+        margin-top: -.01rem;
+        max-height: 200px;
+        overflow-x: hidden;
+        overflow-y: auto;
+        width: 100%;
+    }
+
+    .aaaa {
+        max-width: 300px;
+        max-height: 200px;
+    }
+</style>
+</head>
+<body>
+
+<p>This test should not crash.</p>
+
+<div id="wrapper">
+    <div class="aaaa">
+        <div class="header">
+        </div>
+        <div class="overlap">
+            <ul>
+                <li></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async () => {
+    await UIHelper.renderingUpdate();
+    document.getElementById("wrapper").style.visibility = "hidden";
+
+    await UIHelper.renderingUpdate();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -828,14 +828,19 @@ void RenderLayer::rebuildZOrderLists(std::unique_ptr<Vector<RenderLayer*>>& posZ
     }
 }
 
-void RenderLayer::removeSelfAndDescendantsFromCompositor()
+void RenderLayer::removeSelfFromCompositor()
 {
     if (parent())
         compositor().layerWillBeRemoved(*parent(), *this);
     clearBacking();
+}
 
-    for (RenderLayer* child = firstChild(); child; child = child->nextSibling())
-        child->removeSelfAndDescendantsFromCompositor();
+void RenderLayer::removeDescendantsFromCompositor()
+{
+    for (RenderLayer* child = firstChild(); child; child = child->nextSibling()) {
+        child->removeSelfFromCompositor();
+        child->removeDescendantsFromCompositor();
+    }
 }
 
 void RenderLayer::setWasOmittedFromZOrderTree()
@@ -843,7 +848,13 @@ void RenderLayer::setWasOmittedFromZOrderTree()
     if (m_wasOmittedFromZOrderTree)
         return;
 
-    removeSelfAndDescendantsFromCompositor();
+    ASSERT(!isNormalFlowOnly());
+    removeSelfFromCompositor();
+
+    // Omitting a stacking context removes the whole subtree, otherwise collectLayers will
+    // visit and omit/include descendants separately.
+    if (isStackingContext())
+        removeDescendantsFromCompositor();
 
     if (compositor().hasContentCompositingLayers() && parent())
         parent()->setDescendantsNeedCompositingRequirementsTraversal();
@@ -859,10 +870,10 @@ void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZ
 
     bool isStacking = isStackingContext();
     // Overflow layers are just painted by their enclosing layers, so they don't get put in zorder lists.
-    bool includeHiddenLayer = (m_hasVisibleContent || m_intrinsicallyComposited) || ((m_hasVisibleDescendant || m_hasIntrinsicallyCompositedDescendants) && isStacking);
-    includeHiddenLayer |= page().hasEverSetVisibilityAdjustment();
+    bool layerOrDescendantsAreVisible = (m_hasVisibleContent || m_intrinsicallyComposited) || ((m_hasVisibleDescendant || m_hasIntrinsicallyCompositedDescendants) && isStacking);
+    layerOrDescendantsAreVisible |= page().hasEverSetVisibilityAdjustment();
     if (!isNormalFlowOnly()) {
-        if (includeHiddenLayer) {
+        if (layerOrDescendantsAreVisible) {
             auto& layerList = (zIndex() >= 0) ? positiveZOrderList : negativeZOrderList;
             if (!layerList)
                 layerList = makeUnique<Vector<RenderLayer*>>();
@@ -875,7 +886,7 @@ void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZ
 
     // Recur into our children to collect more layers, but only if we don't establish
     // a stacking context/container.
-    if ((m_hasIntrinsicallyCompositedDescendants || m_hasVisibleDescendant) && !isStacking) {
+    if (!isStacking) {
         for (RenderLayer* child = firstChild(); child; child = child->nextSibling()) {
             // Ignore reflections.
             if (!isReflectionLayer(*child))

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1187,7 +1187,8 @@ private:
 
     void setWasOmittedFromZOrderTree();
     void setWasIncludedInZOrderTree() { m_wasOmittedFromZOrderTree = false; }
-    void removeSelfAndDescendantsFromCompositor();
+    void removeSelfFromCompositor();
+    void removeDescendantsFromCompositor();
 
     void setHasCompositingDescendant(bool b)  { m_hasCompositingDescendant = b; }
     void setHasCompositedNonContainedDescendants(bool value) { m_hasCompositedNonContainedDescendants = value; }


### PR DESCRIPTION
#### fcd3d0ef9ce66b6de9d6df6c8b8882683ed77b14
<pre>
REGRESSION: WebContent process terminates due to invalid RemoteLayerTreeDrawingAreaProxy_CommitLayerTree message.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278556">https://bugs.webkit.org/show_bug.cgi?id=278556</a>
&lt;<a href="https://rdar.apple.com/134572916">rdar://134572916</a>&gt;

Reviewed by Simon Fraser.

281636@main fixed the case where omitting a visibility:hidden layer from the RenderLayer z-order lists caused
a crash, because the compositor wasn&apos;t informed of the removal.

This is a second variant of the same issue, where the omitting happens by not
recursing into a hidden subtree instead of omitting a leaf.

The fix is to stop doing that type of omission, since it&apos;s hard to reason about.
It&apos;s possible that this is slightly slower in some cases (though only back to
how the code ran before the original optimization, not a true regression). The
real performance win comes from hiding these layers from the compositor, so it
shouldn&apos;t be noticeable.

The fix also clarifies some of the code around notifying the compositor, so that
it works in the same way as collectLayers. This prevents a visible decendant of
a non-stacking hidden layer from being removed from the compositor, only to be
added again by collectLayers.

* LayoutTests/compositing/visibility/omitted-nested-hidden-layers-crash-expected.txt: Added.
* LayoutTests/compositing/visibility/omitted-nested-hidden-layers-crash.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::removeSelfFromCompositor):
(WebCore::RenderLayer::removeDescendantsFromCompositor):
(WebCore::RenderLayer::setWasOmittedFromZOrderTree):
(WebCore::RenderLayer::collectLayers):
(WebCore::RenderLayer::removeSelfAndDescendantsFromCompositor): Deleted.
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/282879@main">https://commits.webkit.org/282879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a612dc081d853bba8b6421399008ae1a0736c94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51733 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10265 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70002 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59054 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59217 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6798 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/484 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39458 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->