### PR TITLE
AX: Add the AXTreeFilter class to flatten the AX tree in the platform wrapper layer.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -676,6 +676,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AXTextMarker.h
     accessibility/AXTextRun.h
     accessibility/AXTextStateChangeIntent.h
+    accessibility/AXTreeFilter.h
     accessibility/AXTreeStore.h
     accessibility/AccessibilityListBox.h
     accessibility/AccessibilityMenuListPopup.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -546,6 +546,7 @@ accessibility/AXRemoteFrame.cpp
 accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
 accessibility/AXTextRun.cpp
+accessibility/AXTreeFilter.cpp
 accessibility/AccessibilityARIAGridCell.cpp
 accessibility/AccessibilityARIAGridRow.cpp
 accessibility/AccessibilityARIATable.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -948,7 +948,7 @@ public:
     virtual Node* node() const = 0;
     virtual RenderObject* renderer() const = 0;
 
-    virtual bool accessibilityIsIgnored() const = 0;
+    virtual bool isIgnored() const = 0;
 
     virtual unsigned blockquoteLevel() const = 0;
     virtual unsigned headingLevel() const = 0;
@@ -1035,7 +1035,6 @@ public:
     virtual RemoteAXObjectRef remoteParentObject() const = 0;
 #endif
     virtual AXCoreObject* parentObject() const = 0;
-    virtual AXCoreObject* parentObjectUnignored() const = 0;
 
     virtual AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) = 0;
     virtual bool isDescendantOfRole(AccessibilityRole) const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -675,7 +675,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
         stream.dumpProperty("renderName", axObject->renderer()->renderName());
 
     if (options & AXStreamOptions::ParentID) {
-        auto* parent = object.parentObjectUnignored();
+        auto* parent = object.parentObject();
         stream.dumpProperty("parentID", parent ? parent->objectID() : AXID());
     }
 
@@ -688,7 +688,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
         auto* objectWithInterestingHTML = role == AccessibilityRole::Button ? // Add here other roles of interest.
             &object : nullptr;
 
-        auto* parent = object.parentObjectUnignored();
+        auto* parent = object.parentObject();
         if (role == AccessibilityRole::StaticText && parent)
             objectWithInterestingHTML = parent;
 

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -232,10 +232,10 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
     size_t endIndex = isForward ? 0 : childrenSize;
 
     // If the startObject is ignored, we should use an accessible sibling as a start element instead.
