### PR TITLE
CanvasRenderingContext2D globalAlpha property is ignored for some values of globalCompositeOperation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div id="source"></div>
+        <div id="destination"></div>
+        <script>
+            function createCanvas(parent, width, height) {
+                const canvas = document.createElement("canvas");
+                canvas.width = width;
+                canvas.height = height;
+                parent.append(canvas);
+                return canvas;
+            }
+
+            function fillRects(canvas, color, alpha, diagonal) {
+                const ctx = canvas.getContext("2d");
+                ctx.fillStyle = color;
+                ctx.globalAlpha = alpha;
+                if (diagonal == "left") {
+                    ctx.fillRect(60, 60, 50, 50);
+                    ctx.fillRect(110, 110, 50, 50);
+                } else {
+                    ctx.fillRect(60, 110, 50, 50);
+                    ctx.fillRect(110, 60, 50, 50);
+                }
+            }
+
+            fillRects(createCanvas(source, 200, 200), "#ff0000", 0.5, "left");
+            fillRects(createCanvas(source, 200, 200), "#ff0000", 0.5, "right");
+            fillRects(createCanvas(destination, 200, 200), "#777777", 0.5, "left");
+
+            let canvas = createCanvas(destination, 200, 200);
+            fillRects(canvas, "#777777", 0.5, "left");
+            fillRects(canvas, "#ff0000", 0.5, "right");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="match" href="2d.composite.full.mode.alpha-expected.html">
+        <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000" />
+    </head>
+    <body>
+        <div id="source"></div>
+        <div id="destination"></div>
+        <script>
+            function createCanvas(parent, width, height) {
+                const canvas = document.createElement("canvas");
+                canvas.width = width;
+                canvas.height = height;
+                parent.append(canvas);
+                return canvas;
+            }
+
+            function fillRects(canvas, alpha, compositeOperation) {
+                const ctx = canvas.getContext("2d");
+                ctx.fillStyle = "#777777";
+                ctx.fillRect(10, 10, 100, 100);
+                ctx.fillRect(110, 110, 100, 100);
+
+                ctx.globalCompositeOperation = compositeOperation;
+                ctx.globalAlpha = alpha;
+                ctx.fillStyle = "#ff0000";
+                ctx.fillRect(60, 60, 100, 100);
+            }
+
+            fillRects(createCanvas(source, 200, 200), 0.5, 'source-in');
+            fillRects(createCanvas(source, 200, 200), 0.5, 'source-out');
+            fillRects(createCanvas(destination, 200, 200), 0.5, `destination-in`);
+            fillRects(createCanvas(destination, 200, 200), 0.5, 'destination-atop');
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -159,9 +159,15 @@ void BifurcatedGraphicsContext::beginTransparencyLayer(float opacity)
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::beginTransparencyLayer(CompositeOperator, BlendMode)
+void BifurcatedGraphicsContext::beginTransparencyLayer(CompositeOperator compositeOperator, BlendMode blendMode)
 {
-    beginTransparencyLayer(1);
+    GraphicsContext::beginTransparencyLayer(compositeOperator, blendMode);
+    m_primaryContext.beginTransparencyLayer(compositeOperator, blendMode);
+    m_secondaryContext.beginTransparencyLayer(compositeOperator, blendMode);
+
+    GraphicsContext::save(GraphicsContextState::Purpose::TransparencyLayer);
+
+    VERIFY_STATE_SYNCHRONIZATION();
 }
 
 void BifurcatedGraphicsContext::endTransparencyLayer()

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1034,7 +1034,9 @@ void GraphicsContextCG::beginTransparencyLayer(float opacity)
 
 void GraphicsContextCG::beginTransparencyLayer(CompositeOperator, BlendMode)
 {
-    beginTransparencyLayer(1);
+    // Passing state().alpha() to beginTransparencyLayer(opacity) will
+    // preserve the current global alpha.
+    beginTransparencyLayer(state().alpha());
 }
 
 void GraphicsContextCG::endTransparencyLayer()


### PR DESCRIPTION
#### 40b19269f440dbfe44035f50d2b0ccbe6e3fe58d
<pre>
CanvasRenderingContext2D globalAlpha property is ignored for some values of globalCompositeOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=278454">https://bugs.webkit.org/show_bug.cgi?id=278454</a>
<a href="https://rdar.apple.com/134840885">rdar://134840885</a>

Reviewed by Simon Fraser.

beginTransparencyLayer(opacity) sets the global alpha to `opacity`. Then it
calls CGContextBeginTransparencyLayer() which sets the global alpha to 1.
Calling CGContextEndTransparencyLayer() restores the global alpha back to
`opacity` before compositing the transparency layer back to the destination
context.

beginTransparencyLayer(CompositeOperator, BlendMode) is called only from canvas.
It passes `opacity` = 1 to beginTransparencyLayer(opacity). This will set the
alpha of both the transparency layer and the destination context to 1. This will
display everything opaque.

The fix is to make beginTransparencyLayer(CompositeOperator, BlendMode) pass
state().alpha() to beginTransparencyLayer(opacity) so the current global alpha
is preserved.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.full.mode.alpha.html: Added.
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::beginTransparencyLayer):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::beginTransparencyLayer):

Canonical link: <a href="https://commits.webkit.org/282965@main">https://commits.webkit.org/282965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5bd9c530462517c6d522754d1f79c310131613e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52066 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10601 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13405 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59390 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56114 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/857 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39939 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->