### PR TITLE
[css-view-transitions-2] mismatched-snapshot-containing-block-size-skips fails.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6839,7 +6839,6 @@ imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-014.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-017.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-018.html [ Failure ]
-imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-021.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-022.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-036.html [ Failure ]
 
@@ -7500,6 +7499,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-pai
 # Fuzzy failure, pixel rounding in <iframe>?
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html [ ImageOnlyFailure ]
 webkit.org/b/278028 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]
+webkit.org/b/278756 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal.html [ Failure ]
 
 # prerender not supported.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/prerender-removed-during-navigation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips-expected.txt
@@ -1,5 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Skipping view transition because viewport size changed.
-CONSOLE MESSAGE: TypeError: e.data.startsWith is not a function. (In 'e.data.startsWith('FAIL:')', 'e.data.startsWith' is undefined)
 
 PASS
 View transitions: mismatched snapshot containing block size skips transition.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html
@@ -117,9 +117,10 @@ if (is_harness_page) {
       // This simply ensures the test only runs if render blocking was
       // successful since a fetch failure looks the same as never blocking
       // rendering.
-      Promise.all([rendering_blocked_promise, rendering_unblocked_promise]).then(() => {
+      Promise.all([rendering_blocked_promise, rendering_unblocked_promise]).then(async () => {
         window.viewTransition = e.viewTransition;
         window.opener.postMessage('pagereveal');
+        await Promise.allSettled([e.viewTransition.ready]);
       }, () => {});
     });
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL when navigating away before revealing, never start a view transition assert_equals: expected "did reveal new page without transition" but got "did reveal old page"
+PASS when navigating away before revealing, never start a view transition
 

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -110,7 +110,9 @@ private:
     static void processCallback(Node*);
     void clearSheet();
 
+    void potentiallyBlockRendering();
     void unblockRendering();
+    bool isImplicitlyPotentiallyRenderBlocking() const;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;


### PR DESCRIPTION
#### b982f2ab277ebfcf72ca4cd78b3862e256be1e81
<pre>
[css-view-transitions-2] mismatched-snapshot-containing-block-size-skips fails.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278759">https://bugs.webkit.org/show_bug.cgi?id=278759</a>
&lt;<a href="https://rdar.apple.com/134829177">rdar://134829177</a>&gt;

Reviewed by Tim Nguyen.

This test largely failed because render blocking for &lt;link rel=stylesheet
blocking=render&gt; wasn&apos;t working.

This commit fixes that, making sure we call blockRenderingOn for stylesheet
links. It&apos;s somewhat complicated that both rel=stylesheet and rel=expect cause
render blocking, but other don&apos;t, and we need to handle mutations correctly.

It refactors the code for blocking in HTMLLinkElement into a single place, and
changes m_blockingList to be instantiated when the attribute is set (the rare
case), rather than when it&apos;s queried (the common case).

It also updates test expectations a bit so that there&apos;s links to the current
investigations for unfixed failures.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::process):
(WebCore::HTMLLinkElement::processInternalResourceLink):
(WebCore::HTMLLinkElement::blockRendering):
(WebCore::HTMLLinkElement::isImplicitlyPotentiallyRenderBlocking const):
(WebCore::HTMLLinkElement::isPotentiallyRenderBlocking const):
(WebCore::HTMLLinkElement::removedFromAncestor):
(WebCore::HTMLLinkElement::setCSSStyleSheet):
* Source/WebCore/html/HTMLLinkElement.h:

Canonical link: <a href="https://commits.webkit.org/283119@main">https://commits.webkit.org/283119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8183712a32f8907bd059415249b19dd86dfae51d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52375 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10933 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13804 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59754 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14143 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70924 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59703 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59977 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14388 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1232 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40374 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42632 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->