### PR TITLE
Make download placeholder and final URL available to client

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -92,6 +92,8 @@ public:
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     void publishProgress(const URL&, std::span<const uint8_t>, WebKit::UseDownloadPlaceholder);
+    void setPlaceholderURL(NSURL *);
+    void setFinalURL(NSURL *);
 #endif
 
     DownloadID downloadID() const { return m_downloadID; }
@@ -117,6 +119,11 @@ private:
 
     void platformCancelNetworkLoad(CompletionHandler<void(std::span<const uint8_t>)>&&);
     void platformDestroyDownload();
+    void platformDidFinish(CompletionHandler<void()>&&);
+
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    void startUpdatingProgress() const;
+#endif
 
     CheckedRef<DownloadManager> m_downloadManager;
     DownloadID m_downloadID;
@@ -129,10 +136,10 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<NSURLSessionDownloadTask> m_downloadTask;
     RetainPtr<NSProgress> m_progress;
-#endif
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     RetainPtr<NSData> m_bookmarkData;
     RetainPtr<NSURL> m_bookmarkURL;
+#endif
 #endif
     PAL::SessionID m_sessionID;
     bool m_hasReceivedData { false };

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -432,6 +432,8 @@ public:
     void allowFilesAccessFromWebProcess(WebCore::ProcessIdentifier, const Vector<String>&, CompletionHandler<void()>&&);
     void allowFileAccessFromWebProcess(WebCore::ProcessIdentifier, const String&, CompletionHandler<void()>&&);
 
+    bool enableModernDownloadProgress() const { return m_enableModernDownloadProgress; }
+
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
@@ -599,6 +601,7 @@ private:
     int m_mediaStreamingActivitityToken { NOTIFY_TOKEN_INVALID };
     bool m_isParentProcessFullWebBrowserOrRunningTest { false };
 #endif
+    bool m_enableModernDownloadProgress { false };
 };
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -78,7 +78,9 @@ struct NetworkProcessCreationParameters {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     bool builtInNotificationsEnabled { false };
 #endif
-
+#if PLATFORM(COCOA)
+    bool enableModernDownloadProgress { false };
+#endif
     Vector<WebsiteDataStoreParameters> websiteDataStoreParameters;
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashSet<String> localhostAliasesForTesting;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -56,6 +56,9 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     bool builtInNotificationsEnabled
 #endif
+#if PLATFORM(COCOA)
+    bool enableModernDownloadProgress
+#endif
 
     Vector<WebKit::WebsiteDataStoreParameters> websiteDataStoreParameters
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -115,6 +115,7 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
     if (auditToken && [NEFilterSource respondsToSelector:@selector(setDelegation:)])
         [NEFilterSource setDelegation:&auditToken.value()];
 #endif
+    m_enableModernDownloadProgress = parameters.enableModernDownloadProgress;
 }
 
 RetainPtr<CFDataRef> NetworkProcess::sourceApplicationAuditData() const

--- a/Source/WebKit/UIProcess/API/APIDownloadClient.h
+++ b/Source/WebKit/UIProcess/API/APIDownloadClient.h
@@ -60,13 +60,15 @@ public:
     virtual void legacyDidStart(WebKit::DownloadProxy&) { }
     virtual void didReceiveAuthenticationChallenge(WebKit::DownloadProxy&, WebKit::AuthenticationChallengeProxy& challenge) { challenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::Cancel); }
     virtual void didReceiveData(WebKit::DownloadProxy&, uint64_t, uint64_t, uint64_t) { }
