### PR TITLE
[JSC] Add JS-prefix to runtime/IteratorPrototype.h

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1040,7 +1040,6 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/Intrinsic.h
     runtime/IterationKind.h
     runtime/IteratorOperations.h
-    runtime/IteratorPrototype.h
     runtime/JSArray.h
     runtime/JSArrayInlines.h
     runtime/JSArrayBuffer.h
@@ -1086,6 +1085,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSInternalPromise.h
     runtime/JSIterator.h
     runtime/JSIteratorConstructor.h
+    runtime/JSIteratorPrototype.h
     runtime/JSLexicalEnvironment.h
     runtime/JSLock.h
     runtime/JSMap.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -864,7 +864,7 @@
 		276B38D92A71D26400252F4E /* JSAsyncGeneratorFunctionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B42A71D25A00252F4E /* JSAsyncGeneratorFunctionInlines.h */; };
 		276B38DA2A71D26400252F4E /* JSCalleeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B52A71D25A00252F4E /* JSCalleeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		276B38DB2A71D26400252F4E /* NumberConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B62A71D25A00252F4E /* NumberConstructorInlines.h */; };
-		276B38DC2A71D26400252F4E /* IteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B72A71D25B00252F4E /* IteratorPrototypeInlines.h */; };
+		276B38DC2A71D26400252F4E /* JSIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B72A71D25B00252F4E /* JSIteratorPrototypeInlines.h */; };
 		276B38DD2A71D26400252F4E /* JSCustomSetterFunctionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B82A71D25B00252F4E /* JSCustomSetterFunctionInlines.h */; };
 		276B38DE2A71D26400252F4E /* NullGetterFunctionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38B92A71D25B00252F4E /* NullGetterFunctionInlines.h */; };
 		276B38DF2A71D26400252F4E /* ProxyObjectInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38BA2A71D25B00252F4E /* ProxyObjectInlines.h */; };
@@ -1280,7 +1280,7 @@
 		70B791971C024A29002481E2 /* GeneratorFunctionPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 70B791881C024432002481E2 /* GeneratorFunctionPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70B791991C024A29002481E2 /* GeneratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 70B7918A1C024432002481E2 /* GeneratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70B7919C1C024A49002481E2 /* JSGeneratorFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 70B7918D1C024462002481E2 /* JSGeneratorFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		70DC3E0A1B2DF2C700054299 /* IteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 70DC3E081B2DF2C700054299 /* IteratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		70DC3E0A1B2DF2C700054299 /* JSIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 70DC3E081B2DF2C700054299 /* JSIteratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70EC0EC31AA0D7DA00B6AAFA /* JSStringIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 70EC0EBD1AA0D7DA00B6AAFA /* JSStringIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70EC0EC71AA0D7DA00B6AAFA /* StringIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 70EC0EC11AA0D7DA00B6AAFA /* StringIteratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70ECA6061AFDBEA200449739 /* JSTemplateObjectDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 70ECA6011AFDBEA200449739 /* JSTemplateObjectDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3841,7 +3841,7 @@
 		276B38B42A71D25A00252F4E /* JSAsyncGeneratorFunctionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSAsyncGeneratorFunctionInlines.h; sourceTree = "<group>"; };
 		276B38B52A71D25A00252F4E /* JSCalleeInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCalleeInlines.h; sourceTree = "<group>"; };
 		276B38B62A71D25A00252F4E /* NumberConstructorInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NumberConstructorInlines.h; sourceTree = "<group>"; };
-		276B38B72A71D25B00252F4E /* IteratorPrototypeInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IteratorPrototypeInlines.h; sourceTree = "<group>"; };
+		276B38B72A71D25B00252F4E /* JSIteratorPrototypeInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIteratorPrototypeInlines.h; sourceTree = "<group>"; };
 		276B38B82A71D25B00252F4E /* JSCustomSetterFunctionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCustomSetterFunctionInlines.h; sourceTree = "<group>"; };
 		276B38B92A71D25B00252F4E /* NullGetterFunctionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NullGetterFunctionInlines.h; sourceTree = "<group>"; };
 		276B38BA2A71D25B00252F4E /* ProxyObjectInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyObjectInlines.h; sourceTree = "<group>"; };
@@ -4459,8 +4459,8 @@
 		70B7918E1C0244C9002481E2 /* SourceCodeKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceCodeKey.h; sourceTree = "<group>"; };
 		70B7918F1C0244EC002481E2 /* GeneratorPrototype.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = GeneratorPrototype.js; sourceTree = "<group>"; };
 		70B791901C0246CE002481E2 /* GeneratorPrototype.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratorPrototype.lut.h; sourceTree = "<group>"; };
-		70DC3E071B2DF2C700054299 /* IteratorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IteratorPrototype.cpp; sourceTree = "<group>"; };
-		70DC3E081B2DF2C700054299 /* IteratorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IteratorPrototype.h; sourceTree = "<group>"; };
+		70DC3E071B2DF2C700054299 /* JSIteratorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSIteratorPrototype.cpp; sourceTree = "<group>"; };
+		70DC3E081B2DF2C700054299 /* JSIteratorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIteratorPrototype.h; sourceTree = "<group>"; };
 		70DE9A081BE7D670005D89D9 /* LLIntAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LLIntAssembly.h; sourceTree = "<group>"; };
 		70EC0EBC1AA0D7DA00B6AAFA /* JSStringIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSStringIterator.cpp; sourceTree = "<group>"; };
 		70EC0EBD1AA0D7DA00B6AAFA /* JSStringIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringIterator.h; sourceTree = "<group>"; };
@@ -8274,9 +8274,6 @@
 				8B9F6D551D5912FA001C739F /* IterationKind.h */,
 				70113D491A8DB093003848C4 /* IteratorOperations.cpp */,
 				70113D4A1A8DB093003848C4 /* IteratorOperations.h */,
