### PR TITLE
Web Inspector: add support for `ignoreList` in sourcemaps

### DIFF
--- a/LayoutTests/inspector/debugger/resources/source-map.js.map
+++ b/LayoutTests/inspector/debugger/resources/source-map.js.map
@@ -11,5 +11,6 @@
         "import { middle } from \"./middle.js\"\n\nglobalThis.outer = function(x) {\n    let y = \"outer\";\n    y += middle(x);\n    return y;\n};\n"
     ],
     "mappings": "MAAO,SAASA,EAAMC,EAAG,CACrB,MAAO,QAAUA,CACrB,CCAO,SAASC,EAAOC,EAAG,CACtB,IAAIC,EAAI,SACR,OAAAA,GAAKC,EAAMF,CAAC,EACLC,CACX,CCJA,WAAW,MAAQ,SAASE,EAAG,CAC3B,IAAIC,EAAI,QACR,OAAAA,GAAKC,EAAOF,CAAC,EACNC,CACX",
-    "names": ["inner", "x", "middle", "x", "y", "inner", "x", "y", "middle"]
+    "names": ["inner", "x", "middle", "x", "y", "inner", "x", "y", "middle"],
+    "ignoreList": [1]
 }

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner-expected.txt
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner-expected.txt
@@ -9,22 +9,6 @@ Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
 Triggering pause...
-PAUSE AT n:3:8
-      0    import { inner } from "./inner.js"
-      1
- ->   2    export |function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
-      5        return y;
-
-PAUSE AT t:6:12
-      2    export function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
- ->   5        return |y;
-      6    }
-      7
-
 PAUSE AT t:3:1
       0    import { middle } from "./middle.js"
       1
@@ -56,7 +40,6 @@ Unblackboxing script...
 
 -- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.middle
 Fetching scripts...
-Blackboxing script...
 Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
@@ -94,7 +77,6 @@ PAUSE AT Global Code:1:10
 --- Source Unavailable ---
 
 Removing breakpoint...
-Unblackboxing script...
 
 -- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.outer
 Fetching scripts...
@@ -108,22 +90,6 @@ PAUSE AT n:2:5
  ->   1        |return "inner" + x;
       2    }
       3
-
-PAUSE AT n:3:8
-      0    import { inner } from "./inner.js"
-      1
- ->   2    export |function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
-      5        return y;
-
-PAUSE AT t:6:12
-      2    export function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
- ->   5        return |y;
-      6    }
-      7
 
 PAUSE AT Global Code:1:10
 --- Source Unavailable ---

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner.html
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner.html
@@ -78,10 +78,7 @@ function test()
         name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.middle",
         async test() {
             InspectorTest.log("Fetching scripts...");
-            let {inner, middle} = await getResources();
-
-            InspectorTest.log("Blackboxing script...");
-            WI.debuggerManager.setShouldBlackboxScript(middle, true);
+            let {inner} = await getResources();
 
             InspectorTest.log("Finding pause location...");
             let location = inner.createSourceCodeLocation(1, 0); // first line of `inner`
@@ -100,9 +97,6 @@ function test()
 
             InspectorTest.log("Removing breakpoint...");
             WI.debuggerManager.removeBreakpoint(breakpoint);
-
-            InspectorTest.log("Unblackboxing script...");
-            WI.debuggerManager.setShouldBlackboxScript(middle, false);
         },
     });
 

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle-expected.txt
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle-expected.txt
@@ -9,49 +9,6 @@ Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
 Triggering pause...
-PAUSE AT t:4:5
-      0    import { inner } from "./inner.js"
-      1
-      2    export function middle(x) {
- ->   3        |let y = "middle";
-      4        y += inner(x);
-      5        return y;
-      6    }
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
-PAUSE AT n:3:8
-      0    import { inner } from "./inner.js"
-      1
- ->   2    export |function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
-      5        return y;
-
-PAUSE AT t:6:12
-      2    export function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
- ->   5        return |y;
-      6    }
-      7
-
 PAUSE AT t:3:1
       0    import { middle } from "./middle.js"
       1
@@ -83,7 +40,6 @@ Unblackboxing script...
 
 -- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.middle
 Fetching scripts...
-Blackboxing script...
 Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
@@ -121,7 +77,6 @@ PAUSE AT Global Code:1:10
 --- Source Unavailable ---
 
 Removing breakpoint...
-Unblackboxing script...
 
 -- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.outer
 Fetching scripts...
@@ -130,54 +85,11 @@ Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
 Triggering pause...
