### PR TITLE
Adopt some more smart pointers in DOM code

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -505,9 +505,9 @@ void DocumentMarkerController::forEach<DocumentMarkerController::IterationDirect
         return;
     ASSERT(!m_markers.isEmpty());
 
-    for (auto& node : intersectingNodes(range)) {
-        if (auto list = m_markers.get(&node)) {
-            auto offsetRange = characterDataOffsetRange(range, node);
+    for (Ref node : intersectingNodes(range)) {
+        if (auto list = m_markers.get(node.ptr())) {
+            auto offsetRange = characterDataOffsetRange(range, node.get());
             for (auto& marker : *list) {
                 // Markers are stored in order, so stop if we are now past the specified range.
                 if (marker.startOffset() >= offsetRange.end)

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -362,8 +362,8 @@ void EventLoop::forEachAssociatedContext(const Function<void(ScriptExecutionCont
 
 bool EventLoop::findMatchingAssociatedContext(const Function<bool(ScriptExecutionContext&)>& predicate)
 {
-    for (auto& context : m_associatedContexts) {
-        if (predicate(context))
+    for (Ref context : m_associatedContexts) {
+        if (predicate(context.get()))
             return true;
     }
     return false;

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -80,13 +80,13 @@ CSSStyleSheet* ExtensionStyleSheets::pageUserSheet()
     if (m_pageUserSheet)
         return m_pageUserSheet.get();
     
-    Page* owningPage = m_document->page();
+    RefPtr owningPage = m_document->page();
     if (!owningPage)
-        return 0;
+        return nullptr;
     
     String userSheetText = owningPage->userStyleSheet();
     if (userSheetText.isEmpty())
-        return 0;
+        return nullptr;
     
     m_pageUserSheet = createExtensionsStyleSheet(protectedDocument().get(), m_document->settings().userStyleSheetLocation(), userSheetText, UserStyleLevel::User);
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -230,7 +230,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
                 return;
             }
 
-            auto page = this->page();
+            RefPtr page = this->page();
             if (!page || (this->document().hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) || m_pendingFullscreenElement != element.ptr() || !element->isConnected()) {
                 handleError("Invalid state when requesting fullscreen."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
                 return;
@@ -436,7 +436,7 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
         if (mode == ExitMode::Resize)
             unfullscreenDocument(exitDocument);
         else {
-            auto fullscreenElement = exitDocument->fullscreenManager().fullscreenElement();
+            RefPtr fullscreenElement = exitDocument->fullscreenManager().fullscreenElement();
             clearFullscreenFlags(*fullscreenElement);
             fullscreenElement->removeFromTopLayer();
         }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -889,7 +889,7 @@ Node::Editability Node::computeEditabilityWithStyle(const RenderStyle* incomingS
             return incomingStyle;
         if (isDocumentNode())
             return renderStyle();
-        auto* element = dynamicDowncast<Element>(*this);
+        RefPtr element = dynamicDowncast<Element>(*this);
         if (!element)
             element = parentElementInComposedTree();
         return element ? const_cast<Element&>(*element).computedStyleForEditability() : nullptr;

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -177,7 +177,7 @@ void StyledElement::dirtyStyleAttribute()
 
 void StyledElement::invalidateStyleAttribute()
 {
-    if (auto* inlineStyle = this->inlineStyle()) {
+    if (RefPtr inlineStyle = this->inlineStyle()) {
         if (usesStyleBasedEditability(*inlineStyle))
             protectedDocument()->setHasElementUsingStyleBasedEditability();
     }


### PR DESCRIPTION
#### f98593ede9ba7582dedf768fb4f8d11cadb279ce
<pre>
Adopt some more smart pointers in DOM code
<a href="https://bugs.webkit.org/show_bug.cgi?id=278704">https://bugs.webkit.org/show_bug.cgi?id=278704</a>

Reviewed by Chris Dumez.

Addressing some assorted alpha.webkit.UncountedLocalVarsChecker
warnings.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationDirection::Forwards&gt;):
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::findMatchingAssociatedContext):
* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::ExtensionStyleSheets::pageUserSheet):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::finishExitFullscreen):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::computeEditabilityWithStyle const):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::invalidateStyleAttribute):

Canonical link: <a href="https://commits.webkit.org/282809@main">https://commits.webkit.org/282809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c3c174b6351b5430fd51c0e9e1aeb0bdc8291d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51767 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10300 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13035 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13805 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70044 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59089 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59254 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/522 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39500 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41762 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->