### PR TITLE
Implement FocusOptions.focusVisible

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focusVisible-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focusVisible-expected.txt
@@ -1,8 +1,8 @@
 ABC
 
-FAIL FocusOptions.focusVisible: button assert_equals: :focus-visible expected true but got false
-FAIL FocusOptions.focusVisible: input assert_equals: :focus-visible expected false but got true
-FAIL FocusOptions.focusVisible: #contenteditable assert_equals: :focus-visible expected false but got true
-FAIL FocusOptions.focusVisible: #tabindex assert_equals: :focus-visible expected true but got false
+PASS FocusOptions.focusVisible: button
+PASS FocusOptions.focusVisible: input
+PASS FocusOptions.focusVisible: #contenteditable
+PASS FocusOptions.focusVisible: #tabindex
 PASS FocusOptions.focusVisible: #not_focusable
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -944,7 +944,7 @@ void Element::setFocus(bool value, FocusVisibility visibility)
     for (RefPtr element = this; element; element = element->parentElementInComposedTree())
         element->setHasFocusWithin(value);
 
-    setHasFocusVisible(value && (visibility == FocusVisibility::Visible || shouldAlwaysHaveFocusVisibleWhenFocused(*this)));
+    setHasFocusVisible(value && (visibility == FocusVisibility::Visible || (visibility == FocusVisibility::Invisible && shouldAlwaysHaveFocusVisibleWhenFocused(*this))));
 }
 
 void Element::setHasFocusVisible(bool value)
@@ -953,7 +953,6 @@ void Element::setHasFocusVisible(bool value)
 
 #if ASSERT_ENABLED
     ASSERT(!value || focused());
-    ASSERT(!focused() || !shouldAlwaysHaveFocusVisibleWhenFocused(*this) || value);
 #endif
 
     if (hasFocusVisible() == value)
@@ -3899,7 +3898,9 @@ void Element::focus(const FocusOptions& options)
             return;
 
         FocusOptions optionsWithVisibility = options;
-        if (options.trigger == FocusTrigger::Bindings && document->wasLastFocusByClick())
+        if (options.focusVisible)
+            optionsWithVisibility.visibility = *options.focusVisible ? FocusVisibility::Visible : FocusVisibility::ForceInvisible;
+        else if (options.trigger == FocusTrigger::Bindings && document->wasLastFocusByClick())
             optionsWithVisibility.visibility = FocusVisibility::Invisible;
         else if (options.trigger != FocusTrigger::Click)
             optionsWithVisibility.visibility = FocusVisibility::Visible;

--- a/Source/WebCore/dom/FocusOptions.h
+++ b/Source/WebCore/dom/FocusOptions.h
@@ -34,7 +34,7 @@ enum class FocusRemovalEventsMode : bool { Dispatch, DoNotDispatch };
 
 enum class FocusTrigger : uint8_t { Other, Click, Bindings };
 
-enum class FocusVisibility : bool { Invisible, Visible };
+enum class FocusVisibility : uint8_t { Invisible, Visible, ForceInvisible };
 
 struct FocusOptions {
     SelectionRestorationMode selectionRestorationMode { SelectionRestorationMode::RestoreOrSelectAll };
@@ -43,6 +43,7 @@ struct FocusOptions {
     FocusTrigger trigger { FocusTrigger::Other };
     FocusVisibility visibility { FocusVisibility::Invisible };
     bool preventScroll { false };
+    std::optional<bool> focusVisible { std::nullopt };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/FocusOptions.idl
+++ b/Source/WebCore/dom/FocusOptions.idl
@@ -25,4 +25,5 @@
 
 dictionary FocusOptions {
    boolean preventScroll = false;
+   boolean focusVisible;
 };


### PR DESCRIPTION
#### 20aaacc363ae8d250a9b0c203c4053b2818abfe4
<pre>
Implement FocusOptions.focusVisible
<a href="https://bugs.webkit.org/show_bug.cgi?id=242456">https://bugs.webkit.org/show_bug.cgi?id=242456</a>

Reviewed by Manuel Rego Casasnovas.

Implement the focusVisible item in FocusOptions.

When this value is provided the focus visibility is enabled or disabled, if the value isn&apos;t provided
we fallback to an implementation defined value.

An assertion is removed as the case that&apos;s being protected against is now valid.

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/processing-model/focusVisible-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setFocus):
(WebCore::Element::setHasFocusVisible):
(WebCore::Element::focus):
* Source/WebCore/dom/FocusOptions.h:
* Source/WebCore/dom/FocusOptions.idl:

Canonical link: <a href="https://commits.webkit.org/287959@main">https://commits.webkit.org/287959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db5967b28aba90466ac9660f2f4bd2b1410d404

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63151 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20923 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27765 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13646 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7898 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->