### PR TITLE
[JSC] Remove unnecessary memmove and strlen for dragonbox ToShortest

### DIFF
--- a/Source/WTF/wtf/dragonbox/dragonbox_to_chars.h
+++ b/Source/WTF/wtf/dragonbox/dragonbox_to_chars.h
@@ -140,8 +140,8 @@ void ToExponential(Float value, StringBuilder* result_builder)
     ASSERT((std::is_same<Float, double>::value) || (std::is_same<Float, float>::value));
     constexpr size_t buffer_length = 1 + (std::is_same<Float, float>::value ? to_exponential_max_string_length<ieee754_binary32>() : to_exponential_max_string_length<ieee754_binary64>());
     char buffer[buffer_length];
-    detail::to_chars<Mode::ToExponential>(value, buffer);
-    result_builder->AddString(buffer);
+    auto* cursor = detail::to_chars_n<Mode::ToExponential>(value, buffer);
+    result_builder->AddSubstring(buffer, cursor - buffer);
 }
 
 // See `ToShortest` in double-conversion.h for detailed definitons.
@@ -151,8 +151,8 @@ void ToShortest(Float value, StringBuilder* result_builder)
     ASSERT((std::is_same<Float, double>::value) || (std::is_same<Float, float>::value));
     constexpr size_t buffer_length = 1 + (std::is_same<Float, float>::value ? max_string_length<ieee754_binary32>() : max_string_length<ieee754_binary64>());
     char buffer[buffer_length];
-    detail::to_chars<Mode::ToShortest>(value, buffer);
-    result_builder->AddString(buffer);
+    auto* cursor = detail::to_chars_n<Mode::ToShortest>(value, buffer);
+    result_builder->AddSubstring(buffer, cursor - buffer);
 }
 
 } // namespace dragonbox


### PR DESCRIPTION
#### 77992f06d88e04b09ba1e097b8297932df5305c1
<pre>
[JSC] Remove unnecessary memmove and strlen for dragonbox ToShortest
<a href="https://bugs.webkit.org/show_bug.cgi?id=278703">https://bugs.webkit.org/show_bug.cgi?id=278703</a>
<a href="https://rdar.apple.com/134763943">rdar://134763943</a>

Reviewed by Yijia Huang.

1. dragonbox::ToExponential / dragonbox::ToShortest were doing unnecessary strlen. This patch removes it.
2. FastStringifier employs dragonbox::to_char_n directly so that we remove one more unnecessary memmove observed in the profile.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):
* Source/WTF/wtf/dragonbox/dragonbox_to_chars.h:
(WTF::dragonbox::ToExponential):
(WTF::dragonbox::ToShortest):

Canonical link: <a href="https://commits.webkit.org/282798@main">https://commits.webkit.org/282798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeb6a52085eb798c9c965bb3536f49db03ff8ff3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68297 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14883 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51727 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10266 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13757 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57387 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69996 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63520 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59049 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59212 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/479 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85281 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9743 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39452 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15039 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->