### PR TITLE
[web-animations] Physical properties should take priority over logical properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001-expected.txt
@@ -10,8 +10,8 @@ PASS Physical properties with variables win over logical properties
 FAIL Logical shorthands follow the usual prioritization based on number of component longhands assert_equals: expected "300px" but got "0px"
 PASS Physical longhands win over logical shorthands
 PASS Logical longhands win over physical shorthands
-FAIL Physical shorthands win over logical shorthands assert_equals: expected "200px" but got "100px"
-FAIL Physical shorthands using variables win over logical shorthands assert_equals: expected "200px" but got "100px"
+PASS Physical shorthands win over logical shorthands
+PASS Physical shorthands using variables win over logical shorthands
 PASS Physical properties and logical properties can be mixed
 PASS Physical shorthands and logical shorthands can be mixed
 PASS Physical properties win over logical properties even when some keyframes only have logical properties


### PR DESCRIPTION
#### 74dcb4aac602ab55cee2d8b3f7e7b3ea263a538d
<pre>
[web-animations] Physical properties should take priority over logical properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=277334">https://bugs.webkit.org/show_bug.cgi?id=277334</a>
<a href="https://rdar.apple.com/133278333">rdar://133278333</a>

Reviewed by Antti Koivisto.

When processing the list of animated CSS properties for a keyframe provided via the JS API,
we must ensure that we group them in such a way that longhands win over shorthands and that
physical properties win over logical properties. We now divide CSS properties encountered
via the JS API in four distinct groups organized as follows:

1. logical shorthands
2. physical shorthands
3. logical longhands
4. physical longhands

In this list, the later properties win over the earlier properties.

This allows us to recover from 281543@main which regressed the two subtests that are now
PASS results again.

* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::processKeyframeLikeObject):

Canonical link: <a href="https://commits.webkit.org/282815@main">https://commits.webkit.org/282815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36049bc55b16bc55b8097ee97a1cc4f112281fa4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14913 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51749 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13022 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70026 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8252 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12868 "Found 1 new test failure: fast/webgpu/type-checker-array-without-argument.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59071 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59235 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/510 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9750 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39482 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->