### PR TITLE
Implement Path::definitelyEqual()

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -65,6 +65,32 @@ Path::Path(const Path& other)
     *this = other;
 }
 
+bool Path::definitelyEqual(const Path& other) const
+{
+    if (&other == this)
+        return true;
+
+    return WTF::switchOn(m_data,
+        [&](std::monostate) {
+            return other.isEmpty();
+        },
+        [&](const PathSegment& segment) {
+            auto otherSegment = other.singleSegment();
+            return otherSegment && segment == otherSegment.value();
+        },
+        [&](const DataRef<PathImpl>& impl) {
+            if (impl->isEmpty())
+                return other.isEmpty();
+
+            if (auto singleSegment = impl->singleSegment()) {
+                auto otherSegment = other.singleSegment();
+                return otherSegment && singleSegment == otherSegment.value();
+            }
+
+            return impl.ptr() && other.asImpl() && impl->definitelyEqual(*other.asImpl());
+        });
+}
+
 Path::Path(PathSegment&& segment)
 {
     m_data = WTFMove(segment);
@@ -100,6 +126,11 @@ PathImpl& Path::ensureImpl()
         return *impl;
 
     return setImpl(PathStream::create());
+}
+
+void Path::ensureImplForTesting()
+{
+    ensureImpl();
 }
 
 PathImpl* Path::asImpl()
@@ -363,6 +394,32 @@ std::optional<PathDataLine> Path::singleDataLine() const
 
     if (auto impl = asImpl())
         return impl->singleDataLine();
+
+    return std::nullopt;
+}
+
+std::optional<PathRect> Path::singleRect() const
+{
+    if (auto segment = asSingle()) {
+        if (auto data = std::get_if<PathRect>(&segment->data()))
+            return *data;
+    }
+
+    if (auto impl = asImpl())
+        return impl->singleRect();
+
+    return std::nullopt;
+}
+
+std::optional<PathRoundedRect> Path::singleRoundedRect() const
+{
+    if (auto segment = asSingle()) {
+        if (auto data = std::get_if<PathRoundedRect>(&segment->data()))
+            return *data;
+    }
+
+    if (auto impl = asImpl())
+        return impl->singleRoundedRect();
 
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -55,6 +55,8 @@ public:
     Path& operator=(const Path&) = default;
     Path& operator=(Path&&) = default;
 
+    WEBCORE_EXPORT bool definitelyEqual(const Path&) const;
+
     WEBCORE_EXPORT void moveTo(const FloatPoint&);
 
     WEBCORE_EXPORT void addLineTo(const FloatPoint&);
@@ -85,6 +87,8 @@ public:
 
     WEBCORE_EXPORT std::optional<PathSegment> singleSegment() const;
     std::optional<PathDataLine> singleDataLine() const;
+    std::optional<PathRect> singleRect() const;
+    std::optional<PathRoundedRect> singleRoundedRect() const;
     std::optional<PathArc> singleArc() const;
     std::optional<PathClosedArc> singleClosedArc() const;
     std::optional<PathDataQuadCurve> singleQuadCurve() const;
@@ -111,6 +115,8 @@ public:
     WEBCORE_EXPORT FloatRect fastBoundingRect() const;
     FloatRect boundingRect() const;
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier = { }) const;
+
+    WEBCORE_EXPORT void ensureImplForTesting();
 
 private:
     PlatformPathImpl& ensurePlatformPathImpl();

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -48,6 +48,8 @@ public:
 
     virtual bool isPathStream() const { return false; }
 
+    virtual bool definitelyEqual(const PathImpl&) const = 0;
+
     virtual Ref<PathImpl> copy() const = 0;
 
     void addSegment(PathSegment);
@@ -74,6 +76,8 @@ public:
 
     virtual std::optional<PathSegment> singleSegment() const { return std::nullopt; }
     virtual std::optional<PathDataLine> singleDataLine() const { return std::nullopt; }
+    virtual std::optional<PathRect> singleRect() const { return std::nullopt; }
+    virtual std::optional<PathRoundedRect> singleRoundedRect() const { return std::nullopt; }
     virtual std::optional<PathArc> singleArc() const { return std::nullopt; }
     virtual std::optional<PathClosedArc> singleClosedArc() const { return std::nullopt; }
     virtual std::optional<PathDataQuadCurve> singleQuadCurve() const { return std::nullopt; }

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -79,6 +79,18 @@ PathStream::PathStream(PathSegment&& segment)
 {
 }
 
