### PR TITLE
Align oncuechange event handler handling with other event handlers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-all-global-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-all-global-events-expected.txt
@@ -71,8 +71,8 @@ FAIL oncontextrestored: the content attribute must execute when an event is disp
 PASS oncontextrestored: dispatching an Event at a <meta> element must trigger element.oncontextrestored
 PASS oncuechange: must be on the appropriate locations for GlobalEventHandlers
 PASS oncuechange: the default value must be null
-FAIL oncuechange: the content attribute must be compiled into a function as the corresponding property assert_equals: The oncuechange property must be a function expected "function" but got "object"
-FAIL oncuechange: the content attribute must execute when an event is dispatched assert_true: Dispatching an event must run the code expected true got undefined
+PASS oncuechange: the content attribute must be compiled into a function as the corresponding property
+PASS oncuechange: the content attribute must execute when an event is dispatched
 PASS oncuechange: dispatching an Event at a <meta> element must trigger element.oncuechange
 PASS ondblclick: must be on the appropriate locations for GlobalEventHandlers
 PASS ondblclick: the default value must be null

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
@@ -61,8 +61,8 @@ PASS oncontextmenu: dynamic changes on the attribute
 PASS oncontextmenu: dispatching an Event at a <math> element must trigger element.oncontextmenu
 PASS oncuechange: must be on the appropriate locations for GlobalEventHandlers
 PASS oncuechange: the default value must be null
-FAIL oncuechange: the content attribute must be compiled into a function as the corresponding property assert_equals: The oncuechange property must be a function expected "function" but got "object"
-FAIL oncuechange: dynamic changes on the attribute assert_equals: The oncuechange property must be a function (set attribute) expected "function" but got "object"
+PASS oncuechange: the content attribute must be compiled into a function as the corresponding property
+PASS oncuechange: dynamic changes on the attribute
 PASS oncuechange: dispatching an Event at a <math> element must trigger element.oncuechange
 PASS ondblclick: must be on the appropriate locations for GlobalEventHandlers
 PASS ondblclick: the default value must be null

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt
@@ -95,6 +95,7 @@ CONSOLE MESSAGE: This requires a TrustedScript value else it violates the follow
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS Event handler onclick should be blocked.
 PASS Event handler onchange should be blocked.
@@ -124,7 +125,7 @@ PASS Event handler div.onclose should be blocked.
 PASS Event handler div.oncontentvisibilityautostatechange should be blocked.
 PASS Event handler div.oncontextmenu should be blocked.
 PASS Event handler div.oncopy should be blocked.
-FAIL Event handler div.oncuechange should be blocked. assert_throws_js: function "_ => element.setAttribute(name, "2+2")" did not throw
+PASS Event handler div.oncuechange should be blocked.
 PASS Event handler div.oncut should be blocked.
 PASS Event handler div.ondblclick should be blocked.
 PASS Event handler div.ondrag should be blocked.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
@@ -71,8 +71,8 @@ FAIL oncontextrestored: dynamic changes on the attribute assert_equals: The onco
 FAIL oncontextrestored: dispatching an Event at a <math> element must trigger element.oncontextrestored assert_equals: The event must be fired at the <math> element expected (object) Element node <math></math> but got (undefined) undefined
 PASS oncuechange: must be on the appropriate locations for GlobalEventHandlers
 PASS oncuechange: the default value must be null
-FAIL oncuechange: the content attribute must be compiled into a function as the corresponding property assert_equals: The oncuechange property must be a function expected "function" but got "object"
-FAIL oncuechange: dynamic changes on the attribute assert_equals: The oncuechange property must be a function (set attribute) expected "function" but got "object"
+PASS oncuechange: the content attribute must be compiled into a function as the corresponding property
+PASS oncuechange: dynamic changes on the attribute
 PASS oncuechange: dispatching an Event at a <math> element must trigger element.oncuechange
 PASS ondblclick: must be on the appropriate locations for GlobalEventHandlers
 PASS ondblclick: the default value must be null

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
@@ -71,8 +71,8 @@ FAIL oncontextrestored: dynamic changes on the attribute assert_equals: The onco
 FAIL oncontextrestored: dispatching an Event at a <math> element must trigger element.oncontextrestored assert_equals: The event must be fired at the <math> element expected (object) Element node <math></math> but got (undefined) undefined
 PASS oncuechange: must be on the appropriate locations for GlobalEventHandlers
 PASS oncuechange: the default value must be null
-FAIL oncuechange: the content attribute must be compiled into a function as the corresponding property assert_equals: The oncuechange property must be a function expected "function" but got "object"
-FAIL oncuechange: dynamic changes on the attribute assert_equals: The oncuechange property must be a function (set attribute) expected "function" but got "object"
+PASS oncuechange: the content attribute must be compiled into a function as the corresponding property
+PASS oncuechange: dynamic changes on the attribute
 PASS oncuechange: dispatching an Event at a <math> element must trigger element.oncuechange
 PASS ondblclick: must be on the appropriate locations for GlobalEventHandlers
 PASS ondblclick: the default value must be null

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt
@@ -71,8 +71,8 @@ FAIL oncontextrestored: dynamic changes on the attribute assert_equals: The onco
 FAIL oncontextrestored: dispatching an Event at a <math> element must trigger element.oncontextrestored assert_equals: The event must be fired at the <math> element expected (object) Element node <math></math> but got (undefined) undefined
 PASS oncuechange: must be on the appropriate locations for GlobalEventHandlers
 PASS oncuechange: the default value must be null
-FAIL oncuechange: the content attribute must be compiled into a function as the corresponding property assert_equals: The oncuechange property must be a function expected "function" but got "object"
-FAIL oncuechange: dynamic changes on the attribute assert_equals: The oncuechange property must be a function (set attribute) expected "function" but got "object"
+PASS oncuechange: the content attribute must be compiled into a function as the corresponding property
+PASS oncuechange: dynamic changes on the attribute
 PASS oncuechange: dispatching an Event at a <math> element must trigger element.oncuechange
 PASS ondblclick: must be on the appropriate locations for GlobalEventHandlers
 PASS ondblclick: the default value must be null

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -290,9 +290,6 @@ const AtomString& HTMLElement::eventNameForEventHandlerAttribute(const Qualified
     static NeverDestroyed map = [] {
         EventHandlerNameMap map;
         JSHTMLElement::forEachEventHandlerContentAttribute([&] (const AtomString& attributeName, const AtomString& eventName) {
-            // FIXME: Remove this special case. This has an [EventHandler] line in the IDL but was not historically in this map.
-            if (attributeName == oncuechangeAttr.get().localName())
-                return;
             map.add(attributeName, eventName);
         });
         // FIXME: Remove these special cases. These are not in IDL with [EventHandler] but were historically in this map.


### PR DESCRIPTION
#### d253da832c4cea6027de9129f31ce89f3c89c834
<pre>
Align oncuechange event handler handling with other event handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=172985">https://bugs.webkit.org/show_bug.cgi?id=172985</a>
<a href="https://rdar.apple.com/98254058">rdar://98254058</a>

Reviewed by Eric Carlson.

This was not done in 245224@main presumably to keep it as a strict
refactoring, but there is no reason not to do this now.

* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-all-global-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/html5-tree/math-global-event-handlers.tentative-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::eventNameForEventHandlerAttribute):

Canonical link: <a href="https://commits.webkit.org/282977@main">https://commits.webkit.org/282977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27b839e59c640978dabb09cc955b195d42f4d8ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68791 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15374 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52067 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10607 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70497 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59394 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56121 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59594 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/table/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14299 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/868 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39944 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->