### PR TITLE
Port DownloadID from LegacyNullableObjectIdentifier to ObjectIdentifier

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -61,8 +61,6 @@ Download::Download(DownloadManager& downloadManager, DownloadID downloadID, Netw
     , m_sessionID(session.sessionID())
     , m_testSpeedMultiplier(session.testSpeedMultiplier())
 {
-    ASSERT(m_downloadID);
-
     m_downloadManager.didCreateDownload();
 }
 
@@ -75,8 +73,6 @@ Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NSUR
     , m_sessionID(session.sessionID())
     , m_testSpeedMultiplier(session.testSpeedMultiplier())
 {
-    ASSERT(m_downloadID);
-
     m_downloadManager.didCreateDownload();
 }
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadID.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadID.h
@@ -32,6 +32,6 @@ namespace WebKit {
 enum class AllowOverwrite : bool { No, Yes };
 
 enum class DownloadIdentifierType { };
-using DownloadID = LegacyNullableObjectIdentifier<DownloadIdentifierType>;
+using DownloadID = ObjectIdentifier<DownloadIdentifierType>;
 
 }

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -125,7 +125,7 @@ void PendingDownload::didReceiveResponse(WebCore::ResourceResponse&& response, P
 
 uint64_t PendingDownload::messageSenderDestinationID() const
 {
-    return m_networkLoad->pendingDownloadID().toUInt64();
+    return m_networkLoad->pendingDownloadID()->toUInt64();
 }
     
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -121,12 +121,11 @@ public:
     NetworkDataTaskClient* client() const { return m_client.get(); }
     void clearClient() { m_client = nullptr; }
 
-    DownloadID pendingDownloadID() const { return m_pendingDownloadID; }
+    std::optional<DownloadID> pendingDownloadID() const { return m_pendingDownloadID.asOptional(); }
     PendingDownload* pendingDownload() const;
     void setPendingDownloadID(DownloadID downloadID)
     {
         ASSERT(!m_pendingDownloadID);
-        ASSERT(downloadID);
         m_pendingDownloadID = downloadID;
     }
     void setPendingDownload(PendingDownload&);
@@ -175,7 +174,7 @@ protected:
     WeakPtr<NetworkSession> m_session;
     WeakPtr<NetworkDataTaskClient> m_client;
     WeakPtr<PendingDownload> m_pendingDownload;
-    DownloadID m_pendingDownloadID;
+    Markable<DownloadID> m_pendingDownloadID;
     String m_user;
     String m_password;
     String m_partition;

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -451,9 +451,9 @@ void NetworkDataTaskBlob::download()
     }
 
     auto& downloadManager = m_networkProcess->downloadManager();
-    auto download = makeUnique<Download>(downloadManager, m_pendingDownloadID, *this, *m_session, suggestedFilename());
+    auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
     auto* downloadPtr = download.get();
-    downloadManager.dataTaskBecameDownloadTask(m_pendingDownloadID, WTFMove(download));
+    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
     downloadPtr->didCreateDestination(m_pendingDownloadLocation);
 
     ASSERT(!m_client);
@@ -472,7 +472,7 @@ bool NetworkDataTaskBlob::writeDownload(std::span<const uint8_t> data)
     }
 
     m_downloadBytesWritten += bytesWritten;
-    auto* download = m_networkProcess->downloadManager().download(m_pendingDownloadID);
+    auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
     download->didReceiveData(bytesWritten, m_downloadBytesWritten, m_totalSize);
     return true;
@@ -502,7 +502,7 @@ void NetworkDataTaskBlob::didFailDownload(const ResourceError& error)
     if (m_client)
         m_client->didCompleteWithError(error);
     else {
-        auto* download = m_networkProcess->downloadManager().download(m_pendingDownloadID);
+        auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
         ASSERT(download);
         download->didFail(error, { });
     }
@@ -522,7 +522,7 @@ void NetworkDataTaskBlob::didFinishDownload()
     }
 
     clearStream();
-    auto* download = m_networkProcess->downloadManager().download(m_pendingDownloadID);
+    auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
     download->didFinish();
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -173,9 +173,9 @@ void NetworkDataTaskDataURL::downloadDecodedData(Vector<uint8_t>&& data)
     }
 
     auto& downloadManager = m_session->networkProcess().downloadManager();
