### PR TITLE
[css-view-transitions-2] at-rule-in-layer-cascade fails.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View Transitions: @view-transition cascaldes correclty with layers. assert_not_equals: ViewTransition must be triggered. got disallowed value null
+PASS View Transitions: @view-transition cascaldes correclty with layers.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-external-stylesheet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-external-stylesheet-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View Transitions: @view-transition cascaldes correclty with layers in separate external stylesheets. assert_not_equals: ViewTransition must be triggered. got disallowed value null
+PASS View Transitions: @view-transition cascaldes correclty with layers in separate external stylesheets.
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -208,6 +208,7 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
     case StyleRuleType::FontFeatureValues:
     case StyleRuleType::Keyframes:
     case StyleRuleType::Property:
+    case StyleRuleType::ViewTransition:
         disallowDynamicMediaQueryEvaluationIfNeeded();
         if (m_resolver)
             m_collectedResolverMutatingRules.append({ rule, m_currentCascadeLayerIdentifier });
@@ -219,10 +220,6 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
             addChildRules(supportsRule->childRules());
         return;
     }
-    case StyleRuleType::ViewTransition:
-        if (m_ruleSet)
-            m_ruleSet->setViewTransitionRule(uncheckedDowncast<StyleRuleViewTransition>(rule));
-        return;
 
     case StyleRuleType::Import:
     case StyleRuleType::Margin:
@@ -478,6 +475,10 @@ void RuleSetBuilder::addMutatingRulesToResolver()
             auto& registry = m_resolver->document().styleScope().customPropertyRegistry();
             registry.registerFromStylesheet(styleRuleProperty->descriptor());
             continue;
+        }
+        if (auto* styleRuleViewTransition = dynamicDowncast<StyleRuleViewTransition>(rule.get())) {
+            if (m_ruleSet)
+                m_ruleSet->setViewTransitionRule(*styleRuleViewTransition);
         }
     }
 }


### PR DESCRIPTION
#### 4f34754b7b36ff66550252f95a6214a09fe1d16b
<pre>
[css-view-transitions-2] at-rule-in-layer-cascade fails.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278762">https://bugs.webkit.org/show_bug.cgi?id=278762</a>
&lt;<a href="https://rdar.apple.com/134830743">rdar://134830743</a>&gt;

Reviewed by Tim Nguyen.

ViewTransitionRules need to be added to m_collectedResolverMutatingRules, and handled after any @layer sorting has been applied.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-external-stylesheet-expected.txt:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):

Canonical link: <a href="https://commits.webkit.org/282832@main">https://commits.webkit.org/282832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40f4cb3472971d8d85dc0802a340af26389f232

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51832 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10361 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13115 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59323 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14213 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/592 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39593 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->