### PR TITLE
[IFC][SVG text] Use inline iterator more for SVG text

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -31,8 +31,10 @@
 #include "InlineIteratorTextBoxInlines.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderCombineText.h"
+#include "RenderSVGInlineText.h"
 #include "RenderStyleInlines.h"
 #include "SVGInlineTextBox.h"
+#include "SVGTextFragment.h"
 
 namespace WebCore {
 namespace InlineIterator {
@@ -48,6 +50,28 @@ const FontCascade& TextBox::fontCascade() const
         return renderer->textCombineFont();
 
     return style().fontCascade();
+}
+
+FloatRect TextBox::calculateBoundariesIncludingSVGTransform() const
+{
+    if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
+        return svgText->calculateBoundaries();
+    return visualRectIgnoringBlockDirection();
+}
+
+const Vector<SVGTextFragment>& TextBox::svgTextFragments() const
+{
+    static NeverDestroyed<Vector<SVGTextFragment>> emptyFragments;
+
+    auto* svgInlineText = dynamicDowncast<RenderSVGInlineText>(renderer());
+    if (!svgInlineText)
+        return emptyFragments;
+
+    if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
+        return svgText->textFragments();
+
+    // FIXME: Implement.
+    return emptyFragments;
 }
 
 TextBoxIterator::TextBoxIterator(Box::PathVariant&& pathVariant)

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+struct SVGTextFragment;
+
 namespace InlineIterator {
 
 class TextBox : public Box {
@@ -46,6 +48,9 @@ public:
     TextBoxSelectableRange selectableRange() const;
 
     const FontCascade& fontCascade() const;
+
+    FloatRect calculateBoundariesIncludingSVGTransform() const;
+    const Vector<SVGTextFragment>& svgTextFragments() const;
 
     inline TextRun textRun(TextRunMode = TextRunMode::Painting) const;
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -494,14 +494,6 @@ void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, un
 }
 #endif
 
-static FloatRect boundariesForTextBox(const InlineIterator::TextBox& textBox)
-{
-    if (auto* svgInlineTextBox = dynamicDowncast<SVGInlineTextBox>(textBox.legacyInlineBox()))
-        return svgInlineTextBox->calculateBoundaries();
-
-    return textBox.visualRectIgnoringBlockDirection();
-}
-
 static std::optional<IntRect> ellipsisRectForTextBox(const InlineIterator::TextBox& textBox, unsigned start, unsigned end)
 {
     auto lineBox = textBox.lineBox();
@@ -530,7 +522,7 @@ static Vector<FloatQuad> collectAbsoluteQuads(const RenderText& textRenderer, bo
 {
     Vector<FloatQuad> quads;
     for (auto& textBox : InlineIterator::textBoxesFor(textRenderer)) {
-        auto boundaries = boundariesForTextBox(textBox);
+        auto boundaries = textBox.calculateBoundariesIncludingSVGTransform();
 
         // Shorten the width of this text box if it ends in an ellipsis.
         if (clipping == ClippingOption::ClipToEllipsis) {
@@ -651,7 +643,7 @@ Vector<FloatQuad> RenderText::absoluteQuadsForRange(unsigned start, unsigned end
         }
 
         if (start <= textBox.start() && textBox.end() <= end) {
-            auto boundaries = boundariesForTextBox(textBox);
+            auto boundaries = textBox.calculateBoundariesIncludingSVGTransform();
 
             if (useSelectionHeight) {
                 LayoutRect selectionRect = selectionRectForTextBox(textBox, start, end);

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -27,6 +27,7 @@
 #include "CSSFontSelector.h"
 #include "FloatConversion.h"
 #include "FloatQuad.h"
+#include "InlineIteratorBox.h"
 #include "InlineRunAndOffset.h"
 #include "LegacyRenderSVGRoot.h"
 #include "RenderAncestorIterator.h"
@@ -129,8 +130,8 @@ std::unique_ptr<LegacyInlineTextBox> RenderSVGInlineText::createTextBox()
 FloatRect RenderSVGInlineText::floatLinesBoundingBox() const
 {
     FloatRect boundingBox;
-    for (auto* box = firstTextBox(); box; box = box->nextTextBox())
-        boundingBox.unite(box->calculateBoundaries());
+    for (auto& box : InlineIterator::textBoxesFor(*this))
+        boundingBox.unite(box.calculateBoundariesIncludingSVGTransform());
 
     return boundingBox;
 }
@@ -158,7 +159,7 @@ bool RenderSVGInlineText::characterStartsNewTextChunk(int position) const
 
 VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, HitTestSource, const RenderFragmentContainer*)
 {
-    if (!firstTextBox() || text().isEmpty())
+    if (!InlineIterator::firstTextBoxFor(*this) || text().isEmpty())
         return createVisiblePosition(0, Affinity::Downstream);
 
     float baseline = m_scaledFont.metricsOfPrimaryFont().ascent();
@@ -173,11 +174,11 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
     float closestDistance = std::numeric_limits<float>::max();
     float closestDistancePosition = 0;
     const SVGTextFragment* closestDistanceFragment = nullptr;
-    SVGInlineTextBox* closestDistanceBox = nullptr;
+    const SVGInlineTextBox* closestDistanceBox = nullptr;
 
     AffineTransform fragmentTransform;
-    for (auto* box = firstTextBox(); box; box = box->nextTextBox()) {
-        Vector<SVGTextFragment>& fragments = box->textFragments();
+    for (auto& box : InlineIterator::textBoxesFor(*this)) {
+        auto& fragments = box.svgTextFragments();
 
         unsigned textFragmentsSize = fragments.size();
         for (unsigned i = 0; i < textFragmentsSize; ++i) {
@@ -192,7 +193,7 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
 
             if (distance < closestDistance) {
                 closestDistance = distance;
-                closestDistanceBox = box;
+                closestDistanceBox = downcast<SVGInlineTextBox>(box.legacyInlineBox());
                 closestDistanceFragment = &fragment;
                 closestDistancePosition = fragmentRect.x();
             }
@@ -247,11 +248,6 @@ bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
     scaledFont = FontCascade(WTFMove(fontDescription));
     scaledFont.update(renderer.document().protectedFontSelector().ptr());
     return true;
-}
-
-SVGInlineTextBox* RenderSVGInlineText::firstTextBox() const
-{
-    return downcast<SVGInlineTextBox>(RenderText::firstLegacyTextBox());
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -55,8 +55,6 @@ public:
     // Preserves floating point precision for the use in DRT. It knows how to round and does a better job than enclosingIntRect.
     FloatRect floatLinesBoundingBox() const;
 
-    SVGInlineTextBox* firstTextBox() const;
-
 private:
     ASCIILiteral renderName() const override { return "RenderSVGInlineText"_s; }
 

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -31,6 +31,8 @@
 #include "SVGRenderTreeAsText.h"
 
 #include "ColorSerialization.h"
+#include "InlineIteratorBoxInlines.h"
+#include "InlineIteratorInlineBox.h"
 #include "LegacyRenderSVGImage.h"
 #include "LegacyRenderSVGResourceClipperInlines.h"
 #include "LegacyRenderSVGResourceFilterInlines.h"
@@ -322,7 +324,7 @@ static TextStream& operator<<(TextStream& ts, const LegacyRenderSVGShape& shape)
 
 static void writeRenderSVGTextBox(TextStream& ts, const RenderSVGText& text)
 {
-    auto* box = downcast<SVGRootInlineBox>(text.legacyRootBox());
+    auto box = InlineIterator::firstRootInlineBoxFor(text);
     if (!box)
         return;
 
@@ -335,20 +337,20 @@ static void writeRenderSVGTextBox(TextStream& ts, const RenderSVGText& text)
         writeNameValuePair(ts, "color"_s, serializationForRenderTreeAsText(text.style().visitedDependentColor(CSSPropertyColor)));
 }
 
-static inline void writeSVGInlineTextBox(TextStream& ts, SVGInlineTextBox* textBox)
+static inline void writeSVGInlineTextBox(TextStream& ts, const InlineIterator::TextBox& textBox)
 {
-    Vector<SVGTextFragment>& fragments = textBox->textFragments();
+    auto& fragments = textBox.svgTextFragments();
     if (fragments.isEmpty())
         return;
 
-    Ref svgStyle = textBox->renderer().style().svgStyle();
-    String text = textBox->renderer().text();
+    Ref svgStyle = textBox.renderer().style().svgStyle();
+    String text = textBox.renderer().text();
 
     TextStream::IndentScope indentScope(ts);
 
     unsigned fragmentsSize = fragments.size();
     for (unsigned i = 0; i < fragmentsSize; ++i) {
-        SVGTextFragment& fragment = fragments.at(i);
+        auto& fragment = fragments.at(i);
         ts << indent;
 
         unsigned startOffset = fragment.characterOffset;
@@ -357,7 +359,7 @@ static inline void writeSVGInlineTextBox(TextStream& ts, SVGInlineTextBox* textB
         // FIXME: Remove this hack, once the new text layout engine is completly landed. We want to preserve the old layout test results for now.
         ts << "chunk 1 "_s;
         TextAnchor anchor = svgStyle->textAnchor();
-        bool isVerticalText = textBox->renderer().style().isVerticalWritingMode();
+        bool isVerticalText = textBox.renderer().style().isVerticalWritingMode();
         if (anchor == TextAnchor::Middle) {
             ts << "(middle anchor"_s;
             if (isVerticalText)
@@ -370,8 +372,8 @@ static inline void writeSVGInlineTextBox(TextStream& ts, SVGInlineTextBox* textB
             ts << ") "_s;
         } else if (isVerticalText)
             ts << "(vertical) "_s;
-        startOffset -= textBox->start();
-        endOffset -= textBox->start();
+        startOffset -= textBox.start();
+        endOffset -= textBox.start();
         // </hack>
 
         ts << "text run "_s << i + 1 << " at ("_s << fragment.x << ',' << fragment.y << ')';
@@ -381,7 +383,7 @@ static inline void writeSVGInlineTextBox(TextStream& ts, SVGInlineTextBox* textB
         else
             ts << " width "_s << fragment.width;
 
-        if (!textBox->isLeftToRightDirection())
+        if (!textBox.isLeftToRightDirection())
             ts << " RTL"_s;
 
         ts << ": "_s << quoteAndEscapeNonPrintables(text.substring(fragment.characterOffset, fragment.length)) << '\n';
@@ -390,7 +392,7 @@ static inline void writeSVGInlineTextBox(TextStream& ts, SVGInlineTextBox* textB
 
 static inline void writeSVGInlineTextBoxes(TextStream& ts, const RenderSVGInlineText& text)
 {
-    for (auto* box = text.firstTextBox(); box; box = box->nextTextBox())
+    for (auto& box : InlineIterator::textBoxesFor(text))
         writeSVGInlineTextBox(ts, box);
 }
 


### PR DESCRIPTION
#### 0117521c3a0c3a7c4a6c2924b8d45e451038da1c
<pre>
[IFC][SVG text] Use inline iterator more for SVG text
<a href="https://bugs.webkit.org/show_bug.cgi?id=278722">https://bugs.webkit.org/show_bug.cgi?id=278722</a>
<a href="https://rdar.apple.com/134775045">rdar://134775045</a>

Reviewed by Alan Baradlay.

Access the legacy SVG inline boxes via the iterator instead of directly.
This is a step towards using IFC for SVG text.

* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::TextBox::calculateBoundariesIncludingSVGTransform const):
(WebCore::InlineIterator::TextBox::svgTextFragments const):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::collectAbsoluteQuads):
(WebCore::RenderText::absoluteQuadsForRange const):
(WebCore::boundariesForTextBox): Deleted.
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::floatLinesBoundingBox const):
(WebCore::RenderSVGInlineText::positionForPoint):
(WebCore::RenderSVGInlineText::firstTextBox const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeRenderSVGTextBox):
(WebCore::writeSVGInlineTextBox):
(WebCore::writeSVGInlineTextBoxes):

Canonical link: <a href="https://commits.webkit.org/282797@main">https://commits.webkit.org/282797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e0a0fa5aa949e7775c76ab746e47c59269b2457

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51758 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10291 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55646 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13025 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13794 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59244 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/512 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->