-				70DC3E071B2DF2C700054299 /* IteratorPrototype.cpp */,
-				70DC3E081B2DF2C700054299 /* IteratorPrototype.h */,
-				276B38B72A71D25B00252F4E /* IteratorPrototypeInlines.h */,
 				93ADFCE60CCBD7AC00D30B08 /* JSArray.cpp */,
 				938772E5038BFE19008635CE /* JSArray.h */,
 				0F2B66B417B6B5AB00A7AE3F /* JSArrayBuffer.cpp */,
@@ -8391,6 +8388,9 @@
 				05517CA12C74004700ED0CD5 /* JSIterator.h */,
 				05517CA22C74004700ED0CD5 /* JSIteratorConstructor.cpp */,
 				05517CA02C74004700ED0CD5 /* JSIteratorConstructor.h */,
+				70DC3E071B2DF2C700054299 /* JSIteratorPrototype.cpp */,
+				70DC3E081B2DF2C700054299 /* JSIteratorPrototype.h */,
+				276B38B72A71D25B00252F4E /* JSIteratorPrototypeInlines.h */,
 				14DA818F0D99FD2000B0A4FB /* JSLexicalEnvironment.cpp */,
 				14DA818E0D99FD2000B0A4FB /* JSLexicalEnvironment.h */,
 				276B39032A71D2B300252F4E /* JSLexicalEnvironmentInlines.h */,
@@ -11117,8 +11117,6 @@
 				8B9F6D561D5912FA001C739F /* IterationKind.h in Headers */,
 				53D41EC923C0081A00AE984B /* IterationModeMetadata.h in Headers */,
 				70113D4C1A8DB093003848C4 /* IteratorOperations.h in Headers */,
-				70DC3E0A1B2DF2C700054299 /* IteratorPrototype.h in Headers */,
-				276B38DC2A71D26400252F4E /* IteratorPrototypeInlines.h in Headers */,
 				BC18C4130E16F5CD00B34460 /* JavaScript.h in Headers */,
 				A503FA1A188E0FB000110F14 /* JavaScriptCallFrame.h in Headers */,
 				1429D9300ED22D7000B89619 /* JIT.h in Headers */,
