### PR TITLE
AX: Implement the Mac AXMisspellingTextMarkerRange API using the new AXSearchManager::findMatchingRange.

### DIFF
--- a/LayoutTests/accessibility/search-misspellings.html
+++ b/LayoutTests/accessibility/search-misspellings.html
@@ -21,18 +21,21 @@ if (accessibilityController) {
     content = accessibilityController.accessibleElementById("content");
 
     output += "Find all misspelled word from the beginning of content:\n";
-    startRange = content.textMarkerRangeForMarkers(content.startTextMarker, content.startTextMarker);
-    result = content.textMarkerRangeForSearchPredicate(startRange, true, "AXMisspelledWordSearchKey");
+    result = content.textMarkerRangeForMarkers(content.startTextMarker, content.startTextMarker);
+    result = content.textMarkerRangeForSearchPredicate(result, true, "AXMisspelledWordSearchKey");
     while (result) {
         output += `${content.stringForTextMarkerRange(result)}\n`;
+        content.setSelectedTextMarkerRange(result);
         result = content.textMarkerRangeForSearchPredicate(result, true, "AXMisspelledWordSearchKey");
     }
 
     output += "Find all misspelled words backwards from the end of content:\n";
-    startRange = content.textMarkerRangeForMarkers(content.endTextMarker, content.endTextMarker);
-    result = content.textMarkerRangeForSearchPredicate(startRange, false, "AXMisspelledWordSearchKey");
+    result = content.textMarkerRangeForMarkers(content.endTextMarker, content.endTextMarker);
+    content.setSelectedTextMarkerRange(result);
+    result = content.textMarkerRangeForSearchPredicate(result, false, "AXMisspelledWordSearchKey");
     while (result) {
         output += `${content.stringForTextMarkerRange(result)}\n`;
+        content.setSelectedTextMarkerRange(result);
         result = content.textMarkerRangeForSearchPredicate(result, false, "AXMisspelledWordSearchKey");
     }
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -919,7 +919,9 @@ public:
 
     virtual bool hasBoldFont() const = 0;
     virtual bool hasItalicFont() const = 0;
-    virtual Vector<CharacterRange> spellCheckerResultRanges() const = 0;
+
+    // Returns all ranges of misspellings contained within the object.
+    virtual Vector<AXTextMarkerRange> misspellingRanges() const = 0;
     virtual std::optional<SimpleRange> misspellingRange(const SimpleRange& start, AccessibilitySearchDirection) const = 0;
     virtual std::optional<SimpleRange> visibleCharacterRange() const = 0;
     virtual bool hasPlainText() const = 0;

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -123,9 +123,11 @@ bool AXSearchManager::matchForSearchKeyAtIndex(RefPtr<AXCoreObject> axObject, co
     case AccessibilitySearchKey::LiveRegion:
         return axObject->supportsLiveRegion();
     case AccessibilitySearchKey::MisspelledWord: {
-        auto ranges = axObject->spellCheckerResultRanges();
-        m_spellCheckerResultRanges.set(axObject->objectID(), ranges);
-        return !ranges.isEmpty();
+        auto ranges = axObject->misspellingRanges();
+        bool hasMisspelling = !ranges.isEmpty();
+        if (hasMisspelling)
+            m_misspellingRanges.set(axObject->objectID(), WTFMove(ranges));
+        return hasMisspelling;
     }
     case AccessibilitySearchKey::Outline:
         return axObject->isTree();
@@ -273,7 +275,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
 
 AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsInternal(const AccessibilitySearchCriteria& criteria)
 {
-    AXTRACE("Accessibility::findMatchingObjectsInternal"_s);
+    AXTRACE("AXSearchManager::findMatchingObjectsInternal"_s);
     AXLOG(criteria);
 
     AXCoreObject::AccessibilityChildrenVector results;
@@ -333,6 +335,8 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
 
 std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(AccessibilitySearchCriteria&& criteria)
 {
+    AXTRACE("AXSearchManager::findMatchingRange"_s);
+
     // Currently, this method only supports searching for the next/previous misspelling.
     // FIXME: support other types of ranges, like italicized.
     if (criteria.searchKeys.size() != 1 || criteria.searchKeys[0] != AccessibilitySearchKey::MisspelledWord || criteria.resultsLimit != 1) {
@@ -344,24 +348,24 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     RefPtr startObject = criteria.startObject;
     if (!startObject)
         startObject = criteria.anchorObject;
+    AXLOG(startObject);
 
     bool forward = criteria.searchDirection == AccessibilitySearchDirection::Next;
     if (match(startObject, criteria)) {
-        AXTextMarkerRange startRange { startObject->treeID(), startObject->objectID(), criteria.startRange };
-        const auto& characterRanges = m_spellCheckerResultRanges.get(startObject->objectID());
-        ASSERT(!characterRanges.isEmpty());
+        ASSERT(m_misspellingRanges.contains(startObject->objectID()));
+        const auto& ranges = m_misspellingRanges.get(startObject->objectID());
+        ASSERT(!ranges.isEmpty());
 
+        AXTextMarkerRange startRange { startObject->treeID(), startObject->objectID(), criteria.startRange };
         if (forward) {
-            for (auto it = characterRanges.begin(); it != characterRanges.end(); ++it) {
-                AXTextMarkerRange range { startObject->treeID(), startObject->objectID(), *it };
-                if (range > startRange)
-                    return range;
+            for (auto it = ranges.begin(); it != ranges.end(); ++it) {
+                if (*it > startRange)
+                    return *it;
             }
         } else {
-            for (auto it = characterRanges.rbegin(); it != characterRanges.rend(); ++it) {
-                AXTextMarkerRange range { startObject->treeID(), startObject->objectID(), *it };
-                if (range < startRange)
-                    return range;
+            for (auto it = ranges.rbegin(); it != ranges.rend(); ++it) {
+                if (*it < startRange)
+                    return *it;
             }
         }
     }
@@ -370,10 +374,11 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     auto objects = findMatchingObjectsInternal(criteria);
     if (!objects.isEmpty() && objects[0]) {
         auto& object = *objects[0];
-        const auto& characterRanges = m_spellCheckerResultRanges.get(object.objectID());
-        ASSERT(!characterRanges.isEmpty());
-        auto& characterRange = forward ? characterRanges[0] : characterRanges.last();
-        return { { object.treeID(), object.objectID(), characterRange } };
+        AXLOG(object);
+        ASSERT(m_misspellingRanges.contains(object.objectID()));
+        const auto& ranges = m_misspellingRanges.get(object.objectID());
+        ASSERT(!ranges.isEmpty());
+        return forward ? ranges[0] : ranges.last();
     }
     return std::nullopt;
 }

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -102,7 +102,7 @@ private:
     bool matchForSearchKeyAtIndex(RefPtr<AXCoreObject>, const AccessibilitySearchCriteria&, size_t);
 
     // Keeps the ranges of misspellings for each object.
-    HashMap<AXID, Vector<CharacterRange>> m_spellCheckerResultRanges;
+    HashMap<AXID, Vector<AXTextMarkerRange>> m_misspellingRanges;
 };
 
 inline AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjects(AccessibilitySearchCriteria&& criteria)

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -232,7 +232,7 @@ public:
 
     bool hasBoldFont() const override { return false; }
     bool hasItalicFont() const override { return false; }
-    Vector<CharacterRange> spellCheckerResultRanges() const final;
+    Vector<AXTextMarkerRange> misspellingRanges() const final;
     std::optional<SimpleRange> misspellingRange(const SimpleRange& start, AccessibilitySearchDirection) const override;
     bool hasPlainText() const override { return false; }
     bool hasSameFont(const AXCoreObject&) const override { return false; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1792,11 +1792,11 @@ bool AXIsolatedObject::isSelectedOptionActive() const
     return false;
 }
 
-Vector<CharacterRange> AXIsolatedObject::spellCheckerResultRanges() const
+Vector<AXTextMarkerRange> AXIsolatedObject::misspellingRanges() const
 {
-    return Accessibility::retrieveValueFromMainThread<Vector<CharacterRange>>([this] () -> Vector<CharacterRange> {
+    return Accessibility::retrieveValueFromMainThread<Vector<AXTextMarkerRange>>([this] () -> Vector<AXTextMarkerRange> {
         if (auto* axObject = associatedAXObject())
-            return axObject->spellCheckerResultRanges();
+            return axObject->misspellingRanges();
         return { };
     });
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -469,7 +469,7 @@ private:
     bool isSelectedOptionActive() const final;
     bool hasBoldFont() const final { return boolAttributeValue(AXPropertyName::HasBoldFont); }
     bool hasItalicFont() const final { return boolAttributeValue(AXPropertyName::HasItalicFont); }
-    Vector<CharacterRange> spellCheckerResultRanges() const final;
+    Vector<AXTextMarkerRange> misspellingRanges() const final;
     bool hasPlainText() const final { return boolAttributeValue(AXPropertyName::HasPlainText); }
     bool hasSameFont(const AXCoreObject&) const final;
     bool hasSameFontColor(const AXCoreObject&) const final;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3350,7 +3350,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attribute isEqualToString:AXMisspellingTextMarkerRangeAttribute]) {
         return (id)Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRangeRef>([&dictionary, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRangeRef> {
-            auto* backingObject = protectedSelf.get().axBackingObject;
+            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
             if (!backingObject)
                 return nil;
 
@@ -3358,13 +3358,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             if (!criteria.first)
                 return nil;
 
-            auto range = criteria.first.simpleRange();
-            if (!range)
+            auto characterRange = criteria.first.characterRange();
+            if (!characterRange)
                 return nil;
 
-            if (auto misspellRange = backingObject->misspellingRange(*range, criteria.second))
-                return AXTextMarkerRange(*misspellRange).platformData();
-            return nil;
+            RefPtr startObject = criteria.second == AccessibilitySearchDirection::Next ? criteria.first.end().object() : criteria.first.start().object();
+            auto misspellingRange = AXSearchManager().findMatchingRange(AccessibilitySearchCriteria {
+                backingObject.get(), startObject.get(), *characterRange,
+                criteria.second,
+                { AccessibilitySearchKey::MisspelledWord }, { }, 1
+            });
+            if (!misspellingRange)
+                return nil;
+            return misspellingRange->platformData();
         });
     }
 


### PR DESCRIPTION
#### 6968f29a69b714d0328c16b2ef2f4986c3b9208c
<pre>
AX: Implement the Mac AXMisspellingTextMarkerRange API using the new AXSearchManager::findMatchingRange.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278752">https://bugs.webkit.org/show_bug.cgi?id=278752</a>
&lt;<a href="https://rdar.apple.com/problem/134820936">rdar://problem/134820936</a>&gt;

Reviewed by Tyler Wilcock.

This allows the unification of the code paths for this functionality in both Mac and iOS. Fixes several bugs covered by misspelling-range.html and search-misspellings.html.

* LayoutTests/accessibility/search-misspellings.html:
Added setting the selection after finding a misspelling range which more closely resembles how VoiceOver uses this API.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
(WebCore::AXSearchManager::findMatchingObjectsInternal):
(WebCore::AXSearchManager::findMatchingRange):
* Source/WebCore/accessibility/AXSearchManager.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::misspellingRanges const):
(WebCore::AccessibilityObject::spellCheckerResultRanges const): Renamed misspellingRanges.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::misspellingRanges const):
(WebCore::AXIsolatedObject::spellCheckerResultRanges const): Renamed.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/282874@main">https://commits.webkit.org/282874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/078cef63239fd5eb49babb9fb43ac127255d34e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51910 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10437 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37280 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13212 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/stretch-along-block-axis-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13999 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13046 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55922 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14232 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/679 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39696 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->