### PR TITLE
AX: Remove "accessibility" prefix from functions accessibilityIsIgnored, computeAccessibilityIsIgnored, accessibilityIsIgnoredByDefault

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -950,7 +950,7 @@ public:
     virtual Node* node() const = 0;
     virtual RenderObject* renderer() const = 0;
 
-    virtual bool accessibilityIsIgnored() const = 0;
+    virtual bool isIgnored() const = 0;
 
     virtual unsigned blockquoteLevel() const = 0;
     virtual unsigned headingLevel() const = 0;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -344,7 +344,7 @@ bool AXObjectCache::modalElementHasAccessibleContent(Element& element)
     while (!nodeStack.isEmpty()) {
         for (auto* node = nodeStack.takeLast(); node; node = node->nextSibling()) {
             if (auto* axObject = getOrCreate(*node)) {
-                if (!axObject->computeAccessibilityIsIgnored())
+                if (!axObject->computeIsIgnored())
                     return true;
 
 #if USE(ATSPI)
@@ -527,7 +527,7 @@ AccessibilityObject* AXObjectCache::focusedObjectForNode(Node* focusedNode)
             return dynamicDowncast<AccessibilityObject>(descendant);
     }
 
-    if (focus->accessibilityIsIgnored())
+    if (focus->isIgnored())
         return focus->parentObjectUnignored();
     return focus;
 }
@@ -902,7 +902,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(Node& node, IsPartOfRelation isP
     cacheAndInitializeWrapper(*newObject, &node);
     // Compute the object's initial ignored status.
     newObject->recomputeIsIgnored();
-    // Sometimes asking accessibilityIsIgnored() will cause the newObject to be deallocated, and then
+    // Sometimes asking isIgnored() will cause the newObject to be deallocated, and then
     // it will disappear when this function is finished, leading to a use-after-free.
     if (newObject->isDetached())
         return nullptr;
@@ -926,7 +926,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
     cacheAndInitializeWrapper(object.get(), &renderer);
     // Compute the object's initial ignored status.
     object->recomputeIsIgnored();
-    // Sometimes asking accessibilityIsIgnored() will cause the newObject to be deallocated, and then
+    // Sometimes asking isIgnored() will cause the newObject to be deallocated, and then
     // it will disappear when this function is finished, leading to a use-after-free.
     if (object->isDetached())
         return nullptr;
@@ -2068,7 +2068,7 @@ void AXObjectCache::postTextStateChangeNotification(const Position& position, co
 
 #if PLATFORM(COCOA) || USE(ATSPI)
     AccessibilityObject* object = getOrCreate(*node);
-    if (object && object->accessibilityIsIgnored()) {
+    if (object && object->isIgnored()) {
 #if PLATFORM(COCOA)
         if (position.atLastEditingPositionForNode()) {
             if (AccessibilityObject* nextSibling = object->nextSiblingUnignored(1))
@@ -2863,7 +2863,7 @@ CharacterOffset AXObjectCache::traverseToOffsetInRange(const SimpleRange& range,
         behaviors.add(TextIteratorBehavior::EntersTextControls);
     TextIterator iterator(range, behaviors);
     
-    // Enable the cache here for accessibilityIsIgnored calls in replacedNodeNeedsCharacter
+    // Enable the cache here for isIgnored calls in replacedNodeNeedsCharacter.
     AXAttributeCacheEnabler enableCache(this);
 
     // When the range has zero length, there might be replaced node or brTag that we need to increment the characterOffset.
@@ -4953,9 +4953,9 @@ bool AXObjectCache::addRelation(AccessibilityObject* origin, AccessibilityObject
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         if (auto tree = AXIsolatedTree::treeForPageID(m_pageID)) {
-            if (origin && origin->accessibilityIsIgnored())
+            if (origin && origin->isIgnored())
                 deferAddUnconnectedNode(*origin);
-            if (target && target->accessibilityIsIgnored())
+            if (target && target->isIgnored())
                 deferAddUnconnectedNode(*target);
         }
 #endif

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -46,7 +46,7 @@ private:
     virtual ~AXRemoteFrame() = default;
 
     AccessibilityRole determineAccessibilityRole() { return AccessibilityRole::RemoteFrame; }
-    bool computeAccessibilityIsIgnored() const { return false; }
+    bool computeIsIgnored() const { return false; }
     bool isAXRemoteFrame() const { return true; }
     LayoutRect elementRect() const;
 

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -234,10 +234,10 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
     size_t endIndex = isForward ? 0 : childrenSize;
 
     // If the startObject is ignored, we should use an accessible sibling as a start element instead.
-    if (startObject && startObject->accessibilityIsIgnored() && startObject->isDescendantOfObject(object.get())) {
+    if (startObject && startObject->isIgnored() && startObject->isDescendantOfObject(object.get())) {
         RefPtr<AXCoreObject> parentObject = startObject->parentObject();
         // Go up the parent chain to find the highest ancestor that's also being ignored.
-        while (parentObject && parentObject->accessibilityIsIgnored()) {
+        while (parentObject && parentObject->isIgnored()) {
             if (parentObject == object)
                 break;
             startObject = parentObject;
@@ -249,7 +249,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
         ASSERT(is<AccessibilityObject>(startObject));
         auto* newStartObject = dynamicDowncast<AccessibilityObject>(startObject.get());
         // Get the un-ignored sibling based on the search direction, and update the searchPosition.
-        if (newStartObject && newStartObject->accessibilityIsIgnored())
+        if (newStartObject && newStartObject->isIgnored())
             newStartObject = isForward ? newStartObject->previousSiblingUnignored() : newStartObject->nextSiblingUnignored();
         startObject = newStartObject;
     }

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
@@ -66,7 +66,7 @@ AccessibilityTable* AccessibilityARIAGridCell::parentTable() const
     // which pass the tests for inclusion.
     return dynamicDowncast<AccessibilityTable>(Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (const auto& ancestor) {
         RefPtr ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor);
-        return ancestorTable && ancestorTable->isExposable() && !ancestorTable->accessibilityIsIgnored();
+        return ancestorTable && ancestorTable->isExposable() && !ancestorTable->isIgnored();
     }));
 }
     

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -76,7 +76,7 @@ String AccessibilityAttachment::roleDescription() const
     return AXAttachmentRoleText();
 }
 
-bool AccessibilityAttachment::computeAccessibilityIsIgnored() const
+bool AccessibilityAttachment::computeIsIgnored() const
 {
     return false;
 }

--- a/Source/WebCore/accessibility/AccessibilityAttachment.h
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.h
@@ -50,7 +50,7 @@ private:
 
     String roleDescription() const override;
     float valueForRange() const override;
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     void accessibilityText(Vector<AccessibilityText>&) const override;
 };
     

--- a/Source/WebCore/accessibility/AccessibilityLabel.cpp
+++ b/Source/WebCore/accessibility/AccessibilityLabel.cpp
@@ -48,9 +48,9 @@ Ref<AccessibilityLabel> AccessibilityLabel::create(RenderObject& renderer)
     return adoptRef(*new AccessibilityLabel(renderer));
 }
 
-bool AccessibilityLabel::computeAccessibilityIsIgnored() const
+bool AccessibilityLabel::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
 
 String AccessibilityLabel::stringValue() const

--- a/Source/WebCore/accessibility/AccessibilityLabel.h
+++ b/Source/WebCore/accessibility/AccessibilityLabel.h
@@ -40,7 +40,7 @@ public:
     bool containsOnlyStaticText() const;
 private:
     explicit AccessibilityLabel(RenderObject&);
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Label; }
 

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -63,9 +63,9 @@ Ref<AccessibilityList> AccessibilityList::create(Node& node)
     return adoptRef(*new AccessibilityList(node));
 }
 
-bool AccessibilityList::computeAccessibilityIsIgnored() const
+bool AccessibilityList::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
     
 bool AccessibilityList::isUnorderedList() const
@@ -108,11 +108,11 @@ bool AccessibilityList::childHasPseudoVisibleListItemMarkers(Node* node)
     if (!axBeforePseudo)
         return false;
     
-    if (!axBeforePseudo->accessibilityIsIgnored())
+    if (!axBeforePseudo->isIgnored())
         return true;
     
     for (const auto& child : axBeforePseudo->children()) {
-        if (!child->accessibilityIsIgnored())
+        if (!child->isIgnored())
             return true;
     }
     

--- a/Source/WebCore/accessibility/AccessibilityList.h
+++ b/Source/WebCore/accessibility/AccessibilityList.h
@@ -46,7 +46,7 @@ private:
     bool isOrderedList() const override;
     bool isDescriptionList() const override;
 
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     AccessibilityRole determineAccessibilityRole() override;
     bool childHasPseudoVisibleListItemMarkers(Node*);
 };

--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -156,7 +156,7 @@ AccessibilityObject* AccessibilityListBox::elementAccessibilityHitTest(const Int
         }
     }
     
-    if (listBoxOption && !listBoxOption->accessibilityIsIgnored())
+    if (listBoxOption && !listBoxOption->isIgnored())
         return listBoxOption;
     
     return axObjectCache()->getOrCreate(renderer());

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -102,16 +102,13 @@ LayoutRect AccessibilityListBoxOption::elementRect() const
     return { };
 }
 