+bool PathStream::definitelyEqual(const PathImpl& other) const
+{
+    RefPtr otherAsPathStream = dynamicDowncast<PathStream>(other);
+    if (!otherAsPathStream)
+        return false;
+
+    if (otherAsPathStream.get() == this)
+        return true;
+
+    return segments() == otherAsPathStream->segments();
+}
+
 Ref<PathImpl> PathStream::copy() const
 {
     return create(m_segments);
@@ -219,6 +231,16 @@ std::optional<DataType> PathStream::singleDataType() const
 std::optional<PathDataLine> PathStream::singleDataLine() const
 {
     return singleDataType<PathDataLine>();
+}
+
+std::optional<PathRect> PathStream::singleRect() const
+{
+    return singleDataType<PathRect>();
+}
+
+std::optional<PathRoundedRect> PathStream::singleRoundedRect() const
+{
+    return singleDataType<PathRoundedRect>();
 }
 
 std::optional<PathArc> PathStream::singleArc() const

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -40,6 +40,7 @@ public:
     static Ref<PathStream> create(const Vector<FloatPoint>&);
     static Ref<PathStream> create(Vector<PathSegment>&&);
 
+    bool definitelyEqual(const PathImpl&) const final;
     Ref<PathImpl> copy() const final;
 
     void add(PathMoveTo) final;
@@ -88,6 +89,8 @@ private:
 
     std::optional<PathSegment> singleSegment() const final;
     std::optional<PathDataLine> singleDataLine() const final;
+    std::optional<PathRect> singleRect() const final;
+    std::optional<PathRoundedRect> singleRoundedRect() const final;
     std::optional<PathArc> singleArc() const final;
     std::optional<PathClosedArc> singleClosedArc() const final;
     std::optional<PathDataQuadCurve> singleQuadCurve() const final;

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -74,6 +74,24 @@ PathCairo::PathCairo(RefPtr<cairo_t>&& platformPath, RefPtr<PathStream>&& elemen
     ASSERT(m_platformPath);
 }
 
+bool PathCairo::definitelyEqual(const PathImpl& otherImpl) const
+{
+    RefPtr otherAsPathCairo = dynamicDowncast<PathCairo>(otherImpl);
+    if (!otherAsPathCairo) {
+        // We could convert other to a platform path to compare, but that would be expensive.
+        return false;
+    }
+
+    if (otherAsPathCairo.get() == this)
+        return true;
+
+    if (m_elementsStream && otherAsPathCairo->m_elementsStream)
+        return m_elementsStream->definitelyEqual(*otherAsPathCairo->m_elementsStream);
+
+    // There doesn't seem to be an API to compare cairo_path_t.
+    return false;
+}
+
 Ref<PathImpl> PathCairo::copy() const
 {
     auto platformPathCopy = adoptRef(cairo_create(adoptRef(cairo_image_surface_create(CAIRO_FORMAT_A8, 1, 1)).get()));

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.h
@@ -51,6 +51,7 @@ public:
 
     void addPath(const PathCairo&, const AffineTransform&);
 
+    bool definitelyEqual(const PathImpl&) const final;
     Ref<PathImpl> copy() const final;
     void add(PathMoveTo) final;
     void add(PathLineTo) final;

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -72,6 +72,23 @@ PathCG::PathCG(RetainPtr<CGMutablePathRef>&& platformPath)
     ASSERT(m_platformPath);
 }
 
+bool PathCG::definitelyEqual(const PathImpl& otherImpl) const
+{
+    RefPtr otherAsPathCGImpl = dynamicDowncast<PathCG>(otherImpl);
+    if (!otherAsPathCGImpl) {
+        // We could convert other to a CG path to compare, but that would be expensive.
+        return false;
+    }
+
+    if (otherAsPathCGImpl.get() == this)
+        return true;
+
+    if (!m_platformPath && !otherAsPathCGImpl->platformPath())
+        return true;
+
+    return CGPathEqualToPath(m_platformPath.get(), otherAsPathCGImpl->platformPath());
+}
+
 Ref<PathImpl> PathCG::copy() const
 {
     return create({ platformPath() });

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -51,6 +51,7 @@ public:
 
     void addPath(const PathCG&, const AffineTransform&);
 
+    bool definitelyEqual(const PathImpl&) const final;
     Ref<PathImpl> copy() const final;
     void add(PathMoveTo) final;
     void add(PathLineTo) final;

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -65,6 +65,20 @@ PathSkia::PathSkia(const SkPath& platformPath)
 {
 }
 
+bool PathSkia::definitelyEqual(const PathImpl& otherImpl) const
+{
+    RefPtr otherAsPathSkia = dynamicDowncast<PathSkia>(otherImpl);
+    if (!otherAsPathSkia) {
+        // We could convert other to a platform path to compare, but that would be expensive.
+        return false;
+    }
+
+    if (otherAsPathSkia.get() == this)
+        return true;
+
+    return m_platformPath == otherAsPathSkia->m_platformPath;
+}
+
 Ref<PathImpl> PathSkia::copy() const
 {
     return adoptRef(*new PathSkia(m_platformPath));

--- a/Source/WebCore/platform/graphics/skia/PathSkia.h
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.h
@@ -49,6 +49,7 @@ public:
 
     void addPath(const PathSkia&, const AffineTransform&);
 
+    bool definitelyEqual(const PathImpl&) const final;
     Ref<PathImpl> copy() const final;
     void add(PathMoveTo) final;
     void add(PathLineTo) final;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -212,6 +212,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/MonospaceFontTests.cpp
         Tests/WebCore/NowPlayingInfoTests.cpp
         Tests/WebCore/ParsedContentRange.cpp
+        Tests/WebCore/PathTests.cpp
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RenderStyleChange.cpp
         Tests/WebCore/SecurityOrigin.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		0F4FFA9E1ED3AA8500F7111F /* SnapshotViaRenderInContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F4FFA9D1ED3AA8500F7111F /* SnapshotViaRenderInContext.mm */; };
 		0F5651F71FCE4DDC00310FBC /* NoHistoryItemScrollToFragment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F5651F61FCE4DDB00310FBC /* NoHistoryItemScrollToFragment.mm */; };
 		0F5651F91FCE513500310FBC /* scroll-to-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F5651F81FCE50E800310FBC /* scroll-to-anchor.html */; };
