### PR TITLE
Skip wasm sampling profiler tests for watchOS and tvOS since they do not support

### DIFF
--- a/JSTests/stress/sampling-profiler-wasm-name-section.js
+++ b/JSTests/stress/sampling-profiler-wasm-name-section.js
@@ -1,9 +1,10 @@
+//@ skip if ["arm"].include?($architecture)
+//@ skip if $platform == "tvos" || $platform == "watchos"
+//@ runDefault
+
 // This test is statistical, and without optimizing Wasm tiers the likelihood
 // of hitting the deepest expected stack trace is very low, so disable.
 // FIXME: remove when 32-bit platforms support optimizing Wasm tiers
-//@ skip if ["arm"].include?($architecture)
-//
-//@ runDefault
 
 /*
 This test loads a WebAssembly file compiled by Emscripten with:

--- a/JSTests/stress/sampling-profiler-wasm.js
+++ b/JSTests/stress/sampling-profiler-wasm.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture == "arm"
+//@ skip if $platform == "tvos" || $platform == "watchos"
 //@ runDefault
 
 if (platformSupportsSamplingProfiler() && $vm.isWasmSupported()) {


### PR DESCRIPTION
#### e84c28d0ffb3c9e5b80d2c023914dcb270551caa
<pre>
Skip wasm sampling profiler tests for watchOS and tvOS since they do not support
<a href="https://bugs.webkit.org/show_bug.cgi?id=278733">https://bugs.webkit.org/show_bug.cgi?id=278733</a>
<a href="https://rdar.apple.com/134743040">rdar://134743040</a>

Reviewed by Mark Lam.

SamplingProfiler + wasm combination is supported only in JIT environment. Other platforms will not successfully report the results.
This patch skip them on tvOS and watchOS.

* JSTests/stress/sampling-profiler-wasm-name-section.js:
* JSTests/stress/sampling-profiler-wasm.js:

Canonical link: <a href="https://commits.webkit.org/282817@main">https://commits.webkit.org/282817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9598d419160a142883514133b0959352256f0d54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14943 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51779 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37062 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13817 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57447 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70056 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63580 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59103 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59268 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/531 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85341 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9752 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39512 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15055 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->