### PR TITLE
Cannot use element fullscreen for video fullscreen when Fullscreen API is disabled

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7511,15 +7511,16 @@ VerticalFormControlsEnabled:
 VideoFullscreenRequiresElementFullscreen:
   type: bool
   status: embedder
-  condition: PLATFORM(IOS_FAMILY)
+  condition: ENABLE(FULLSCREEN_API)
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: defaultVideoFullscreenRequiresElementFullscreen()
     WebCore:
       default: false
-      
+  sharedPreferenceForWebProcess: true
+
 VideoPresentationModeAPIEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -135,7 +135,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
     }
 
     // There is a previously-established user preference, security risk, or platform limitation.
-    if (!page() || !page()->settings().fullScreenEnabled()) {
+    if (!page() || !page()->isFullscreenManagerEnabled()) {
         handleError("Fullscreen API is disabled."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;
     }
@@ -488,7 +488,7 @@ bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEn
     }
 
     INFO_LOG(LOGIDENTIFIER);
-    ASSERT(page()->settings().fullScreenEnabled());
+    ASSERT(page()->isFullscreenManagerEnabled());
 
 #if ENABLE(VIDEO)
     if (RefPtr mediaElement = dynamicDowncast<HTMLMediaElement>(element))

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -228,14 +228,14 @@ bool HTMLVideoElement::supportsFullscreen(HTMLMediaElementEnums::VideoFullscreen
     if (!player()->supportsFullscreen())
         return false;
 
+#if ENABLE(FULLSCREEN_API)
 #if PLATFORM(IOS_FAMILY)
     // Fullscreen implemented by player.
     if (!document().settings().videoFullscreenRequiresElementFullscreen())
         return true;
 #endif
 
-#if ENABLE(FULLSCREEN_API)
-    if (videoFullscreenMode == HTMLMediaElementEnums::VideoFullscreenModeStandard && !document().settings().fullScreenEnabled())
+    if (videoFullscreenMode == HTMLMediaElementEnums::VideoFullscreenModeStandard && !page->isFullscreenManagerEnabled())
         return false;
 
     // If the full screen API is enabled and is supported for the current element

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5038,4 +5038,12 @@ void Page::setLastAuthentication(LoginStatus::AuthenticationType authType)
     m_lastAuthentication = loginStatus.releaseReturnValue();
 }
 
+#if ENABLE(FULLSCREEN_API)
+bool Page::isFullscreenManagerEnabled() const
+{
+    Ref settings = protectedSettings();
+    return settings->fullScreenEnabled() || settings->videoFullscreenRequiresElementFullscreen();
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1204,6 +1204,10 @@ public:
     void setLastAuthentication(LoginStatus::AuthenticationType);
     const std::optional<LoginStatus>& lastAuthentication() const { return m_lastAuthentication; }
 
+#if ENABLE(FULLSCREEN_API)
+    WEBCORE_EXPORT bool isFullscreenManagerEnabled() const;
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -77,6 +77,10 @@ bool defaultAlternateFormControlDesignEnabled()
     return PAL::currentUserInterfaceIdiomIsVision();
 }
 
+#endif
+
+#if ENABLE(FULLSCREEN_API)
+
 bool defaultVideoFullscreenRequiresElementFullscreen()
 {
 #if USE(APPLE_INTERNAL_SDK)
@@ -84,7 +88,12 @@ bool defaultVideoFullscreenRequiresElementFullscreen()
         return true;
 #endif
 
-    return PAL::currentUserInterfaceIdiomIsVision();
+#if PLATFORM(IOS_FAMILY)
+    if (PAL::currentUserInterfaceIdiomIsVision())
+        return true;
+#endif
+
+    return false;
 }
 
 #endif

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -71,12 +71,15 @@ bool defaultPassiveTouchListenersAsDefaultOnDocument();
 bool defaultCSSOMViewScrollingAPIEnabled();
 bool defaultShouldPrintBackgrounds();
 bool defaultAlternateFormControlDesignEnabled();
-bool defaultVideoFullscreenRequiresElementFullscreen();
 bool defaultUseAsyncUIKitInteractions();
 bool defaultWriteRichTextDataWhenCopyingOrDragging();
 #if ENABLE(TEXT_AUTOSIZING)
 bool defaultTextAutosizingUsesIdempotentMode();
 #endif
+#endif
+
+#if ENABLE(FULLSCREEN_API)
+bool defaultVideoFullscreenRequiresElementFullscreen();
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1657,6 +1657,16 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->allowPrivacySensitiveOperationsInNonPersistentDataStores();
 }
 
