### PR TITLE
REGRESSION (282540@main): [ visionOS, iOS ] fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.html is a constant failure

### DIFF
--- a/LayoutTests/fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields-expected.txt
+++ b/LayoutTests/fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields-expected.txt
@@ -22,9 +22,6 @@ PASS: movementY is correct.
 pointermove fired.
 PASS: movementX is correct.
 PASS: movementY is correct.
-pointermove fired.
-PASS: movementX is correct.
-PASS: movementY is correct.
 pointerup fired.
 PASS: movementX is correct.
 PASS: movementY is correct.


### PR DESCRIPTION
#### cd0ab0d3f82b4e638f6d304043fe7afc25b60723
<pre>
REGRESSION (282540@main): [ visionOS, iOS ] fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=278684">https://bugs.webkit.org/show_bug.cgi?id=278684</a>
<a href="https://rdar.apple.com/134737069">rdar://134737069</a>

Unreviewed test expectation adjustment.

The test expectations for fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.html,
as introduced originally in 263829@main, is a bit misleading because
correctness does not necessarily _require_ exactly 6 pointermove events
during the drag gesture.

With 282540@main, we started dispatching one less pointermove in certain
touch event paths, which meant that the test in the bug started failing.
This patch simply updates the expectations for the test since we are still
clearly observing pointermove events throughout the drag gesture.

* LayoutTests/fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields-expected.txt:

Canonical link: <a href="https://commits.webkit.org/282768@main">https://commits.webkit.org/282768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/747166698505c847dab524967ed120f55ddd9472

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14846 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15126 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10231 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67307 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55574 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32313 "Failed to checkout and rebase branch from PR 32735") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13720 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8185 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55669 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/6764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9725 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->