### PR TITLE
[editing] Use appropriate startOfParagraph in mergeParagraphs.

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3871,7 +3871,6 @@ webkit.org/b/264680 media/video-page-visibility-restriction.html [ Pass Timeout 
 webkit.org/b/264680 webgl/webgl-visible-after-context-restore.html [ ImageOnlyFailure Pass ]
 
 webkit.org/b/265942 imported/w3c/web-platform-tests/editing/run [ Slow ]
-webkit.org/b/266465 [ Debug ] imported/w3c/web-platform-tests/editing/run/delete.html?6001-7000 [ Crash ]
 
 webkit.org/b/266636 fast/multicol/last-set-crash.html [ Skip ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/run/delete_6001-7000-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/run/delete_6001-7000-expected.txt
@@ -230,7 +230,7 @@ PASS [["delete",""]] "<span style=display:inline-block>fo[o</span><span style=di
 PASS [["delete",""]] "<span style=display:inline-block>fo[o</span><span style=display:inline-block>b]ar</span>" queryCommandValue("delete") after
 PASS [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>": execCommand("delete", false, "") return value
 PASS [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>" checks for modifications to non-editable content
-FAIL [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<span style=\"display:inline-table\">fo</span><span style=\"display:inline-table\">ar</span>" but got "<span style=\"display:inline-table\">f<br>o<span style=\"display:inline-table\">ar</span></span>"
+FAIL [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<span style=\"display:inline-table\">fo</span><span style=\"display:inline-table\">ar</span>" but got "<span style=\"display:inline-table\"></span><span style=\"display:inline-table\">fo</span><span style=\"display:inline-table\">ar</span>"
 PASS [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>" queryCommandIndeterm("delete") before
 PASS [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>" queryCommandState("delete") before
 PASS [["delete",""]] "<span style=display:inline-table>fo[o</span><span style=display:inline-table>b]ar</span>" queryCommandValue("delete") before
@@ -896,7 +896,7 @@ PASS [["delete",""]] "<div>abc  </div> <div>  []def</div>" queryCommandState("de
 PASS [["delete",""]] "<div>abc  </div> <div>  []def</div>" queryCommandValue("delete") after
 PASS [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar": execCommand("delete", false, "") return value
 PASS [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar" checks for modifications to non-editable content
-FAIL [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foobar" but got "foo<img contenteditable=\"false\" src=\"/img/lion.svg\">bar"
+FAIL [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foobar" but got ""
 PASS [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar" queryCommandIndeterm("delete") before
 PASS [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar" queryCommandState("delete") before
 PASS [["delete",""]] "foo<img contenteditable=false src=/img/lion.svg>[]bar" queryCommandValue("delete") before

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -810,7 +810,8 @@ void DeleteSelectionCommand::mergeParagraphs()
     
     if (mergeDestination == startOfParagraphToMove)
         return;
-        
+
+    VisiblePosition currentStartOfParagraphToMove = startOfParagraph(startOfParagraphToMove, CanSkipOverEditingBoundary);
     VisiblePosition endOfParagraphToMove = endOfParagraph(startOfParagraphToMove, CanSkipOverEditingBoundary);
     
     if (mergeDestination == endOfParagraphToMove)
@@ -847,8 +848,8 @@ void DeleteSelectionCommand::mergeParagraphs()
     // moveParagraphs will insert placeholders if it removes blocks that would require their use, don't let block
     // removals that it does cause the insertion of *another* placeholder.
     bool needPlaceholder = m_needPlaceholder;
-    bool paragraphToMergeIsEmpty = (startOfParagraphToMove == endOfParagraphToMove);
-    moveParagraph(startOfParagraphToMove, endOfParagraphToMove, mergeDestination, false, !paragraphToMergeIsEmpty);
+    bool paragraphToMergeIsEmpty = (currentStartOfParagraphToMove == endOfParagraphToMove);
+    moveParagraph(currentStartOfParagraphToMove, endOfParagraphToMove, mergeDestination, false, !paragraphToMergeIsEmpty);
     m_needPlaceholder = needPlaceholder;
     // The endingPosition was likely clobbered by the move, so recompute it (moveParagraph selects the moved paragraph).
 


### PR DESCRIPTION
#### ae3c1353c1444e3ed9b14450b5099997f7f4730c
<pre>
[editing] Use appropriate startOfParagraph in mergeParagraphs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266465">https://bugs.webkit.org/show_bug.cgi?id=266465</a>

Reviewed by Ryosuke Niwa.

startOfParagraphToMove in mergeParagraphs is a VisiblePosition coming
from m_downstreamEnd, which can&apos;t guarantee to be a start of paragrph.
This patch makes sure that the appropriate startOfParagraph is used and
it fixes a related assert complain.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/run/delete_6001-7000-expected.txt:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::mergeParagraphs):

Canonical link: <a href="https://commits.webkit.org/282962@main">https://commits.webkit.org/282962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c70c6e8d56803baa38031d375a167d6833f096ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51865 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10394 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32484 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70181 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59190 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14293 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/628 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40715 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->