+- (void)_setVideoFullscreenRequiresElementFullscreen:(BOOL)videoFullscreenRequiresElementFullscreen
+{
+    _preferences->setVideoFullscreenRequiresElementFullscreen(videoFullscreenRequiresElementFullscreen);
+}
+
+- (BOOL)_videoFullscreenRequiresElementFullscreen
+{
+    return _preferences->videoFullscreenRequiresElementFullscreen();
+}
+
 @end
 
 @implementation WKPreferences (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -192,6 +192,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setManagedMediaSourceHighThreshold:) double _managedMediaSourceHighThreshold WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, setter=_setMediaCapabilityGrantsEnabled:) BOOL _mediaCapabilityGrantsEnabled WK_API_AVAILABLE(ios(17.4), visionos(1.1)) WK_API_UNAVAILABLE(macos);
 @property (nonatomic, setter=_setAllowPrivacySensitiveOperationsInNonPersistentDataStores:) BOOL _allowPrivacySensitiveOperationsInNonPersistentDataStores WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setVideoFullscreenRequiresElementFullscreen:) BOOL _videoFullscreenRequiresElementFullscreen WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -591,7 +591,6 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
 #if PLATFORM(IOS_FAMILY)
     pageConfiguration->preferences().setAlternateFormControlDesignEnabled(WebKit::defaultAlternateFormControlDesignEnabled());
-    pageConfiguration->preferences().setVideoFullscreenRequiresElementFullscreen(WebKit::defaultVideoFullscreenRequiresElementFullscreen());
 #endif
 
     // For SharedPreferencesForWebProcess

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(FULLSCREEN_API)
-[EnabledBy=FullScreenEnabled]
+[EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen]
 messages -> WebFullScreenManagerProxy NotRefCounted {
     SupportsFullScreen(bool withKeyboard) -> (bool supportsFullScreen) Synchronous
     EnterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -163,9 +163,9 @@ void WebFullScreenManager::didReceiveMessage(IPC::Connection& connection, IPC::D
     didReceiveWebFullScreenManagerMessage(connection, decoder);
 }
 
-bool WebFullScreenManager::supportsFullScreen(bool withKeyboard)
+bool WebFullScreenManager::supportsFullScreenForElement(const WebCore::Element& element, bool withKeyboard)
 {
-    if (!m_page->corePage()->settings().fullScreenEnabled())
+    if (!m_page->corePage()->isFullscreenManagerEnabled())
         return false;
 
     return m_page->injectedBundleFullScreenClient().supportsFullScreen(m_page.ptr(), withKeyboard);

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -64,7 +64,7 @@ public:
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
-    bool supportsFullScreen(bool withKeyboard);
+    bool supportsFullScreenForElement(const WebCore::Element&, bool withKeyboard);
     void enterFullScreenForElement(WebCore::Element*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void exitFullScreenForElement(WebCore::Element*);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1318,9 +1318,9 @@ void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, H
 
 #if ENABLE(FULLSCREEN_API)
 
-bool WebChromeClient::supportsFullScreenForElement(const Element&, bool withKeyboard)
+bool WebChromeClient::supportsFullScreenForElement(const Element& element, bool withKeyboard)
 {
-    return protectedPage()->fullScreenManager()->supportsFullScreen(withKeyboard);
+    return protectedPage()->fullScreenManager()->supportsFullScreenForElement(element, withKeyboard);
 }
 
 void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
@@ -29,6 +29,7 @@
 
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebKit.h>
 
@@ -76,13 +77,9 @@ TEST(Fullscreen, AudioLifecycle)
     ASSERT_FALSE([webView _canEnterFullscreen]);
 }
 
-TEST(Fullscreen, VideoLifecycle)
+static void runTest(WKWebViewConfiguration *configuration)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    [configuration preferences].elementFullscreenEnabled = YES;
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration]);
     ASSERT_FALSE([webView _canEnterFullscreen]);
     ASSERT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
 
