### PR TITLE
[Writing Tools] Send entire contents as context to Writing Tools for Compose composition type

### DIFF
--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -104,7 +104,7 @@ String WritingToolsController::plainText(const SimpleRange& range)
 
 #pragma mark - Static utility helper methods.
 
-static std::optional<SimpleRange> contextRangeForDocument(const Document& document)
+static std::optional<SimpleRange> contextRangeForSession(const Document& document, const std::optional<WritingTools::Session>& session)
 {
     // If the selection is a range, the range of the context should be the range of the paragraph
     // surrounding the selection range, unless such a range is empty.
@@ -113,14 +113,23 @@ static std::optional<SimpleRange> contextRangeForDocument(const Document& docume
 
     auto selection = document.selection().selection();
 
-    if (selection.isRange()) {
-        auto startOfFirstParagraph = startOfParagraph(selection.start());
-        auto endOfLastParagraph = endOfParagraph(selection.end());
+    if (session && session->compositionType == WritingTools::Session::CompositionType::SmartReply) {
+        // The session context range for Smart Replies should only be the selected text range (it should not be expanded).
+        return selection.firstRange();
+    }
 
-        auto paragraphRange = makeSimpleRange(startOfFirstParagraph, endOfLastParagraph);
+    if (!session || session->compositionType != WritingTools::Session::CompositionType::Compose) {
+        // If the session is a Compose session, the range should be the range of the entire editable content.
 
-        if (paragraphRange && hasAnyPlainText(*paragraphRange, defaultTextIteratorBehaviors))
-            return paragraphRange;
+        if (selection.isRange()) {
+            auto startOfFirstParagraph = startOfParagraph(selection.start());
+            auto endOfLastParagraph = endOfParagraph(selection.end());
+
+            auto paragraphRange = makeSimpleRange(startOfFirstParagraph, endOfLastParagraph);
+
+            if (paragraphRange && hasAnyPlainText(*paragraphRange, defaultTextIteratorBehaviors))
+                return paragraphRange;
+        }
     }
 
     auto startOfFirstEditableContent = startOfEditableContent(selection.start());
@@ -153,14 +162,12 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
         return;
     }
 
-    auto contextRange = contextRangeForDocument(*document);
+    auto contextRange = contextRangeForSession(*document, session);
     if (!contextRange) {
         RELEASE_LOG(WritingTools, "WritingToolsController::willBeginWritingToolsSession (%s) => no context range", session ? session->identifier.toString().utf8().data() : "");
         completionHandler({ });
         return;
     }
-
-    auto selectedTextRange = document->selection().selection().firstRange();
 
     if (session && session->compositionType == WritingTools::Session::CompositionType::SmartReply) {
         // Smart replies are a unique use case of the Writing Tools delegate methods;
@@ -169,7 +176,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
 
         ASSERT(session->type == WritingTools::Session::Type::Composition);
 
-        m_state = CompositionState { { }, { WritingToolsCompositionCommand::create(Ref { *document }, *selectedTextRange) }, *session };
+        m_state = CompositionState { { }, { WritingToolsCompositionCommand::create(Ref { *document }, *contextRange) }, *session };
 
         completionHandler({ { WTF::UUID { 0 }, AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:@""])), CharacterRange { 0, 0 } } });
         return;
@@ -177,6 +184,8 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
 
     // The attributed string produced uses all `IncludedElement`s so that no information is lost; each element
     // will be encoded as an NSTextAttachment.
+
+    auto selectedTextRange = document->selection().selection().firstRange();
 
     auto attributedStringFromRange = editingAttributedString(*contextRange, { IncludedElement::Images, IncludedElement::Attachments, IncludedElement::PreservedContent });
     auto selectedTextCharacterRange = characterRange(*contextRange, *selectedTextRange);

--- a/Source/WebCore/page/writing-tools/WritingToolsTypes.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsTypes.h
@@ -60,6 +60,7 @@ enum class SessionType : uint8_t {
 
 enum class SessionCompositionType : uint8_t {
     None,
+    Compose,
     SmartReply,
     Other,
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6482,6 +6482,7 @@ header: <WebCore/WritingToolsTypes.h>
 header: <WebCore/WritingToolsTypes.h>
 [CustomHeader] enum class WebCore::WritingTools::SessionCompositionType : uint8_t {
     None,
+    Compose,
     SmartReply,
     Other
 };

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
@@ -146,6 +146,9 @@ WebCore::WritingTools::Session::CompositionType convertToWebCompositionSessionTy
     case WTCompositionSessionTypeNone:
         return WebCore::WritingTools::Session::CompositionType::None;
 
+    case WTCompositionSessionTypeCompose:
+        return WebCore::WritingTools::Session::CompositionType::Compose;
+
     case WTCompositionSessionTypeSmartReply:
         return WebCore::WritingTools::Session::CompositionType::SmartReply;
 


### PR DESCRIPTION
#### ceb2721f3072abc286af88e9d1f124e3cfc1fc03
<pre>
[Writing Tools] Send entire contents as context to Writing Tools for Compose composition type
<a href="https://bugs.webkit.org/show_bug.cgi?id=278766">https://bugs.webkit.org/show_bug.cgi?id=278766</a>
<a href="https://rdar.apple.com/131875217">rdar://131875217</a>

Reviewed by Abrar Rahman Protyasha.

For the Compose composition type sessions, send the entire range of the editable content instead
of just the enclosing paragraph(s).

* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::contextRangeForSession):
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::contextRangeForDocument): Deleted.
* Source/WebCore/page/writing-tools/WritingToolsTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm:
(WebKit::convertToWebCompositionSessionType):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, ShowAffordance)):
(TEST(WritingTools, CompositionWithComposeCompositionType)):

Canonical link: <a href="https://commits.webkit.org/282859@main">https://commits.webkit.org/282859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/830cf67c11d03a12ba8c8fc5e68afdf304beb8c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51839 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10368 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13122 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70146 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/597 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39602 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->