### PR TITLE
[IFC][SVG Text] Add iterator type for SVG text boxes

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1853,6 +1853,7 @@ layout/integration/inline/InlineIteratorBox.cpp
 layout/integration/inline/InlineIteratorInlineBox.cpp
 layout/integration/inline/InlineIteratorLineBox.cpp
 layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
+layout/integration/inline/InlineIteratorSVGTextBox.cpp
 layout/integration/inline/InlineIteratorTextBox.cpp
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
 layout/integration/inline/LayoutIntegrationInlineContent.cpp

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
@@ -62,6 +62,11 @@ bool BoxIterator::atEnd() const
     });
 }
 
+bool Box::isSVGText() const
+{
+    return isText() && renderer().isRenderSVGInlineText();
+}
+
 LeafBoxIterator Box::nextOnLine() const
 {
     return LeafBoxIterator(*this).traverseNextOnLine();

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -54,6 +54,7 @@ public:
     Box(PathVariant&&);
 
     bool isText() const;
+    bool isSVGText() const;
     bool isInlineBox() const;
     bool isRootInlineBox() const;
     bool isLineBreak() const;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InlineIteratorSVGTextBox.h"
+
+#include "SVGInlineTextBox.h"
+#include "SVGTextFragment.h"
+
+namespace WebCore {
+namespace InlineIterator {
+
+SVGTextBox::SVGTextBox(PathVariant&& path)
+    : TextBox(WTFMove(path))
+{
+}
+
+FloatRect SVGTextBox::calculateBoundariesIncludingSVGTransform() const
+{
+    if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
+        return svgText->calculateBoundaries();
+    return visualRectIgnoringBlockDirection();
+}
+
+const Vector<SVGTextFragment>& SVGTextBox::svgTextFragments() const
+{
+    if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
+        return svgText->textFragments();
+
+    // FIXME: Implement.
+    static NeverDestroyed<Vector<SVGTextFragment>> emptyFragments;
+    return emptyFragments;
+}
+
+const SVGInlineTextBox* SVGTextBox::legacyInlineBox() const
+{
+    return downcast<SVGInlineTextBox>(TextBox::legacyInlineBox());
+}
+
+SVGTextBoxIterator::SVGTextBoxIterator(Box::PathVariant&& path)
+    : TextBoxIterator(WTFMove(path))
+{
+}
+
+SVGTextBoxIterator::SVGTextBoxIterator(const Box& box)
+    : TextBoxIterator(box)
+{
+}
+
+SVGTextBoxIterator firstTextBoxFor(const RenderSVGInlineText& text)
+{
+    if (auto* lineLayout = LayoutIntegration::LineLayout::containing(text))
+        return { *lineLayout->textBoxesFor(text) };
+
+    return { BoxLegacyPath { text.firstLegacyTextBox() } };
+}
+
+SVGTextBoxRange textBoxesFor(const RenderSVGInlineText& text)
+{
+    return { firstTextBoxFor(text) };
+}
+
+}
+}

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InlineIteratorTextBox.h"
+#include "RenderSVGInlineText.h"
+
+namespace WebCore {
+
+class SVGInlineTextBox;
+struct SVGTextFragment;
+
+namespace InlineIterator {
+
+class SVGTextBox : public TextBox {
+public:
+    SVGTextBox(PathVariant&&);
+
+    FloatRect calculateBoundariesIncludingSVGTransform() const;
+    const Vector<SVGTextFragment>& svgTextFragments() const;
+
+    const RenderSVGInlineText& renderer() const { return downcast<RenderSVGInlineText>(TextBox::renderer()); }
+
+    const SVGInlineTextBox* legacyInlineBox() const;
+};
+
+class SVGTextBoxIterator : public TextBoxIterator {
+public:
+    SVGTextBoxIterator() = default;
+    SVGTextBoxIterator(Box::PathVariant&&);
+    SVGTextBoxIterator(const Box&);
+
+    SVGTextBoxIterator& operator++() { return downcast<SVGTextBoxIterator>(traverseNextTextBox()); }
+
+    const SVGTextBox& operator*() const { return get(); }
+    const SVGTextBox* operator->() const { return &get(); }
+
+private:
+    const SVGTextBox& get() const { return downcast<SVGTextBox>(m_box); }
+};
+
+class SVGTextBoxRange {
+public:
+    SVGTextBoxRange(SVGTextBoxIterator begin)
+        : m_begin(begin)
+    {
+    }
+
+    SVGTextBoxIterator begin() const { return m_begin; }
+    EndIterator end() const { return { }; }
+
+private:
+    SVGTextBoxIterator m_begin;
+};
+
+SVGTextBoxIterator firstTextBoxFor(const RenderSVGInlineText&);
+SVGTextBoxRange textBoxesFor(const RenderSVGInlineText&);
+
+}
+}
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::InlineIterator::SVGTextBox)
+static bool isType(const WebCore::InlineIterator::Box& box) { return box.isSVGText(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::InlineIterator::SVGTextBoxIterator)
+static bool isType(const WebCore::InlineIterator::BoxIterator& box) { return !box || box->isSVGText(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -31,10 +31,8 @@
 #include "InlineIteratorTextBoxInlines.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderCombineText.h"
-#include "RenderSVGInlineText.h"
 #include "RenderStyleInlines.h"
 #include "SVGInlineTextBox.h"
-#include "SVGTextFragment.h"
 
 namespace WebCore {
 namespace InlineIterator {
@@ -50,28 +48,6 @@ const FontCascade& TextBox::fontCascade() const
         return renderer->textCombineFont();
 
     return style().fontCascade();
-}
-
-FloatRect TextBox::calculateBoundariesIncludingSVGTransform() const
-{
-    if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
-        return svgText->calculateBoundaries();
-    return visualRectIgnoringBlockDirection();
-}
-
-const Vector<SVGTextFragment>& TextBox::svgTextFragments() const
-{
-    static NeverDestroyed<Vector<SVGTextFragment>> emptyFragments;
-
-    auto* svgInlineText = dynamicDowncast<RenderSVGInlineText>(renderer());
-    if (!svgInlineText)
-        return emptyFragments;
-
-    if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
-        return svgText->textFragments();
-
-    // FIXME: Implement.
-    return emptyFragments;
 }
 
 TextBoxIterator::TextBoxIterator(Box::PathVariant&& pathVariant)

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -30,8 +30,6 @@
 
 namespace WebCore {
 
-struct SVGTextFragment;
-
 namespace InlineIterator {
 
 class TextBox : public Box {
@@ -48,9 +46,6 @@ public:
     TextBoxSelectableRange selectableRange() const;
 
     const FontCascade& fontCascade() const;
-
-    FloatRect calculateBoundariesIncludingSVGTransform() const;
-    const Vector<SVGTextFragment>& svgTextFragments() const;
 
     inline TextRun textRun(TextRunMode = TextRunMode::Painting) const;
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -36,7 +36,7 @@
 #include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorLineBoxInlines.h"
 #include "InlineIteratorLogicalOrderTraversal.h"
-#include "InlineIteratorTextBox.h"
+#include "InlineIteratorSVGTextBox.h"
 #include "InlineIteratorTextBoxInlines.h"
 #include "InlineRunAndOffset.h"
 #include "LayoutInlineTextBox.h"
@@ -522,7 +522,8 @@ static Vector<FloatQuad> collectAbsoluteQuads(const RenderText& textRenderer, bo
 {
     Vector<FloatQuad> quads;
     for (auto& textBox : InlineIterator::textBoxesFor(textRenderer)) {
-        auto boundaries = textBox.calculateBoundariesIncludingSVGTransform();
+        auto* svgTextBox = dynamicDowncast<InlineIterator::SVGTextBox>(textBox);
+        auto boundaries = svgTextBox ? svgTextBox->calculateBoundariesIncludingSVGTransform() : textBox.visualRectIgnoringBlockDirection();
 
         // Shorten the width of this text box if it ends in an ellipsis.
         if (clipping == ClippingOption::ClipToEllipsis) {
@@ -643,7 +644,8 @@ Vector<FloatQuad> RenderText::absoluteQuadsForRange(unsigned start, unsigned end
         }
 
         if (start <= textBox.start() && textBox.end() <= end) {
-            auto boundaries = textBox.calculateBoundariesIncludingSVGTransform();
+            auto* svgTextBox = dynamicDowncast<InlineIterator::SVGTextBox>(textBox);
+            auto boundaries = svgTextBox ? svgTextBox->calculateBoundariesIncludingSVGTransform() : textBox.visualRectIgnoringBlockDirection();
 
             if (useSelectionHeight) {
                 LayoutRect selectionRect = selectionRectForTextBox(textBox, start, end);

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -27,7 +27,7 @@
 #include "CSSFontSelector.h"
 #include "FloatConversion.h"
 #include "FloatQuad.h"
-#include "InlineIteratorBox.h"
+#include "InlineIteratorSVGTextBox.h"
 #include "InlineRunAndOffset.h"
 #include "LegacyRenderSVGRoot.h"
 #include "RenderAncestorIterator.h"

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -33,6 +33,7 @@
 #include "ColorSerialization.h"
 #include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorInlineBox.h"
+#include "InlineIteratorSVGTextBox.h"
 #include "LegacyRenderSVGImage.h"
 #include "LegacyRenderSVGResourceClipperInlines.h"
 #include "LegacyRenderSVGResourceFilterInlines.h"
@@ -337,7 +338,7 @@ static void writeRenderSVGTextBox(TextStream& ts, const RenderSVGText& text)
         writeNameValuePair(ts, "color"_s, serializationForRenderTreeAsText(text.style().visitedDependentColor(CSSPropertyColor)));
 }
 
-static inline void writeSVGInlineTextBox(TextStream& ts, const InlineIterator::TextBox& textBox)
+static inline void writeSVGInlineTextBox(TextStream& ts, const InlineIterator::SVGTextBox& textBox)
 {
     auto& fragments = textBox.svgTextFragments();
     if (fragments.isEmpty())


### PR DESCRIPTION
#### fa90b205c783365c5df173aabcf5d075a2f61708
<pre>
[IFC][SVG Text] Add iterator type for SVG text boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=278786">https://bugs.webkit.org/show_bug.cgi?id=278786</a>
<a href="https://rdar.apple.com/134848118">rdar://134848118</a>

Reviewed by Alan Baradlay.

Add SVGTextBoxIterator for iterating SVG text boxes.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp:
(WebCore::InlineIterator::Box::isSVGText const):
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp: Copied from Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp.
(WebCore::InlineIterator::SVGTextBox::SVGTextBox):
(WebCore::InlineIterator::SVGTextBox::calculateBoundariesIncludingSVGTransform const):
(WebCore::InlineIterator::SVGTextBox::svgTextFragments const):
(WebCore::InlineIterator::SVGTextBox::legacyInlineBox const):
(WebCore::InlineIterator::SVGTextBoxIterator::SVGTextBoxIterator):
(WebCore::InlineIterator::firstTextBoxFor):
(WebCore::InlineIterator::textBoxesFor):
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h: Added.
(WebCore::InlineIterator::SVGTextBox::renderer const):
(WebCore::InlineIterator::SVGTextBoxIterator::operator++):
(WebCore::InlineIterator::SVGTextBoxIterator::operator* const):
(WebCore::InlineIterator::SVGTextBoxIterator::operator-&gt; const):
(WebCore::InlineIterator::SVGTextBoxIterator::get const):
(WebCore::InlineIterator::SVGTextBoxRange::SVGTextBoxRange):
(WebCore::InlineIterator::SVGTextBoxRange::begin const):
(WebCore::InlineIterator::SVGTextBoxRange::end const):
(isType):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::TextBox::calculateBoundariesIncludingSVGTransform const): Deleted.
(WebCore::InlineIterator::TextBox::svgTextFragments const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::collectAbsoluteQuads):
(WebCore::RenderText::absoluteQuadsForRange const):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGInlineTextBox):

Canonical link: <a href="https://commits.webkit.org/282844@main">https://commits.webkit.org/282844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9d64fc6398c63514b67c83917f9ccca7a790246

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51864 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32483 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70179 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59357 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/627 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39635 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->