### PR TITLE
[Flatpak SDK] Provide libsysprof-capture-4

### DIFF
--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -46,6 +46,7 @@ depends:
 - sdk/sccache.bst
 - sdk/sparkle-cdm.bst
 - sdk/svt-av1.bst
+- sdk/sysprof-capture.bst
 - sdk/unifdef.bst
 - sdk/woff2.bst
 - sdk/wpebackend-fdo.bst

--- a/Tools/buildstream/elements/sdk/libdex.bst
+++ b/Tools/buildstream/elements/sdk/libdex.bst
@@ -1,0 +1,29 @@
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- freedesktop-sdk.bst:components/glib.bst
+
+variables:
+  meson-local: >-
+    -Ddocs=false
+    -Dexamples=false
+    -Dsysprof=false
+    -Dtests=false
+    -Dvapi=false
+    -Deventfd=enabled
+    -Dliburing=disabled
+    -Dintrospection=disabled
+
+sources:
+- kind: tar
+  url: gnome_downloads:libdex/0.6/libdex-0.6.1.tar.xz
+  ref: d176de6578571e32a8c0b603b6a5a13fa5f87fb6b5442575b38ec5af16b17a92
+
+public:
+  bst:
+    integration-commands:
+    - |
+      test $(pkg-config --modversion libdex-1) = 0.6.1

--- a/Tools/buildstream/elements/sdk/sysprof-capture.bst
+++ b/Tools/buildstream/elements/sdk/sysprof-capture.bst
@@ -1,0 +1,28 @@
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- sdk/libdex.bst
+
+variables:
+  meson-local: >-
+    -Dgtk=false
+    -Dsysprofd=host
+    -Dhelp=false
+    -Dlibsysprof=false
+    -Dtools=false
+    -Dtests=false
+    -Dexamples=false
+
+sources:
+- kind: tar
+  url: gnome_downloads:sysprof/46/sysprof-46.0.tar.xz
+  ref: 73aa7e75ebab3e4e0946a05a723df7e6ee4249e3b9e884dba35500aba2a1d176
+
+public:
+  bst:
+    integration-commands:
+    - |
+      test $(pkg-config --modversion sysprof-capture-4) = 46.0


### PR DESCRIPTION
#### 710e147fed432f3cc0984deac2afb12af6338fc4
<pre>
[Flatpak SDK] Provide libsysprof-capture-4
<a href="https://bugs.webkit.org/show_bug.cgi?id=277626">https://bugs.webkit.org/show_bug.cgi?id=277626</a>

Reviewed by Philippe Normand.

Import build recipes for the sysprof-capture library and its dependency
libdex, to be included in the Flatpak SDK. The sysprof-capture recipe
configures sysprof to only build the static capture library, which is
the only component strictly needed to build the WPE and GTK ports. The
rest of the tools are to be used from the host (sysprofd, sysprof-cli,
etc.) and therefore it makes no sense to include them at this time in
the Flatpak SDK.

* Tools/buildstream/elements/sdk-platform.bst: List sysprof-capture.bst.
* Tools/buildstream/elements/sdk/libdex.bst: Added.
* Tools/buildstream/elements/sdk/sysprof-capture.bst: Added.

Canonical link: <a href="https://commits.webkit.org/282865@main">https://commits.webkit.org/282865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1e6bff660edadc0387148716f6d57bc0a54edaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17121 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/68547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/15131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/68547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/15131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67592 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/68547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/14005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/70246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8471 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/70246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8505 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/55927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/70246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7006 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9781 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/40523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->