-#if HAVE(MODERN_DOWNLOADPROGRESS)
-    virtual void decidePlaceholderPolicy(WebKit::DownloadProxy&, CompletionHandler<void(WebKit::UseDownloadPlaceholder)>&& completionHandler) { completionHandler(WebKit::UseDownloadPlaceholder::No); }
-#endif
+    virtual void decidePlaceholderPolicy(WebKit::DownloadProxy&, CompletionHandler<void(WebKit::UseDownloadPlaceholder, const WTF::URL&)>&& completionHandler) { completionHandler(WebKit::UseDownloadPlaceholder::No, { }); }
     virtual void decideDestinationWithSuggestedFilename(WebKit::DownloadProxy&, const WebCore::ResourceResponse&, const WTF::String&, CompletionHandler<void(WebKit::AllowOverwrite, WTF::String)>&& completionHandler) { completionHandler(WebKit::AllowOverwrite::No, { }); }
     virtual void didCreateDestination(WebKit::DownloadProxy&, const WTF::String&) { }
     virtual void didFinish(WebKit::DownloadProxy&) { }
     virtual void didFail(WebKit::DownloadProxy&, const WebCore::ResourceError&, API::Data* resumeData) { }
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    virtual void didReceivePlaceholderURL(WebKit::DownloadProxy&, const WTF::URL&, std::span<const uint8_t>, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
+    virtual void didReceiveFinalURL(WebKit::DownloadProxy&, const WTF::URL&, std::span<const uint8_t>) { }
+#endif
     virtual void legacyDidCancel(WebKit::DownloadProxy&) { }
     virtual void processDidCrash(WebKit::DownloadProxy&) { }
     virtual void willSendRequest(WebKit::DownloadProxy&, WebCore::ResourceRequest&& request, const WebCore::ResourceResponse&, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler) { completionHandler(WTFMove(request)); }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegatePrivate.h
@@ -50,9 +50,25 @@ WK_SWIFT_UI_ACTOR
  @param download The download for which we need a placeholder policy
  @param completionHandler The completion handler that should be invoked with the chosen policy
  @discussion The placeholder policy specifies whether a placeholder file should be created in
- the Downloads directory when the download is in progress.
+ the Downloads directory when the download is in progress. If the client opts out of the
+ placeholder feature, it can choose to provide a custom URL to publish progress against.
+ This is useful if the client maintains it's own placeholder file.
  */
-- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy, NSURL *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/* @abstract Called when the download receives a placeholder URL
+ @param download The download for which we received a placeholder URL
+ @param completionHandler The completion handler that should be called by the client in response to this call. 
+ @discussion The placeholder URL will normally refer to a file in the Downloads directory
+ */
+- (void)_download:(WKDownload *)download didReceivePlaceholderURL:(NSURL *)url completionHandler:(void (^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/* @abstract Called when the download receives a final URL
+ @param download The download for which we received a final URL
+ @param url The URL of the final download location
+ @discussion The final URL will normally refer to a file in the Downloads directory
+ */
+- (void)_download:(WKDownload *)download didReceiveFinalURL:(NSURL *)url WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -162,13 +162,9 @@ void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::Resour
 
         setDestinationFilename(destination);
 
-#if HAVE(MODERN_DOWNLOADPROGRESS)
-        m_client->decidePlaceholderPolicy(*this, [completionHandler = WTFMove(completionHandler), destination = WTFMove(destination), sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), allowOverwrite] (WebKit::UseDownloadPlaceholder usePlaceholder) mutable {
-            completionHandler(destination, WTFMove(sandboxExtensionHandle), allowOverwrite, usePlaceholder);
+        m_client->decidePlaceholderPolicy(*this, [completionHandler = WTFMove(completionHandler), destination = WTFMove(destination), sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), allowOverwrite] (WebKit::UseDownloadPlaceholder usePlaceholder, const URL& url) mutable {
+            completionHandler(destination, WTFMove(sandboxExtensionHandle), allowOverwrite, usePlaceholder, url);
         });
-#else
-        completionHandler(destination, WTFMove(sandboxExtensionHandle), allowOverwrite, WebKit::UseDownloadPlaceholder::No);
-#endif
     });
 }
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -64,7 +64,7 @@ struct FrameInfoData;
 
 class DownloadProxy : public API::ObjectImpl<API::Object::Type::Download>, public IPC::MessageReceiver {
 public:
-    using DecideDestinationCallback = CompletionHandler<void(String, SandboxExtension::Handle, AllowOverwrite, WebKit::UseDownloadPlaceholder)>;
+    using DecideDestinationCallback = CompletionHandler<void(String, SandboxExtension::Handle, AllowOverwrite, WebKit::UseDownloadPlaceholder, const URL&)>;
 
     template<typename... Args> static Ref<DownloadProxy> create(Args&&... args)
     {
@@ -118,6 +118,10 @@ public:
     void didCreateDestination(const String& path);
     void didFinish();
     void didFail(const WebCore::ResourceError&, std::span<const uint8_t> resumeData);
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    void didReceivePlaceholderURL(const URL&, std::span<const uint8_t> bookmarkData, CompletionHandler<void()>&&);
+    void didReceiveFinalURL(const URL&, std::span<const uint8_t> bookmarkData);
+#endif
     void willSendRequest(WebCore::ResourceRequest&& redirectRequest, const WebCore::ResourceResponse& redirectResponse, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     void decideDestinationWithSuggestedFilename(const WebCore::ResourceResponse&, String&& suggestedFilename, DecideDestinationCallback&&);
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
@@ -24,9 +24,13 @@ messages -> DownloadProxy {
     DidStart(WebCore::ResourceRequest request, String suggestedFilename)
     DidReceiveAuthenticationChallenge(WebCore::AuthenticationChallenge challenge, WebKit::AuthenticationChallengeIdentifier challengeID)
     WillSendRequest(WebCore::ResourceRequest redirectRequest, WebCore::ResourceResponse redirectResponse) -> (WebCore::ResourceRequest newRequest)
-    DecideDestinationWithSuggestedFilename(WebCore::ResourceResponse response, String suggestedFilename) -> (String filename, WebKit::SandboxExtensionHandle handle, enum:bool WebKit::AllowOverwrite allowOverwrite, enum:bool WebKit::UseDownloadPlaceholder useDownloadPlaceholder)
+    DecideDestinationWithSuggestedFilename(WebCore::ResourceResponse response, String suggestedFilename) -> (String filename, WebKit::SandboxExtensionHandle handle, enum:bool WebKit::AllowOverwrite allowOverwrite, enum:bool WebKit::UseDownloadPlaceholder useDownloadPlaceholder, URL alternatePlaceholderURL)
     DidReceiveData(uint64_t bytesWritten, uint64_t totalBytesWritten, uint64_t totalBytesExpectedToWrite)
     DidCreateDestination(String path)
     DidFinish()
     DidFail(WebCore::ResourceError error, std::span<const uint8_t> resumeData)
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    DidReceivePlaceholderURL(URL placeholderURL, std::span<const uint8_t> bookmarkData) -> ()
+    DidReceiveFinalURL(URL finalURL, std::span<const uint8_t> bookmarkData)
+#endif
 }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "DownloadProxy.h"
 
+#import "APIDownloadClient.h"
 #import "NetworkProcessMessages.h"
 #import "NetworkProcessProxy.h"
 #import "WebsiteDataStore.h"
@@ -53,5 +54,17 @@ void DownloadProxy::publishProgress(const URL& url)
     m_dataStore->networkProcess().send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, url, WTFMove(*handle)), 0);
 #endif
 }