+		0F5EC8C32C7F76B900B8051B /* PathTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5EC8BB2C7F76B900B8051B /* PathTests.cpp */; };
 		0FEFAF64271FC2CD005704D7 /* ScrollingCoordinatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FEFAF63271FC2CD005704D7 /* ScrollingCoordinatorTests.mm */; };
 		0FF1134E22D68679009A81DA /* ScrollViewScrollabilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FF1134D22D68679009A81DA /* ScrollViewScrollabilityTests.mm */; };
 		0FF1F0CD2AE205F5006ECC4F /* scrollable-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0FF1F0C52AE204C0006ECC4F /* scrollable-page.html */; };
@@ -2109,6 +2110,7 @@
 		0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		0F5651F61FCE4DDB00310FBC /* NoHistoryItemScrollToFragment.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NoHistoryItemScrollToFragment.mm; sourceTree = "<group>"; };
 		0F5651F81FCE50E800310FBC /* scroll-to-anchor.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "scroll-to-anchor.html"; sourceTree = "<group>"; };
+		0F5EC8BB2C7F76B900B8051B /* PathTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PathTests.cpp; sourceTree = "<group>"; };
 		0FC6C4CB141027E0005B7F0C /* RedBlackTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RedBlackTree.cpp; sourceTree = "<group>"; };
 		0FC6C4CE141034AD005B7F0C /* MetaAllocator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetaAllocator.cpp; sourceTree = "<group>"; };
 		0FE447971B76F1E3009498EB /* ParkingLot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParkingLot.cpp; sourceTree = "<group>"; };
@@ -4540,6 +4542,7 @@
 				5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */,
 				CD225C071C45A69200140761 /* ParsedContentRange.cpp */,
 				AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */,
+				0F5EC8BB2C7F76B900B8051B /* PathTests.cpp */,
 				7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */,
 				6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */,
 				041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */,
@@ -6803,6 +6806,7 @@
 				7C83E0511D0A641800FEBCF3 /* ParsedContentRange.cpp in Sources */,
 				AA96CAB621C7DB5000FD2F97 /* ParsedContentType.cpp in Sources */,
 				7CCE7F0A1A411AE600447C4C /* PasteboardNotifications.mm in Sources */,