-bool AccessibilityListBoxOption::computeAccessibilityIsIgnored() const
+bool AccessibilityListBoxOption::computeIsIgnored() const
 {
-    if (!m_node)
-        return true;
-
-    if (accessibilityIsIgnoredByDefault())
+    if (!m_node || isIgnoredByDefault())
         return true;
 
     auto* parent = parentObject();
-    return parent ? parent->accessibilityIsIgnored() : true;
+    return parent ? parent->isIgnored() : true;
 }
 
 bool AccessibilityListBoxOption::canSetSelectedAttribute() const

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -63,7 +63,7 @@ private:
     int listBoxOptionIndex() const;
     IntRect listBoxOptionRect() const;
     AccessibilityObject* listBoxOptionAccessibilityObject(HTMLElement*) const;
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
 };
 
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
@@ -53,9 +53,9 @@ Ref<AccessibilityMediaObject> AccessibilityMediaObject::create(RenderObject& ren
     return adoptRef(*new AccessibilityMediaObject(renderer));
 }
 
-bool AccessibilityMediaObject::computeAccessibilityIsIgnored() const
+bool AccessibilityMediaObject::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
 
 HTMLMediaElement* AccessibilityMediaObject::mediaElement() const

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.h
@@ -51,7 +51,7 @@ public:
 private:
     enum class AXSeekDirection : bool { Backward, Forward };
     explicit AccessibilityMediaObject(RenderObject&);
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
     bool isMediaObject() const final { return true; }
     
     String stringValue() const override;

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -83,7 +83,7 @@ void AccessibilityMenuList::addChildren()
         return;
 
     downcast<AccessibilityMockObject>(*list).setParent(this);
-    if (list->accessibilityIsIgnored()) {
+    if (list->isIgnored()) {
         cache->remove(list->objectID());
         return;
     }

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
@@ -101,9 +101,9 @@ bool AccessibilityMenuListOption::canSetSelectedAttribute() const
     return isEnabled();
 }
 
-bool AccessibilityMenuListOption::computeAccessibilityIsIgnored() const
+bool AccessibilityMenuListOption::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
 
 LayoutRect AccessibilityMenuListOption::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.h
@@ -56,7 +56,7 @@ private:
     bool canSetSelectedAttribute() const final;
     LayoutRect elementRect() const final;
     String stringValue() const final;
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
 
     WeakPtr<AccessibilityObject> m_parent;
 };

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -63,9 +63,9 @@ bool AccessibilityMenuListPopup::isEnabled() const
     return m_parent->isEnabled();
 }
 