-PAUSE AT t:4:5
-      0    import { inner } from "./inner.js"
-      1
-      2    export function middle(x) {
- ->   3        |let y = "middle";
-      4        y += inner(x);
-      5        return y;
-      6    }
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
 PAUSE AT n:2:5
       0    export function inner(x) {
  ->   1        |return "inner" + x;
       2    }
       3
-
-PAUSE AT n:3:8
-      0    import { inner } from "./inner.js"
-      1
- ->   2    export |function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
-      5        return y;
-
-PAUSE AT t:6:12
-      2    export function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
- ->   5        return |y;
-      6    }
-      7
 
 PAUSE AT Global Code:1:10
 --- Source Unavailable ---

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle.html
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle.html
@@ -80,9 +80,6 @@ function test()
             InspectorTest.log("Fetching scripts...");
             let {middle} = await getResources();
 
-            InspectorTest.log("Blackboxing script...");
-            WI.debuggerManager.setShouldBlackboxScript(middle, true);
-
             InspectorTest.log("Finding pause location...");
             let location = middle.createSourceCodeLocation(3, 0); // first line of `middle`
 
@@ -100,9 +97,6 @@ function test()
 
             InspectorTest.log("Removing breakpoint...");
             WI.debuggerManager.removeBreakpoint(breakpoint);
-
-            InspectorTest.log("Unblackboxing script...");
-            WI.debuggerManager.setShouldBlackboxScript(middle, false);
         },
     });
 

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer-expected.txt
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer-expected.txt
@@ -36,49 +36,6 @@ PAUSE AT <anonymous>:5:5
       6    };
       7
 
-PAUSE AT t:4:5
-      0    import { inner } from "./inner.js"
-      1
-      2    export function middle(x) {
- ->   3        |let y = "middle";
-      4        y += inner(x);
-      5        return y;
-      6    }
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
-PAUSE AT n:3:8
-      0    import { inner } from "./inner.js"
-      1
- ->   2    export |function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
-      5        return y;
-
-PAUSE AT t:6:12
-      2    export function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
- ->   5        return |y;
-      6    }
-      7
-
 PAUSE AT t:3:1
       0    import { middle } from "./middle.js"
       1
@@ -110,7 +67,6 @@ Unblackboxing script...
 
 -- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.middle
 Fetching scripts...
-Blackboxing script...
 Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
@@ -175,7 +131,6 @@ PAUSE AT Global Code:1:10
 --- Source Unavailable ---
 
 Removing breakpoint...
-Unblackboxing script...
 
 -- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.outer
 Fetching scripts...
@@ -184,54 +139,11 @@ Finding pause location...
 Creating breakpoint...
 Adding breakpoint...
 Triggering pause...
-PAUSE AT t:4:5
-      0    import { inner } from "./inner.js"
-      1
-      2    export function middle(x) {
- ->   3        |let y = "middle";
-      4        y += inner(x);
-      5        return y;
-      6    }
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
-PAUSE AT t:5:5
-      1
-      2    export function middle(x) {
-      3        let y = "middle";
- ->   4        |y += inner(x);
-      5        return y;
-      6    }
-      7
-
 PAUSE AT n:2:5
       0    export function inner(x) {
  ->   1        |return "inner" + x;
       2    }
       3
