### PR TITLE
[GStreamer][WebRTC] Initialize all audio/video RTP header extension capabilities

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -181,23 +181,23 @@ private:
     void fillVideoRtpCapabilities(Configuration, RTCRtpCapabilities&);
 
 #define WEBRTC_EXPERIMENTS_HDREXT "http://www.webrtc.org/experiments/rtp-hdrext/"
-    Vector<const char*> m_commonRtpExtensions {
-        "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
-        WEBRTC_EXPERIMENTS_HDREXT "abs-send-time",
-        GST_RTP_HDREXT_BASE "sdes:mid",
-        GST_RTP_HDREXT_BASE "sdes:repaired-rtp-stream-id",
-        GST_RTP_HDREXT_BASE "sdes:rtp-stream-id",
-        GST_RTP_HDREXT_BASE "toffset"
+    Vector<ASCIILiteral> m_commonRtpExtensions {
+        "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"_s,
+        WEBRTC_EXPERIMENTS_HDREXT "abs-send-time"_s,
+        GST_RTP_HDREXT_BASE "sdes:mid"_s,
+        GST_RTP_HDREXT_BASE "sdes:repaired-rtp-stream-id"_s,
+        GST_RTP_HDREXT_BASE "sdes:rtp-stream-id"_s,
+        GST_RTP_HDREXT_BASE "toffset"_s
     };
-    Vector<const char*> m_allAudioRtpExtensions {
-        GST_RTP_HDREXT_BASE "ssrc-audio-level"
+    Vector<ASCIILiteral> m_allAudioRtpExtensions {
+        GST_RTP_HDREXT_BASE "ssrc-audio-level"_s
     };
-    Vector<const char*> m_allVideoRtpExtensions {
-        WEBRTC_EXPERIMENTS_HDREXT "color-space",
-        WEBRTC_EXPERIMENTS_HDREXT "playout-delay",
-        WEBRTC_EXPERIMENTS_HDREXT "video-content-type",
-        WEBRTC_EXPERIMENTS_HDREXT "video-timing",
-        "urn:3gpp:video-orientation"
+    Vector<ASCIILiteral> m_allVideoRtpExtensions {
+        WEBRTC_EXPERIMENTS_HDREXT "color-space"_s,
+        WEBRTC_EXPERIMENTS_HDREXT "playout-delay"_s,
+        WEBRTC_EXPERIMENTS_HDREXT "video-content-type"_s,
+        WEBRTC_EXPERIMENTS_HDREXT "video-timing"_s,
+        "urn:3gpp:video-orientation"_s
     };
 #undef WEBRTC_EXPERIMENTS_HDREXT
 


### PR DESCRIPTION
#### 69a99fe5db4fb99318a4055f57df2a692fcf83c3
<pre>
[GStreamer][WebRTC] Initialize all audio/video RTP header extension capabilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=278792">https://bugs.webkit.org/show_bug.cgi?id=278792</a>

Reviewed by Xabier Rodriguez-Calvar.

In some cases a newly added audio transceiver would induce an SDP offer including only audio RTP
header extensions, without the common extensions. Ditto for video transceivers.

Driving-by, make use of ASCIILiteral in more places in the registry scanner.

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::probeRtpExtensions):
(WebCore::GStreamerRegistryScanner::fillAudioRtpCapabilities):
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
(WebCore::GStreamerRegistryScanner::audioRtpExtensions):
(WebCore::GStreamerRegistryScanner::videoRtpExtensions):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:

Canonical link: <a href="https://commits.webkit.org/282898@main">https://commits.webkit.org/282898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10e4371d6f3925a3ad379879d6593035c7723be8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15503 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67684 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32596 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14097 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/70348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8563 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/70348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8597 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/70348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14246 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7081 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39794 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->