-bool AccessibilityMenuListPopup::computeAccessibilityIsIgnored() const
+bool AccessibilityMenuListPopup::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
 
 std::optional<AXCoreObject::AccessibilityChildrenVector> AccessibilityMenuListPopup::selectedChildren()

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
@@ -55,7 +55,7 @@ private:
     bool press() override;
     void addChildren() override;
     void handleChildrenChanged();
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     std::optional<AccessibilityChildrenVector> selectedChildren() final;
 
     AccessibilityMenuListOption* menuListOptionAccessibilityObject(HTMLElement*) const;

--- a/Source/WebCore/accessibility/AccessibilityMockObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.cpp
@@ -35,9 +35,9 @@ AccessibilityMockObject::AccessibilityMockObject()
 
 AccessibilityMockObject::~AccessibilityMockObject() = default;
     
-bool AccessibilityMockObject::computeAccessibilityIsIgnored() const
+bool AccessibilityMockObject::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
     
 }

--- a/Source/WebCore/accessibility/AccessibilityMockObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.h
@@ -50,7 +50,7 @@ private:
     bool isMockObject() const final { return true; }
     bool isDetachedFromParent() override { return !m_parent; }
 
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
 };
 
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -657,7 +657,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::visibleChildr
     return result;
 }
 
