### PR TITLE
[CSS] Contextually invalid selectors have a specificity of 0

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+    Contextually invalid selectors due to :is() should not match and have no
+    specificity
+</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting/#nest-selector" />
+<link
+    rel="match"
+    href="/css/reference/ref-filled-green-100px-square-only.html"
+/>
+<style>
+    div {
+        color: green;
+        background-color: currentColor;
+        width: 100px;
+        height: 100px;
+    }
+
+    p {
+        color: initial;
+    }
+
+    *,
+    ::before {
+        & * {
+            color: red;
+        }
+    }
+
+    :is(*, ::before) * {
+        color: purple;
+    }
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div></div>

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -898,6 +898,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                     context.matchedHostPseudoClass |= subcontext.matchedHostPseudoClass;
 
                     // Pseudo elements are not valid inside :is()/:matches()
+                    // They should also have a specificity of 0 (CSSSelector::simpleSelectorSpecificity)
                     if (localDynamicPseudoIdSet)
                         continue;
 


### PR DESCRIPTION
#### 9309d6597f2ba096a1af23917982f76b820574a3
<pre>
[CSS] Contextually invalid selectors have a specificity of 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=277739">https://bugs.webkit.org/show_bug.cgi?id=277739</a>
<a href="https://rdar.apple.com/133391094">rdar://133391094</a>

Reviewed by Tim Nguyen.

<a href="https://github.com/w3c/csswg-drafts/issues/9600">https://github.com/w3c/csswg-drafts/issues/9600</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors.html: Added.
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::maxSpecificity):
(WebCore::simpleSelectorSpecificity):

Canonical link: <a href="https://commits.webkit.org/282944@main">https://commits.webkit.org/282944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6731a51890c3fb42cf9cf4df135cbdefd412a1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15620 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52040 "Failed to checkout and rebase branch from PR 32779") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10583 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13385 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14214 "Failed to checkout and rebase branch from PR 32779") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13210 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56094 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/837 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39912 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->