@@ -124,6 +121,24 @@ TEST(Fullscreen, VideoLifecycle)
     });
     ASSERT_FALSE([webView _canEnterFullscreen]);
     ASSERT_TRUE(canEnterFullscreenChanged);
+}
+
+TEST(Fullscreen, VideoLifecycle)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    [configuration preferences].elementFullscreenEnabled = YES;
+
+    runTest(configuration.get());
+}
+
+TEST(Fullscreen, VideoLifecycleElementFullscreenDisabled)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    [configuration preferences]._videoFullscreenRequiresElementFullscreen = YES;
+
+    runTest(configuration.get());
 }
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### a76e340b35bc50788d5cdea53a31a425496882e5
<pre>
Cannot use element fullscreen for video fullscreen when Fullscreen API is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=278796">https://bugs.webkit.org/show_bug.cgi?id=278796</a>
<a href="https://rdar.apple.com/134863159">rdar://134863159</a>

Reviewed by Jer Noble and Ryosuke Niwa.

Clients that enable the VideoFullscreenRequiresElementFullscreen preference use the element
fullscreen infrastructure to implement video fullscreen by making the &lt;video&gt; element the
fullscreen element and rendering WebKit&apos;s built-in media controls. However, this mechanism does
not work in clients that choose not to expose the Fullscreen API to websites (by disabling the
FullScreenEnabled preference).

It should still be possible to enter video fullscreen (via element fullscreen) in clients that
disable the Fullscreen API, so this change makes it so by supporting internal calls to
FullscreenManager::requestFullscreenForElement() when either the
VideoFullscreenRequiresElementFullscreen or FullScreenEnabled preferences are enabled.

Added an API test.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
    Changed the conditional for VideoFullscreenRequiresElementFullscreen to ENABLE(FULLSCREEN_API)
    and moved the default value setter to here from WKWebView.mm.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::willEnterFullscreen):
    Used Page::isFullscreenManagerEnabled() to check if it&apos;s possible to enter element fullscreen.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::videoUsesElementFullscreen const):
    Simplified compile-time conditionals.

(WebCore::HTMLMediaElement::enterFullscreen):
    Used Page::isFullscreenManagerEnabled() to check if it&apos;s possible to enter element fullscreen.

(WebCore::HTMLMediaElement::exitFullscreen):
    Removed the unnecessary fullScreenEnabled() check, since we couldn&apos;t have a
    currentFullscreenElement() if the feature weren&apos;t enabled.

* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::supportsFullscreen const):
    Simplified compile-time conditionals.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::isFullscreenManagerEnabled const):
* Source/WebCore/page/Page.h:
    Added. Returns true if VideoFullscreenRequiresElementFullscreen or FullScreenEnabled are enabled.

* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultVideoFullscreenRequiresElementFullscreen):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setupPageConfiguration:withPool:]):
    Set VideoFullscreenRequiresElementFullscreen to true by default on supported platforms.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
    Enabled IPC messages if VideoFullscreenRequiresElementFullscreen or FullScreenEnabled are enabled.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::supportsFullScreenForElement):
(WebKit::WebFullScreenManager::supportsFullScreen): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::supportsFullScreenForElement):
    Used Page::isFullscreenManagerEnabled() to check if it&apos;s possible to enter element fullscreen.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm:
(runTest):
(TEST(Fullscreen, VideoLifecycle)):
(TEST(Fullscreen, VideoLifecycleElementFullscreenDisabled)):
    Added an API test.

Canonical link: <a href="https://commits.webkit.org/283033@main">https://commits.webkit.org/283033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af5e9b276577dc7425161a2299304cc20b18bb32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52197 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14454 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58085 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70701 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64215 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59527 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59745 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1037 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85981 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40151 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15156 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->