-bool AccessibilityNodeObject::computeAccessibilityIsIgnored() const
+bool AccessibilityNodeObject::computeIsIgnored() const
 {
 #ifndef NDEBUG
     // Double-check that an AccessibilityObject is never accessed before
@@ -2927,14 +2927,14 @@ AccessibilityRole AccessibilityNodeObject::determineAriaRoleAttribute() const
 AccessibilityRole AccessibilityNodeObject::remapAriaRoleDueToParent(AccessibilityRole role) const
 {
     // Some objects change their role based on their parent.
-    // However, asking for the unignoredParent calls accessibilityIsIgnored(), which can trigger a loop.
-    // While inside the call stack of creating an element, we need to avoid accessibilityIsIgnored().
+    // However, asking for the unignoredParent calls isIgnored(), which can trigger a loop.
+    // While inside the call stack of creating an element, we need to avoid isIgnored().
     // https://bugs.webkit.org/show_bug.cgi?id=65174
 
     if (role != AccessibilityRole::ListBoxOption && role != AccessibilityRole::MenuItem)
         return role;
 
-    for (AccessibilityObject* parent = parentObject(); parent && !parent->accessibilityIsIgnored(); parent = parent->parentObject()) {
+    for (AccessibilityObject* parent = parentObject(); parent && !parent->isIgnored(); parent = parent->parentObject()) {
         AccessibilityRole parentAriaRole = parent->ariaRoleAttribute();
 
         // Selects and listboxes both have options as child roles, but they map to different roles within WebCore.

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -168,7 +168,7 @@ protected:
     virtual AccessibilityRole determineAriaRoleAttribute() const;
     AccessibilityRole remapAriaRoleDueToParent(AccessibilityRole) const;
 
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     void addChildren() override;
     void clearChildren() override;
     void updateChildrenIfNecessary() override;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -257,13 +257,13 @@ public:
     RenderObject* renderer() const override { return nullptr; }
     const RenderStyle* style() const;
 
-    // Note: computeAccessibilityIsIgnored does not consider whether an object is ignored due to presence of modals.
-    // Use accessibilityIsIgnored as the word of law when determining if an object is ignored.
-    virtual bool computeAccessibilityIsIgnored() const { return true; }
-    bool accessibilityIsIgnored() const override;
+    // Note: computeIsIgnored does not consider whether an object is ignored due to presence of modals.
+    // Use isIgnored as the word of law when determining if an object is ignored.
+    virtual bool computeIsIgnored() const { return true; }
+    bool isIgnored() const override;
     void recomputeIsIgnored();
     AccessibilityObjectInclusion defaultObjectInclusion() const;
-    bool accessibilityIsIgnoredByDefault() const;
+    bool isIgnoredByDefault() const;
     bool isARIAHidden() const;
 
     bool isShowingValidationMessage() const;
@@ -899,7 +899,7 @@ private:
     std::optional<BoundaryPoint> lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect) const;
 
     // Note that "withoutCache" refers to the lack of referencing AXComputedObjectAttributeCache in the function, not the AXObjectCache parameter we pass in here.
-    bool accessibilityIsIgnoredWithoutCache(AXObjectCache*) const;
+    bool isIgnoredWithoutCache(AXObjectCache*) const;
     void setLastKnownIsIgnoredValue(bool);
     void ariaTreeRows(AccessibilityChildrenVector& rows, AccessibilityChildrenVector& ancestors);
     AccessibilityChildrenVector ariaListboxSelectedChildren();
@@ -939,8 +939,8 @@ inline bool AccessibilityObject::hasDisplayContents() const
 
 inline void AccessibilityObject::recomputeIsIgnored()
 {
-    // accessibilityIsIgnoredWithoutCache will update m_lastKnownIsIgnoredValue and perform any necessary actions if it has changed.
-    accessibilityIsIgnoredWithoutCache(axObjectCache());
+    // isIgnoredWithoutCache will update m_lastKnownIsIgnoredValue and perform any necessary actions if it has changed.
+    isIgnoredWithoutCache(axObjectCache());
 }
 
 inline std::optional<BoundaryPoint> AccessibilityObject::lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect) const

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -46,9 +46,9 @@ Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(Rende
     return adoptRef(*new AccessibilityProgressIndicator(renderer));
 }
 
-bool AccessibilityProgressIndicator::computeAccessibilityIsIgnored() const
+bool AccessibilityProgressIndicator::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
     
 String AccessibilityProgressIndicator::valueDescription() const

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
@@ -49,7 +49,7 @@ private:
     HTMLProgressElement* progressElement() const;
     HTMLMeterElement* meterElement() const;
     
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1080,14 +1080,14 @@ static bool webAreaIsPresentational(RenderObject* renderer)
     return false;
 }
 
-bool AccessibilityRenderObject::computeAccessibilityIsIgnored() const
+bool AccessibilityRenderObject::computeIsIgnored() const
 {
 #ifndef NDEBUG
     ASSERT(m_initialized);
 #endif
 
     if (!m_renderer)
-        return AccessibilityNodeObject::computeAccessibilityIsIgnored();
+        return AccessibilityNodeObject::computeIsIgnored();
 
     // Check first if any of the common reasons cause this element to be ignored.
     // Then process other use cases that need to be applied to all the various roles
@@ -1182,7 +1182,7 @@ bool AccessibilityRenderObject::computeAccessibilityIsIgnored() const
             if (ancestor->roleValue() == AccessibilityRole::TextField)
                 return true;
 
-            if (checkForIgnored && !ancestor->accessibilityIsIgnored()) {
+            if (checkForIgnored && !ancestor->isIgnored()) {
                 checkForIgnored = false;
                 // Static text beneath MenuItems and MenuButtons are just reported along with the menu item, so it's ignored on an individual level.
                 if (ancestor->isMenuItem() || ancestor->isMenuButton())
@@ -1457,7 +1457,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         return { };
 
     // FIXME: Need to handle PseudoId::FirstLetter. Right now, it will be chopped off from the other
-    // other text in the line, and AccessibilityRenderObject::computeAccessibilityIsIgnored ignores the
+    // other text in the line, and AccessibilityRenderObject::computeIsIgnored ignores the
     // first-letter RenderText, meaning we can't recover it later by combining text across AX objects.
 
     Vector<AXTextRun> runs;
@@ -1660,7 +1660,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityRenderObject::documentLin
         if (auto* renderer = current->renderer()) {
             RefPtr<AccessibilityObject> axObject = document.axObjectCache()->getOrCreate(*renderer);
             ASSERT(axObject);
-            if (!axObject->accessibilityIsIgnored() && axObject->isLink())
+            if (!axObject->isIgnored() && axObject->isLink())
                 result.append(axObject);
         } else {
             auto* parent = current->parentNode();
@@ -2035,7 +2035,7 @@ AccessibilityObject* AccessibilityRenderObject::accessibilityHitTest(const IntPo
     // Allow the element to perform any hit-testing it might need to do to reach non-render children.
     result = result->elementAccessibilityHitTest(point);
 
-    if (result && result->accessibilityIsIgnored()) {
+    if (result && result->isIgnored()) {
         // If this element is the label of a control, a hit test should return the control.
         auto* controlObject = result->controlForLabelElement();
         if (controlObject && !controlObject->titleUIElement())
@@ -2273,7 +2273,7 @@ void AccessibilityRenderObject::addImageMapChildren()
         areaObject.setHTMLAreaElement(&area);
         areaObject.setHTMLMapElement(map.get());
         areaObject.setParent(this);
-        if (!areaObject.accessibilityIsIgnored())
+        if (!areaObject.isIgnored())
             addChild(&areaObject);
         else
             axObjectCache()->remove(areaObject.objectID());
@@ -2392,7 +2392,7 @@ void AccessibilityRenderObject::updateAttachmentViewParents()
 {
     // Only the unignored parent should set the attachment parent, because that's what is reflected in the AX 
     // hierarchy to the client.
-    if (accessibilityIsIgnored())
+    if (isIgnored())
         return;
     
     for (const auto& child : m_children) {
@@ -2443,7 +2443,7 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
         if (child->renderer()) {
             // Find out where the last render sibling is located within m_children.
             AXCoreObject* childObject = axObjectCache()->get(child->renderer());
-            if (childObject && childObject->accessibilityIsIgnored()) {
+            if (childObject && childObject->isIgnored()) {
                 auto& children = childObject->children();
                 if (children.size())
                     childObject = children.last().get();
@@ -2471,7 +2471,7 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
 #if USE(ATSPI)
 RenderObject* AccessibilityRenderObject::markerRenderer() const
 {
-    if (accessibilityIsIgnored() || !isListItem() || !m_renderer || !m_renderer->isRenderListItem())
+    if (isIgnored() || !isListItem() || !m_renderer || !m_renderer->isRenderListItem())
         return nullptr;
 
     return uncheckedDowncast<RenderListItem>(*m_renderer).markerRenderer();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -149,7 +149,7 @@ protected:
 
     bool shouldIgnoreAttributeRole() const override;
     AccessibilityRole determineAccessibilityRole() override;
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
 
 #if ENABLE(MATHML)
     virtual bool isIgnoredElementWithinMathTree() const;

--- a/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
@@ -212,7 +212,7 @@ bool AccessibilitySVGElement::hasTitleOrDescriptionChild() const
     return false;
 }
 
-bool AccessibilitySVGElement::computeAccessibilityIsIgnored() const
+bool AccessibilitySVGElement::computeIsIgnored() const
 {
     // According to the SVG Accessibility API Mappings spec, items should be excluded if:
     // * They would be excluded according to the Core Accessibility API Mappings.
@@ -259,7 +259,7 @@ bool AccessibilitySVGElement::computeAccessibilityIsIgnored() const
         return true;
     }
 
-    return AccessibilityRenderObject::computeAccessibilityIsIgnored();
+    return AccessibilityRenderObject::computeIsIgnored();
 }
 
 bool AccessibilitySVGElement::inheritsPresentationalRole() const

--- a/Source/WebCore/accessibility/AccessibilitySVGElement.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGElement.h
@@ -47,7 +47,7 @@ private:
     void accessibilityText(Vector<AccessibilityText>&) const final;
     AccessibilityRole determineAccessibilityRole() override;
     bool inheritsPresentationalRole() const final;
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
 
     AccessibilityObject* targetForUseElement() const;
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -196,13 +196,13 @@ void AccessibilityScrollView::clearChildren()
     m_childrenDirty = false;
 }
 
-bool AccessibilityScrollView::computeAccessibilityIsIgnored() const
+bool AccessibilityScrollView::computeIsIgnored() const
 {
     AccessibilityObject* webArea = webAreaObject();
     if (!webArea)
         return true;
 
-    return webArea->accessibilityIsIgnored();
+    return webArea->isIgnored();
 }
 
 void AccessibilityScrollView::addRemoteFrameChild()

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -52,7 +52,7 @@ private:
     ScrollView* currentScrollView() const;
     ScrollableArea* getScrollableAreaIfScrollable() const override { return currentScrollView(); }
     void scrollTo(const IntPoint&) const override;
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     bool isAccessibilityScrollViewInstance() const override { return true; }
     bool isEnabled() const override { return true; }
     bool hasRemoteFrameChild() const final { return m_remoteFrame; }

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -99,7 +99,7 @@ void AccessibilitySlider::addChildren()
 
     // Before actually adding the value indicator to the hierarchy,
     // allow the platform to make a final decision about it.
-    if (thumb->accessibilityIsIgnored())
+    if (thumb->isIgnored())
         cache->remove(thumb->objectID());
     else
         addChild(thumb.ptr());
@@ -176,9 +176,9 @@ LayoutRect AccessibilitySliderThumb::elementRect() const
     return LayoutRect();
 }
 
-bool AccessibilitySliderThumb::computeAccessibilityIsIgnored() const
+bool AccessibilitySliderThumb::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySlider.h
+++ b/Source/WebCore/accessibility/AccessibilitySlider.h
@@ -73,7 +73,7 @@ private:
     AccessibilitySliderThumb();
 
     bool isSliderThumb() const override { return true; }
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -517,7 +517,7 @@ void AccessibilityTable::addChildren()
             return;
         processedRows.add(row);
 
-        if (row->roleValue() != AccessibilityRole::Unknown && row->accessibilityIsIgnored()) {
+        if (row->roleValue() != AccessibilityRole::Unknown && row->isIgnored()) {
             // Skip ignored rows (except for those ignored because they have an unknown role, which will happen after a table has become un-exposed but is potentially becoming re-exposed).
             // This is an addition on top of the HTML algorithm because the computed AX table has extra restrictions (e.g. cannot contain aria-hidden or role="presentation" rows).
             return;
@@ -887,7 +887,7 @@ AccessibilityRole AccessibilityTable::roleValue() const
     return AccessibilityRole::Table;
 }
     
-bool AccessibilityTable::computeAccessibilityIsIgnored() const
+bool AccessibilityTable::computeIsIgnored() const
 {
     AccessibilityObjectInclusion decision = defaultObjectInclusion();
     if (decision == AccessibilityObjectInclusion::IncludeObject)
@@ -896,7 +896,7 @@ bool AccessibilityTable::computeAccessibilityIsIgnored() const
         return true;
     
     if (!isExposable())
-        return AccessibilityRenderObject::computeAccessibilityIsIgnored();
+        return AccessibilityRenderObject::computeIsIgnored();
 
     return false;
 }

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -104,7 +104,7 @@ protected:
     // Used in type checking function is<AccessibilityTable>.
     bool isAccessibilityTableInstance() const final { return true; }
 
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
 
     void addRow(AccessibilityTableRow&, unsigned, unsigned& maxColumnCount);
 

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -62,7 +62,7 @@ Ref<AccessibilityTableCell> AccessibilityTableCell::create(Node& node)
     return adoptRef(*new AccessibilityTableCell(node));
 }
 
-bool AccessibilityTableCell::computeAccessibilityIsIgnored() const
+bool AccessibilityTableCell::computeIsIgnored() const
 {
     auto decision = defaultObjectInclusion();
     if (decision == AccessibilityObjectInclusion::IncludeObject)
@@ -76,7 +76,7 @@ bool AccessibilityTableCell::computeAccessibilityIsIgnored() const
     if (!element() && !inTable)
         return true;
 
-    return !isExposedTableCell() && AccessibilityRenderObject::computeAccessibilityIsIgnored();
+    return !isExposedTableCell() && AccessibilityRenderObject::computeIsIgnored();
 }
 
 AccessibilityTable* AccessibilityTableCell::parentTable() const

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -86,7 +86,7 @@ protected:
 private:
     // If a table cell is not exposed as a table cell, a TH element can serve as its title UI element.
     AccessibilityObject* titleUIElement() const final;
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
     String expandedTextValue() const final;
     bool supportsExpandedTextValue() const final;
     AccessibilityTableRow* ariaOwnedByParent() const;

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -86,7 +86,7 @@ void AccessibilityTableColumn::setColumnIndex(unsigned columnIndex)
 #endif
 }
 
-bool AccessibilityTableColumn::computeAccessibilityIsIgnored() const
+bool AccessibilityTableColumn::computeIsIgnored() const
 {
     if (!m_parent)
         return true;
@@ -95,7 +95,7 @@ bool AccessibilityTableColumn::computeAccessibilityIsIgnored() const
     return true;
 #endif
     
-    return m_parent->accessibilityIsIgnored();
+    return m_parent->isIgnored();
 }
     
 void AccessibilityTableColumn::addChildren()

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.h
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.h
@@ -54,7 +54,7 @@ public:
 private:
     AccessibilityTableColumn();
     
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     bool isTableColumn() const override { return true; }
 
     bool isAccessibilityTableColumnInstance() const final { return true; }

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -49,7 +49,7 @@ LayoutRect AccessibilityTableHeaderContainer::elementRect() const
     return m_headerRect;
 }
 
-bool AccessibilityTableHeaderContainer::computeAccessibilityIsIgnored() const
+bool AccessibilityTableHeaderContainer::computeIsIgnored() const
 {
     if (!m_parent)
         return true;
@@ -58,7 +58,7 @@ bool AccessibilityTableHeaderContainer::computeAccessibilityIsIgnored() const
     return true;
 #endif
 
-    return m_parent->accessibilityIsIgnored();
+    return m_parent->isIgnored();
 }
 
 void AccessibilityTableHeaderContainer::addChildren()

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
@@ -48,7 +48,7 @@ public:
 private:
     AccessibilityTableHeaderContainer();
     
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
 
     LayoutRect m_headerRect;
 }; 

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -84,7 +84,7 @@ AccessibilityObject* AccessibilityTableRow::observableObject() const
     return parentTable();
 }
     
-bool AccessibilityTableRow::computeAccessibilityIsIgnored() const
+bool AccessibilityTableRow::computeIsIgnored() const
 {    
     AccessibilityObjectInclusion decision = defaultObjectInclusion();
     if (decision == AccessibilityObjectInclusion::IncludeObject)
@@ -93,7 +93,7 @@ bool AccessibilityTableRow::computeAccessibilityIsIgnored() const
         return true;
     
     if (!isTableRow())
-        return AccessibilityRenderObject::computeAccessibilityIsIgnored();
+        return AccessibilityRenderObject::computeIsIgnored();
 
     return isDOMHidden() || ignoredFromPresentationalRole();
 }

--- a/Source/WebCore/accessibility/AccessibilityTableRow.h
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.h
@@ -65,7 +65,7 @@ protected:
 private:
     bool isTableRow() const final;
     AccessibilityObject* observableObject() const final;
-    bool computeAccessibilityIsIgnored() const final;
+    bool computeIsIgnored() const final;
 
     unsigned m_rowIndex;
 };

--- a/Source/WebCore/accessibility/AccessibilityTree.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTree.cpp
@@ -62,9 +62,9 @@ Ref<AccessibilityTree> AccessibilityTree::create(Node& node)
     return adoptRef(*new AccessibilityTree(node));
 }
 
-bool AccessibilityTree::computeAccessibilityIsIgnored() const
+bool AccessibilityTree::computeIsIgnored() const
 {
-    return accessibilityIsIgnoredByDefault();
+    return isIgnoredByDefault();
 }
 
 AccessibilityRole AccessibilityTree::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AccessibilityTree.h
+++ b/Source/WebCore/accessibility/AccessibilityTree.h
@@ -42,7 +42,7 @@ public:
 private:
     explicit AccessibilityTree(RenderObject&);
     explicit AccessibilityTree(Node&);
-    bool computeAccessibilityIsIgnored() const override;
+    bool computeIsIgnored() const override;
     AccessibilityRole determineAccessibilityRole() override;
     bool isTreeValid() const;
 };

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -531,7 +531,7 @@ void AccessibilityObjectAtspi::setParent(std::optional<AccessibilityObjectAtspi*
         return;
 
     m_parent = atspiParent;
-    if (!m_coreObject || m_coreObject->accessibilityIsIgnored())
+    if (!m_coreObject || m_coreObject->isIgnored())
         return;
 
     AccessibilityAtspi::singleton().parentChanged(*this);
@@ -1152,7 +1152,7 @@ void AccessibilityObjectAtspi::childAdded(AccessibilityObjectAtspi& child)
     if (!m_isRegistered)
         return;
 
-    if (!m_coreObject || m_coreObject->accessibilityIsIgnored())
+    if (!m_coreObject || m_coreObject->isIgnored())
         return;
 
     AccessibilityAtspi::singleton().childrenChanged(*this, child, AccessibilityAtspi::ChildrenChanged::Added);
@@ -1358,7 +1358,7 @@ void AccessibilityObjectAtspi::updateBackingStore()
 
 bool AccessibilityObjectAtspi::isIgnored() const
 {
-    return m_coreObject ? m_coreObject->accessibilityIsIgnored() : true;
+    return m_coreObject ? m_coreObject->isIgnored() : true;
 }
 
 void AccessibilityObject::detachPlatformWrapper(AccessibilityDetachmentType detachmentType)

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectHyperlinkAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectHyperlinkAtspi.cpp
@@ -84,7 +84,7 @@ unsigned AccessibilityObjectAtspi::offsetInParent() const
     int index = -1;
     const auto& children = parent->children();
     for (const auto& child : children) {
-        if (child->accessibilityIsIgnored())
+        if (child->isIgnored())
             continue;
 
         auto* wrapper = child->wrapper();

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectHypertextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectHypertextAtspi.cpp
@@ -63,7 +63,7 @@ unsigned AccessibilityObjectAtspi::hyperlinkCount() const
     unsigned linkCount = 0;
     const auto& children = m_coreObject->children();
     for (const auto& child : children) {
-        if (child->accessibilityIsIgnored())
+        if (child->isIgnored())
             continue;
 
         auto* wrapper = child->wrapper();
@@ -85,7 +85,7 @@ AccessibilityObjectAtspi* AccessibilityObjectAtspi::hyperlink(unsigned index) co
 
     int linkIndex = -1;
     for (const auto& child : children) {
-        if (child->accessibilityIsIgnored())
+        if (child->isIgnored())
             continue;
 
         auto* wrapper = child->wrapper();

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -340,7 +340,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     case AccessibilityRole::Tab:
     case AccessibilityRole::TextField:
     case AccessibilityRole::ToggleButton:
-        return !self.axBackingObject->accessibilityIsIgnored();
+        return !self.axBackingObject->isIgnored();
     default:
         return false;
     }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -239,7 +239,7 @@ private:
     bool canSetSelectedAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetSelectedAttribute); }
     bool canSetSelectedChildren() const final { return boolAttributeValue(AXPropertyName::CanSetSelectedChildren); }
     // We should never create an isolated object from an ignored live object, so we can hardcode this to false.
-    bool accessibilityIsIgnored() const final { return false; }
+    bool isIgnored() const final { return false; }
     unsigned blockquoteLevel() const final { return unsignedAttributeValue(AXPropertyName::BlockquoteLevel); }
     unsigned headingLevel() const final { return unsignedAttributeValue(AXPropertyName::HeadingLevel); }
     AccessibilityButtonState checkboxOrRadioValue() const final { return propertyValue<AccessibilityButtonState>(AXPropertyName::ButtonState); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -167,7 +167,7 @@ Ref<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
 
     for (auto& relatedObjectID : relations.keys()) {
         RefPtr axObject = axObjectCache.objectForID(relatedObjectID);
-        if (axObject && axObject->accessibilityIsIgnored())
+        if (axObject && axObject->isIgnored())
             tree->addUnconnectedNode(axObject.releaseNonNull());
     }
 
@@ -257,7 +257,7 @@ void AXIsolatedTree::generateSubtree(AccessibilityObject& axObject)
 bool AXIsolatedTree::shouldCreateNodeChange(AccessibilityObject& axObject)
 {
     // We should never create an isolated object from a detached or ignored object.
-    return !axObject.isDetached() && (!axObject.accessibilityIsIgnored() || m_unconnectedNodes.contains(axObject.objectID()));
+    return !axObject.isDetached() && (!axObject.isIgnored() || m_unconnectedNodes.contains(axObject.objectID()));
 }
 
 std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Ref<AccessibilityObject> axObject, AttachWrapper attachWrapper)
@@ -778,7 +778,7 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
 
         if (updateTableAncestorColumns && is<AccessibilityTable>(*ancestor)) {
             // Only `updateChildren` if the table is unignored, because otherwise `updateChildren` will ascend and update the next highest unignored ancestor, which doesn't accomplish our goal of updating table columns.
-            if (ancestor->accessibilityIsIgnored())
+            if (ancestor->isIgnored())
                 break;
             // Use `NodeUpdateOptions::childrenUpdate()` rather than `updateNodeProperty` because `childrenUpdate()` will ensure the columns (which are children) will have associated isolated objects created.
             queueNodeUpdate(ancestor->objectID(), NodeUpdateOptions::childrenUpdate());

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -314,7 +314,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
-    object.accessibilityIsIgnored();
+    object.isIgnored();
 }
 #endif
 
@@ -484,7 +484,7 @@ void AXObjectCache::createIsolatedObjectIfNeeded(AccessibilityObject& object)
     if (!wrapper || [wrapper hasIsolatedObject])
         return;
 
-    if (object.accessibilityIsIgnored())
+    if (object.isIgnored())
         deferAddUnconnectedNode(object);
 }
 #endif

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -77,7 +77,7 @@ void AccessibilityObject::overrideAttachmentParent(AccessibilityObject* parent)
     
     id parentWrapper = nil;
     if (parent) {
-        if (parent->accessibilityIsIgnored())
+        if (parent->isIgnored())
             parent = parent->parentObjectUnignored();
         parentWrapper = parent->wrapper();
     }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -246,12 +246,12 @@ static NSArray *convertMathPairsToNSArray(const AccessibilityObject::Accessibili
         WebAccessibilityObjectWrapper *wrappers[2];
         NSString *keys[2];
         NSUInteger count = 0;
-        if (pair.first && pair.first->wrapper() && !pair.first->accessibilityIsIgnored()) {
+        if (pair.first && pair.first->wrapper() && !pair.first->isIgnored()) {
             wrappers[0] = pair.first->wrapper();
             keys[0] = subscriptKey;
             count = 1;
         }
-        if (pair.second && pair.second->wrapper() && !pair.second->accessibilityIsIgnored()) {
+        if (pair.second && pair.second->wrapper() && !pair.second->isIgnored()) {
             wrappers[count] = pair.second->wrapper();
             keys[count] = superscriptKey;
             count += 1;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2508,7 +2508,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if (backingObject->isAttachment())
         return [[self attachmentView] accessibilityIsIgnored];
-    return backingObject->accessibilityIsIgnored();
+    return backingObject->isIgnored();
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -154,7 +154,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Node*, Node* newFocuse
         return;
 
     if (RefPtr focusedObject = focusedObjectForPage(page)) {
-        ASSERT(!focusedObject->accessibilityIsIgnored());
+        ASSERT(!focusedObject->isIgnored());
         postPlatformNotification(*focusedObject, AXFocusedUIElementChanged);
     }
 }

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -178,8 +178,8 @@ ExceptionOr<std::optional<InspectorAuditAccessibilityObject::ComputedProperties>
         computedProperties.headingLevel = axObject->headingLevel();
         computedProperties.hidden = axObject->isHidden();
         computedProperties.hierarchicalLevel = axObject->hierarchicalLevel();
-        computedProperties.ignored = axObject->accessibilityIsIgnored();
-        computedProperties.ignoredByDefault = axObject->accessibilityIsIgnoredByDefault();
+        computedProperties.ignored = axObject->isIgnored();
+        computedProperties.ignoredByDefault = axObject->isIgnoredByDefault();
 
         String invalidValue = axObject->invalidStatus();
         if (invalidValue == "false"_s)

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1207,7 +1207,7 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
 
     String elementRole;
     if (AXObjectCache* axObjectCache = node.document().axObjectCache()) {
-        if (auto* axObject = axObjectCache->getOrCreate(node); axObject && !axObject->accessibilityIsIgnored())
+        if (auto* axObject = axObjectCache->getOrCreate(node); axObject && !axObject->isIgnored())
             elementRole = axObject->computedRoleString();
     }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2321,8 +2321,8 @@ Ref<Inspector::Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildO
                     focused = axObject->isFocused();
             }
 
-            ignored = axObject->accessibilityIsIgnored();
-            ignoredByDefault = axObject->accessibilityIsIgnoredByDefault();
+            ignored = axObject->isIgnored();
+            ignoredByDefault = axObject->isIgnoredByDefault();
             
             String invalidValue = axObject->invalidStatus();
             if (invalidValue == "false"_s)


### PR DESCRIPTION
#### e704d5918c7ded72a92a22d3a5c9babde8d85128
<pre>
AX: Remove &quot;accessibility&quot; prefix from functions accessibilityIsIgnored, computeAccessibilityIsIgnored, accessibilityIsIgnoredByDefault
<a href="https://bugs.webkit.org/show_bug.cgi?id=278802">https://bugs.webkit.org/show_bug.cgi?id=278802</a>
<a href="https://rdar.apple.com/134871455">rdar://134871455</a>

Reviewed by Andres Gonzalez.

This prefix is unnecessary and makes these functions more unwieldy to call.

Credit to Andres Gonzalez whose idea it was to make this change as part
of <a href="https://github.com/WebKit/WebKit/pull/32839/files.">https://github.com/WebKit/WebKit/pull/32839/files.</a>

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::modalElementHasAccessibleContent):
(WebCore::AXObjectCache::focusedObjectForNode):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::postTextStateChangeNotification):
(WebCore::AXObjectCache::traverseToOffsetInRange):
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendChildrenToArray):
* Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp:
(WebCore::AccessibilityARIAGridCell::parentTable const):
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::computeIsIgnored const):
(WebCore::AccessibilityAttachment::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityAttachment.h:
* Source/WebCore/accessibility/AccessibilityLabel.cpp:
(WebCore::AccessibilityLabel::computeIsIgnored const):
(WebCore::AccessibilityLabel::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityLabel.h:
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::computeIsIgnored const):
(WebCore::AccessibilityList::childHasPseudoVisibleListItemMarkers):
(WebCore::AccessibilityList::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityList.h:
* Source/WebCore/accessibility/AccessibilityListBox.cpp:
(WebCore::AccessibilityListBox::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::computeIsIgnored const):
(WebCore::AccessibilityListBoxOption::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/AccessibilityMediaObject.cpp:
(WebCore::AccessibilityMediaObject::computeIsIgnored const):
(WebCore::AccessibilityMediaObject::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityMediaObject.h:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::addChildren):
* Source/WebCore/accessibility/AccessibilityMenuListOption.cpp:
(WebCore::AccessibilityMenuListOption::computeIsIgnored const):
(WebCore::AccessibilityMenuListOption::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityMenuListOption.h:
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::computeIsIgnored const):
(WebCore::AccessibilityMenuListPopup::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityMenuListPopup.h:
* Source/WebCore/accessibility/AccessibilityMockObject.cpp:
(WebCore::AccessibilityMockObject::computeIsIgnored const):
(WebCore::AccessibilityMockObject::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityMockObject.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeIsIgnored const):
(WebCore::AccessibilityNodeObject::remapAriaRoleDueToParent const):
(WebCore::AccessibilityNodeObject::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::parentObjectUnignored const):
(WebCore::AccessibilityObject::nextSiblingUnignored const):
(WebCore::AccessibilityObject::previousSiblingUnignored const):
(WebCore::AccessibilityObject::firstAccessibleObjectFromNode):
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::replacedNodeNeedsCharacter):
(WebCore::AccessibilityObject::computedRoleString const):
(WebCore::AccessibilityObject::isIgnoredByDefault const):
(WebCore::AccessibilityObject::isIgnored const):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):
(WebCore::AccessibilityObject::accessibilityIsIgnoredByDefault const): Deleted.
(WebCore::AccessibilityObject::accessibilityIsIgnored const): Deleted.
(WebCore::AccessibilityObject::accessibilityIsIgnoredWithoutCache const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::computeIsIgnored const):
(WebCore::AccessibilityObject::recomputeIsIgnored):
(WebCore::AccessibilityObject::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::computeIsIgnored const):
(WebCore::AccessibilityProgressIndicator::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityProgressIndicator.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::textRuns):
(WebCore::AccessibilityRenderObject::documentLinks):
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):
(WebCore::AccessibilityRenderObject::addImageMapChildren):
(WebCore::AccessibilityRenderObject::updateAttachmentViewParents):
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren):
(WebCore::AccessibilityRenderObject::markerRenderer const):
(WebCore::AccessibilityRenderObject::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilitySVGElement.cpp:
(WebCore::AccessibilitySVGElement::computeIsIgnored const):
(WebCore::AccessibilitySVGElement::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilitySVGElement.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::computeIsIgnored const):
(WebCore::AccessibilityScrollView::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::addChildren):
(WebCore::AccessibilitySliderThumb::computeIsIgnored const):
(WebCore::AccessibilitySliderThumb::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilitySlider.h:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::addChildren):
(WebCore::AccessibilityTable::computeIsIgnored const):
(WebCore::AccessibilityTable::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityTable.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::computeIsIgnored const):
(WebCore::AccessibilityTableCell::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::computeIsIgnored const):
(WebCore::AccessibilityTableColumn::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableColumn.h:
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::computeIsIgnored const):
(WebCore::AccessibilityTableHeaderContainer::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::computeIsIgnored const):
(WebCore::AccessibilityTableRow::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableRow.h:
* Source/WebCore/accessibility/AccessibilityTree.cpp:
(WebCore::AccessibilityTree::computeIsIgnored const):
(WebCore::AccessibilityTree::computeAccessibilityIsIgnored const): Deleted.
* Source/WebCore/accessibility/AccessibilityTree.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::setParent):
(WebCore::AccessibilityObjectAtspi::childAdded):
(WebCore::AccessibilityObjectAtspi::isIgnored const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectHyperlinkAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::offsetInParent const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectHypertextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::hyperlinkCount const):
(WebCore::AccessibilityObjectAtspi::hyperlink const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityCanFuzzyHitTest]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::retrieveObjectForIDFromMainThread const):
(WebCore::AXIsolatedTree::shouldCreateNodeChange):
(WebCore::AXIsolatedTree::updateDependentProperties):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::exerciseIsIgnored):
(WebCore::AXObjectCache::createIsolatedObjectIfNeeded):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::overrideAttachmentParent):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(convertMathPairsToNSArray):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
(WebCore::InspectorAuditAccessibilityObject::getComputedProperties):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawElementTitle):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Canonical link: <a href="https://commits.webkit.org/282875@main">https://commits.webkit.org/282875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f680c3e275e91216c5e7b4193c952311a68d967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15407 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70242 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59237 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55921 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14233 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/678 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39698 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40776 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->