### PR TITLE
[WPE] Remove WPEBackend-FDO protocol remmnants from API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -25,10 +25,6 @@
 #include <glib/gstdio.h>
 #include <wtf/glib/GRefPtr.h>
 
-#if PLATFORM(WPE) && USE(WPEBACKEND_FDO_AUDIO_EXTENSION)
-#include <wpe/extensions/audio.h>
-#endif
-
 class IsPlayingAudioWebViewTest : public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(IsPlayingAudioWebViewTest);
@@ -1770,142 +1766,6 @@ static void testWebViewFrameDisplayed(FrameDisplayedTest* test, gconstpointer)
 }
 #endif
 
-#if PLATFORM(WPE) && USE(WPEBACKEND_FDO_AUDIO_EXTENSION)
-enum class RenderingState {
-    Unknown,
-    Started,
-    Paused,
-    Stopped
-};
-
-class AudioRenderingWebViewTest : public WebViewTest {
-public:
-    MAKE_GLIB_TEST_FIXTURE_WITH_SETUP_TEARDOWN(AudioRenderingWebViewTest, setup, teardown);
-
-    static void setup()
-    {
-    }
-
-    static void teardown()
-    {
-        wpe_audio_register_receiver(nullptr, nullptr);
-    }
-
-    AudioRenderingWebViewTest()
-    {
-        wpe_audio_register_receiver(&m_audioReceiver, this);
-    }
-
-    void handleStart(uint32_t id, int32_t channels, const char* layout, int32_t sampleRate)
-    {
-        g_assert(m_state == RenderingState::Unknown);
-        g_assert_false(m_streamId.has_value());
-        g_assert_cmpuint(id, ==, 0);
-        m_streamId = id;
-        m_state = RenderingState::Started;
-        g_assert_cmpint(channels, ==, 2);
-        g_assert_cmpstr(layout, ==, "S16LE");
-        g_assert_cmpint(sampleRate, ==, 44100);
-    }
-
-    void handleStop(uint32_t id)
-    {
-        g_assert_cmpuint(*m_streamId, ==, id);
-        g_assert(m_state != RenderingState::Unknown);
-        m_state = RenderingState::Stopped;
-        g_main_loop_quit(m_mainLoop);
-        m_streamId.reset();
-    }
-
-    void handlePause(uint32_t id)
-    {
-        g_assert_cmpuint(*m_streamId, ==, id);
-        g_assert(m_state != RenderingState::Unknown);
-        m_state = RenderingState::Paused;
-    }
-
-    void handleResume(uint32_t id)
-    {
-        g_assert_cmpuint(*m_streamId, ==, id);
-        g_assert(m_state == RenderingState::Paused);
-        m_state = RenderingState::Started;
-    }
-
-    void handlePacket(struct wpe_audio_packet_export* packet_export, uint32_t id, int32_t fd, uint32_t size)
-    {
-        g_assert_cmpuint(*m_streamId, ==, id);
-        g_assert(m_state == RenderingState::Started || m_state == RenderingState::Paused);
-        g_assert_cmpuint(size, >, 0);
-        wpe_audio_packet_export_release(packet_export);
-    }
-
-    void waitUntilStarted()
-    {
-        g_timeout_add(200, [](gpointer userData) -> gboolean {
-            auto* test = static_cast<AudioRenderingWebViewTest*>(userData);
-            if (test->state() == RenderingState::Started) {
-                test->quitMainLoop();
-                return G_SOURCE_REMOVE;
-            }
-            return G_SOURCE_CONTINUE;
-        }, this);
-        g_main_loop_run(m_mainLoop);
-    }
-
-    void waitUntilPaused()
-    {
-        g_timeout_add(200, [](gpointer userData) -> gboolean {
-            auto* test = static_cast<AudioRenderingWebViewTest*>(userData);
-            if (test->state() == RenderingState::Paused) {
-                test->quitMainLoop();
-                return G_SOURCE_REMOVE;
-            }
-            return G_SOURCE_CONTINUE;
-        }, this);
-        g_main_loop_run(m_mainLoop);
-    }
-
-    void waitUntilEOS()
-    {
-        g_main_loop_run(m_mainLoop);
-    }
-
-    RenderingState state() const { return m_state; }
-
-private:
-    static const struct wpe_audio_receiver m_audioReceiver;
-    RenderingState m_state { RenderingState::Unknown };
-    std::optional<uint32_t> m_streamId;
-};
-
-const struct wpe_audio_receiver AudioRenderingWebViewTest::m_audioReceiver = {
-    [](void* data, uint32_t id, int32_t channels, const char* layout, int32_t sampleRate) { static_cast<AudioRenderingWebViewTest*>(data)->handleStart(id, channels, layout, sampleRate); },
-    [](void* data, struct wpe_audio_packet_export* packet_export, uint32_t id, int32_t fd, uint32_t size) { static_cast<AudioRenderingWebViewTest*>(data)->handlePacket(packet_export, id, fd, size); },
-    [](void* data, uint32_t id) { static_cast<AudioRenderingWebViewTest*>(data)->handleStop(id); },
-    [](void* data, uint32_t id) { static_cast<AudioRenderingWebViewTest*>(data)->handlePause(id); },
-    [](void* data, uint32_t id) { static_cast<AudioRenderingWebViewTest*>(data)->handleResume(id); }
-};
-
-static void testWebViewExternalAudioRendering(AudioRenderingWebViewTest* test, gconstpointer)
-{
-    GUniquePtr<char> resourcePath(g_build_filename(Test::getResourcesDir(Test::WebKit2Resources).data(), "file-with-video.html", nullptr));
-    GUniquePtr<char> resourceURL(g_filename_to_uri(resourcePath.get(), nullptr, nullptr));
-    webkit_web_view_load_uri(test->m_webView, resourceURL.get());
-    test->waitUntilLoadFinished();
-
-    test->runJavaScriptAndWaitUntilFinished("playVideo();", nullptr);
-    test->waitUntilStarted();
-    g_assert(test->state() == RenderingState::Started);
-    test->runJavaScriptAndWaitUntilFinished("pauseVideo();", nullptr);
-    test->waitUntilPaused();
-    g_assert(test->state() == RenderingState::Paused);
-
-    test->runJavaScriptAndWaitUntilFinished("playVideo(); seekNearTheEnd();", nullptr);
-    test->waitUntilEOS();
-    g_assert(test->state() == RenderingState::Stopped);
-}
-#endif
-
 class WebViewTerminateWebProcessTest: public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(WebViewTerminateWebProcessTest);