+				0F5EC8C32C7F76B900B8051B /* PathTests.cpp in Sources */,
 				7C83E0531D0A643A00FEBCF3 /* PendingAPIRequestURL.cpp in Sources */,
 				E325C90723E3870200BC7D3B /* PictureInPictureSupport.mm in Sources */,
 				7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/Path.h>
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(Path, DefinitelyEqual)
+{
+    Path path1;
+    Path path2;
+    const Path emptyPath;
+
+    // Empty vs. empty.
+    ASSERT_TRUE(path1.definitelyEqual(path2));
+
+    constexpr auto testRect = FloatRect { 23, 12, 100, 200 };
+
+    // Single segment vs. single segment.
+    path1.addRect(testRect);
+    path2.addRect(testRect);
+
+    ASSERT_TRUE(path1.definitelyEqual(path1));
+    ASSERT_TRUE(path1.definitelyEqual(path2));
+    ASSERT_TRUE(path2.definitelyEqual(path1));
+
+    // Single segment vs. impl.
+    path1.ensureImplForTesting();
+    ASSERT_TRUE(path1.definitelyEqual(path2));
+    ASSERT_TRUE(path2.definitelyEqual(path1));
+
+    // Impl vs. impl.
+    path2.ensureImplForTesting();
+    ASSERT_TRUE(path1.definitelyEqual(path2));
+    ASSERT_TRUE(path2.definitelyEqual(path1));
+
+    // Trigger impl. copying
+    auto pathCopy = path1;
+    ASSERT_TRUE(path1.definitelyEqual(pathCopy));
+    ASSERT_TRUE(pathCopy.definitelyEqual(path1));
+
+    // Empty vs. empty impl.
+    Path emptyImplPath;
+    emptyImplPath.ensureImplForTesting();
+    ASSERT_TRUE(emptyPath.definitelyEqual(emptyImplPath));
+    ASSERT_TRUE(emptyImplPath.definitelyEqual(emptyPath));
+}
+
+TEST(Path, DefinitelyNotEqual)
+{
+    Path path1;
+    Path path2;
+    const Path emptyPath;
+
+    constexpr auto testRect1 = FloatRect { 23, 12, 100, 200 };
+    constexpr auto testRect2 = FloatRect { 23, 13, 100, 200 };
+    path1.addRect(testRect1);
+
+    // Single segment vs. empty.
+    ASSERT_FALSE(path1.definitelyEqual(emptyPath));
+    ASSERT_FALSE(emptyPath.definitelyEqual(path1));
+
+    // Single segment vs single segment.
+    path2.addRect(testRect2);
+    ASSERT_FALSE(path1.definitelyEqual(path2));
+    ASSERT_FALSE(path2.definitelyEqual(path1));
+
+    // Empty vs impl.
+    path1.ensureImplForTesting();
+    ASSERT_FALSE(emptyPath.definitelyEqual(path1));
+    ASSERT_FALSE(path1.definitelyEqual(emptyPath));
+
+    // Impl vs impl.
+    path2.ensureImplForTesting();
+    ASSERT_FALSE(path1.definitelyEqual(path2));
+    ASSERT_FALSE(path2.definitelyEqual(path1));
+}
+
+}


### PR DESCRIPTION
#### 4f3c53d350112f5964409a79f655bd3cfc05390b
<pre>
Implement Path::definitelyEqual()
<a href="https://bugs.webkit.org/show_bug.cgi?id=278751">https://bugs.webkit.org/show_bug.cgi?id=278751</a>
<a href="https://rdar.apple.com/134817798">rdar://134817798</a>

Reviewed by Cameron McCormack and Nikolas Zimmermann.

Implement `Path::definitelyEqual()` which will return true if two paths are known to contain
equivalent data. It may return false in some cases for equivalent paths, for example
if one contains a platform path, and one contains a PathStream.

`Path::definitelyEqual()` has to take care to handle the three states of the variant
on both sides.

PathCG and PathSkia can test for platform path equality. PathCairo cannot.

Also implement Path::singleRect() and Path::singleRoundedRect() which will be used
in future.

Add some API tests to exercise Path::definitelyEqual() for various Path states.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::definitelyEqual const):
(WebCore::Path::ensureImplForTesting):
(WebCore::Path::singleRect const):
(WebCore::Path::singleRoundedRect const):
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathImpl.h:
(WebCore::PathImpl::singleRect const):
(WebCore::PathImpl::singleRoundedRect const):
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::definitelyEqual const):
(WebCore::PathStream::singleRect const):
(WebCore::PathStream::singleRoundedRect const):
* Source/WebCore/platform/graphics/PathStream.h:
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::definitelyEqual const):
* Source/WebCore/platform/graphics/cairo/PathCairo.h:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::definitelyEqual const):
* Source/WebCore/platform/graphics/cg/PathCG.h:
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::definitelyEqual const):
* Source/WebCore/platform/graphics/skia/PathSkia.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp: Added.
(TestWebKitAPI::TEST(Path, DefinitelyEqual)):
(TestWebKitAPI::TEST(Path, DefinitelyNotEqual)):

Canonical link: <a href="https://commits.webkit.org/282873@main">https://commits.webkit.org/282873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75a38913cedf8d8dcb5d9b5ce192be418e8bed1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15399 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10434 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13209 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59238 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55920 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14231 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7001 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/677 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39690 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->