### PR TITLE
[GStreamer] Add scaleResolutionDownBy support in the video encoder

### DIFF
--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -219,6 +219,7 @@ struct _WebKitVideoEncoderPrivate {
     BitrateMode bitrateMode;
     LatencyMode latencyMode;
     RefPtr<WebKitVideoEncoderBitRateAllocation> bitRateAllocation;
+    double scaleResolutionDownBy;
 };
 
 #define webkit_video_encoder_parent_class parent_class
@@ -231,6 +232,7 @@ enum {
     PROP_KEYFRAME_INTERVAL,
     PROP_BITRATE_MODE,
     PROP_LATENCY_MODE,
+    PROP_SCALE_RESOLUTION_DOWN_BY,
     N_PROPS
 };
 
@@ -257,6 +259,9 @@ static void videoEncoderGetProperty(GObject* object, guint propertyId, GValue* v
         break;
     case PROP_LATENCY_MODE:
         g_value_set_enum(value, priv->latencyMode);
+        break;
+    case PROP_SCALE_RESOLUTION_DOWN_BY:
+        g_value_set_double(value, priv->scaleResolutionDownBy);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propertyId, pspec);
@@ -533,6 +538,21 @@ void videoEncoderSetBitRateAllocation(WebKitVideoEncoder* self, RefPtr<WebKitVid
     }
 }
 
+void videoEncoderScaleResolutionDownBy(WebKitVideoEncoder* self, double scaleResolutionDownBy)
+{
+    self->priv->scaleResolutionDownBy = scaleResolutionDownBy;
+
+    auto pad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "sink"));
+    if (!pad)
+        return;
+
+    auto peer = adoptGRef(gst_pad_get_peer(pad.get()));
+    if (!peer)
+        return;
+
+    gst_pad_send_event(peer.get(), gst_event_new_reconfigure());
+}
+
 static void videoEncoderSetProperty(GObject* object, guint propertyId, const GValue* value, GParamSpec* pspec)
 {
     auto* self = WEBKIT_VIDEO_ENCODER(object);
@@ -561,6 +581,9 @@ static void videoEncoderSetProperty(GObject* object, guint propertyId, const GVa
             auto encoder = Encoders::definition(priv->encoderId);
             encoder->setLatencyMode(priv->encoder.get(), priv->latencyMode);
         }
+        break;
+    case PROP_SCALE_RESOLUTION_DOWN_BY:
+        videoEncoderScaleResolutionDownBy(self, g_value_get_double(value));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propertyId, pspec);
@@ -615,6 +638,30 @@ static void videoEncoderConstructed(GObject* encoder)
                 RELEASE_ASSERT(bitrate);
                 g_object_set(parent, "bitrate", static_cast<uint32_t>(*bitrate), nullptr);
                 return TRUE;
+            }
+        }
+
+        if (GST_EVENT_TYPE(event) == GST_EVENT_CAPS) {
+            auto self = WEBKIT_VIDEO_ENCODER(parent);
+            auto scaleResolutionDownBy = self->priv->scaleResolutionDownBy;
+            if (scaleResolutionDownBy > 1.0) {
+                GST_DEBUG_OBJECT(self, "Applying scale factor: %f", scaleResolutionDownBy);
+                GstCaps* caps;
+                gst_event_parse_caps(event, &caps);
+                if (caps && gst_caps_get_size(caps)) {
+                    auto writableCaps = adoptGRef(gst_caps_copy(caps));
+                    auto structure = gst_caps_get_structure(writableCaps.get(), 0);
+                    auto width = gstStructureGet<int>(structure, "width"_s);
+                    auto height = gstStructureGet<int>(structure, "height"_s);
+                    if (width && height) {
+                        int newWidth = *width / scaleResolutionDownBy;
+                        int newHeight = *height / scaleResolutionDownBy;
+                        gst_structure_set(structure, "width", G_TYPE_INT, newWidth, "height", G_TYPE_INT, newHeight, nullptr);
+                        GST_DEBUG_OBJECT(self, "Modified caps: %" GST_PTR_FORMAT, writableCaps.get());
+                        auto newCapsEvent = adoptGRef(gst_event_new_caps(writableCaps.get()));
+                        gst_event_replace(&event, newCapsEvent.get());
+                    }
+                }
             }
         }
         return gst_pad_event_default(pad, parent, event);
@@ -999,6 +1046,8 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
         nullptr, nullptr, VIDEO_ENCODER_TYPE_BITRATE_MODE, CONSTANT_BITRATE_MODE, WEBKIT_PARAM_READWRITE));
     g_object_class_install_property(objectClass, PROP_LATENCY_MODE, g_param_spec_enum("latency-mode",
         nullptr, nullptr, VIDEO_ENCODER_TYPE_LATENCY_MODE, REALTIME_LATENCY_MODE, WEBKIT_PARAM_READWRITE));
+    g_object_class_install_property(objectClass, PROP_SCALE_RESOLUTION_DOWN_BY, g_param_spec_double("scale-resolution-down-by",
+        nullptr, nullptr, 0, G_MAXDOUBLE, 1, static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT)));
 }
 
 #undef NUMBER_OF_THREADS


### PR DESCRIPTION
#### e202e61ca1cc6cfea7eaf739b3ffc30519da215a
<pre>
[GStreamer] Add scaleResolutionDownBy support in the video encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=278779">https://bugs.webkit.org/show_bug.cgi?id=278779</a>

Reviewed by Xabier Rodriguez-Calvar.

This is going to be used for simulcast handling in the GstWebRTC backend. The property name matches
the corresponding attribute of the RTCRtpEncodingParameters.

* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderGetProperty):
(videoEncoderScaleResolutionDownBy):
(videoEncoderSetProperty):
(videoEncoderConstructed):
(webkit_video_encoder_class_init):

Canonical link: <a href="https://commits.webkit.org/282891@main">https://commits.webkit.org/282891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23cda04514fe8297993d55af950b9fb5d77912a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51854 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32473 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13925 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70166 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8391 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12983 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59178 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59346 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14242 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/616 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->