@@ -2221,9 +2081,6 @@ void beforeAll()
 #endif
     WebViewTest::add("WebKitWebView", "is-audio-muted", testWebViewIsAudioMuted);
     WebViewTest::add("WebKitWebView", "autoplay-policy", testWebViewAutoplayPolicy);
-#if PLATFORM(WPE) && USE(WPEBACKEND_FDO_AUDIO_EXTENSION)
-    AudioRenderingWebViewTest::add("WebKitWebView", "external-audio-rendering", testWebViewExternalAudioRendering);
-#endif
     WebViewTest::add("WebKitWebView", "is-web-process-responsive", testWebViewIsWebProcessResponsive);
     WebViewTerminateWebProcessTest::add("WebKitWebView", "terminate-web-process", testWebViewTerminateWebProcess);
     WebViewTerminateWebProcessTest::add("WebKitWebView", "terminate-unresponsive-web-process", testWebViewTerminateUnresponsiveWebProcess);

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -105,9 +105,6 @@
             "/webkit/WebKitWebView/fullscreen": {
                 "expected": {"gtk": {"status": ["SKIP"], "bug": "webkit.org/b/248203"}}
             },
-            "/webkit/WebKitWebView/external-audio-rendering": {
-                "expected": {"wpe": {"status": ["FAIL", "TIMEOUT"], "bug": "webkit.org/b/262625"}}
-            },
             "/webkit/WebKitWebView/cut-copy-paste/editable": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/263417"}}
             },


### PR DESCRIPTION
#### 40a6aadb3d270764edd7c2c0607024598e870dd1
<pre>
[WPE] Remove WPEBackend-FDO protocol remmnants from API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=278783">https://bugs.webkit.org/show_bug.cgi?id=278783</a>

Reviewed by Adrian Perez de Castro.

This left-over was unused since 281281@main.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(beforeAll):
(AudioRenderingWebViewTest::setup): Deleted.
(AudioRenderingWebViewTest::teardown): Deleted.
(AudioRenderingWebViewTest::AudioRenderingWebViewTest): Deleted.
(AudioRenderingWebViewTest::handleStart): Deleted.
(AudioRenderingWebViewTest::handleStop): Deleted.
(AudioRenderingWebViewTest::handlePause): Deleted.
(AudioRenderingWebViewTest::handleResume): Deleted.
(AudioRenderingWebViewTest::handlePacket): Deleted.
(AudioRenderingWebViewTest::waitUntilStarted): Deleted.
(AudioRenderingWebViewTest::waitUntilPaused): Deleted.
(AudioRenderingWebViewTest::waitUntilEOS): Deleted.
(AudioRenderingWebViewTest::state const): Deleted.

Canonical link: <a href="https://commits.webkit.org/282838@main">https://commits.webkit.org/282838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82bab7835c8f54c873755100202b0be1c257bff6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66570 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/51543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15338 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10388 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32476 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37182 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13147 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13932 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55858 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/621 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39629 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->