### PR TITLE
CSSViewTransitionRule navigation descriptor should be a CSSOMString.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL CSSViewTransitionRule is correctly parsed and accessible via CSSOM. assert_equals: expected "" but got "none"
+PASS CSSViewTransitionRule is correctly parsed and accessible via CSSOM.
 PASS `navigation: auto` is correctly parsed.
 PASS `navigation: none` is correctly parsed.
 PASS @view-transition fails parsing with a preamble

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -115,6 +115,15 @@ String CSSViewTransitionRule::cssText() const
     return builder.toString();
 }
 
+AtomString CSSViewTransitionRule::navigation() const
+{
+    if (!m_viewTransitionRule->navigation())
+        return emptyAtom();
+    if (*m_viewTransitionRule->navigation() == ViewTransitionNavigation::Auto)
+        return "auto"_s;
+    return "none"_s;
+}
+
 void CSSViewTransitionRule::reattach(StyleRuleBase& rule)
 {
     m_viewTransitionRule = downcast<StyleRuleViewTransition>(rule);

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -67,7 +67,7 @@ public:
     void reattach(StyleRuleBase&) final;
     StyleRuleType styleRuleType() const final { return StyleRuleType::ViewTransition; }
 
-    ViewTransitionNavigation navigation() const { return m_viewTransitionRule->computedNavigation(); }
+    AtomString navigation() const;
     Vector<AtomString> types() const { return m_viewTransitionRule->types(); }
 
 private:

--- a/Source/WebCore/css/CSSViewTransitionRule.idl
+++ b/Source/WebCore/css/CSSViewTransitionRule.idl
@@ -26,13 +26,11 @@
  typedef USVString CSSOMString;
 
 // https://www.w3.org/TR/css-view-transitions-2/#view-transition-rule
-enum ViewTransitionNavigation { "auto", "none" };
-
 [
     EnabledBySetting=CrossDocumentViewTransitionsEnabled,
     Exposed=Window
 ]
 interface CSSViewTransitionRule : CSSRule {
-  readonly attribute ViewTransitionNavigation navigation;
+  readonly attribute [AtomString] CSSOMString navigation;
   readonly attribute FrozenArray<[AtomString] CSSOMString> types;
 };


### PR DESCRIPTION
#### a384dc3baae8736902b75860b5daf07d1dc4a15b
<pre>
CSSViewTransitionRule navigation descriptor should be a CSSOMString.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278492">https://bugs.webkit.org/show_bug.cgi?id=278492</a>
&lt;<a href="https://rdar.apple.com/134447014">rdar://134447014</a>&gt;

Reviewed by Tim Nguyen.

<a href="https://github.com/w3c/csswg-drafts/issues/10654">https://github.com/w3c/csswg-drafts/issues/10654</a> aligned the spec with existing
WPTs, so we can do this now and get a new pass.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom-expected.txt:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
(WebCore::CSSViewTransitionRule::navigation const):
* Source/WebCore/css/CSSViewTransitionRule.h:
* Source/WebCore/css/CSSViewTransitionRule.idl:

Canonical link: <a href="https://commits.webkit.org/282824@main">https://commits.webkit.org/282824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8143e793ba482f0437977605db9b9c53d97b9478

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51814 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10345 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13093 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70114 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12935 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59138 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55804 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/571 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39571 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->