-    if (startObject && startObject->accessibilityIsIgnored() && startObject->isDescendantOfObject(object.get())) {
+    if (startObject && startObject->isIgnored() && startObject->isDescendantOfObject(object.get())) {
         RefPtr<AXCoreObject> parentObject = startObject->parentObject();
         // Go up the parent chain to find the highest ancestor that's also being ignored.
-        while (parentObject && parentObject->accessibilityIsIgnored()) {
+        while (parentObject && parentObject->isIgnored()) {
             if (parentObject == object)
                 break;
             startObject = parentObject;
@@ -247,7 +247,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
         ASSERT(is<AccessibilityObject>(startObject));
         auto* newStartObject = dynamicDowncast<AccessibilityObject>(startObject.get());
         // Get the un-ignored sibling based on the search direction, and update the searchPosition.
-        if (newStartObject && newStartObject->accessibilityIsIgnored())
+        if (newStartObject && newStartObject->isIgnored())
             newStartObject = isForward ? newStartObject->previousSiblingUnignored() : newStartObject->nextSiblingUnignored();
         startObject = newStartObject;
     }
@@ -294,11 +294,11 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
     RefPtr<AXCoreObject> previousObject;
     if (!isForward && startObject != criteria.anchorObject) {
         previousObject = startObject;
-        startObject = startObject->parentObjectUnignored();
+        startObject = startObject->parentObject();
     }
 
     // The outer loop steps up the parent chain each time (unignored is important here because otherwise elements would be searched twice)
-    for (auto* stopSearchElement = criteria.anchorObject->parentObjectUnignored(); startObject && startObject != stopSearchElement; startObject = startObject->parentObjectUnignored()) {
+    for (auto* stopSearchElement = criteria.anchorObject->parentObject(); startObject && startObject != stopSearchElement; startObject = startObject->parentObject()) {
         // Only append the children after/before the previous element, so that the search does not check elements that are
         // already behind/ahead of start element.
         AXCoreObject::AccessibilityChildrenVector searchStack;

--- a/Source/WebCore/accessibility/AXTreeFilter.cpp
+++ b/Source/WebCore/accessibility/AXTreeFilter.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXTreeFilter.h"
+
+#include "AXLogger.h"
+#include "AccessibilityARIAGridRow.h"
+#include "AccessibilityTable.h"
+#include "AccessibilityTableCell.h"
+
+namespace WebCore {
+
+AXCoreObject* AXTreeFilter::parent(const AXCoreObject& object)
+{
+    if (auto* axObject = dynamicDowncast<AccessibilityObject>(object))
+        return parent(*axObject);
+    if (auto* isolatedObject = dynamicDowncast<AXIsolatedObject>(object))
+        return parent(*isolatedObject);
+    return nullptr;
+}
+
+bool AXTreeFilter::isIgnored(const AccessibilityObject& object)
+{
+    AXTRACE("AXTreeFilter::isIgnored"_s);
+
+    if (object.isLabel()) {
+        // FIXME: this is a "naive attempt" to eliminate duplication of labels. More work on this is needed.
+        RefPtr nextSibling = object.nextSiblingUnignored(10);
+        if (nextSibling && nextSibling->isTextControl()) {
+            String label = object.title();
+            String text = nextSibling->title();
+            if (label == text)
+                return true;
+        }
+    }
+    return false;
+}
+
+AccessibilityObject* AXTreeFilter::parent(const AccessibilityObject& object)
+{
+    if (auto* cell = dynamicDowncast<AccessibilityTableCell>(&object)) {
+        if (auto* row = cell->ariaOwnedByParent())
+            return row;
+    } else if (auto* gridRow = dynamicDowncast<AccessibilityARIAGridRow>(&object)) {
+        if (auto* table = gridRow->parentTable())
+            return table;
+    }
+
+    return Accessibility::findAncestor(object, false, [] (const auto& ancestor) {
+        return !ancestor.isIgnored();
+    });
+}
+
+AXIsolatedObject* AXTreeFilter::parent(const AXIsolatedObject& object)
+{
+    return object.parentObject();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXTreeFilter.h
+++ b/Source/WebCore/accessibility/AXTreeFilter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AXIsolatedObject.h"
+#include "AccessibilityObject.h"
+
+namespace WebCore {
+
+class AXTreeFilter {
+public:
+    static bool isIgnored(const AccessibilityObject&);
+    static bool isIgnored(AccessibilityObject* object) { return object ? isIgnored(*object) : true; }
+
+    static AccessibilityObject* parent(const AccessibilityObject&);
+    static AccessibilityObject* parent(AccessibilityObject* object) { return object ? parent(*object) : nullptr; }
+
+    static AXIsolatedObject* parent(const AXIsolatedObject&);
+    static AXIsolatedObject* parent(AXIsolatedObject* object) { return object ? parent(*object) : nullptr; }
+
+    static AXCoreObject* parent(const AXCoreObject&);
+    static AXCoreObject* parent(AXCoreObject* object) { return object ? parent(*object) : nullptr; }
+    // FIXME: add children(xxx) methods.
+};
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
@@ -66,7 +66,7 @@ AccessibilityTable* AccessibilityARIAGridCell::parentTable() const
     // which pass the tests for inclusion.
     return dynamicDowncast<AccessibilityTable>(Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (const auto& ancestor) {
         RefPtr ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor);
-        return ancestorTable && ancestorTable->isExposable() && !ancestorTable->accessibilityIsIgnored();
+        return ancestorTable && ancestorTable->isExposable() && !ancestorTable->isIgnored();
     }));
 }
     

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityARIAGridRow.h"
 
+#include "AXTreeFilter.h"
 #include "AccessibilityObject.h"
 #include "AccessibilityTable.h"
 
@@ -64,22 +65,22 @@ bool AccessibilityARIAGridRow::isARIATreeGridRow() const
     
     return parent->isTreeGrid();
 }
-    
+
 AXCoreObject::AccessibilityChildrenVector AccessibilityARIAGridRow::disclosedRows()
 {
-    AccessibilityChildrenVector disclosedRows;
-    // The contiguous disclosed rows will be the rows in the table that 
+    // The contiguous disclosed rows will be the rows in the table that
     // have an aria-level of plus 1 from this row.
-    RefPtr parent = parentObjectUnignored();
+    RefPtr parent = AXTreeFilter::parent(*this);
     if (auto* axTable = dynamicDowncast<AccessibilityTable>(*parent); !axTable || !axTable->isExposable())
-        return disclosedRows;
+        return { };
 
     // Search for rows that match the correct level. 
     // Only take the subsequent rows from this one that are +1 from this row's level.
     int index = rowIndex();
     if (index < 0)
-        return disclosedRows;
+        return { };
 
+    AccessibilityChildrenVector disclosedRows;
     unsigned level = hierarchicalLevel();
     auto allRows = parent->rows();
     int rowCount = allRows.size();
@@ -94,12 +95,12 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityARIAGridRow::disclosedRow
 
     return disclosedRows;
 }
-    
+
 AXCoreObject* AccessibilityARIAGridRow::disclosedByRow() const
 {
     // The row that discloses this one is the row in the table
     // that is aria-level subtract 1 from this row.
-    RefPtr parent = parentObjectUnignored();
+    RefPtr parent = AXTreeFilter::parent(*this);
     if (auto* axTable = dynamicDowncast<AccessibilityTable>(*parent); !axTable || !axTable->isExposable())
         return nullptr;
 
@@ -122,13 +123,6 @@ AXCoreObject* AccessibilityARIAGridRow::disclosedByRow() const
     }
 
     return nullptr;
-}
-
-AccessibilityObject* AccessibilityARIAGridRow::parentObjectUnignored() const
-{
-    if (auto* table = parentTable())
-        return table;
-    return AccessibilityTableRow::parentObjectUnignored();
 }
 
 AccessibilityTable* AccessibilityARIAGridRow::parentTable() const

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
@@ -33,8 +33,9 @@
 namespace WebCore {
     
 class AccessibilityTable;
-    
+
 class AccessibilityARIAGridRow final : public AccessibilityTableRow {
+    friend class AXTreeFilter;
 public:
     static Ref<AccessibilityARIAGridRow> create(RenderObject&);
     static Ref<AccessibilityARIAGridRow> create(Node&);
@@ -44,7 +45,6 @@ public:
     AXCoreObject* disclosedByRow() const override;
 
     AXCoreObject* rowHeader() final;
-    
 private:
     explicit AccessibilityARIAGridRow(RenderObject&);
     explicit AccessibilityARIAGridRow(Node&);
@@ -52,7 +52,6 @@ private:
 
     bool isARIATreeGridRow() const override;
     AccessibilityTable* parentTable() const override;
-    AccessibilityObject* parentObjectUnignored() const override;
 };
 
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -108,11 +108,11 @@ bool AccessibilityList::childHasPseudoVisibleListItemMarkers(Node* node)
     if (!axBeforePseudo)
         return false;
     
-    if (!axBeforePseudo->accessibilityIsIgnored())
+    if (!axBeforePseudo->isIgnored())
         return true;
     
     for (const auto& child : axBeforePseudo->children()) {
-        if (!child->accessibilityIsIgnored())
+        if (!child->isIgnored())
             return true;
     }
     

--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -156,7 +156,7 @@ AccessibilityObject* AccessibilityListBox::elementAccessibilityHitTest(const Int
         }
     }
     
-    if (listBoxOption && !listBoxOption->accessibilityIsIgnored())
+    if (listBoxOption && !listBoxOption->isIgnored())
         return listBoxOption;
     
     return axObjectCache()->getOrCreate(renderer());

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -111,7 +111,7 @@ bool AccessibilityListBoxOption::computeAccessibilityIsIgnored() const
         return true;
 
     auto* parent = parentObject();
-    return parent ? parent->accessibilityIsIgnored() : true;
+    return parent ? parent->isIgnored() : true;
 }
 
 bool AccessibilityListBoxOption::canSetSelectedAttribute() const

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -31,6 +31,7 @@
 #include "AccessibilityMathMLElement.h"
 
 #include "AXObjectCache.h"
+#include "AXTreeFilter.h"
 #include "MathMLNames.h"
 #include "RenderStyleInlines.h"
 
@@ -199,16 +200,15 @@ bool AccessibilityMathMLElement::isMathTableCell() const
 
 bool AccessibilityMathMLElement::isMathScriptObject(AccessibilityMathScriptObjectType type) const
 {
-    AXCoreObject* parent = parentObjectUnignored();
+    auto* parent = AXTreeFilter::parent(*this);
     if (!parent)
         return false;
-
     return type == AccessibilityMathScriptObjectType::Subscript ? this == parent->mathSubscriptObject() : this == parent->mathSuperscriptObject();
 }
 
 bool AccessibilityMathMLElement::isMathMultiscriptObject(AccessibilityMathMultiscriptObjectType type) const
 {
-    AXCoreObject* parent = parentObjectUnignored();
+    auto* parent = AXTreeFilter::parent(*this);
     if (!parent || !parent->isMathMultiscript())
         return false;
 

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -83,7 +83,7 @@ void AccessibilityMenuList::addChildren()
         return;
 
     downcast<AccessibilityMockObject>(*list).setParent(this);
-    if (list->accessibilityIsIgnored()) {
+    if (list->isIgnored()) {
         cache->remove(list->objectID());
         return;
     }

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2927,14 +2927,14 @@ AccessibilityRole AccessibilityNodeObject::determineAriaRoleAttribute() const
 AccessibilityRole AccessibilityNodeObject::remapAriaRoleDueToParent(AccessibilityRole role) const
 {
     // Some objects change their role based on their parent.
-    // However, asking for the unignoredParent calls accessibilityIsIgnored(), which can trigger a loop.
-    // While inside the call stack of creating an element, we need to avoid accessibilityIsIgnored().
+    // However, asking for the unignoredParent calls isIgnored(), which can trigger a loop.
+    // While inside the call stack of creating an element, we need to avoid isIgnored().
     // https://bugs.webkit.org/show_bug.cgi?id=65174
 
     if (role != AccessibilityRole::ListBoxOption && role != AccessibilityRole::MenuItem)
         return role;
 
-    for (AccessibilityObject* parent = parentObject(); parent && !parent->accessibilityIsIgnored(); parent = parent->parentObject()) {
+    for (auto* parent = parentObject(); parent && !parent->isIgnored(); parent = parent->parentObject()) {
         AccessibilityRole parentAriaRole = parent->ariaRoleAttribute();
 
         // Selects and listboxes both have options as child roles, but they map to different roles within WebCore.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -260,7 +260,7 @@ public:
     // Note: computeAccessibilityIsIgnored does not consider whether an object is ignored due to presence of modals.
     // Use accessibilityIsIgnored as the word of law when determining if an object is ignored.
     virtual bool computeAccessibilityIsIgnored() const { return true; }
-    bool accessibilityIsIgnored() const override;
+    bool isIgnored() const override;
     void recomputeIsIgnored();
     AccessibilityObjectInclusion defaultObjectInclusion() const;
     bool accessibilityIsIgnoredByDefault() const;
@@ -339,7 +339,6 @@ public:
     AccessibilityObject* previousSiblingUnignored(unsigned limit = std::numeric_limits<unsigned>::max()) const;
     AccessibilityObject* parentObject() const override { return nullptr; }
     AccessibilityObject* displayContentsParent() const;
-    AccessibilityObject* parentObjectUnignored() const override;
     virtual AccessibilityObject* parentObjectIfExists() const { return nullptr; }
     static AccessibilityObject* firstAccessibleObjectFromNode(const Node*);
     AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) final;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -36,7 +36,7 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-    
+
 class AccessibilitySVGRoot;
 class AXObjectCache;
 class Element;

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -202,7 +202,7 @@ bool AccessibilityScrollView::computeAccessibilityIsIgnored() const
     if (!webArea)
         return true;
 
-    return webArea->accessibilityIsIgnored();
+    return webArea->isIgnored();
 }
 
 void AccessibilityScrollView::addRemoteFrameChild()

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -99,7 +99,7 @@ void AccessibilitySlider::addChildren()
 
     // Before actually adding the value indicator to the hierarchy,
     // allow the platform to make a final decision about it.
-    if (thumb->accessibilityIsIgnored())
+    if (thumb->isIgnored())
         cache->remove(thumb->objectID());
     else
         addChild(thumb.ptr());

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -517,7 +517,7 @@ void AccessibilityTable::addChildren()
             return;
         processedRows.add(row);
 
-        if (row->roleValue() != AccessibilityRole::Unknown && row->accessibilityIsIgnored()) {
+        if (row->roleValue() != AccessibilityRole::Unknown && row->isIgnored()) {
             // Skip ignored rows (except for those ignored because they have an unknown role, which will happen after a table has become un-exposed but is potentially becoming re-exposed).
             // This is an addition on top of the HTML algorithm because the computed AX table has extra restrictions (e.g. cannot contain aria-hidden or role="presentation" rows).
             return;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityTableCell.h"
 
 #include "AXObjectCache.h"
+#include "AXTreeFilter.h"
 #include "AccessibilityTable.h"
 #include "AccessibilityTableRow.h"
 #include "HTMLParserIdioms.h"
@@ -122,11 +123,11 @@ AccessibilityTable* AccessibilityTableCell::parentTable() const
     
     return tableFromRenderTree.get();
 }
-    
+
 bool AccessibilityTableCell::isExposedTableCell() const
 {
     // If the parent table is an accessibility table, then we are a table cell.
-    // This used to check if the unignoredParent was a row, but that exploded performance if
+    // This used to check if the unignored parent was a row, but that exploded performance if
     // this was in nested tables. This check should be just as good.
     auto* parentTable = this->parentTable();
     return parentTable && parentTable->isExposable();
@@ -322,18 +323,9 @@ AccessibilityTableRow* AccessibilityTableCell::ariaOwnedByParent() const
     return nullptr;
 }
 
-AccessibilityObject* AccessibilityTableCell::parentObjectUnignored() const
-{
-    if (auto ownerParent = ariaOwnedByParent())
-        return ownerParent;
-    return AccessibilityRenderObject::parentObjectUnignored();
-}
-
 AccessibilityTableRow* AccessibilityTableCell::parentRow() const
 {
-    if (auto ownerParent = ariaOwnedByParent())
-        return ownerParent;
-    return dynamicDowncast<AccessibilityTableRow>(parentObjectUnignored());
+    return dynamicDowncast<AccessibilityTableRow>(AXTreeFilter::parent(*this));
 }
 
 void AccessibilityTableCell::ensureIndexesUpToDate() const

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -36,6 +36,7 @@ class AccessibilityTable;
 class AccessibilityTableRow;
 
 class AccessibilityTableCell : public AccessibilityRenderObject {
+    friend class AXTreeFilter;
 public:
     static Ref<AccessibilityTableCell> create(RenderObject&);
     static Ref<AccessibilityTableCell> create(Node&);
@@ -81,7 +82,6 @@ protected:
 
     AccessibilityTableRow* parentRow() const;
     AccessibilityRole determineAccessibilityRole() final;
-    AccessibilityObject* parentObjectUnignored() const override;
 
 private:
     // If a table cell is not exposed as a table cell, a TH element can serve as its title UI element.

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -95,7 +95,7 @@ bool AccessibilityTableColumn::computeAccessibilityIsIgnored() const
     return true;
 #endif
     
-    return m_parent->accessibilityIsIgnored();
+    return m_parent->isIgnored();
 }
     
 void AccessibilityTableColumn::addChildren()

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -58,7 +58,7 @@ bool AccessibilityTableHeaderContainer::computeAccessibilityIsIgnored() const
     return true;
 #endif
 
-    return m_parent->accessibilityIsIgnored();
+    return m_parent->isIgnored();
 }
 
 void AccessibilityTableHeaderContainer::addChildren()

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -531,7 +531,7 @@ void AccessibilityObjectAtspi::setParent(std::optional<AccessibilityObjectAtspi*
         return;
 
     m_parent = atspiParent;
-    if (!m_coreObject || m_coreObject->accessibilityIsIgnored())
+    if (!m_coreObject || m_coreObject->isIgnored())
         return;
 
     AccessibilityAtspi::singleton().parentChanged(*this);
@@ -1152,7 +1152,7 @@ void AccessibilityObjectAtspi::childAdded(AccessibilityObjectAtspi& child)
     if (!m_isRegistered)
         return;
 
-    if (!m_coreObject || m_coreObject->accessibilityIsIgnored())
+    if (!m_coreObject || m_coreObject->isIgnored())
         return;
 
     AccessibilityAtspi::singleton().childrenChanged(*this, child, AccessibilityAtspi::ChildrenChanged::Added);
@@ -1358,7 +1358,7 @@ void AccessibilityObjectAtspi::updateBackingStore()
 
 bool AccessibilityObjectAtspi::isIgnored() const
 {
-    return m_coreObject ? m_coreObject->accessibilityIsIgnored() : true;
+    return m_coreObject ? m_coreObject->isIgnored() : true;
 }
 
 void AccessibilityObject::detachPlatformWrapper(AccessibilityDetachmentType detachmentType)

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectHyperlinkAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectHyperlinkAtspi.cpp
@@ -84,7 +84,7 @@ unsigned AccessibilityObjectAtspi::offsetInParent() const
     int index = -1;
     const auto& children = parent->children();
     for (const auto& child : children) {
-        if (child->accessibilityIsIgnored())
+        if (child->isIgnored())
             continue;
 
         auto* wrapper = child->wrapper();

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectHypertextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectHypertextAtspi.cpp
@@ -63,7 +63,7 @@ unsigned AccessibilityObjectAtspi::hyperlinkCount() const
     unsigned linkCount = 0;
     const auto& children = m_coreObject->children();
     for (const auto& child : children) {
-        if (child->accessibilityIsIgnored())
+        if (child->isIgnored())
             continue;
 
         auto* wrapper = child->wrapper();
@@ -85,7 +85,7 @@ AccessibilityObjectAtspi* AccessibilityObjectAtspi::hyperlink(unsigned index) co
 
     int linkIndex = -1;
     for (const auto& child : children) {
-        if (child->accessibilityIsIgnored())
+        if (child->isIgnored())
             continue;
 
         auto* wrapper = child->wrapper();

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -340,7 +340,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     case AccessibilityRole::Tab:
     case AccessibilityRole::TextField:
     case AccessibilityRole::ToggleButton:
-        return !self.axBackingObject->accessibilityIsIgnored();
+        return !self.axBackingObject->isIgnored();
     default:
         return false;
     }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -33,6 +33,7 @@
 #include "AXLogger.h"
 #include "AXSearchManager.h"
 #include "AXTextRun.h"
+#include "AXTreeFilter.h"
 #include "AccessibilityNodeObject.h"
 #include "DateComponents.h"
 #include "HTMLNames.h"
@@ -58,7 +59,7 @@ AXIsolatedObject::AXIsolatedObject(const Ref<AccessibilityObject>& axObject, AXI
     ASSERT(isMainThread());
     ASSERT(objectID().isValid());
 
-    auto* axParent = axObject->parentObjectUnignored();
+    auto* axParent = AXTreeFilter::parent(axObject);
     m_parentID = axParent ? axParent->objectID() : AXID();
 
     // Allocate a capacity based on the minimum properties an object has (based on measurements from a real webpage).
@@ -682,7 +683,7 @@ void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& se
 
 AXCoreObject* AXIsolatedObject::sibling(AXDirection direction) const
 {
-    RefPtr parent = parentObjectUnignored();
+    RefPtr parent = parentObject();
     if (!parent)
         return nullptr;
     const auto& siblings = parent->children();
@@ -698,7 +699,7 @@ AXCoreObject* AXIsolatedObject::sibling(AXDirection direction) const
 AXCoreObject* AXIsolatedObject::siblingOrParent(AXDirection direction) const
 {
     auto* sibling = this->sibling(direction);
-    return sibling ? sibling : parentObjectUnignored();
+    return sibling ? sibling : parentObject();
 }
 
 bool AXIsolatedObject::isDetachedFromParent()
@@ -781,11 +782,6 @@ bool AXIsolatedObject::fileUploadButtonReturnsValueInTitle() const
 AXIsolatedObject* AXIsolatedObject::focusedUIElement() const
 {
     return tree()->focusedNode().get();
-}
-    
-AXIsolatedObject* AXIsolatedObject::parentObjectUnignored() const
-{
-    return tree()->objectForID(parent()).get();
 }
 
 AXIsolatedObject* AXIsolatedObject::scrollBar(AccessibilityOrientation orientation)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -68,8 +68,7 @@ public:
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
     AXCoreObject* sibling(AXDirection) const;
     AXCoreObject* siblingOrParent(AXDirection) const;
-    AXIsolatedObject* parentObject() const final { return parentObjectUnignored(); }
-    AXIsolatedObject* parentObjectUnignored() const final;
+    AXIsolatedObject* parentObject() const final { return tree()->objectForID(parent()).get(); }
     AXIsolatedObject* editableAncestor() final { return Accessibility::editableAncestor(*this); };
     bool canSetFocusAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetFocusAttribute); }
 
@@ -239,7 +238,7 @@ private:
     bool canSetSelectedAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetSelectedAttribute); }
     bool canSetSelectedChildren() const final { return boolAttributeValue(AXPropertyName::CanSetSelectedChildren); }
     // We should never create an isolated object from an ignored live object, so we can hardcode this to false.
-    bool accessibilityIsIgnored() const final { return false; }
+    bool isIgnored() const final { return false; }
     unsigned blockquoteLevel() const final { return unsignedAttributeValue(AXPropertyName::BlockquoteLevel); }
     unsigned headingLevel() const final { return unsignedAttributeValue(AXPropertyName::HeadingLevel); }
     AccessibilityButtonState checkboxOrRadioValue() const final { return propertyValue<AccessibilityButtonState>(AXPropertyName::ButtonState); }

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -314,7 +314,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
-    object.accessibilityIsIgnored();
+    object.isIgnored();
 }
 #endif
 
@@ -484,7 +484,7 @@ void AXObjectCache::createIsolatedObjectIfNeeded(AccessibilityObject& object)
     if (!wrapper || [wrapper hasIsolatedObject])
         return;
 
-    if (object.accessibilityIsIgnored())
+    if (object.isIgnored())
         deferAddUnconnectedNode(object);
 }
 #endif

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -27,6 +27,7 @@
 #import "AccessibilityObject.h"
 
 #import "AXRemoteFrame.h"
+#import "AXTreeFilter.h"
 #import "AccessibilityLabel.h"
 #import "AccessibilityList.h"
 #import "ColorCocoa.h"
@@ -74,12 +75,12 @@ void AccessibilityObject::overrideAttachmentParent(AccessibilityObject* parent)
 {
     if (!isAttachment())
         return;
-    
+
     id parentWrapper = nil;
-    if (parent) {
-        if (parent->accessibilityIsIgnored())
-            parent = parent->parentObjectUnignored();
-        parentWrapper = parent->wrapper();
+    if (parent && parent->isIgnored()) {
+        parent = AXTreeFilter::parent(parent);
+        if (parent)
+            parentWrapper = parent->wrapper();
     }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -246,12 +246,12 @@ static NSArray *convertMathPairsToNSArray(const AccessibilityObject::Accessibili
         WebAccessibilityObjectWrapper *wrappers[2];
         NSString *keys[2];
         NSUInteger count = 0;
-        if (pair.first && pair.first->wrapper() && !pair.first->accessibilityIsIgnored()) {
+        if (pair.first && pair.first->wrapper() && !pair.first->isIgnored()) {
             wrappers[0] = pair.first->wrapper();
             keys[0] = subscriptKey;
             count = 1;
         }
-        if (pair.second && pair.second->wrapper() && !pair.second->accessibilityIsIgnored()) {
+        if (pair.second && pair.second->wrapper() && !pair.second->isIgnored()) {
             wrappers[count] = pair.second->wrapper();
             keys[count] = superscriptKey;
             count += 1;

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -153,10 +153,12 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Node*, Node* newFocuse
     if (!page || !page->chrome().platformPageClient())
         return;
 
-    if (RefPtr focusedObject = focusedObjectForPage(page)) {
-        ASSERT(!focusedObject->accessibilityIsIgnored());
-        postPlatformNotification(*focusedObject, AXFocusedUIElementChanged);
-    }
+    RefPtr focusedObject = focusedObjectForPage(page);
+    if (!focusedObject)
+        return;
+
+    ASSERT(!focusedObject->isIgnored());
+    postPlatformNotification(*focusedObject, AXFocusedUIElementChanged);
 }
 
 void AXObjectCache::platformPerformDeferredCacheUpdate()

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -29,6 +29,7 @@
 
 #include "AXCoreObject.h"
 #include "AXObjectCache.h"
+#include "AXTreeFilter.h"
 #include "AccessibilityNodeObject.h"
 #include "ContainerNode.h"
 #include "Document.h"
@@ -178,7 +179,7 @@ ExceptionOr<std::optional<InspectorAuditAccessibilityObject::ComputedProperties>
         computedProperties.headingLevel = axObject->headingLevel();
         computedProperties.hidden = axObject->isHidden();
         computedProperties.hierarchicalLevel = axObject->hierarchicalLevel();
-        computedProperties.ignored = axObject->accessibilityIsIgnored();
+        computedProperties.ignored = axObject->isIgnored();
         computedProperties.ignoredByDefault = axObject->accessibilityIsIgnoredByDefault();
 
         String invalidValue = axObject->invalidStatus();
@@ -305,7 +306,7 @@ ExceptionOr<RefPtr<Node>> InspectorAuditAccessibilityObject::getParentNode(Node&
     ERROR_IF_NO_ACTIVE_AUDIT();
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
-        if (AXCoreObject* parentObject = axObject->parentObjectUnignored())
+        if (auto* parentObject = AXTreeFilter::parent(axObject))
             return parentObject->node();
     }
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1204,7 +1204,7 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
 
     String elementRole;
     if (AXObjectCache* axObjectCache = node.document().axObjectCache()) {
-        if (auto* axObject = axObjectCache->getOrCreate(node); axObject && !axObject->accessibilityIsIgnored())
+        if (auto* axObject = axObjectCache->getOrCreate(&node); axObject && !axObject->isIgnored())
             elementRole = axObject->computedRoleString();
     }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -32,6 +32,7 @@
 #include "InspectorDOMAgent.h"
 
 #include "AXObjectCache.h"
+#include "AXTreeFilter.h"
 #include "AccessibilityNodeObject.h"
 #include "AddEventListenerOptions.h"
 #include "Attr.h"
@@ -2318,7 +2319,7 @@ Ref<Inspector::Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildO
                     focused = axObject->isFocused();
             }
 
-            ignored = axObject->accessibilityIsIgnored();
+            ignored = axObject->isIgnored();
             ignoredByDefault = axObject->accessibilityIsIgnoredByDefault();
             
             String invalidValue = axObject->invalidStatus();
@@ -2385,7 +2386,7 @@ Ref<Inspector::Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildO
                 }
             }
 
-            if (AXCoreObject* parentObject = axObject->parentObjectUnignored())
+            if (auto* parentObject = AXTreeFilter::parent(axObject))
                 parentNode = parentObject->node();
 
             supportsPressed = axObject->pressedIsPresent();

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -804,7 +804,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (BOOL)accessibilityIsIgnored
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    return _impl->accessibilityIsIgnored();
+    return _impl->isIgnored();
 }
 
 - (id)accessibilityHitTest:(NSPoint)point

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -473,7 +473,7 @@ public:
     void accessibilityRegisterUIProcessTokens();
     void updateRemoteAccessibilityRegistration(bool registerProcess);
     id accessibilityFocusedUIElement();
-    bool accessibilityIsIgnored() const { return false; }
+    bool isIgnored() const { return false; }
     id accessibilityHitTest(CGPoint);
     void enableAccessibilityIfNecessary();
     id accessibilityAttributeValue(NSString *, id parameter = nil);


### PR DESCRIPTION
#### c98473860d2164fddb0426fc7b5ae5743850606f
<pre>
AX: Add the AXTreeFilter class to flatten the AX tree in the platform wrapper layer.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278799">https://bugs.webkit.org/show_bug.cgi?id=278799</a>
&lt;<a href="https://rdar.apple.com/problem/134865910">rdar://problem/134865910</a>&gt;

Reviewed by NOBODY (OOPS!).

This patch introduces the AXTreeFilter class as the centralized mechanism to flatten the AX tree, i.e., not to expose unnecessary AX objects. This is the first of a series of changes whose goals are:
- Filter out objects in the platform wrapper layer. This will allow to have different filters for different platforms and clients.
- The AX core layer will not ignore any object in neither the live nor isolated trees. This will straightline much of the existing complexity associated with creating and updating the isolated tree given ignored objects.

(This is work in progress.)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c98473860d2164fddb0426fc7b5ae5743850606f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64490 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43860 "Hash c9847386 for PR 32839 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17086 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68513 "Hash c9847386 for PR 32839 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15097 "Hash c9847386 for PR 32839 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66609 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51586 "Hash c9847386 for PR 32839 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15377 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/68513 "Hash c9847386 for PR 32839 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/15097 "Hash c9847386 for PR 32839 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67558 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/51586 "Hash c9847386 for PR 32839 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55808 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/68513 "Hash c9847386 for PR 32839 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/51586 "Hash c9847386 for PR 32839 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13186 "Found 36 new test failures: accessibility/animated-dropdown.html accessibility/aria-modal-with-text-crash.html accessibility/button-inside-label-ax-text.html accessibility/display-contents/aria-grid.html accessibility/display-contents/object-ordering.html accessibility/display-contents/table-dynamic.html accessibility/display-contents/table-section-elements.html accessibility/display-contents/table.html accessibility/dynamically-changing-iframe-remains-accessible.html accessibility/empty-text-under-element-cached.html ... (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13971 "Hash c9847386 for PR 32839 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/51586 "Hash c9847386 for PR 32839 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13515 "Found 43 new test failures: accessibility/animated-dropdown.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-modal-with-text-crash.html accessibility/button-inside-label-ax-text.html accessibility/display-contents/aria-grid.html accessibility/display-contents/dynamically-added-children.html accessibility/display-contents/object-ordering.html accessibility/display-contents/table-dynamic.html accessibility/display-contents/table-section-elements.html accessibility/display-contents/table.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70212 "Hash c9847386 for PR 32839 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8437 "Hash c9847386 for PR 32839 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13026 "Found 42 new test failures: accessibility/animated-dropdown.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-modal-with-text-crash.html accessibility/button-inside-label-ax-text.html accessibility/display-contents/aria-grid.html accessibility/display-contents/dynamically-added-children.html accessibility/display-contents/object-ordering.html accessibility/display-contents/table-dynamic.html accessibility/display-contents/table-section-elements.html accessibility/display-contents/table.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/70212 "Hash c9847386 for PR 32839 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8471 "Hash c9847386 for PR 32839 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55897 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/70212 "Hash c9847386 for PR 32839 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/659 "Found 60 new test failures: accessibility/animated-dropdown.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-modal-with-text-crash.html accessibility/button-inside-label-ax-text.html accessibility/display-contents/aria-grid.html accessibility/display-contents/dynamically-added-children.html accessibility/display-contents/object-ordering.html accessibility/display-contents/table-dynamic.html accessibility/display-contents/table-section-elements.html accessibility/display-contents/table.html ... (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39668 "Hash c9847386 for PR 32839 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40746 "Hash c9847386 for PR 32839 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41929 "Failed to checkout and rebase branch from PR 32839") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40489 "Hash c9847386 for PR 32839 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->