### PR TITLE
[GStreamer][WebAudio] Convert GstFFT raw pointers to GUniquePtrs

### DIFF
--- a/Source/WebCore/platform/audio/FFTFrame.h
+++ b/Source/WebCore/platform/audio/FFTFrame.h
@@ -32,7 +32,7 @@
 #include "AudioArray.h"
 
 #if USE(GSTREAMER)
-#include <gst/fft/gstfftf32.h>
+#include "GUniquePtrGStreamer.h"
 #endif // USE(GSTREAMER)
 
 #if USE(ACCELERATE)
@@ -105,8 +105,8 @@ private:
 #endif
 
 #if USE(GSTREAMER)
-    GstFFTF32* m_fft;
-    GstFFTF32* m_inverseFft;
+    GUniquePtr<GstFFTF32> m_fft;
+    GUniquePtr<GstFFTF32> m_inverseFft;
     UniqueArray<GstFFTF32Complex> m_complexData;
 #endif // USE(GSTREAMER)
 

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -24,6 +24,7 @@
 #include <gst/audio/audio.h>
 #include <gst/base/gstbytereader.h>
 #include <gst/base/gstflowcombiner.h>
+#include <gst/fft/gstfftf32.h>
 #include <gst/gstsegment.h>
 #include <gst/gststructure.h>
 #include <gst/pbutils/install-plugins.h>
@@ -47,6 +48,7 @@ WTF_DEFINE_GPTR_DELETER(GstByteReader, gst_byte_reader_free)
 WTF_DEFINE_GPTR_DELETER(GstVideoConverter, gst_video_converter_free)
 WTF_DEFINE_GPTR_DELETER(GstAudioConverter, gst_audio_converter_free)
 WTF_DEFINE_GPTR_DELETER(GstAudioInfo, gst_audio_info_free)
+WTF_DEFINE_GPTR_DELETER(GstFFTF32, gst_fft_f32_free)
 
 #if defined(BUILDING_WebCore) && USE(GSTREAMER_WEBRTC)
 WTF_DEFINE_GPTR_DELETER(GstWebRTCSessionDescription, gst_webrtc_session_description_free)


### PR DESCRIPTION
#### a315a6d8a2940cddc18999609d6d6796c3593305
<pre>
[GStreamer][WebAudio] Convert GstFFT raw pointers to GUniquePtrs
<a href="https://bugs.webkit.org/show_bug.cgi?id=278712">https://bugs.webkit.org/show_bug.cgi?id=278712</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/audio/FFTFrame.h:
* Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp:
(WebCore::FFTFrame::FFTFrame):
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):
(WebCore::FFTFrame::~FFTFrame): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/282836@main">https://commits.webkit.org/282836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b2c7972dce9f1e9154ba1b2e994babc43716c0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51738 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10271 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13002 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59060 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59223 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/491 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39466 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->