-    auto download = makeUnique<Download>(downloadManager, m_pendingDownloadID, *this, *m_session, suggestedFilename());
+    auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
     auto* downloadPtr = download.get();
-    downloadManager.dataTaskBecameDownloadTask(m_pendingDownloadID, WTFMove(download));
+    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
     downloadPtr->didCreateDestination(m_pendingDownloadLocation);
 
     if (-1 == FileSystem::writeToFile(downloadDestinationFile, data.span())) {

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -75,7 +75,7 @@ public:
     void setPendingDownloadID(DownloadID);
     void setSuggestedFilename(const String&);
     void setPendingDownload(PendingDownload&);
-    DownloadID pendingDownloadID() { return m_task->pendingDownloadID(); }
+    std::optional<DownloadID> pendingDownloadID() { return m_task->pendingDownloadID(); }
 
     bool shouldCaptureExtraNetworkLoadMetrics() const final;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -202,7 +202,7 @@ void ServiceWorkerDownloadTask::didReceiveData(const IPC::SharedBufferReference&
 
     callOnMainRunLoop([this, protectedThis = Ref { *this }, bytesWritten] {
         m_downloadBytesWritten += bytesWritten;
-        if (auto* download = m_networkProcess->downloadManager().download(m_pendingDownloadID))
+        if (auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID))
             download->didReceiveData(bytesWritten, m_downloadBytesWritten, std::max(m_expectedContentLength.value_or(0), m_downloadBytesWritten));
     });
 }
@@ -230,7 +230,7 @@ void ServiceWorkerDownloadTask::didFinish()
         if (RefPtr sandboxExtension = std::exchange(m_sandboxExtension, nullptr))
             sandboxExtension->revoke();
 
-        if (auto download = m_networkProcess->downloadManager().download(m_pendingDownloadID))
+        if (auto download = m_networkProcess->downloadManager().download(*m_pendingDownloadID))
             download->didFinish();
 
         if (m_client)
