### PR TITLE
REGRESSION(282339@main): [GTK] Broke a11y bus connection under flatpak

### DIFF
--- a/Source/WTF/wtf/glib/Sandbox.cpp
+++ b/Source/WTF/wtf/glib/Sandbox.cpp
@@ -79,6 +79,15 @@ bool isInsideSnap()
     return returnValue;
 }
 
+bool shouldUseBubblewrap()
+{
+#if ENABLE(BUBBLEWRAP_SANDBOX)
+    return !isInsideFlatpak() && !isInsideSnap() && !isInsideUnsupportedContainer();
+#else
+    return false;
+#endif
+}
+
 bool shouldUsePortal()
 {
     static bool returnValue = []() -> bool {

--- a/Source/WTF/wtf/glib/Sandbox.h
+++ b/Source/WTF/wtf/glib/Sandbox.h
@@ -26,6 +26,7 @@ namespace WTF {
 WTF_EXPORT_PRIVATE bool isInsideFlatpak();
 WTF_EXPORT_PRIVATE bool isInsideUnsupportedContainer();
 WTF_EXPORT_PRIVATE bool isInsideSnap();
+WTF_EXPORT_PRIVATE bool shouldUseBubblewrap();
 WTF_EXPORT_PRIVATE bool shouldUsePortal();
 
 WTF_EXPORT_PRIVATE const CString& sandboxedUserRuntimeDirectory();
@@ -35,6 +36,7 @@ WTF_EXPORT_PRIVATE const CString& sandboxedUserRuntimeDirectory();
 using WTF::isInsideFlatpak;
 using WTF::isInsideUnsupportedContainer;
 using WTF::isInsideSnap;
+using WTF::shouldUseBubblewrap;
 using WTF::shouldUsePortal;
 
 using WTF::sandboxedUserRuntimeDirectory;

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -224,7 +224,7 @@ void ProcessLauncher::launchProcess()
 #if ENABLE(BUBBLEWRAP_SANDBOX)
     // You cannot use bubblewrap within Flatpak or some containers so lets ensure it never happens.
     // Snap can allow it but has its own limitations that require workarounds.
-    else if (sandboxEnabled && !isInsideFlatpak() && !isInsideSnap() && !isInsideUnsupportedContainer())
+    else if (sandboxEnabled && shouldUseBubblewrap())
         process = bubblewrapSpawn(launcher.get(), m_launchOptions, argv, &error.outPtr());
 #endif // ENABLE(BUBBLEWRAP_SANDBOX)
     else

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -160,7 +160,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     if (address)
         parameters.accessibilityBusAddress = String::fromUTF8(address);
     else
-        parameters.accessibilityBusAddress = m_sandboxEnabled ? sandboxedAccessibilityBusAddress() : accessibilityBusAddress();
+        parameters.accessibilityBusAddress = m_sandboxEnabled && shouldUseBubblewrap() ? sandboxedAccessibilityBusAddress() : accessibilityBusAddress();
 #endif
 
 #if PLATFORM(GTK)
@@ -213,7 +213,8 @@ void WebProcessPool::setSandboxEnabled(bool enabled)
 
     m_sandboxEnabled = true;
 #if USE(ATSPI)
-    m_sandboxedAccessibilityBusAddress = makeString("unix:path="_s, FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(sandboxedUserRuntimeDirectory().data()), "at-spi-bus"_s));
+    if (shouldUseBubblewrap())
+        m_sandboxedAccessibilityBusAddress = makeString("unix:path="_s, FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(sandboxedUserRuntimeDirectory().data()), "at-spi-bus"_s));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -32,7 +32,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <wtf/FileSystem.h>
-
+#include <wtf/glib/Sandbox.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -55,7 +55,8 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
 
         launchOptions.extraSandboxPaths = m_processPool->sandboxPaths();
 #if USE(ATSPI)
-        launchOptions.extraInitializationData.set("sandboxedAccessibilityBusAddress"_s, m_processPool->sandboxedAccessibilityBusAddress());
+        if (shouldUseBubblewrap())
+            launchOptions.extraInitializationData.set("sandboxedAccessibilityBusAddress"_s, m_processPool->sandboxedAccessibilityBusAddress());
 #endif
     }
 }


### PR DESCRIPTION
#### 205f5b1570eea508bf7366f542ec19277d9036aa
<pre>
REGRESSION(282339@main): [GTK] Broke a11y bus connection under flatpak
<a href="https://bugs.webkit.org/show_bug.cgi?id=278743">https://bugs.webkit.org/show_bug.cgi?id=278743</a>

Reviewed by Michael Catanzaro.

Only use the sandboxed a11 bus address when using bubblewrap.

* Source/WTF/wtf/glib/Sandbox.cpp:
(WTF::shouldUseBubblewrap):
* Source/WTF/wtf/glib/Sandbox.h:
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::setSandboxEnabled):
* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformGetLaunchOptions):

Canonical link: <a href="https://commits.webkit.org/282896@main">https://commits.webkit.org/282896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0065eb981dedaa1c0b6499cb321006c16e6aeae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15050 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51853 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10381 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13924 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57554 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70165 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63687 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12982 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59177 "Found 3 new test failures: imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_under_load.https.optional.html?mouse imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_under_load.https.optional.html?pen imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59344 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/614 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85448 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39621 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->