+
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+void DownloadProxy::didReceivePlaceholderURL(const URL& placeholderURL, std::span<const uint8_t> bookmarkData, CompletionHandler<void()>&& completionHandler)
+{
+    m_client->didReceivePlaceholderURL(*this, placeholderURL, bookmarkData, WTFMove(completionHandler));
+}
+
+void DownloadProxy::didReceiveFinalURL(const URL& finalURL, std::span<const uint8_t> bookmarkData)
+{
+    m_client->didReceiveFinalURL(*this, finalURL, bookmarkData);
+}
+#endif
 
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -209,7 +209,9 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     parameters.builtInNotificationsEnabled = DeprecatedGlobalSettings::builtInNotificationsEnabled();
 #endif
-
+#if PLATFORM(COCOA)
+    parameters.enableModernDownloadProgress = CFPreferencesGetAppBooleanValue(CFSTR("EnableModernDownloadProgress"), CFSTR("com.apple.WebKit"), nullptr);
+#endif
     parameters.allowedFirstPartiesForCookies = WebProcessProxy::allowedFirstPartiesForCookies();
 
 #if PLATFORM(COCOA)

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
@@ -32,6 +32,8 @@ enum class DownloadCallback : uint8_t {
     DecideDestination,
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     DecidePlaceholderPolicy,
+    DidReceivePlaceholderURL,
+    DidReceiveFinalURL,
 #endif
     DidFinish,
     DidFailWithError,
@@ -53,6 +55,10 @@ enum class DownloadCallback : uint8_t {
 @property (nonatomic, copy) void (^navigationResponseDidBecomeDownload)(WKWebView *, WKNavigationResponse *, WKDownload *);
 @property (nonatomic, copy) void (^decidePolicyForNavigationAction)(WKNavigationAction *, void (^)(WKNavigationActionPolicy));
 @property (nonatomic, copy) void (^decidePolicyForNavigationResponse)(WKNavigationResponse *, void (^)(WKNavigationResponsePolicy));
+
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+@property (nonatomic, copy) void (^decidePlaceholderPolicy)(WKDownload *, void (^)(_WKPlaceholderPolicy, NSURL *));
+#endif
 
 - (void)waitForDownloadDidFinish;
 - (Vector<DownloadCallback>)takeCallbackRecord;

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
@@ -59,10 +59,21 @@
 }
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy))completionHandler
+- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy, NSURL *))completionHandler
 {
     _callbackRecord.append(DownloadCallback::DecidePlaceholderPolicy);
-    completionHandler(_WKPlaceholderPolicyDisable);
+    completionHandler(_WKPlaceholderPolicyDisable, nil);
+}
+
+- (void)_download:(WKDownload *)download didReceivePlaceholderURL:(NSURL *)url completionHandler:(void (^)(void))completionHandler
+{
+    _callbackRecord.append(DownloadCallback::DidReceivePlaceholderURL);
+    completionHandler();
+}
+
+- (void)_download:(WKDownload *)download didReceiveFinalURL:(NSURL *)url
+{
+    _callbackRecord.append(DownloadCallback::DidReceiveFinalURL);
 }
 #endif
 