-
-PAUSE AT n:3:8
-      0    import { inner } from "./inner.js"
-      1
- ->   2    export |function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
-      5        return y;
-
-PAUSE AT t:6:12
-      2    export function middle(x) {
-      3        let y = "middle";
-      4        y += inner(x);
- ->   5        return |y;
-      6    }
-      7
 
 PAUSE AT Global Code:1:10
 --- Source Unavailable ---

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer.html
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer.html
@@ -78,10 +78,7 @@ function test()
         name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.middle",
         async test() {
             InspectorTest.log("Fetching scripts...");
-            let {middle, outer} = await getResources();
-
-            InspectorTest.log("Blackboxing script...");
-            WI.debuggerManager.setShouldBlackboxScript(middle, true);
+            let {outer} = await getResources();
 
             InspectorTest.log("Finding pause location...");
             let location = outer.createSourceCodeLocation(3, 0); // first line of `outer`
@@ -100,9 +97,6 @@ function test()
 
             InspectorTest.log("Removing breakpoint...");
             WI.debuggerManager.removeBreakpoint(breakpoint);
-
-            InspectorTest.log("Unblackboxing script...");
-            WI.debuggerManager.setShouldBlackboxScript(middle, false);
         },
     });
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -552,6 +552,9 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
     blackboxDataForSourceCode(sourceCode)
     {
+        if (sourceCode instanceof WI.SourceMapResource && sourceCode.ignored)
+            return {type: DebuggerManager.BlackboxType.URL};
+
         for (let regex of this._blackboxedPatternDataMap.keys()) {
             if (regex.test(sourceCode.contentIdentifier))
                 return {type: DebuggerManager.BlackboxType.Pattern, regex};
@@ -578,6 +581,9 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         this._blackboxedURLsSetting.value.toggleIncludes(sourceCode.contentIdentifier, shouldBlackbox);
         this._blackboxedURLsSetting.save();
+
+        if (!shouldBlackbox && sourceCode instanceof WI.SourceMapResource)
+            sourceCode.ignored = false;
 
         this._updateBlackbox(WI.targets, sourceCode);
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -1579,9 +1579,6 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         this._sourceMapURLMap.set(sourceMapURL, sourceMap);
 
-        for (let source of sourceMap.sources())
-            sourceMap.addResource(new WI.SourceMapResource(source, sourceMap));
-
         // Associate the SourceMap with the originalSourceCode.
         sourceMap.originalSourceCode.addSourceMap(sourceMap);
 

--- a/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
@@ -25,7 +25,7 @@
 
 WI.SourceMapResource = class SourceMapResource extends WI.Resource
 {
-    constructor(url, sourceMap)
+    constructor(url, sourceMap, {ignored} = {})
     {
         super(url);
 
@@ -33,6 +33,7 @@ WI.SourceMapResource = class SourceMapResource extends WI.Resource
         console.assert(sourceMap);
 
         this._sourceMap = sourceMap;
+        this._ignored = ignored || false;
 
         var inheritedMIMEType = this._sourceMap.originalSourceCode instanceof WI.Resource ? this._sourceMap.originalSourceCode.syntheticMIMEType : null;
 
@@ -54,6 +55,9 @@ WI.SourceMapResource = class SourceMapResource extends WI.Resource
     // Public
 
     get sourceMap() { return this._sourceMap; }
+
+    get ignored() { return this._ignored; }
+    set ignored(ignored) { this._ignored = ignored; }
 
     get sourceMapDisplaySubpath()
     {


### PR DESCRIPTION
#### 33603fbb606c9966fb1e5a6fdcd2caba8e027f1b
<pre>
Web Inspector: add support for `ignoreList` in sourcemaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=275673">https://bugs.webkit.org/show_bug.cgi?id=275673</a>

Reviewed by Yusuke Suzuki.

This allows source map generating tools to specify a new `ignoreList` top-level property that will cause Web Inspector to ignore/blackbox the corresponding resource (with each value being an index in the `sources` top-level property) by default.

For example, this could be used to automatically mark any sources loaded from `node_modules` as being ignored by default since that&apos;s usually not 1st party code.

* Source/WebInspectorUI/UserInterface/Models/SourceMap.js:
(WI.SourceMap):
(WI.SourceMap.prototype.get resources):
(WI.SourceMap.prototype.resourceForURL):
(WI.SourceMap.prototype.calculateBlackboxSourceRangesForProtocol):
(WI.SourceMap.prototype._parseMap):
(WI.SourceMap.prototype.addResource): Deleted.
(WI.SourceMap.prototype.sources): Deleted.
* Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js:
(WI.SourceMapResource):
(WI.SourceMapResource.prototype.get ignored): Added.
(WI.SourceMapResource.prototype.set ignored): Added.
Parse `ignoreList` and store whether a given resource should be ignored/blackboxed by default.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.blackboxDataForSourceCode):
(WI.DebuggerManager.prototype.setShouldBlackboxScript):
If a `WI.SourceMapResource` is ignored/blackboxed by default, treat it as though it was `WI.DebuggerManager.BlackboxType.URL`.
Also allow the developer to un-ignore the `WI.SourceMapResource` to allow pausing in it if they &quot;disagree&quot; with the source map.

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype._sourceMapLoadAndParseSucceeded):
Drive-by: Adjust how `WI.SourceMapResource` are associated with `WI.SourceMap`.

* LayoutTests/inspector/debugger/resources/source-map.js.map:
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner.html:
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner-expected.txt:
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle.html:
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle-expected.txt:
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer.html:
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer-expected.txt:

Canonical link: <a href="https://commits.webkit.org/283903@main">https://commits.webkit.org/283903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff0654ef2bf2ccf66ab0a62e364421bbe5dd318

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51710 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10248 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32329 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69979 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59033 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55692 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59193 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15043 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/468 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39435 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->