### PR TITLE
Navigation preload ready message is lost if the IPC connection to the worker context is not already created

### DIFF
--- a/LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Setup activated but not running worker
+PASS Service worker preloadResponse is correctly served when there is no running worker when receiving the preload response
+

--- a/LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+<script src="/common/utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+const url = "/WebKit/service-workers/resources/fetch-service-worker-preload-script.py?useNavigationPreloadPromise=true&token=" + token();
+
+promise_test(async (test) => {
+    if (window.testRunner) {
+        testRunner.setUseSeparateServiceWorkerProcess(true);
+        await fetch("").then(() => { }, () => { });
+    }
+
+    const registration = await navigator.serviceWorker.register("/WebKit/service-workers/simple-fetch-service-worker-preload-worker.js", { scope : url });
+    await waitForState(registration.installing ? registration.installing : registration.active, "activated");
+
+    if (registration.navigationPreload)
+        await registration.navigationPreload.enable();
+
+    if (window.testRunner) {
+        testRunner.terminateServiceWorkers();
+        await fetch("").then(() => { }, () => { });
+    }
+}, "Setup activated but not running worker");
+
+promise_test(async (test) => {
+    await fetch(url + "&value=use-preload", { method: 'POST' });
+
+    const frame = await withIframe(url);
+    assert_equals(frame.contentWindow.value, "use-preload");
+}, "Service worker preloadResponse is correctly served when there is no running worker when receiving the preload response");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/simple-fetch-service-worker-preload-worker.js
+++ b/LayoutTests/http/wpt/service-workers/simple-fetch-service-worker-preload-worker.js
@@ -1,0 +1,39 @@
+self.addEventListener('fetch', async (event) => {
+    if (event.request.url.includes("no-fetch-event-handling"))
+        return;
+
+    if (event.request.url.includes("useNavigationPreloadPromise") && event.preloadResponse) {
+        event.respondWith(event.preloadResponse);
+        return;
+    }
+
+    if (event.request.url.includes("getResponseFromNavigationPreload") && event.preloadResponse) {
+        event.respondWith((async () => {
+            const response = await event.preloadResponse;
+            if (response)
+                 return response;
+            return fetch(event.request);
+        })());
+        return;
+    }
+
+    if (event.request.url.includes("getResponseFromRequestWithCustomHeader")) {
+        const newRequest = new Request(event.request, {
+            headers: { "x-custom-header": "my-custom-header" },
+        });
+        event.respondWith(fetch(newRequest));
+        return;
+    }
+
+    if (event.request.url.includes("getCloneResponseFromNavigationPreload") && event.preloadResponse) {
+        event.respondWith((async () => {
+            const response = await event.preloadResponse;
+            if (response)
+                 return response.clone();
+            return fetch(event.request);
+        })());
+        return;
+    }
+
+    event.respondWith(fetch(event.request));
+});

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -124,6 +124,7 @@ private:
     template<typename Message> bool sendToClient(Message&&);
 
     RefPtr<NetworkResourceLoader> protectedLoader() const;
+    void sendNavigationPreloadUpdate();
 
     WeakPtr<WebSWServerConnection> m_swServerConnection;
     WeakPtr<NetworkResourceLoader> m_loader;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -168,6 +168,8 @@ void ServiceWorkerNavigationPreloader::didReceiveResponse(ResourceResponse&& res
 {
     RELEASE_LOG(ServiceWorker, "ServiceWorkerNavigationPreloader::didReceiveResponse %p", this);
 
+    m_didReceiveResponseOrError = true;
+
     if (response.isRedirection())
         response.setTainting(ResourceResponse::Tainting::Opaqueredirect);
 
@@ -203,6 +205,7 @@ void ServiceWorkerNavigationPreloader::didFailLoading(const ResourceError& error
 {
     RELEASE_LOG(ServiceWorker, "ServiceWorkerNavigationPreloader::didFailLoading %p", this);
 
+    m_didReceiveResponseOrError = true;
     m_error = error;
     didComplete();
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -63,6 +63,7 @@ public:
     const WebCore::ResourceResponse& response() const { return m_response; }
     const WebCore::NetworkLoadMetrics& networkLoadMetrics() const { return m_networkLoadMetrics; }
     bool isServiceWorkerNavigationPreloadEnabled() const { return m_state.enabled; }
+    bool didReceiveResponseOrError() const { return m_didReceiveResponseOrError; }
 
     bool convertToDownload(DownloadManager&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
 
@@ -103,6 +104,7 @@ private:
     bool m_isStarted { false };
     bool m_isCancelled { false };
     bool m_shouldCaptureExtraNetworkLoadMetrics { false };
+    bool m_didReceiveResponseOrError { false };
     MonotonicTime m_startTime;
 };
 


### PR DESCRIPTION
#### f0bfc40dac3c35cdced3162988f7f8cc9eba0228
<pre>
Navigation preload ready message is lost if the IPC connection to the worker context is not already created
<a href="https://bugs.webkit.org/show_bug.cgi?id=278789">https://bugs.webkit.org/show_bug.cgi?id=278789</a>
<a href="https://rdar.apple.com/134853479">rdar://134853479</a>

Reviewed by Chris Dumez.

Receiving a navigation preload response in network process may race with establishing the IPC connection to the service worker process.
If the former happens before the latter, we would never tell the service worker process that the navigation preload response is ready.

To prevent this, we store a boolean in ServiceWorkerNavigationPreloader telling whether the preload received a response (or a failure).
We send the message if the service worker process connection is available.
Otherwise, we wait for the service worker process connection to become available to send it.
In that case, we make sure to send the navigation preload response ready message after the fetch event messqge.

Covered by the new test, which often hits this issue as the local server can often beat the creation of the service worker process.
.
* LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https.html: Added.
* LayoutTests/http/wpt/service-workers/simple-fetch-service-worker-preload-worker.js: Added.
(async event.event.request.url.includes.event.preloadResponse.async return):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::startFetch):
(WebKit::ServiceWorkerFetchTask::loadResponseFromPreloader):
(WebKit::ServiceWorkerFetchTask::preloadResponseIsReady):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
(WebKit::ServiceWorkerNavigationPreloader::willSendRedirectedRequest):
(WebKit::ServiceWorkerNavigationPreloader::didFinishLoading):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h:

Canonical link: <a href="https://commits.webkit.org/282907@main">https://commits.webkit.org/282907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43edc00e92b588aa4b25531352b934c1f0282053

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51877 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10406 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13167 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13953 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70194 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/641 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39650 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->