### PR DESCRIPTION
#### 5078adc67152c261c7fb6c83de4a4fc4540c8164
<pre>
Make download placeholder and final URL available to client
<a href="https://bugs.webkit.org/show_bug.cgi?id=278688">https://bugs.webkit.org/show_bug.cgi?id=278688</a>
<a href="https://rdar.apple.com/134745889">rdar://134745889</a>

Reviewed by Alex Christensen.

In some cases, it is important for the download client to know the location of the
placeholder file created for ongoing downloads as well as the final location. This
patch prepares for this by sending the placeholder URL and final URL from the
Networking process back to the client in the UI process. In order for the UI process
to be able to relocate the file if it is being moved at some point, we also send
bookmark data for the URL. Additionally, this patch adds a URL parameter to the
decidePlaceholderPolicy delegate completion handler, since a client should be able
to specify a custom URL if it chooses to manage the placeholder on its own.

* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
(WebKit::Download::didFinish):
* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp:
(WebKit::DownloadManager::publishDownloadProgress):
(WebKit::DownloadManager::clientReceivedPlaceholderURL): Deleted.
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::publishProgress):
(WebKit::Download::setPlaceholderURL):
(WebKit::Download::setFinalURL):
(WebKit::Download::startUpdatingProgress const):
(WebKit::Download::clientReceivedPlaceholderURL): Deleted.
(WebKit::Download::startObservingProgress const): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::publishDownloadProgress):
(WebKit::NetworkProcess::clientReceivedPlaceholderURL): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/API/APIDownloadClient.h:
(API::DownloadClient::didReceivePlaceholderURL):
(API::DownloadClient::didReceiveFinalURL):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegatePrivate.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in:
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::didReceivePlaceholderURL):
(WebKit::DownloadProxy::didReceiveFinalURL):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(-[ProgressObserver init]):
(-[ProgressObserver observeValueForKeyPath:ofObject:change:context:]):
(-[ProgressObserver waitForProgress]):
(tempFileThatDoesExist):
(TestWebKitAPI::PlaceholderPolicyEnable)):
(TestWebKitAPI::PlaceholderPolicyDisable)):
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm:
(-[TestDownloadDelegate _download:didReceivePlaceholderURL:completionHandler:]):
(-[TestDownloadDelegate _download:didReceiveFinalURL:]):

Canonical link: <a href="https://commits.webkit.org/283386@main">https://commits.webkit.org/283386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0396d90433fe518800195a8196f0d513e2114f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17037 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33723 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14645 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15632 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10101 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60691 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1977 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10013 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->