### PR TITLE
[Skia] Implement remaining color spaces code paths

### DIFF
--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -128,7 +128,9 @@ std::optional<DestinationColorSpace> DestinationColorSpace::asRGB() const
     return DestinationColorSpace(colorSpace);
 
 #elif USE(SKIA)
-    notImplemented();
+    // When using skia, we're not using color spaces consisting of custom lookup tables, so we either yield SRGB or nothing.
+    if (platformColorSpace()->isSRGB())
+        return SRGB();
     return std::nullopt;
 
 #else

--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -51,22 +51,51 @@ inline SkScalar webCoreDoubleToSkScalar(double d)
 static SkGradientShader::Interpolation toSkiaInterpolation(const ColorInterpolationMethod& method)
 {
     SkGradientShader::Interpolation interpolation;
+
     WTF::switchOn(method.colorSpace,
+        [&] (const ColorInterpolationMethod::HSL&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kHSL;
+        },
+        [&] (const ColorInterpolationMethod::HWB&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kHWB;
+        },
+        [&] (const ColorInterpolationMethod::LCH&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kLCH;
+        },
+        [&] (const ColorInterpolationMethod::Lab&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kLab;
+        },
+        [&] (const ColorInterpolationMethod::OKLCH&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLCH;
+        },
+        [&] (const ColorInterpolationMethod::OKLab&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLab;
+        },
         [&] (const ColorInterpolationMethod::SRGB&) {
             interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGB;
-            switch (method.alphaPremultiplication) {
-            case AlphaPremultiplication::Premultiplied:
-                interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kYes;
-                break;
-            case AlphaPremultiplication::Unpremultiplied:
-                interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kNo;
-                break;
-            }
+        },
+        [&] (const ColorInterpolationMethod::SRGBLinear&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
+        },
+        [&] (const ColorInterpolationMethod::XYZD50&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
+        },
+        [&] (const ColorInterpolationMethod::XYZD65&) {
+            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
         },
         [&] (const auto&) {
-            // FIXME: support other color spaces.
-            notImplemented();
+            // FIXME: Support other color spaces once skia has support for them.
         });
+
+    switch (method.alphaPremultiplication) {
+    case AlphaPremultiplication::Premultiplied:
+        interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kYes;
+        break;
+    case AlphaPremultiplication::Unpremultiplied:
+        interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kNo;
+        break;
+    }
+
     return interpolation;
 }
 


### PR DESCRIPTION
#### a46b0578827f20dd9b9d1b5de4545c358f6ebf2a
<pre>
[Skia] Implement remaining color spaces code paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=278784">https://bugs.webkit.org/show_bug.cgi?id=278784</a>

Reviewed by Carlos Garcia Campos.

This change implements all the remaining, not-implemented code paths that use color spaces
in skia builds.

* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::asRGB const):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(WebCore::toSkiaInterpolation):

Canonical link: <a href="https://commits.webkit.org/282957@main">https://commits.webkit.org/282957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93e858d06cfb07e6c3995ae6371ef60e6608a575

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51859 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10389 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13149 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13933 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59185 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59353 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/623 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9820 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39630 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->