### PR TITLE
REGRESSION(281640@main): [GTK] Build broken on non-Linux

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -46,7 +46,7 @@ const GLFence::Capabilities& GLFence::capabilities()
             capabilities.eglSupported = extensions.KHR_fence_sync;
             capabilities.eglServerWaitSupported = extensions.KHR_wait_sync;
         }
-#if OS(LINUX)
+#if OS(UNIX)
         capabilities.eglExportableSupported = extensions.ANDROID_native_fence_sync;
 #endif
         capabilities.glSupported = GLContext::versionFromString(reinterpret_cast<const char*>(glGetString(GL_VERSION))) >= 300;
@@ -78,7 +78,7 @@ std::unique_ptr<GLFence> GLFence::create()
     return nullptr;
 }
 
-#if OS(LINUX)
+#if OS(UNIX)
 std::unique_ptr<GLFence> GLFence::createExportable()
 {
     if (!GLContextWrapper::currentContext())

--- a/Source/WebCore/platform/graphics/egl/GLFence.h
+++ b/Source/WebCore/platform/graphics/egl/GLFence.h
@@ -22,7 +22,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
-#if OS(LINUX)
+#if OS(UNIX)
 #include <wtf/unix/UnixFileDescriptor.h>
 #endif
 
@@ -36,7 +36,7 @@ class GLFence {
 public:
     static bool isSupported();
     WEBCORE_EXPORT static std::unique_ptr<GLFence> create();
-#if OS(LINUX)
+#if OS(UNIX)
     WEBCORE_EXPORT static std::unique_ptr<GLFence> createExportable();
     WEBCORE_EXPORT static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
 #endif
@@ -44,7 +44,7 @@ public:
 
     virtual void clientWait() = 0;
     virtual void serverWait() = 0;
-#if OS(LINUX)
+#if OS(UNIX)
     virtual WTF::UnixFileDescriptor exportFD() { return { }; }
 #endif
 

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
@@ -50,7 +50,7 @@ static std::unique_ptr<GLFence> createEGLFence(EGLenum type, const Vector<EGLAtt
 
     glFlush();
 
-#if OS(LINUX)
+#if OS(UNIX)
     bool isExportable = type == EGL_SYNC_NATIVE_FENCE_ANDROID;
 #else
     bool isExportable = false;
@@ -63,7 +63,7 @@ std::unique_ptr<GLFence> GLFenceEGL::create()
     return createEGLFence(EGL_SYNC_FENCE_KHR, { });
 }
 
-#if OS(LINUX)
+#if OS(UNIX)
 std::unique_ptr<GLFence> GLFenceEGL::createExportable()
 {
     return createEGLFence(EGL_SYNC_NATIVE_FENCE_ANDROID, { });
@@ -117,7 +117,7 @@ void GLFenceEGL::serverWait()
         eglWaitSyncKHR(display.eglDisplay(), m_sync, 0);
 }
 
-#if OS(LINUX)
+#if OS(UNIX)
 UnixFileDescriptor GLFenceEGL::exportFD()
 {
     if (!m_isExportable)

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
@@ -28,7 +28,7 @@ namespace WebCore {
 class GLFenceEGL final : public GLFence {
 public:
     static std::unique_ptr<GLFence> create();
-#if OS(LINUX)
+#if OS(UNIX)
     static std::unique_ptr<GLFence> createExportable();
     static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
 #endif
@@ -38,7 +38,7 @@ public:
 private:
     void clientWait() override;
     void serverWait() override;
-#if OS(LINUX)
+#if OS(UNIX)
     WTF::UnixFileDescriptor exportFD() override;
 #endif
 


### PR DESCRIPTION
#### b53fec47fe5afa14453734ba0992bb3437e1552b
<pre>
REGRESSION(281640@main): [GTK] Build broken on non-Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=277930">https://bugs.webkit.org/show_bug.cgi?id=277930</a>

Reviewed by Adrian Perez de Castro.

Use OS(UNIX) instead of OS(LINUX). If exportable fences are not
available it will fail at runtime as expected.

* Source/WebCore/platform/graphics/egl/GLFence.cpp:
(WebCore::GLFence::capabilities):
* Source/WebCore/platform/graphics/egl/GLFence.h:
* Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp:
(WebCore::createEGLFence):
* Source/WebCore/platform/graphics/egl/GLFenceEGL.h:

Canonical link: <a href="https://commits.webkit.org/282841@main">https://commits.webkit.org/282841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/911acb82a0ecbbbff24f98cfde9a2f8a2b051f94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51851 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13138 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59173 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59340 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/612 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9767 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39619 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->