### PR TITLE
REGRESSION (281966@main): Unable to drag images from Photos into Mail compose on macOS

### DIFF
--- a/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
+++ b/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
@@ -100,23 +100,26 @@
         if (classObject != NSFilePromiseReceiver.class)
             continue;
 
-        id promisedTypeIdentifiers = [_pasteboard propertyListForType:NSFilesPromisePboardType];
-        if (![promisedTypeIdentifiers isKindOfClass:NSArray.class])
-            break;
+        RetainPtr promisedTypeIdentifiers = dynamic_objc_cast<NSArray>([_pasteboard propertyListForType:NSFilesPromisePboardType]);
+        RetainPtr externalPromisedFiles = [_dragAndDropSimulator externalPromisedFiles];
+        RELEASE_ASSERT([promisedTypeIdentifiers count] == [externalPromisedFiles count]);
 
-        for (id object in promisedTypeIdentifiers) {
-            if (![object isKindOfClass:NSString.class])
+        for (id object in promisedTypeIdentifiers.get())
+            RELEASE_ASSERT([object isKindOfClass:NSString.class]);
+
+        NSUInteger itemIndex = 0;
+        for (NSURL *promisedFileURL in externalPromisedFiles.get()) {
+            RetainPtr receiver = adoptNS([[TestFilePromiseReceiver alloc] initWithTypeIdentifier:[promisedTypeIdentifiers objectAtIndex:itemIndex] fileURL:promisedFileURL]);
+            [receiver setDraggingSource:_source.get().get()];
+            [_filePromiseReceivers addObject:receiver.get()];
+
+            RetainPtr item = adoptNS([[NSDraggingItem alloc] _initWithItem:receiver.get()]);
+            block(item.get(), 0, &stop);
+            if (stop)
                 break;
+
+            itemIndex++;
         }
-
-        auto receiver = adoptNS([[TestFilePromiseReceiver alloc] initWithPromisedTypeIdentifiers:promisedTypeIdentifiers dragAndDropSimulator:_dragAndDropSimulator.getAutoreleased()]);
-        [receiver setDraggingSource:_source.get().get()];
-        [_filePromiseReceivers addObject:receiver.get()];
-
-        auto item = adoptNS([[NSDraggingItem alloc] _initWithItem:receiver.get()]);
-        block(item.get(), 0, &stop);
-        if (stop)
-            break;
     }
 }
 

--- a/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.h
+++ b/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.h
@@ -31,7 +31,7 @@
 
 @interface TestFilePromiseReceiver : NSFilePromiseReceiver
 
-- (instancetype)initWithPromisedTypeIdentifiers:(NSArray<NSString *> *)promisedTypeIdentifiers dragAndDropSimulator:(DragAndDropSimulator *)simulator NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTypeIdentifier:(NSString *)promisedTypeIdentifier fileURL:(NSURL *)promisedFileURL NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 @property (nonatomic, weak) id draggingSource;


### PR DESCRIPTION
#### 59cdc6c756949563050436d2e83326afa7c93840
<pre>
REGRESSION (281966@main): Unable to drag images from Photos into Mail compose on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=278749">https://bugs.webkit.org/show_bug.cgi?id=278749</a>
<a href="https://rdar.apple.com/134780008">rdar://134780008</a>

Reviewed by Aditya Keerthi and Charlie Wolfe.

The refactoring around `WebViewImpl::performDragOperation` in <a href="https://commits.webkit.org/281966@main">https://commits.webkit.org/281966@main</a>
introduced a bug, wherein dragging multiple promised files over a web view causes the drop to fail.
This is because the reference to `page` is moved (and cleared) when invoking the iteration block,
causing subsequent calls to exit early (in the `!page` branch).

Fix this by copying a reference to the `WebPageProxy` into each iteration block.

Tested by an existing API test, after augmenting test infrastructure (see below).

Test: WKAttachmentTestsMac.InsertDroppedFilePromisesAsAttachments

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::handleLegacyFilesPasteboard):
* Tools/TestWebKitAPI/mac/TestDraggingInfo.mm:

Refactor some test infrastructure that was intended to simulate dragging and dropping one or more
promised file(s), such that it&apos;s consistent with how AppKit delivers promised data on drop.
Currently, the test harness handles multiple promised file URLs (written via `-writePromisedFiles:`)
by creating a single drag item that contains multiple URLs. However, when dragging and dropping
multiple files or photos into Mail compose, it&apos;s actually dropped as multiple drag items, each with
a single URL and type.

(-[TestDraggingInfo enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:]):
* Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.h:
* Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm:
(-[TestFilePromiseReceiver initWithTypeIdentifier:fileURL:]):
(-[TestFilePromiseReceiver fileTypes]):
(-[TestFilePromiseReceiver fileNames]):
(-[TestFilePromiseReceiver dealloc]):
(-[TestFilePromiseReceiver receivePromisedFilesAtDestination:options:operationQueue:reader:]):
(-[TestFilePromiseReceiver initWithPromisedTypeIdentifiers:dragAndDropSimulator:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/282828@main">https://commits.webkit.org/282828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dba4acae93565b6eddf80ff82eb48713fd0e2c5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51827 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10358 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32446 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13891 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12953 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55822 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14210 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/588 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39588 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->