@@ -265,7 +265,7 @@ void ServiceWorkerDownloadTask::didFailDownload(std::optional<ResourceError>&& e
             sandboxExtension->revoke();
 
         auto resourceError = error.value_or(cancelledError(firstRequest()));
-        if (auto download = m_networkProcess->downloadManager().download(m_pendingDownloadID))
+        if (auto download = m_networkProcess->downloadManager().download(*m_pendingDownloadID))
             download->didFail(resourceError, { });
 
         if (m_client)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -729,8 +729,8 @@ static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, Se
     if (!_sessionWrapper)
         return nullptr;
 
-    if (auto downloadID = _sessionWrapper->downloadMap.get(task.taskIdentifier)) {
-        if (auto download = _session->networkProcess().downloadManager().download(downloadID))
+    if (auto downloadID = _sessionWrapper->downloadMap.getOptional(task.taskIdentifier)) {
+        if (auto download = _session->networkProcess().downloadManager().download(*downloadID))
             return static_cast<NetworkSessionCocoa*>(_session->networkProcess().networkSession(download->sessionID()));
         return nullptr;
     }
@@ -923,12 +923,12 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
     } else if (error) {
         if (!_sessionWrapper)
             return;
-        auto downloadID = _sessionWrapper->downloadMap.take(task.taskIdentifier);
+        auto downloadID = _sessionWrapper->downloadMap.takeOptional(task.taskIdentifier);
         if (!downloadID)
             return;
         if (!_session)
             return;
-        auto* download = _session->networkProcess().downloadManager().download(downloadID);
+        auto* download = _session->networkProcess().downloadManager().download(*downloadID);
         if (!download)
             return;
 
@@ -1145,12 +1145,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     if (!_sessionWrapper)
         return;
-    auto downloadID = _sessionWrapper->downloadMap.take([downloadTask taskIdentifier]);
+    auto downloadID = _sessionWrapper->downloadMap.takeOptional([downloadTask taskIdentifier]);
     if (!downloadID)
         return;
     if (!_session)
         return;
-    auto* download = _session->networkProcess().downloadManager().download(downloadID);
+    auto* download = _session->networkProcess().downloadManager().download(*downloadID);
     if (!download)
         return;
     download->didFinish();
@@ -1162,12 +1162,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (!_sessionWrapper)
         return;
-    auto downloadID = _sessionWrapper->downloadMap.get([downloadTask taskIdentifier]);
+    auto downloadID = _sessionWrapper->downloadMap.getOptional([downloadTask taskIdentifier]);
     if (!downloadID)
         return;
     if (!_session)
         return;
-    auto* download = _session->networkProcess().downloadManager().download(downloadID);
+    auto* download = _session->networkProcess().downloadManager().download(*downloadID);
     if (!download)
         return;
     download->didReceiveData(bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
@@ -1183,7 +1183,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 
     Ref<NetworkDataTaskCocoa> protectedNetworkDataTask(*networkDataTask);
-    auto downloadID = networkDataTask->pendingDownloadID();
+    auto downloadID = *networkDataTask->pendingDownloadID();
     auto& downloadManager = sessionCocoa->networkProcess().downloadManager();
     auto download = makeUnique<WebKit::Download>(downloadManager, downloadID, downloadTask, *sessionCocoa, networkDataTask->suggestedFilename());
     networkDataTask->transferSandboxExtensionToDownload(*download);
@@ -1838,9 +1838,8 @@ void NetworkSessionCocoa::continueDidReceiveChallenge(SessionWrapper& sessionWra
             networkProcess().authenticationManager().didReceiveAuthenticationChallenge(sessionID(), webSocketTask->webProxyPageID(), !webSocketTask->topOrigin().isNull() ? &webSocketTask->topOrigin() : nullptr, challenge, negotiatedLegacyTLS, WTFMove(challengeCompletionHandler));
             return;
         }
-        auto downloadID = sessionWrapper.downloadMap.get(taskIdentifier);
-        if (downloadID) {
-            if (auto* download = networkProcess().downloadManager().download(downloadID)) {
+        if (auto downloadID = sessionWrapper.downloadMap.getOptional(taskIdentifier)) {
+            if (auto* download = networkProcess().downloadManager().download(*downloadID)) {
                 WebCore::AuthenticationChallenge authenticationChallenge { challenge };
                 // Received an authentication challenge for a download being resumed.
                 download->didReceiveChallenge(authenticationChallenge, WTFMove(completionHandler));

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -195,7 +195,7 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&& b
         return;
 
     if (isDownload()) {
-        auto* download = m_session->networkProcess().downloadManager().download(m_pendingDownloadID);
+        auto* download = m_session->networkProcess().downloadManager().download(*m_pendingDownloadID);
         RELEASE_ASSERT(download);
         uint64_t bytesWritten = 0;
         for (auto& segment : buffer.get()) {
@@ -220,7 +220,7 @@ void NetworkDataTaskCurl::curlDidComplete(CurlRequest&, NetworkLoadMetrics&& net
         return;
 
     if (isDownload()) {
-        auto* download = m_session->networkProcess().downloadManager().download(m_pendingDownloadID);
+        auto* download = m_session->networkProcess().downloadManager().download(*m_pendingDownloadID);
         RELEASE_ASSERT(download);
         FileSystem::closeFile(m_downloadDestinationFile);
         m_downloadDestinationFile = FileSystem::invalidPlatformFileHandle;
@@ -245,7 +245,7 @@ void NetworkDataTaskCurl::curlDidFailWithError(CurlRequest& request, ResourceErr
 
     if (isDownload()) {
         deleteDownloadFile();
-        auto* download = m_session->networkProcess().downloadManager().download(m_pendingDownloadID);
+        auto* download = m_session->networkProcess().downloadManager().download(*m_pendingDownloadID);
         RELEASE_ASSERT(download);
         download->didFail(resourceError, { });
         return;
@@ -314,9 +314,9 @@ void NetworkDataTaskCurl::invokeDidReceiveResponse()
             }
 
             auto& downloadManager = m_session->networkProcess().downloadManager();
-            auto download = makeUnique<Download>(downloadManager, m_pendingDownloadID, *this, *m_session, suggestedFilename());
+            auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
             auto* downloadPtr = download.get();
-            downloadManager.dataTaskBecameDownloadTask(m_pendingDownloadID, WTFMove(download));
+            downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
             downloadPtr->didCreateDestination(m_pendingDownloadLocation);
             if (m_curlRequest)
                 m_curlRequest->completeDidReceiveResponse();

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1396,9 +1396,9 @@ void NetworkDataTaskSoup::download()
     m_downloadOutputStream = adoptGRef(G_OUTPUT_STREAM(outputStream.leakRef()));
 
     auto& downloadManager = m_session->networkProcess().downloadManager();
-    auto download = makeUnique<Download>(downloadManager, m_pendingDownloadID, *this, *m_session, suggestedFilename());
+    auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
     auto* downloadPtr = download.get();
-    downloadManager.dataTaskBecameDownloadTask(m_pendingDownloadID, WTFMove(download));
+    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
     downloadPtr->didCreateDestination(m_pendingDownloadLocation);
 
     ASSERT(!m_client);
@@ -1433,7 +1433,7 @@ void NetworkDataTaskSoup::writeDownload()
 void NetworkDataTaskSoup::didWriteDownload(gsize bytesWritten)
 {
     ASSERT(bytesWritten == m_readBuffer.size());
-    auto* download = m_session->networkProcess().downloadManager().download(m_pendingDownloadID);
+    auto* download = m_session->networkProcess().downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
     download->didReceiveData(bytesWritten, 0, 0);
     read();
@@ -1461,7 +1461,7 @@ void NetworkDataTaskSoup::didFinishDownload()
     g_file_set_attributes_async(m_downloadDestinationFile.get(), info.get(), G_FILE_QUERY_INFO_NONE, RunLoopSourcePriority::AsyncIONetwork, nullptr, nullptr, nullptr);
 
     clearRequest();
-    auto* download = m_session->networkProcess().downloadManager().download(m_pendingDownloadID);
+    auto* download = m_session->networkProcess().downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
     download->didFinish();
 }
@@ -1473,7 +1473,7 @@ void NetworkDataTaskSoup::didFailDownload(const ResourceError& error)
     if (m_client)
         dispatchDidCompleteWithError(error);
     else {
-        auto* download = m_session->networkProcess().downloadManager().download(m_pendingDownloadID);
+        auto* download = m_session->networkProcess().downloadManager().download(*m_pendingDownloadID);
         ASSERT(download);
         download->didFail(error, { });
     }

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -72,7 +72,6 @@ template: enum class WebCore::TextManipulationItemIdentifierType
 template: enum class WebCore::TextManipulationTokenIdentifierType
 template: enum class WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
 template: enum class WebKit::ContentWorldIdentifierType
-template: enum class WebKit::DownloadIdentifierType
 template: enum class WebKit::ImageAnalysisRequestIdentifierType
 template: enum class WebKit::MediaDevicePermissionRequestIdentifierType
 template: enum class WebKit::MediaRecorderIdentifierType
@@ -159,6 +158,7 @@ template: enum class WebCore::SWServerToContextConnectionIdentifierType
 template: enum class WebCore::SharedWorkerIdentifierType
 template: enum class WebCore::WindowIdentifierType
 template: enum class WebCore::WorkletGlobalScopeIdentifierType
+template: enum class WebKit::DownloadIdentifierType
 template: struct WebCore::NavigationIdentifierType
 template: struct WebCore::PlatformLayerIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {


### PR DESCRIPTION
#### b1b2371bc0d440f5eab8a05e9d84871a19527442
<pre>
Port DownloadID from LegacyNullableObjectIdentifier to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=278694">https://bugs.webkit.org/show_bug.cgi?id=278694</a>

Reviewed by Sihui Liu.

* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
(WebKit::Download::Download):
* Source/WebKit/NetworkProcess/Downloads/DownloadID.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::messageSenderDestinationID const):
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::pendingDownloadID const):
(WebKit::NetworkDataTask::setPendingDownloadID):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::download):
(WebKit::NetworkDataTaskBlob::writeDownload):
(WebKit::NetworkDataTaskBlob::didFailDownload):
(WebKit::NetworkDataTaskBlob::didFinishDownload):
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::findPendingDownloadLocation):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::didReceiveData):
(WebKit::ServiceWorkerDownloadTask::didFinish):
(WebKit::ServiceWorkerDownloadTask::didFailDownload):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate sessionFromTask:]):
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):
(-[WKNetworkSessionDelegate URLSession:downloadTask:didFinishDownloadingToURL:]):
(-[WKNetworkSessionDelegate URLSession:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didBecomeDownloadTask:]):
(WebKit::NetworkSessionCocoa::continueDidReceiveChallenge):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/282786@main">https://commits.webkit.org/282786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df1666a801c3a8d22b4f3df0a57dbf5bba0c63b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68279 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51711 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10246 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36991 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13739 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59196 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/465 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39434 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->