### PR TITLE
Allow webpushd to select web clip implicitly via origin

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -110,6 +110,7 @@ public:
 
     WEBCORE_EXPORT void removeRecordsBySubscriptionSet(const PushSubscriptionSetIdentifier&, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
     WEBCORE_EXPORT void removeRecordsBySubscriptionSetAndSecurityOrigin(const PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
+    WEBCORE_EXPORT void removeRecordsByBundleIdentifierAndDataStore(const String& bundleIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
 
     WEBCORE_EXPORT void setPushesEnabled(const PushSubscriptionSetIdentifier&, bool, CompletionHandler<void(bool recordsChanged)>&&);
     WEBCORE_EXPORT void setPushesEnabledForOrigin(const PushSubscriptionSetIdentifier&, const String& securityOrigin, bool, CompletionHandler<void(bool recordsChanged)>&&);

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -106,12 +106,12 @@ void NetworkNotificationManager::getNotifications(const URL& registrationURL, co
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetNotifications { registrationURL, tag }, WTFMove(completionHandler));
 }
 
-void NetworkNotificationManager::cancelNotification(const WTF::UUID& notificationID)
+void NetworkNotificationManager::cancelNotification(WebCore::SecurityOriginData&& origin, const WTF::UUID& notificationID)
 {
     if (!m_connection)
         return;
 
-    m_connection->sendWithoutUsingIPCConnection(Messages::PushClientConnection::CancelNotification { notificationID });
+    m_connection->sendWithoutUsingIPCConnection(Messages::PushClientConnection::CancelNotification { WTFMove(origin), notificationID });
 }
 
 void NetworkNotificationManager::clearNotifications(const Vector<WTF::UUID>&)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -78,7 +78,7 @@ public:
 
 private:
     void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
-    void cancelNotification(const WTF::UUID& notificationID) final;
+    void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final { }
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -44,7 +44,7 @@ public:
     virtual ~NotificationManagerMessageHandler() = default;
 
     virtual void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) = 0;
-    virtual void cancelNotification(const WTF::UUID& notificationID) = 0;
+    virtual void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID) = 0;
     virtual void clearNotifications(const Vector<WTF::UUID>& notificationIDs) = 0;
     virtual void didDestroyNotification(const WTF::UUID& notificationID) = 0;
     virtual void pageWasNotifiedOfNotificationPermission() = 0;

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -22,7 +22,7 @@
 
 messages -> NotificationManagerMessageHandler NotRefCounted {
     ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
-    CancelNotification(WTF::UUID notificationID)
+    CancelNotification(WebCore::SecurityOriginData origin, WTF::UUID notificationID)
     ClearNotifications(Vector<WTF::UUID> notificationIDs)
     DidDestroyNotification(WTF::UUID notificationID)
     PageWasNotifiedOfNotificationPermission()

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -63,7 +63,7 @@ void ServiceWorkerNotificationHandler::showNotification(IPC::Connection& connect
     dataStore->showPersistentNotification(&connection, data);
 }
 
-void ServiceWorkerNotificationHandler::cancelNotification(const WTF::UUID& notificationID)
+void ServiceWorkerNotificationHandler::cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID)
 {
     if (auto* dataStore = dataStoreForNotificationID(notificationID))
         dataStore->cancelServiceWorkerNotification(notificationID);

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -40,7 +40,7 @@ public:
 
     void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
 
-    void cancelNotification(const WTF::UUID& notificationID) final;
+    void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID) final;
     void clearNotifications(const Vector<WTF::UUID>& notificationIDs) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final { }

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -51,11 +51,11 @@ void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& con
     callback();
 }
 
