### PR TITLE
Attempting to insert text before a <picture> element inserts the text after the element

### DIFF
--- a/LayoutTests/editing/inserting/insert-text-before-picture-expected.txt
+++ b/LayoutTests/editing/inserting/insert-text-before-picture-expected.txt
@@ -1,0 +1,23 @@
+Test text insertion before <picture>.
+
+Initial state:
+| <picture>
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <#selection-caret>
+|   <img>
+|     src=""
+
+After insertion:
+| "text<#selection-caret>"
+| <picture>
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <img>
+|     src=""

--- a/LayoutTests/editing/inserting/insert-text-before-picture.html
+++ b/LayoutTests/editing/inserting/insert-text-before-picture.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable><picture><source srcset="resources/apple.gif" media="(min-width: 600px)"/><source srcset="resources/mozilla.gif"/><img src=""></picture></div>
+<script>
+
+Markup.description('Test text insertion before <picture>.');
+
+var picture = document.querySelector('picture');
+window.getSelection().setBaseAndExtent(picture, 2, picture, 2);
+Markup.dump(editor, 'Initial state');
+
+document.execCommand('InsertText', false, 'text');
+Markup.dump(editor, 'After insertion');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -31,6 +31,7 @@
 #include "CachedImage.h"
 #include "DocumentInlines.h"
 #include "Editor.h"
+#include "ElementChildIteratorInlines.h"
 #include "ElementInlines.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDListElement.h"
@@ -877,7 +878,16 @@ int caretMinOffset(const Node& node)
 {
     auto* renderer = node.renderer();
     ASSERT(!node.isCharacterDataNode() || !renderer || renderer->isRenderText());
-    return renderer ? renderer->caretMinOffset() : 0;
+
+    if (renderer && renderer->isRenderText())
+        return renderer->caretMinOffset();
+
+    if (RefPtr pictureElement = dynamicDowncast<HTMLPictureElement>(node)) {
+        if (RefPtr firstImage = childrenOfType<HTMLImageElement>(*pictureElement).first())
+            return firstImage->computeNodeIndex();
+    }
+
+    return 0;
 }
 
 // If a node can contain candidates for VisiblePositions, return the offset of the last candidate, otherwise 


### PR DESCRIPTION
#### 93c20dcc345ada6c4f5b8c5b04987e8bd8cd4140
<pre>
Attempting to insert text before a &lt;picture&gt; element inserts the text after the element
<a href="https://bugs.webkit.org/show_bug.cgi?id=278748">https://bugs.webkit.org/show_bug.cgi?id=278748</a>
<a href="https://rdar.apple.com/134378236">rdar://134378236</a>

Reviewed by Wenson Hsieh.

`&lt;picture&gt;` elements may contain one or more `&lt;source&gt;` elements (which are not
rendered) and an `&lt;img&gt;` element. When making selections around a `&lt;picture&gt;`
element, the selection is anchored before or after the `&lt;img&gt;` child.

`CompositeEditCommand::insertNodeAt` is invoked when inserting a node at the
editing position. Since `HTMLPictureElement` cannot have children as a result
of editing (`canHaveChildrenForEditing`) and `caretMinOffset` is 0, the created
text node is always inserted using `insertNodeAfter`.

Fix by updating `caretMinOffset` to return the index of the `&lt;img&gt;` child for
`&lt;picture&gt;` elements. This ensures that when the offset of the parent anchored
equivalent is before the `&lt;img&gt;`, `insertNodeBefore` will be used rather than
`insertNodeAfter`.

* LayoutTests/editing/inserting/insert-text-before-picture-expected.txt: Added.
* LayoutTests/editing/inserting/insert-text-before-picture.html: Added.
* Source/WebCore/editing/Editing.cpp:
(WebCore::caretMinOffset):

`RenderText` is the only renderer-type that returns a non-zero value for
`caretMinOffset`. Consequently, it is safe to consult the `renderer` in
that scenario, similar to `caretMaxOffset`.

Canonical link: <a href="https://commits.webkit.org/282825@main">https://commits.webkit.org/282825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a008ad2bb66df61d40dd2a593e1217d7ddab4c49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51809 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10342 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32428 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13087 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55798 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/567 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9758 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39560 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->