@@ -11267,6 +11265,8 @@
 				E33F50811B8429A400413856 /* JSInternalPromise.h in Headers */,
 				E33F50791B84225700413856 /* JSInternalPromiseConstructor.h in Headers */,
 				E33F50751B8421C000413856 /* JSInternalPromisePrototype.h in Headers */,
+				70DC3E0A1B2DF2C700054299 /* JSIteratorPrototype.h in Headers */,
+				276B38DC2A71D26400252F4E /* JSIteratorPrototypeInlines.h in Headers */,
 				A503FA1E188E0FB000110F14 /* JSJavaScriptCallFramePrototype.h in Headers */,
 				BC18C4160E16F5CD00B34460 /* JSLexicalEnvironment.h in Headers */,
 				276B391B2A71D2B600252F4E /* JSLexicalEnvironmentInlines.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -889,7 +889,6 @@ runtime/IntlSegmentsPrototype.cpp
 runtime/IntlWorkaround.cpp @no-unify // Confine U_HIDE_DRAFT_API's effect to this file.
 runtime/ISO8601.cpp
 runtime/IteratorOperations.cpp
-runtime/IteratorPrototype.cpp
 runtime/JSArray.cpp
 runtime/JSArrayBuffer.cpp
 runtime/JSArrayBufferConstructor.cpp
@@ -930,6 +929,7 @@ runtime/JSInternalPromiseConstructor.cpp
 runtime/JSInternalPromisePrototype.cpp
 runtime/JSIterator.cpp
 runtime/JSIteratorConstructor.cpp
+runtime/JSIteratorPrototype.cpp
 runtime/JSLexicalEnvironment.cpp
 runtime/JSLock.cpp
 runtime/JSMap.cpp

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -108,8 +108,6 @@
 #include "IntlSegmenterPrototype.h"
 #include "IntlSegments.h"
 #include "IntlSegmentsPrototype.h"
-#include "IteratorPrototype.h"
-#include "IteratorPrototypeInlines.h"
 #include "JSAPIWrapperObject.h"
 #include "JSArrayBuffer.h"
 #include "JSArrayBufferConstructor.h"
@@ -145,6 +143,8 @@
 #include "JSInternalPromisePrototype.h"
 #include "JSIterator.h"
 #include "JSIteratorConstructor.h"
+#include "JSIteratorPrototype.h"
+#include "JSIteratorPrototypeInlines.h"
 #include "JSLexicalEnvironmentInlines.h"
 #include "JSMapInlines.h"
 #include "JSMapIteratorInlines.h"
@@ -1109,7 +1109,7 @@ void JSGlobalObject::init(VM& vm)
             init.setConstructor(JSSharedArrayBufferConstructor::create(init.vm, JSSharedArrayBufferConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<JSArrayBufferPrototype*>(init.prototype)));
         });
 
-    m_iteratorPrototype.set(vm, this, IteratorPrototype::create(vm, this, IteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
+    m_iteratorPrototype.set(vm, this, JSIteratorPrototype::create(vm, this, JSIteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
     if (Options::useIteratorHelpers())
         m_iteratorStructure.set(vm, this, JSIterator::createStructure(vm, this, m_iteratorPrototype.get()));
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -75,7 +75,6 @@ class GetterSetter;
 class ImportMap;
 class IntlCollator;
 class IntlNumberFormat;
-class IteratorPrototype;
 class JSArrayBuffer;
 class JSCallee;
 class JSCustomGetterFunction;
@@ -84,6 +83,7 @@ class JSGlobalObjectDebuggable;
 class JSInternalPromise;
 class JSIterator;
 class JSIteratorConstructor;
+class JSIteratorPrototype;
 class JSModuleLoader;
 class JSModuleRecord;
 class JSPromise;
@@ -289,7 +289,7 @@ public:
     WriteBarrier<ArrayPrototype> m_arrayPrototype;
     WriteBarrier<ShadowRealmPrototype> m_shadowRealmPrototype;
     WriteBarrier<RegExpPrototype> m_regExpPrototype;
-    WriteBarrier<IteratorPrototype> m_iteratorPrototype;
+    WriteBarrier<JSIteratorPrototype> m_iteratorPrototype;
     WriteBarrier<AsyncIteratorPrototype> m_asyncIteratorPrototype;
     WriteBarrier<GeneratorFunctionPrototype> m_generatorFunctionPrototype;
     WriteBarrier<GeneratorPrototype> m_generatorPrototype;
@@ -749,7 +749,7 @@ public:
     ShadowRealmPrototype* shadowRealmPrototype() const { return m_shadowRealmPrototype.get(); }
     RegExpPrototype* regExpPrototype() const { return m_regExpPrototype.get(); }
     JSObject* errorPrototype() const { return m_errorStructure.prototype(this); }
-    IteratorPrototype* iteratorPrototype() const { return m_iteratorPrototype.get(); }
+    JSIteratorPrototype* iteratorPrototype() const { return m_iteratorPrototype.get(); }
     AsyncIteratorPrototype* asyncIteratorPrototype() const { return m_asyncIteratorPrototype.get(); }
     GeneratorFunctionPrototype* generatorFunctionPrototype() const { return m_generatorFunctionPrototype.get(); }
     GeneratorPrototype* generatorPrototype() const { return m_generatorPrototype.get(); }

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -30,9 +30,9 @@
 #include "AbstractSlotVisitor.h"
 #include "BuiltinNames.h"
 #include "GetterSetter.h"
-#include "IteratorPrototype.h"
 #include "JSCInlines.h"
 #include "JSIterator.h"
+#include "JSIteratorPrototype.h"
 #include "SlotVisitor.h"
 
 namespace JSC {
@@ -44,14 +44,14 @@ Structure* JSIteratorConstructor::createStructure(VM& vm, JSGlobalObject* global
     return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
 }
 
-JSIteratorConstructor* JSIteratorConstructor::create(VM& vm, Structure* structure, IteratorPrototype* iteratorPrototype)
+JSIteratorConstructor* JSIteratorConstructor::create(VM& vm, Structure* structure, JSIteratorPrototype* iteratorPrototype)
 {
     JSIteratorConstructor* constructor = new (NotNull, allocateCell<JSIteratorConstructor>(vm)) JSIteratorConstructor(vm, structure);
     constructor->finishCreation(vm, iteratorPrototype);
     return constructor;
 }
 
-void JSIteratorConstructor::finishCreation(VM& vm, IteratorPrototype* iteratorPrototype)
+void JSIteratorConstructor::finishCreation(VM& vm, JSIteratorPrototype* iteratorPrototype)
 {
     Base::finishCreation(vm, 0, vm.propertyNames->Iterator.string(), PropertyAdditionMode::WithoutStructureTransition);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, iteratorPrototype, static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-class IteratorPrototype;
+class JSIteratorPrototype;
 
 // https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor
 class JSIteratorConstructor final : public InternalFunction {
@@ -38,14 +38,14 @@ public:
     typedef InternalFunction Base;
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-    static JSIteratorConstructor* create(VM&, Structure*, IteratorPrototype*);
+    static JSIteratorConstructor* create(VM&, Structure*, JSIteratorPrototype*);
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 private:
     JSIteratorConstructor(VM&, Structure*);
 
-    void finishCreation(VM&, IteratorPrototype*);
+    void finishCreation(VM&, JSIteratorPrototype*);
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSIteratorConstructor, InternalFunction);
 

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "config.h"
-#include "IteratorPrototype.h"
+#include "JSIteratorPrototype.h"
 
 #include "JSCBuiltins.h"
 #include "JSCInlines.h"
@@ -38,7 +38,7 @@
 
 namespace JSC {
 
-const ClassInfo IteratorPrototype::s_info = { "Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(IteratorPrototype) };
+const ClassInfo JSIteratorPrototype::s_info = { "Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSIteratorPrototype) };
 
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncIterator);
 static JSC_DECLARE_CUSTOM_GETTER(iteratorProtoConstructorGetter);
@@ -46,7 +46,7 @@ static JSC_DECLARE_CUSTOM_SETTER(iteratorProtoConstructorSetter);
 static JSC_DECLARE_CUSTOM_GETTER(iteratorProtoToStringTagGetter);
 static JSC_DECLARE_CUSTOM_SETTER(iteratorProtoToStringTagSetter);
 
-void IteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
+void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.h
@@ -26,13 +26,39 @@
 
 #pragma once
 
-#include "IteratorPrototype.h"
+#include "JSObject.h"
 
 namespace JSC {
 
-inline Structure* IteratorPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
-{
-    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
-}
+class JSIteratorPrototype final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSIteratorPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static JSIteratorPrototype* create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
+    {
+        JSIteratorPrototype* prototype = new (NotNull, allocateCell<JSIteratorPrototype>(vm)) JSIteratorPrototype(vm, structure);
+        prototype->finishCreation(vm, globalObject);
+        return prototype;
+    }
+
+    DECLARE_INFO;
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+private:
+    JSIteratorPrototype(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+    void finishCreation(VM&, JSGlobalObject*);
+};
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototypeInlines.h
@@ -26,39 +26,13 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include "JSIteratorPrototype.h"
 
 namespace JSC {
 
-class IteratorPrototype final : public JSNonFinalObject {
-public:
-    using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
-
-    template<typename CellType, SubspaceAccess>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
-    {
-        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(IteratorPrototype, Base);
-        return &vm.plainObjectSpace();
-    }
-
-    static IteratorPrototype* create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
-    {
-        IteratorPrototype* prototype = new (NotNull, allocateCell<IteratorPrototype>(vm)) IteratorPrototype(vm, structure);
-        prototype->finishCreation(vm, globalObject);
-        return prototype;
-    }
-
-    DECLARE_INFO;
-
-    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-
-private:
-    IteratorPrototype(VM& vm, Structure* structure)
-        : Base(vm, structure)
-    {
-    }
-    void finishCreation(VM&, JSGlobalObject*);
-};
+inline Structure* JSIteratorPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
 
 } // namespace JSC

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "JSDOMConvert.h"
-#include <JavaScriptCore/IteratorPrototype.h>
+#include <JavaScriptCore/JSIteratorPrototype.h>
 #include <JavaScriptCore/PropertySlot.h>
 #include <type_traits>
 


### PR DESCRIPTION
#### 2a5293362de4ed5006e4fc163063e26cec6acc75
<pre>
[JSC] Add JS-prefix to runtime/IteratorPrototype.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=278710">https://bugs.webkit.org/show_bug.cgi?id=278710</a>

Reviewed by Yusuke Suzuki.

We&apos;ll add some stuffs on Iterator.prototype to implement bug 248650.
<a href="https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype">https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype</a>

Let&apos;s rename the implementation file.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::iteratorPrototype const):
* Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp:
(JSC::JSIteratorConstructor::create):
(JSC::JSIteratorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/JSIteratorConstructor.h:
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp: Renamed from Source/JavaScriptCore/runtime/IteratorPrototype.cpp.
(JSC::JSIteratorPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::JSC_DEFINE_CUSTOM_SETTER):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.h: Renamed from Source/JavaScriptCore/runtime/IteratorPrototype.h.
* Source/JavaScriptCore/runtime/JSIteratorPrototypeInlines.h: Renamed from Source/JavaScriptCore/runtime/IteratorPrototypeInlines.h.
(JSC::JSIteratorPrototype::createStructure):
* Source/WebCore/bindings/js/JSDOMIterator.h:

Canonical link: <a href="https://commits.webkit.org/282852@main">https://commits.webkit.org/282852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e885c9631d1da393e809274420d93b11d4642056

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15012 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51829 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10354 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13108 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13886 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57516 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63649 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59148 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59314 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/585 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85410 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9773 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39583 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15069 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40661 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41844 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->