-void WebNotificationManagerMessageHandler::cancelNotification(const WTF::UUID& notificationID)
+void WebNotificationManagerMessageHandler::cancelNotification(WebCore::SecurityOriginData&& origin, const WTF::UUID& notificationID)
 {
     auto& serviceWorkerNotificationHandler = ServiceWorkerNotificationHandler::singleton();
     if (serviceWorkerNotificationHandler.handlesNotification(notificationID)) {
-        serviceWorkerNotificationHandler.cancelNotification(notificationID);
+        serviceWorkerNotificationHandler.cancelNotification(WTFMove(origin), notificationID);
         return;
     }
     m_webPageProxy.cancelNotification(notificationID);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -37,7 +37,7 @@ private:
     explicit WebNotificationManagerMessageHandler(WebPageProxy&);
 
     void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
-    void cancelNotification(const WTF::UUID& notificationID) final;
+    void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID) final;
     void clearNotifications(const Vector<WTF::UUID>& notificationIDs) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final;

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -230,7 +230,8 @@ void WebNotificationManager::cancel(NotificationData&& notification, WebPage* pa
     auto identifier = notification.notificationID;
     ASSERT(notification.isPersistent() || m_nonPersistentNotificationsContexts.contains(identifier));
 
-    if (!sendNotificationMessage(Messages::NotificationManagerMessageHandler::CancelNotification(identifier), page))
+    auto origin = WebCore::SecurityOriginData::fromURL(URL { notification.originString });
+    if (!sendNotificationMessage(Messages::NotificationManagerMessageHandler::CancelNotification(WTFMove(origin), identifier), page))
         return;
 #else
     UNUSED_PARAM(notification);

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -75,12 +75,15 @@ class PushClientConnection : public RefCounted<PushClientConnection>, public Ide
 public:
     static RefPtr<PushClientConnection> create(xpc_connection_t, IPC::Decoder&);
 
-    WebCore::PushSubscriptionSetIdentifier subscriptionSetIdentifier() const;
+    std::optional<WebCore::PushSubscriptionSetIdentifier> subscriptionSetIdentifierForOrigin(const WebCore::SecurityOriginData&) const;
     const String& hostAppCodeSigningIdentifier() const { return m_hostAppCodeSigningIdentifier; }
     bool hostAppHasPushInjectEntitlement() const { return m_hostAppHasPushInjectEntitlement; };
-
-    const String& pushPartitionString() const { return m_pushPartitionString; }
     std::optional<WTF::UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
+
+    // You almost certainly do not want to use this and should probably use subscriptionSetIdentifierForOrigin instead.
+    const String& pushPartitionIfExists() const { return m_pushPartitionString; }
+
+    String debugDescription() const;
 
     void connectionClosed();
 
@@ -114,7 +117,7 @@ private:
 
     void showNotification(const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
-    void cancelNotification(const WTF::UUID& notificationID);
+    void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID);
     void setAppBadge(WebCore::SecurityOriginData&&, std::optional<uint64_t>);
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
 

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -40,7 +40,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     GetPushTopicsForTesting() -> (Vector<String> enabled, Vector<String> ignored)
     ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
-    CancelNotification(WTF::UUID notificationID)
+    CancelNotification(WebCore::SecurityOriginData origin, WTF::UUID notificationID)
     RequestPushPermission(WebCore::SecurityOriginData origin) -> (bool granted)
     SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
     GetAppBadgeForTesting() -> (std::optional<uint64_t> badge)

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -75,6 +75,7 @@ public:
 
     void removeRecordsForSubscriptionSet(const WebCore::PushSubscriptionSetIdentifier&, CompletionHandler<void(unsigned)>&&);
     void removeRecordsForSubscriptionSetAndOrigin(const WebCore::PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
+    void removeRecordsForBundleIdentifierAndDataStore(const String& bundleIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, CompletionHandler<void(unsigned)>&&);
 
     void didCompleteGetSubscriptionRequest(GetSubscriptionRequest&);
     void didCompleteSubscribeRequest(SubscribeRequest&);

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -110,11 +110,12 @@ static bool webClipExists(String webClipIdentifier)
 
 #endif
 
-#define WEBPUSHDAEMON_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%{public}s [connection=%p, app=%{public}s]: " fmt, __func__, &connection, connection.subscriptionSetIdentifier().debugDescription().utf8().data(), ##__VA_ARGS__)
-#define WEBPUSHDAEMON_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%{public}s [connection=%p, app=%{public}s]: " fmt, __func__, &connection, connection.subscriptionSetIdentifier().debugDescription().utf8().data(), ##__VA_ARGS__)
+#define WEBPUSHDAEMON_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%{public}s [connection=%p, app=%{public}s]: " fmt, __func__, &connection, connection.debugDescription().ascii().data(), ##__VA_ARGS__)
+#define WEBPUSHDAEMON_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%{public}s [connection=%p, app=%{public}s]: " fmt, __func__, &connection, connection.debugDescription().ascii().data(), ##__VA_ARGS__)
 
 using namespace WebKit::WebPushD;
 using WebCore::PushSubscriptionSetIdentifier;
+using WebCore::SecurityOriginData;
 
 namespace WebPushD {
 
@@ -143,22 +144,9 @@ static NSString *platformDefaultActionBundleIdentifier()
 #endif
 }
 
-#if PLATFORM(IOS)
-static RetainPtr<NSString> platformNotificationCenterBundleIdentifier(String webClipIdentifier)
+static RetainPtr<NSString> platformNotificationCenterBundleIdentifier(String pushPartition)
 {
-    return [NSString stringWithFormat:@"com.apple.WebKit.PushBundle.%@", (NSString *)webClipIdentifier];
-}
-#endif
-
-static RetainPtr<NSString> platformNotificationCenterBundleIdentifier(PushClientConnection& connection)
-{
-#if PLATFORM(IOS)
-    return [NSString stringWithFormat:@"com.apple.WebKit.PushBundle.%@", (NSString *)connection.pushPartitionString()];
-#else
-    // FIXME: Calculate the correct values on macOS in a non-testing environment.
-    RELEASE_ASSERT(connection.hostAppCodeSigningIdentifier() == "com.apple.WebKit.TestWebKitAPI"_s);
-    return [NSString stringWithFormat:@"com.apple.WebKit.PushBundle.%@", (NSString *)connection.pushPartitionString()];
-#endif
+    return [NSString stringWithFormat:@"com.apple.WebKit.PushBundle.%@", (NSString *)pushPartition];
 }
 
 static NSString *platformNotificationSourceForDisplay(PushClientConnection& connection)
@@ -335,10 +323,10 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
     }
 
 #if PLATFORM(IOS)
-    auto bundleIdentifier = pushConnection->subscriptionSetIdentifier().bundleIdentifier;
-    auto webClipIdentifier = pushConnection->subscriptionSetIdentifier().pushPartition;
-    if (!getAllowedBundleIdentifiers().contains(bundleIdentifier) || !webClipExists(webClipIdentifier)) {
-        RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - Got message from unexpected app %{public}s", pushConnection->subscriptionSetIdentifier().debugDescription().utf8().data());
+    auto bundleIdentifier = pushConnection->hostAppCodeSigningIdentifier();
+    auto pushPartition = pushConnection->pushPartitionIfExists();
+    if (!getAllowedBundleIdentifiers().contains(bundleIdentifier) || (!pushPartition.isEmpty() && !webClipExists(pushPartition))) {
+        RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - Got message from unexpected bundleIdentifier = %{public}s and pushPartition = %{public}s", bundleIdentifier.ascii().data(), pushPartition.ascii().data());
         updateSubscriptionSetState();
         tryCloseRequestConnection(request);
         return;
@@ -397,10 +385,10 @@ void WebPushDaemon::updateSubscriptionSetState()
         m_pushService->updateSubscriptionSetState(allowedBundleIdentifiers, installedWebClipIdentifiers, []() { });
 
         for (auto& [xpcConnection, pushClientConnection] : m_connectionMap) {
-            auto bundleIdentifier = pushClientConnection->subscriptionSetIdentifier().bundleIdentifier;
-            auto webClipIdentifier = pushClientConnection->subscriptionSetIdentifier().pushPartition;
-            if (!allowedBundleIdentifiers.contains(bundleIdentifier) || !installedWebClipIdentifiers.contains(webClipIdentifier)) {
-                RELEASE_LOG(Push, "WebPushDaemon::updateSubscriptionSetState: killing obsolete connection %p associated with %{public}s", xpcConnection, pushClientConnection->subscriptionSetIdentifier().debugDescription().utf8().data());
+            auto bundleIdentifier = pushClientConnection->hostAppCodeSigningIdentifier();
+            auto pushPartition = pushClientConnection->pushPartitionIfExists();
+            if (!allowedBundleIdentifiers.contains(bundleIdentifier) || (!pushPartition.isEmpty() && !installedWebClipIdentifiers.contains(pushPartition))) {
+                RELEASE_LOG(Push, "WebPushDaemon::updateSubscriptionSetState: killing obsolete connection %p associated with bundleIdentifier = %{public}s and pushPartition = %{public}s", xpcConnection, bundleIdentifier.ascii().data(), pushPartition.ascii().data());
                 xpc_connection_cancel(xpcConnection);
             }
         }
@@ -411,11 +399,15 @@ void WebPushDaemon::updateSubscriptionSetState()
 
 void WebPushDaemon::setPushAndNotificationsEnabledForOrigin(PushClientConnection& connection, const String& originString, bool enabled, CompletionHandler<void()>&& replySender)
 {
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), originString, enabled, replySender = WTFMove(replySender)]() mutable {
-        if (!m_pushService) {
-            replySender();
-            return;
-        }
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(SecurityOriginData::fromURL(URL { originString }));
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", originString.ascii().data());
+        return replySender();
+    }
+
+    runAfterStartingPushService([this, identifier = WTFMove(*maybeIdentifier), originString, enabled, replySender = WTFMove(replySender)]() mutable {
+        if (!m_pushService)
+            return replySender();
 
         m_pushService->setPushesEnabledForSubscriptionSetAndOrigin(identifier, originString, enabled, WTFMove(replySender));
     });
@@ -452,18 +444,15 @@ void WebPushDaemon::injectPushMessageForTesting(PushClientConnection& connection
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
 
     PushSubscriptionSetIdentifier identifier { .bundleIdentifier = message.targetAppCodeSigningIdentifier, .pushPartition = message.pushPartitionString, .dataStoreIdentifier = connection.dataStoreIdentifier() };
-    auto addResult = m_pushMessages.ensure(identifier, [] {
-        return Deque<WebKit::WebPushMessage> { };
-    });
     auto data = message.payload.utf8();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     WebKit::WebPushMessage pushMessage { Vector(data.span()), message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) };
 #else
     WebKit::WebPushMessage pushMessage { Vector(data.span()), message.pushPartitionString, message.registrationURL, { } };
 #endif
-    addResult.iterator->value.append(pushMessage);
+    m_pendingPushMessages.append({ identifier, WTFMove(pushMessage) });
 
-    WEBPUSHDAEMON_RELEASE_LOG(Push, "Injected a test push message for %{public}s at %{public}s with %zu pending messages, payload: %{public}s", message.targetAppCodeSigningIdentifier.utf8().data(), message.registrationURL.string().utf8().data(), addResult.iterator->value.size(), message.payload.utf8().data());
+    WEBPUSHDAEMON_RELEASE_LOG(Push, "Injected a test push message for %{public}s at %{public}s with %zu pending messages, payload: %{public}s", message.targetAppCodeSigningIdentifier.utf8().data(), message.registrationURL.string().utf8().data(), m_pendingPushMessages.size(), message.payload.utf8().data());
 
     notifyClientPushMessageIsAvailable(identifier);
 
@@ -527,12 +516,7 @@ void WebPushDaemon::handleIncomingPush(const PushSubscriptionSetIdentifier& iden
 void WebPushDaemon::handleIncomingPushImpl(const PushSubscriptionSetIdentifier& identifier, WebKit::WebPushMessage&& message)
 {
     ensureIncomingPushTransaction();
-
-    auto addResult = m_pushMessages.ensure(identifier, [] {
-        return Deque<WebKit::WebPushMessage> { };
-    });
-    addResult.iterator->value.append(WTFMove(message));
-
+    m_pendingPushMessages.append({ identifier, WTFMove(message) });
     notifyClientPushMessageIsAvailable(identifier);
 }
 
@@ -607,8 +591,11 @@ void WebPushDaemon::notifyClientPushMessageIsAvailable(const WebCore::PushSubscr
         FBSOpenApplicationOptionKeyPayloadOptions : @{ UIApplicationLaunchOptionsSourceApplicationKey : @"com.apple.WebKit.webpushd" },
     }];
 
-    RetainPtr<FBSOpenApplicationService> openService = adoptNS(SBSCreateOpenApplicationService());
-    [openService openApplication:(NSString *)bundleIdentifier withOptions:options completion:^(BSProcessHandle *process, NSError *error) {
+    // This function doesn't actually follow the create rule, therefore we don't use adoptNS on it.
+    if (!m_openService)
+        m_openService = SBSCreateOpenApplicationService();
+
+    [m_openService openApplication:(NSString *)bundleIdentifier withOptions:options completion:^(BSProcessHandle *process, NSError *error) {
         if (error)
             RELEASE_LOG_ERROR(Push, "Failed to open app to handle push: %{public}@", error);
     }];
@@ -673,50 +660,64 @@ void WebPushDaemon::didShowNotification(const WebCore::PushSubscriptionSetIdenti
         rescheduleSilentPushTimer();
 }
 
+static bool connectionMatchesPendingPushMessage(const PushClientConnection& connection, const PushSubscriptionSetIdentifier& identifierForPendingPushMessage)
+{
+    if (connection.hostAppCodeSigningIdentifier() != identifierForPendingPushMessage.bundleIdentifier)
+        return false;
+
+    if (connection.dataStoreIdentifier() != identifierForPendingPushMessage.dataStoreIdentifier.asOptional())
+        return false;
+
+#if PLATFORM(IOS)
+    // If the connection did not specify a particular push partition (i.e. "implicit webclip mode"),
+    // then we'll return any pending message for that app. Otherwise, it has to match the partition
+    // specified in the message.
+    auto pushPartition = connection.pushPartitionIfExists();
+    return pushPartition.isEmpty() || pushPartition == identifierForPendingPushMessage.pushPartition;
+#else
+    return equalIgnoringNullity(connection.pushPartitionIfExists(), identifierForPendingPushMessage.pushPartition);
+#endif
+}
+
 void WebPushDaemon::getPendingPushMessage(PushClientConnection& connection, CompletionHandler<void(const std::optional<WebKit::WebPushMessage>&)>&& replySender)
 {
-    auto it = m_pushMessages.find(connection.subscriptionSetIdentifier());
-    if (it == m_pushMessages.end()) {
+    auto pendingPushMessage = m_pendingPushMessages.takeFirst([&](const PendingPushMessage& candidate) {
+        return connectionMatchesPendingPushMessage(connection, candidate.identifier);
+    });
+
+    if (pendingPushMessage.identifier.bundleIdentifier.isEmpty()) {
         WEBPUSHDAEMON_RELEASE_LOG(Push, "No pending push message");
         return replySender(std::nullopt);
     }
 
-    auto& pushMessages = it->value;
-    WebKit::WebPushMessage result = pushMessages.takeFirst();
-    size_t remainingMessageCount = pushMessages.size();
-    if (!remainingMessageCount)
-        m_pushMessages.remove(it);
-
-    m_potentialSilentPushes.push_back(PotentialSilentPush { connection.subscriptionSetIdentifier(), result.registrationURL.string(), MonotonicTime::now() + silentPushTimeout() });
+    m_potentialSilentPushes.push_back(PotentialSilentPush { pendingPushMessage.identifier, pendingPushMessage.message.registrationURL.string(), MonotonicTime::now() + silentPushTimeout() });
     if (m_potentialSilentPushes.size() == 1)
         rescheduleSilentPushTimer();
 
-    WEBPUSHDAEMON_RELEASE_LOG(Push, "Fetched 1 push message, %zu remaining", remainingMessageCount);
-    replySender(WTFMove(result));
+    WEBPUSHDAEMON_RELEASE_LOG(Push, "Fetched 1 push message, %zu remaining", m_pendingPushMessages.size());
+    replySender(WTFMove(pendingPushMessage.message));
 
-    if (m_pushMessages.isEmpty())
+    if (m_pendingPushMessages.isEmpty())
         releaseIncomingPushTransaction();
 }
 
 void WebPushDaemon::getPendingPushMessages(PushClientConnection& connection, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender)
 {
-    auto it = m_pushMessages.find(connection.subscriptionSetIdentifier());
-    if (it == m_pushMessages.end()) {
-        WEBPUSHDAEMON_RELEASE_LOG(Push, "No pending push messages");
-        return replySender({ });
-    }
-    auto messages = m_pushMessages.take(it);
-
     Vector<WebKit::WebPushMessage> result;
-    result.reserveCapacity(messages.size());
-    while (!messages.isEmpty())
-        result.append(messages.takeFirst());
+    Deque<PendingPushMessage> newPendingPushMessages;
 
-    WEBPUSHDAEMON_RELEASE_LOG(Push, "Fetched %zu pending push messages", result.size());
+    while (!m_pendingPushMessages.isEmpty()) {
+        auto pendingPushMessage = m_pendingPushMessages.takeFirst();
+        if (connectionMatchesPendingPushMessage(connection, pendingPushMessage.identifier))
+            result.append(WTFMove(pendingPushMessage.message));
+        else
+            newPendingPushMessages.append(WTFMove(pendingPushMessage));
+    }
+
+    m_pendingPushMessages = WTFMove(newPendingPushMessages);
+    WEBPUSHDAEMON_RELEASE_LOG(Push, "Fetched %zu push messages, %zu remaining", result.size(), m_pendingPushMessages.size());
+
     replySender(WTFMove(result));
-    
-    if (m_pushMessages.isEmpty())
-        releaseIncomingPushTransaction();
 }
 
 void WebPushDaemon::getPushTopicsForTesting(PushClientConnection& connection, CompletionHandler<void(Vector<String>, Vector<String>)>&& completionHandler)
@@ -737,21 +738,27 @@ void WebPushDaemon::getPushTopicsForTesting(PushClientConnection& connection, Co
 
 void WebPushDaemon::subscribeToPushService(PushClientConnection& connection, const URL& scopeURL, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender)
 {
-#if PLATFORM(IOS)
-    auto origin = WebCore::SecurityOriginData::fromURL(scopeURL);
+    auto origin = SecurityOriginData::fromURL(scopeURL);
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return replySender(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "User denied push permission"_s }));
+    }
+    auto identifier = WTFMove(*maybeIdentifier);
 
-    const auto& webClipIdentifier = connection.subscriptionSetIdentifier().pushPartition;
+#if PLATFORM(IOS)
+    const auto& webClipIdentifier = identifier.pushPartition;
     RetainPtr webClip = [UIWebClip webClipWithIdentifier:(NSString *)webClipIdentifier];
-    auto webClipOrigin = WebCore::SecurityOriginData::fromURL(URL { [webClip pageURL] });
+    auto webClipOrigin = SecurityOriginData::fromURL(URL { [webClip pageURL] });
 
     if (origin.isNull() || origin.isOpaque() || origin != webClipOrigin) {
         WEBPUSHDAEMON_RELEASE_LOG(Push, "Cannot subscribe because web clip origin %{sensitive}s does not match expected origin %{sensitive}s", webClipOrigin.toString().utf8().data(), origin.toString().utf8().data());
-        return replySender(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, "Unexpected service worker scope"_s }));
+        return replySender(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "User denied push permission"_s }));
     }
 #endif
 
 #if PLATFORM(IOS) && HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(connection);
+    RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
     RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
     UNNotificationSettings *settings = [center notificationSettings];
     if (settings.authorizationStatus != UNAuthorizationStatusAuthorized) {
@@ -760,7 +767,7 @@ void WebPushDaemon::subscribeToPushService(PushClientConnection& connection, con
     }
 #endif
 
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), scope = scopeURL.string(), vapidPublicKey, replySender = WTFMove(replySender)]() mutable {
+    runAfterStartingPushService([this, identifier = WTFMove(identifier), scope = scopeURL.string(), vapidPublicKey, replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
             replySender(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, "Push service initialization failed"_s }));
             return;
@@ -772,7 +779,14 @@ void WebPushDaemon::subscribeToPushService(PushClientConnection& connection, con
 
 void WebPushDaemon::unsubscribeFromPushService(PushClientConnection& connection, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> subscriptionIdentifier, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender)
 {
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), scope = scopeURL.string(), subscriptionIdentifier, replySender = WTFMove(replySender)]() mutable {
+    auto origin = SecurityOriginData::fromURL(scopeURL);
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return replySender(false);
+    }
+
+    runAfterStartingPushService([this, identifier = WTFMove(*maybeIdentifier), scope = scopeURL.string(), subscriptionIdentifier, replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
             replySender(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, "Push service initialization failed"_s }));
             return;
@@ -784,7 +798,14 @@ void WebPushDaemon::unsubscribeFromPushService(PushClientConnection& connection,
 
 void WebPushDaemon::getPushSubscription(PushClientConnection& connection, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender)
 {
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), scope = scopeURL.string(), replySender = WTFMove(replySender)]() mutable {
+    auto origin = SecurityOriginData::fromURL(scopeURL);
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return replySender(std::optional<WebCore::PushSubscriptionData> { });
+    }
+
+    runAfterStartingPushService([this, identifier = WTFMove(*maybeIdentifier), scope = scopeURL.string(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
             replySender(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, "Push service initialization failed"_s }));
             return;
@@ -796,7 +817,13 @@ void WebPushDaemon::getPushSubscription(PushClientConnection& connection, const 
 
 void WebPushDaemon::incrementSilentPushCount(PushClientConnection& connection, const WebCore::SecurityOriginData& securityOrigin, CompletionHandler<void(unsigned)>&& replySender)
 {
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), securityOrigin = securityOrigin.toString(), replySender = WTFMove(replySender)]() mutable {
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(securityOrigin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", securityOrigin.toString().ascii().data());
+        return replySender(0);
+    }
+
+    runAfterStartingPushService([this, identifier = WTFMove(*maybeIdentifier), securityOrigin = securityOrigin.toString(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
             replySender(0);
             return;
@@ -808,19 +835,33 @@ void WebPushDaemon::incrementSilentPushCount(PushClientConnection& connection, c
 
 void WebPushDaemon::removeAllPushSubscriptions(PushClientConnection& connection, CompletionHandler<void(unsigned)>&& replySender)
 {
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), replySender = WTFMove(replySender)]() mutable {
+    PushSubscriptionSetIdentifier identifier { connection.hostAppCodeSigningIdentifier(), connection.pushPartitionIfExists(), connection.dataStoreIdentifier() };
+    runAfterStartingPushService([this, identifier = WTFMove(identifier), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
             replySender(0);
             return;
         }
 
+#if PLATFORM(IOS)
+        // When implicit web clip mode is used, remove all push subscriptions irrespective of webClipIdentifier/pushPartition.
+        if (identifier.pushPartition.isEmpty()) {
+            m_pushService->removeRecordsForBundleIdentifierAndDataStore(identifier.bundleIdentifier, identifier.dataStoreIdentifier, WTFMove(replySender));
+            return;
+        }
+#endif
         m_pushService->removeRecordsForSubscriptionSet(identifier, WTFMove(replySender));
     });
 }
 
 void WebPushDaemon::removePushSubscriptionsForOrigin(PushClientConnection& connection, const WebCore::SecurityOriginData& securityOrigin, CompletionHandler<void(unsigned)>&& replySender)
 {
-    runAfterStartingPushService([this, identifier = connection.subscriptionSetIdentifier(), securityOrigin = securityOrigin.toString(), replySender = WTFMove(replySender)]() mutable {
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(securityOrigin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", securityOrigin.toString().ascii().data());
+        return replySender(0);
+    }
+
+    runAfterStartingPushService([this, identifier = WTFMove(*maybeIdentifier), securityOrigin = securityOrigin.toString(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
             replySender(0);
             return;
@@ -859,18 +900,26 @@ PushClientConnection* WebPushDaemon::toPushClientConnection(xpc_connection_t con
 
 void WebPushDaemon::showNotification(PushClientConnection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources> resources, CompletionHandler<void()>&& completionHandler)
 {
+    auto origin = SecurityOriginData::fromURL(URL { notificationData.originString });
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return completionHandler();
+    }
+    auto identifier = WTFMove(*maybeIdentifier);
+
     RetainPtr content = adoptNS([[UNMutableNotificationContent alloc] init]);
 
     [content setDefaultActionBundleIdentifier:platformDefaultActionBundleIdentifier()];
 
-    content.get().targetContentIdentifier = (NSString *)connection.pushPartitionString();
+    content.get().targetContentIdentifier = (NSString *)identifier.pushPartition;
     content.get().title = (NSString *)notificationData.title;
     content.get().body = (NSString *)notificationData.body;
 
     if (platformShouldPlaySound(notificationData))
         content.get().sound = [UNNotificationSound defaultSound];
 
-    auto notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(connection);
+    auto notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     content.get().icon = [UNNotificationIcon iconForApplicationIdentifier:notificationCenterBundleIdentifier.get()];
@@ -891,7 +940,7 @@ ALLOW_NONLITERAL_FORMAT_END
     if (!center)
         RELEASE_LOG_ERROR(Push, "Failed to instantiate UNUserNotificationCenter center");
 
-    auto blockPtr = makeBlockPtr([this, identifier = crossThreadCopy(connection.subscriptionSetIdentifier()), scope = crossThreadCopy(notificationData.serviceWorkerRegistrationURL.string()), completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    auto blockPtr = makeBlockPtr([this, identifier = crossThreadCopy(identifier), scope = crossThreadCopy(notificationData.serviceWorkerRegistrationURL.string()), completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         WorkQueue::main().dispatch([this, identifier = crossThreadCopy(identifier), scope = crossThreadCopy(scope), error = RetainPtr { error }, completionHandler = WTFMove(completionHandler)] mutable {
             if (error)
                 RELEASE_LOG_ERROR(Push, "Failed to add notification request: %{public}@", error.get());
@@ -906,10 +955,18 @@ ALLOW_NONLITERAL_FORMAT_END
 
 void WebPushDaemon::getNotifications(PushClientConnection& connection, const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    auto placeholderBundleIdentifier = platformNotificationCenterBundleIdentifier(connection);
+    auto origin = SecurityOriginData::fromURL(registrationURL);
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return completionHandler(Vector<WebCore::NotificationData> { });
+    }
+    auto identifier = WTFMove(*maybeIdentifier);
+
+    auto placeholderBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
     RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:placeholderBundleIdentifier.get()]);
 
-    auto blockPtr = makeBlockPtr([identifier = crossThreadCopy(connection.subscriptionSetIdentifier()), completionHandler = WTFMove(completionHandler)](NSArray<UNNotification *> *notifications) mutable {
+    auto blockPtr = makeBlockPtr([identifier = crossThreadCopy(identifier), completionHandler = WTFMove(completionHandler)](NSArray<UNNotification *> *notifications) mutable {
         WorkQueue::main().dispatch([identifier = crossThreadCopy(identifier), notifications = RetainPtr { notifications }, completionHandler = WTFMove(completionHandler)] mutable {
             Vector<WebCore::NotificationData> notificationDatas;
             for (UNNotification *notification in notifications.get()) {
@@ -928,9 +985,16 @@ void WebPushDaemon::getNotifications(PushClientConnection& connection, const URL
     [center getDeliveredNotificationsWithCompletionHandler:blockPtr.get()];
 }
 
-void WebPushDaemon::cancelNotification(PushClientConnection& connection, const WTF::UUID& notificationID)
+void WebPushDaemon::cancelNotification(PushClientConnection& connection, WebCore::SecurityOriginData&& origin, const WTF::UUID& notificationID)
 {
-    auto placeholderBundleIdentifier = platformNotificationCenterBundleIdentifier(connection);
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return;
+    }
+    auto identifier = WTFMove(*maybeIdentifier);
+
+    auto placeholderBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
     RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:placeholderBundleIdentifier.get()]);
 
     auto identifiers = @[ (NSString *)notificationID.toString() ];
@@ -940,7 +1004,12 @@ void WebPushDaemon::cancelNotification(PushClientConnection& connection, const W
 
 void WebPushDaemon::getPushPermissionState(PushClientConnection& connection, const WebCore::SecurityOriginData& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& replySender)
 {
-    auto identifier = connection.subscriptionSetIdentifier();
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return replySender(WebCore::PushPermissionState::Denied);
+    }
+    auto identifier = WTFMove(*maybeIdentifier);
 
 #if PLATFORM(IOS)
     if (identifier.pushPartition.isEmpty()) {
@@ -958,7 +1027,7 @@ void WebPushDaemon::getPushPermissionState(PushClientConnection& connection, con
     }
 #endif
 
-    RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(connection);
+    RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
     RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
 
     auto blockPtr = makeBlockPtr([originString = crossThreadCopy(origin.toString()), replySender = WTFMove(replySender)](UNNotificationSettings *settings) mutable {
@@ -982,7 +1051,12 @@ void WebPushDaemon::getPushPermissionState(PushClientConnection& connection, con
 
 void WebPushDaemon::requestPushPermission(PushClientConnection& connection, const WebCore::SecurityOriginData& origin, CompletionHandler<void(bool)>&& replySender)
 {
-    auto identifier = connection.subscriptionSetIdentifier();
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(origin);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", origin.toString().ascii().data());
+        return replySender(false);
+    }
+    auto identifier = WTFMove(*maybeIdentifier);
 
 #if PLATFORM(IOS)
     if (identifier.pushPartition.isEmpty()) {
@@ -1000,7 +1074,7 @@ void WebPushDaemon::requestPushPermission(PushClientConnection& connection, cons
     }
 #endif
 
-    RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(connection);
+    RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
     RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
     UNAuthorizationOptions options = UNAuthorizationOptionBadge | UNAuthorizationOptionAlert | UNAuthorizationOptionSound;
 
@@ -1020,10 +1094,17 @@ void WebPushDaemon::requestPushPermission(PushClientConnection& connection, cons
 
 void WebPushDaemon::setAppBadge(PushClientConnection& connection, WebCore::SecurityOriginData&& badgeOriginData, std::optional<uint64_t> appBadge)
 {
+    auto maybeIdentifier = connection.subscriptionSetIdentifierForOrigin(badgeOriginData);
+    if (!maybeIdentifier) {
+        WEBPUSHDAEMON_RELEASE_LOG_ERROR(Push, "No web clip associated with origin %{sensitive}s", badgeOriginData.toString().ascii().data());
+        return;
+    }
+
+    auto identifier = WTFMove(*maybeIdentifier);
     URL appPageURL;
 
 #if PLATFORM(IOS)
-    auto webClipIdentifier = connection.pushPartitionString();
+    auto webClipIdentifier = identifier.pushPartition;
     RetainPtr webClip = [UIWebClip webClipWithIdentifier:(NSString *)webClipIdentifier];
     appPageURL = [webClip pageURL];
 #elif PLATFORM(MAC)
@@ -1038,10 +1119,10 @@ void WebPushDaemon::setAppBadge(PushClientConnection& connection, WebCore::Secur
     }
 
 #if PLATFORM(IOS)
-    RetainPtr state = adoptNS([[UISApplicationState alloc] initWithBundleIdentifier:platformNotificationCenterBundleIdentifier(connection).get()]);
+    RetainPtr state = adoptNS([[UISApplicationState alloc] initWithBundleIdentifier:platformNotificationCenterBundleIdentifier(identifier.pushPartition).get()]);
     state.get().badgeValue = appBadge ? [NSNumber numberWithUnsignedLongLong:*appBadge] : nil;
 #elif PLATFORM(MAC)
-    String bundleIdentifier = connection.pushPartitionString().isEmpty() ? connection.hostAppCodeSigningIdentifier() : connection.pushPartitionString();
+    String bundleIdentifier = identifier.pushPartition.isEmpty() ? connection.hostAppCodeSigningIdentifier() : identifier.pushPartition;
     RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc]  initWithBundleIdentifier:(NSString *)bundleIdentifier]);
     if (!center)
         return;
@@ -1049,7 +1130,7 @@ void WebPushDaemon::setAppBadge(PushClientConnection& connection, WebCore::Secur
     UNMutableNotificationContent *content = [UNMutableNotificationContent new];
     content.badge = appBadge ? [NSNumber numberWithLongLong:*appBadge] : nil;
     UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:NSUUID.UUID.UUIDString content:content trigger:nil];
-    RetainPtr debugDescription = (NSString *)connection.subscriptionSetIdentifier().debugDescription();
+    RetainPtr debugDescription = (NSString *)identifier.debugDescription();
     [center addNotificationRequest:request withCompletionHandler:^(NSError *error) {
         if (error) {
             RELEASE_LOG_ERROR(Push, "Error attempting to set badge count for web app %{public}@", debugDescription.get());
@@ -1069,7 +1150,7 @@ void WebPushDaemon::getAppBadgeForTesting(PushClientConnection& connection, Comp
 #else
     RELEASE_ASSERT(m_userNotificationCenterClass == _WKMockUserNotificationCenter.class);
 
-    String bundleIdentifier = connection.pushPartitionString().isEmpty() ? connection.hostAppCodeSigningIdentifier() : connection.pushPartitionString();
+    String bundleIdentifier = connection.pushPartitionIfExists().isEmpty() ? connection.hostAppCodeSigningIdentifier() : connection.pushPartitionIfExists();
     RetainPtr center = adoptNS([[_WKMockUserNotificationCenter alloc] initWithBundleIdentifier:(NSString *)bundleIdentifier]);
     NSNumber *centerBadge = [center getAppBadgeForTesting];
 

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
@@ -37,14 +37,6 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // Opt-in to supporting push for testing purposes.
-    id handler = ^(_WKWebPushAction *action) {
-        // FIXME: Make this callback do something useful by returning an appropriate WKWebsiteDataStore
-        return (WKWebsiteDataStore *)nil;
-    };
-
-    [WKWebsiteDataStore _setWebPushActionHandler:handler];
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIStoryboard *frameworkMainStoryboard = [UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle bundleForClass:[AppDelegate class]]];
@@ -52,6 +44,11 @@
 #pragma clang diagnostic pop
     if (!viewController)
         return NO;
+
+    WKWebsiteDataStore *dataStore = viewController.dataStore;
+    [WKWebsiteDataStore _setWebPushActionHandler:^(_WKWebPushAction *action) {
+        return dataStore;
+    }];
 
     NSURL *url = launchOptions[UIApplicationLaunchOptionsURLKey];
     if (url)

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.h
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.h
@@ -26,6 +26,7 @@
 #import <UIKit/UIKit.h>
 
 @class WKWebView;
+@class WKWebsiteDataStore;
 @class TabViewController;
 @class SettingsViewController;
 
@@ -41,6 +42,7 @@
 @property (strong, nonatomic) NSURL *initialURL;
 @property (strong, nonatomic) WKWebView *currentWebView;
 @property (strong, nonatomic) NSMutableArray<WKWebView *> *webViews;
+@property (strong, nonatomic, readonly) WKWebsiteDataStore *dataStore;
 
 
 - (IBAction)reload:(id)sender;

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
@@ -60,6 +60,7 @@ static const NSString * const kURLArgumentString = @"--url";
 @end
 
 @interface WebViewController () <WKNavigationDelegate> {
+    WKWebsiteDataStore *_dataStore;
     WKWebView *_currentWebView;
     NSURL *_initialURL;
 }
@@ -162,6 +163,16 @@ void* URLContext = &URLContext;
     return _currentWebView;
 }
 
+- (WKWebsiteDataStore *)dataStore
+{
+    if (!_dataStore) {
+        _WKWebsiteDataStoreConfiguration *dataStoreConfiguration = [[_WKWebsiteDataStoreConfiguration alloc] init];
+        dataStoreConfiguration.webPushMachServiceName = @"com.apple.webkit.webpushd.service";
+        _dataStore = [[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration];
+    }
+    return _dataStore;
+}
+
 - (void)setCurrentWebView:(WKWebView *)webView
 {
     [_currentWebView removeObserver:self forKeyPath:@"estimatedProgress" context:EstimatedProgressContext];
@@ -211,11 +222,7 @@ void* URLContext = &URLContext;
     configuration.preferences._notificationEventEnabled = YES;
     configuration.preferences._appBadgeEnabled = YES;
     configuration.preferences.elementFullscreenEnabled = YES;
-
-    _WKWebsiteDataStoreConfiguration *dataStoreConfiguration = [[_WKWebsiteDataStoreConfiguration alloc] init];
-    dataStoreConfiguration.webPushMachServiceName = @"com.apple.webkit.webpushd.service";
-    // FIXME: Set an appropriate webPushPartitionString
-    configuration.websiteDataStore = [[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration];
+    configuration.websiteDataStore = [self dataStore];
 
     WKWebView *webView = [[WKWebView alloc] initWithFrame:self.webViewContainer.bounds configuration:configuration];
     webView.inspectable = YES;


### PR DESCRIPTION
#### fe1d144d508e27966b447ec6c7f400d84a63ce92
<pre>
Allow webpushd to select web clip implicitly via origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=278768">https://bugs.webkit.org/show_bug.cgi?id=278768</a>
<a href="https://rdar.apple.com/134520632">rdar://134520632</a>

Reviewed by Brady Eidson.

For some webpushd clients, it makes more sense to allow clients to specify the web clip they want to
operate on implicitly via origin rather than explicitly passing in the web clip identifier. This can
make sense if e.g. a client wants multiple web clips to share the same service worker since they are
part of the same origin. In this case, we select the oldest web clip associated with the origin as
the representative web clip for that origin.

The way this works is that on iOS, we now allow webClipIdentifier/pushPartition to be empty at
connection startup time. If this is the case, then each IPC infers the effective webClipIdentifier.
This works by basically adding a subscriptionSetForOrigin call to every webpushd IPC.

Most IPCs already pass an origin, so this just works. I had to change a few IPCs to make them
compatible however:

 - cancelNotification now takes in an origin as well as a notification identifier (the origin is
   necessary for implicit web clip selection to work).
 - removeAllPushSubscriptions removes all subscriptions irrespective of web clip identifier when
   in implicit web clip mode. This required making some changes to PushDatabase and PushService.

I tested this by hooking up the push action handler in 282672@main to get and process push events.
However I left that part out of this patch since Brady is also working on that logic and want to
avoid merge conflicts. As part of that testing that hookup, I fixed some other issues:

 - The UIProcess-side permissions lookup in NetworkProcessProxy is not necessary anymore and I
   conditionalized it.
 - SBSCreateOpenApplicationService does not actually follow the create rule, which was causing
   webpushd crashes, so I stopped using that with adoptNS.
 - Hooked up MobileMiniBrowser&apos;s data store to its push action handler.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::removeRecordsByBundleIdentifierAndDataStore):
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::cancelNotification):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::processPushMessage):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::cancelNotification):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::cancelNotification):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::cancel):
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::PushClientConnection::hostAppHasPushInjectEntitlement const):
(WebPushD::PushClientConnection::pushPartitionIfExists const):
(WebPushD::PushClientConnection::pushPartitionString const): Deleted.
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::isValidPushPartition):
(WebPushD::webClipIdentifierForOrigin):
(WebPushD::PushClientConnection::subscriptionSetIdentifierForOrigin const):
(WebPushD::PushClientConnection::debugDescription const):
(WebPushD::PushClientConnection::cancelNotification):
(WebPushD::PushClientConnection::subscriptionSetIdentifier const): Deleted.
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::removeRecordsForBundleIdentifierAndDataStore):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformNotificationCenterBundleIdentifier):
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::updateSubscriptionSetState):
(WebPushD::WebPushDaemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::handleIncomingPushImpl):
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):
(WebPushD::connectionMatchesPendingPushMessage):
(WebPushD::WebPushDaemon::getPendingPushMessage):
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::unsubscribeFromPushService):
(WebPushD::WebPushDaemon::getPushSubscription):
(WebPushD::WebPushDaemon::incrementSilentPushCount):
(WebPushD::WebPushDaemon::removeAllPushSubscriptions):
(WebPushD::WebPushDaemon::removePushSubscriptionsForOrigin):
(WebPushD::WebPushDaemon::showNotification):
(WebPushD::WebPushDaemon::getNotifications):
(WebPushD::WebPushDaemon::cancelNotification):
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::requestPushPermission):
(WebPushD::WebPushDaemon::setAppBadge):
(WebPushD::WebPushDaemon::getAppBadgeForTesting):
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m:
(-[AppDelegate application:didFinishLaunchingWithOptions:]):
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.h:
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m:
(-[WebViewController dataStore]):
(-[WebViewController createWebView]):
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::PushDatabaseTest::removeRecordsByBundleIdentifierAndDataStore):
(TestWebKitAPI::TEST_F(PushDatabaseTest, RemoveRecordsByBundleIdentifierAndDataStore)):

Canonical link: <a href="https://commits.webkit.org/282857@main">https://commits.webkit.org/282857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f380f687a4e797eac77d22751c00e9a9fe2b5fc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15382 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55813 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13976 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70217 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8442 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55901 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6984 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->