### PR TITLE
Suppress zero-length text SVG inline renderers

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt
@@ -17,19 +17,15 @@ layer at (0,0) size 800x600
             RenderSVGTSpan {altGlyph} at (0,0) size 44x75
               RenderSVGInlineText {#text} at (0,0) size 44x75
                 chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.20: "H"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (43,0) size 38x75
               RenderSVGInlineText {#text} at (43,0) size 38x75
                 chunk 1 text run 1 at (183.20,190.00) startOffset 0 endOffset 1 width 37.20: "A"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (80,0) size 41x75
               RenderSVGInlineText {#text} at (80,0) size 41x75
                 chunk 1 text run 1 at (220.40,190.00) startOffset 0 endOffset 1 width 40.20: "P"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (120,0) size 41x75
               RenderSVGInlineText {#text} at (120,0) size 41x75
                 chunk 1 text run 1 at (260.60,190.00) startOffset 0 endOffset 1 width 40.20: "P"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (160,0) size 39x75
               RenderSVGInlineText {#text} at (160,0) size 38x75
                 chunk 1 text run 1 at (300.80,190.00) startOffset 0 endOffset 1 width 37.20: "Y"

--- a/LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt
@@ -30,7 +30,6 @@ layer at (0,0) size 800x600
         chunk 1 text run 1 at (35.63,10.00) startOffset 0 endOffset 1 width 4.06: " "
       RenderSVGTSpan {tspan} at (-10,4) size 0x1
         RenderSVGInlineText {#text} at (-10,4) size 0x0
-      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGText {text} at (65,42) size 120x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 120x10
         chunk 1 (middle anchor) text run 1 at (65.31,50.00) startOffset 0 endOffset 36 width 119.38: "Font size should decrease monotonic."

--- a/LayoutTests/platform/glib/svg/text/textPathBoundsBug-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/textPathBoundsBug-expected.txt
@@ -10,4 +10,5 @@ layer at (0,0) size 800x600
           chunk 1 (middle anchor) text run 2 at (110.50,100.00) startOffset 5 endOffset 6 width 7.00: "6"
           chunk 1 (middle anchor) text run 3 at (117.50,100.00) startOffset 6 endOffset 7 width 7.00: "7"
           chunk 1 (middle anchor) text run 4 at (124.50,100.00) startOffset 7 endOffset 8 width 7.00: "8"
-      RenderSVGInlineText {#text} at (0,0) size 0x0
+selection start: position 0 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document
+selection end:   position 8 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document

--- a/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,7 +13,6 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (339,96) size 45x30
           RenderSVGInlineText {#text} at (339,96) size 45x30
             chunk 1 text run 1 at (389.00,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
-        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt
@@ -17,19 +17,15 @@ layer at (0,0) size 800x600
             RenderSVGTSpan {altGlyph} at (0,0) size 44x75
               RenderSVGInlineText {#text} at (0,0) size 44x75
                 chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.33: "H"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (43,0) size 38x75
               RenderSVGInlineText {#text} at (43,0) size 38x75
                 chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 37.50: "A"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (80,0) size 41x75
               RenderSVGInlineText {#text} at (80,0) size 41x75
                 chunk 1 text run 1 at (220.83,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (120,0) size 41x75
               RenderSVGInlineText {#text} at (120,0) size 41x75
                 chunk 1 text run 1 at (260.85,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (160,0) size 39x75
               RenderSVGInlineText {#text} at (160,0) size 38x75
                 chunk 1 text run 1 at (300.87,190.00) startOffset 0 endOffset 1 width 37.50: "Y"

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,7 +13,6 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (337,96) size 46x30
           RenderSVGInlineText {#text} at (337,96) size 45x30
             chunk 1 text run 1 at (387.50,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
-        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
@@ -15,19 +15,15 @@ layer at (0,0) size 480x360
           RenderSVGTSpan {altGlyph} at (0,0) size 44x75
             RenderSVGInlineText {#text} at (0,0) size 44x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.33: "H"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (43,0) size 38x75
             RenderSVGInlineText {#text} at (43,0) size 38x75
               chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 37.50: "A"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (80,0) size 41x75
             RenderSVGInlineText {#text} at (80,0) size 41x75
               chunk 1 text run 1 at (220.83,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (120,0) size 41x75
             RenderSVGInlineText {#text} at (120,0) size 41x75
               chunk 1 text run 1 at (260.85,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (160,0) size 39x75
             RenderSVGInlineText {#text} at (160,0) size 38x75
               chunk 1 text run 1 at (300.87,190.00) startOffset 0 endOffset 1 width 37.50: "Y"

--- a/LayoutTests/platform/ios/svg/text/font-size-below-point-five-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/font-size-below-point-five-expected.txt
@@ -31,7 +31,6 @@ layer at (0,0) size 800x600
       RenderSVGTSpan {tspan} at (28,14) size 2x1
         RenderSVGInlineText {#text} at (28,14) size 1x1
           chunk 1 text run 1 at (38.99,10.00) startOffset 0 endOffset 1 width 0.05: "6"
-      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGText {text} at (64,42) size 122x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 121x10
         chunk 1 (middle anchor) text run 1 at (64.90,50.00) startOffset 0 endOffset 36 width 120.20: "Font size should decrease monotonic."

--- a/LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt
@@ -15,19 +15,15 @@ layer at (0,0) size 800x600
           RenderSVGTSpan {altGlyph} at (0,0) size 44x75
             RenderSVGInlineText {#text} at (0,0) size 44x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.33: "H"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (43,0) size 38x75
             RenderSVGInlineText {#text} at (43,0) size 38x75
               chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 37.50: "A"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (80,0) size 41x75
             RenderSVGInlineText {#text} at (80,0) size 41x75
               chunk 1 text run 1 at (220.83,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (120,0) size 41x75
             RenderSVGInlineText {#text} at (120,0) size 41x75
               chunk 1 text run 1 at (260.85,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (160,0) size 39x75
             RenderSVGInlineText {#text} at (160,0) size 38x75
               chunk 1 text run 1 at (300.87,190.00) startOffset 0 endOffset 1 width 37.50: "Y"

--- a/LayoutTests/platform/ios/svg/text/text-hkern-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/text-hkern-expected.txt
@@ -22,4 +22,3 @@ layer at (0,0) size 800x600
           chunk 1 text run 2 at (7.50,70.00) startOffset 1 endOffset 2 width 5.00: "2"
           chunk 1 text run 3 at (13.75,70.00) startOffset 2 endOffset 3 width 7.50: "3"
           chunk 1 text run 4 at (22.50,70.00) startOffset 3 endOffset 4 width 10.00: "4"
-      RenderSVGInlineText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt
@@ -17,19 +17,15 @@ layer at (0,0) size 800x600
             RenderSVGTSpan {altGlyph} at (0,0) size 44x76
               RenderSVGInlineText {#text} at (0,0) size 44x76
                 chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.33: "H"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (43,0) size 38x76
               RenderSVGInlineText {#text} at (43,0) size 38x76
                 chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 37.50: "A"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (80,0) size 41x76
               RenderSVGInlineText {#text} at (80,0) size 41x76
                 chunk 1 text run 1 at (220.83,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (120,0) size 41x76
               RenderSVGInlineText {#text} at (120,0) size 41x76
                 chunk 1 text run 1 at (260.85,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-            RenderSVGInlineText {#text} at (0,0) size 0x0
             RenderSVGTSpan {altGlyph} at (160,0) size 39x76
               RenderSVGInlineText {#text} at (160,0) size 38x76
                 chunk 1 text run 1 at (300.87,190.00) startOffset 0 endOffset 1 width 37.50: "Y"

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,7 +13,6 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (337,96) size 46x31
           RenderSVGInlineText {#text} at (337,96) size 45x31
             chunk 1 text run 1 at (387.50,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
-        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/mac/svg/text/font-size-below-point-five-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/font-size-below-point-five-expected.txt
@@ -31,7 +31,6 @@ layer at (0,0) size 800x600
       RenderSVGTSpan {tspan} at (28,14) size 2x1
         RenderSVGInlineText {#text} at (28,14) size 1x1
           chunk 1 text run 1 at (38.99,10.00) startOffset 0 endOffset 1 width 0.05: "6"
-      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGText {text} at (64,42) size 122x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 121x10
         chunk 1 (middle anchor) text run 1 at (64.90,50.00) startOffset 0 endOffset 36 width 120.20: "Font size should decrease monotonic."

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,7 +13,6 @@ layer at (0,0) size 800x600
         RenderSVGTSpan {tspan} at (338,96) size 46x30
           RenderSVGInlineText {#text} at (338,96) size 45x30
             chunk 1 text run 1 at (388.40,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
-        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (83,332) size 639x3 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (83,382) size 639x3 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (83,157) size 639x3 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
@@ -15,19 +15,15 @@ layer at (0,0) size 800x600
           RenderSVGTSpan {altGlyph} at (0,0) size 45x75
             RenderSVGInlineText {#text} at (0,0) size 45x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 45.00: "H"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (45,0) size 38x75
             RenderSVGInlineText {#text} at (45,0) size 38x75
               chunk 1 text run 1 at (185.00,190.00) startOffset 0 endOffset 1 width 37.20: "A"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (82,0) size 37x75
             RenderSVGInlineText {#text} at (82,0) size 36x75
               chunk 1 text run 1 at (222.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (118,0) size 37x75
             RenderSVGInlineText {#text} at (118,0) size 36x75
               chunk 1 text run 1 at (258.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (154,0) size 38x75
             RenderSVGInlineText {#text} at (154,0) size 38x75
               chunk 1 text run 1 at (294.20,190.00) startOffset 0 endOffset 1 width 37.20: "Y"

--- a/LayoutTests/platform/wpe/svg/text/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/text/text-altglyph-01-b-expected.txt
@@ -15,19 +15,15 @@ layer at (0,0) size 800x600
           RenderSVGTSpan {altGlyph} at (0,0) size 45x75
             RenderSVGInlineText {#text} at (0,0) size 45x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 45.00: "H"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (45,0) size 38x75
             RenderSVGInlineText {#text} at (45,0) size 38x75
               chunk 1 text run 1 at (185.00,190.00) startOffset 0 endOffset 1 width 37.20: "A"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (82,0) size 37x75
             RenderSVGInlineText {#text} at (82,0) size 36x75
               chunk 1 text run 1 at (222.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (118,0) size 37x75
             RenderSVGInlineText {#text} at (118,0) size 36x75
               chunk 1 text run 1 at (258.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGInlineText {#text} at (0,0) size 0x0
           RenderSVGTSpan {altGlyph} at (154,0) size 38x75
             RenderSVGInlineText {#text} at (154,0) size 38x75
               chunk 1 text run 1 at (294.20,190.00) startOffset 0 endOffset 1 width 37.20: "Y"

--- a/LayoutTests/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,7 +13,6 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (0,0) size 46x31
           RenderSVGInlineText {#text} at (337,96) size 45x30
             chunk 1 text run 1 at (387.50,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
-        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/svg/custom/invalid-text-content-expected.txt
+++ b/LayoutTests/svg/custom/invalid-text-content-expected.txt
@@ -15,5 +15,4 @@ layer at (0,0) size 800x600
         RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGInlineText {#text} at (0,0) size 0x0
-      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]

--- a/LayoutTests/svg/text/textPathBoundsBug-expected.txt
+++ b/LayoutTests/svg/text/textPathBoundsBug-expected.txt
@@ -10,4 +10,5 @@ layer at (0,0) size 800x600
           chunk 1 (middle anchor) text run 2 at (110.01,100.00) startOffset 5 endOffset 6 width 6.67: "6"
           chunk 1 (middle anchor) text run 3 at (116.68,100.00) startOffset 6 endOffset 7 width 6.67: "7"
           chunk 1 (middle anchor) text run 4 at (123.36,100.00) startOffset 7 endOffset 8 width 6.67: "8"
-      RenderSVGInlineText {#text} at (0,0) size 0x0
+selection start: position 0 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document
+selection end:   position 8 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document

--- a/LayoutTests/svg/text/textPathBoundsBug.svg
+++ b/LayoutTests/svg/text/textPathBoundsBug.svg
@@ -7,6 +7,11 @@
 
 <script>
 if (window.testRunner)
-    window.testRunner.dumpSelectionRect();
+    testRunner.dumpSelectionRect();
+var range = document.createRange();
+range.selectNode(window.document.documentElement);
+var selection = window.getSelection();
+selection.removeAllRanges();
+selection.addRange(range);
 </script>
 </svg>

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -2,6 +2,7 @@
  * (C) 1999 Lars Knoll (knoll@kde.org)
  * (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -97,6 +98,8 @@ public:
     Vector<FloatQuad> absoluteQuadsClippedToEllipsis() const;
 
     Position positionForPoint(const LayoutPoint&, HitTestSource) final;
+
+    bool hasEmptyText() const { return m_text.isEmpty(); }
 
     UChar characterAt(unsigned) const;
     unsigned length() const final { return text().length(); }

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -50,6 +51,19 @@ std::unique_ptr<LegacyInlineFlowBox> RenderSVGInline::createInlineFlowBox()
     auto box = makeUnique<SVGInlineFlowBox>(*this);
     box->setHasVirtualLogicalHeight();
     return box;
+}
+
+bool RenderSVGInline::isChildAllowed(const RenderObject& child, const RenderStyle& style) const
+{
+    auto isEmptySVGInlineText = [](const RenderObject* object) {
+        const auto svgInlineText = dynamicDowncast<RenderSVGInlineText>(object);
+        return svgInlineText && svgInlineText->hasEmptyText();
+    };
+
+    if (isEmptySVGInlineText(&child))
+        return false;
+
+    return RenderElement::isChildAllowed(child, style);
 }
 
 FloatRect RenderSVGInline::objectBoundingBox() const

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2006 Apple Inc.
+ * Copyright (C) 2006-2024 Apple Inc.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -34,6 +35,8 @@ public:
     virtual ~RenderSVGInline();
 
     inline SVGGraphicsElement& graphicsElement() const;
+
+    bool isChildAllowed(const RenderObject&, const RenderStyle&) const override;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
@@ -83,7 +83,12 @@ Ref<SVGTextElement> RenderSVGText::protectedTextElement() const
 
 bool RenderSVGText::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
-    return child.isInline();
+    auto isEmptySVGInlineText = [](const RenderObject* object) {
+        const auto svgInlineText = dynamicDowncast<RenderSVGInlineText>(object);
+        return svgInlineText && svgInlineText->hasEmptyText();
+    };
+
+    return child.isInline() && !isEmptySVGInlineText(&child);
 }
 
 RenderSVGText* RenderSVGText::locateRenderSVGTextAncestor(RenderObject& start)


### PR DESCRIPTION
#### bce920e27ee7ce10c3ab46cec651368b974dd10a
<pre>
Suppress zero-length text SVG inline renderers

<a href="https://bugs.webkit.org/show_bug.cgi?id=119719">https://bugs.webkit.org/show_bug.cgi?id=119719</a>
<a href="https://rdar.apple.com/134851694">rdar://134851694</a>

Reviewed by Nikolas Zimmermann.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/e4c158a33d34264796abfa683d0413568dfdcde0">https://chromium.googlesource.com/chromium/blink/+/e4c158a33d34264796abfa683d0413568dfdcde0</a>

The SVG text layout functions assert non-zero metrics for SVG inline text
(see SVGTextLayoutEngine::layoutTextOnLineOrPath, for example). Normally,
we don&apos;t instantiate renderers for zero-length inline text (see Text::textRendererIsNeeded),
but the RenderSVGInlineText constructor  performs whitespace filtering to support xml:space semantics
(<a href="http://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs)">http://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs)</a> and can end up with
empty text while still passing the non-zero length test in Text::textRendererIsNeeded
(for example a single newline gets deleted when xml:space=&quot;default&quot;).

Enter RenderText::positionLineBox() which attempts to fix things up by
removing zero length inline boxes. But removing boxes at this point is bad
for business because it invalidates (marks as dirty and clears computed metrics)
parent boxes and sibling boxes during layout, and throws subsequent computations off.

The patch adds isChildAllowed()-based validation for SVG inline text. This prevents
zero-length-text renderers from being inserted into the tree in the first place.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt:
* LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt:
* LayoutTests/platform/glib/svg/text/textPathBoundsBug-expected.txt:
* LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/ios/svg/text/font-size-below-point-five-expected.txt:
* LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/ios/svg/text/text-hkern-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/text-altglyph-01-b-manual-expected.txt:
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/mac/svg/text/font-size-below-point-five-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/wpe/svg/text/text-altglyph-01-b-expected.txt:
* LayoutTests/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/svg/custom/invalid-text-content-expected.txt:
* LayoutTests/svg/text/textPathBoundsBug-expected.txt:
* LayoutTests/svg/text/textPathBoundsBug.svg:
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::hasEmptyText const):
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::isChildAllowed const):
* Source/WebCore/rendering/svg/RenderSVGInline.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::isChildAllowed const):

Canonical link: <a href="https://commits.webkit.org/282894@main">https://commits.webkit.org/282894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/548cea723e041e95751392695b39768dd66c4ac3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51924 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10448 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14018 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70259 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59251 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55938 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59429 "Found 3 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14244 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/693 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39715 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40793 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->