### PR TITLE
Navigation: always resolve URLs with UTF-8

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset={{GET[encoding]}}> <!-- ends up as <meta charset> by default which is windows-1252 -->
+<meta name=variant content="?encoding=windows-1252">
+<meta name=variant content="?encoding=x-cp1251">
+<meta name=variant content="?encoding=utf8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i" src="/common/blank.html"></iframe>
+<!-- Test for https://github.com/whatwg/html/pull/9756 -->
+
+<script>
+async_test(t => {
+  window.onload = t.step_func(() => {
+    i.contentWindow.navigation.navigate("?\u00FF");
+
+    i.onload = t.step_func_done(() => {
+      const iframeURL = new URL(i.contentWindow.navigation.currentEntry.url);
+      assert_equals(iframeURL.pathname, "/common/blank.html", "pathname");
+      assert_equals(iframeURL.search, "?%C3%BF", "search");
+    });
+  });
+}, "navigate() should resolve URLs assuming UTF-8, ignoring the document's encoding");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=utf8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=utf8-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS navigate() should resolve URLs assuming UTF-8, ignoring the document's encoding
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=windows-1252-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=windows-1252-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS navigate() should resolve URLs assuming UTF-8, ignoring the document's encoding
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=x-cp1251-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=x-cp1251-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS navigate() should resolve URLs assuming UTF-8, ignoring the document's encoding
+

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -282,7 +282,7 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
 Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    auto newURL = window()->document()->completeURL(url);
+    auto newURL = window()->document()->completeURL(url, ScriptExecutionContext::ForceUTF8::Yes);
     const URL& currentURL = scriptExecutionContext()->url();
 
     if (!newURL.isValid())


### PR DESCRIPTION
#### 3443b5d8286227bf8813025e88ca5f9e942b1ccd
<pre>
Navigation: always resolve URLs with UTF-8
<a href="https://bugs.webkit.org/show_bug.cgi?id=276809">https://bugs.webkit.org/show_bug.cgi?id=276809</a>

Reviewed by Alex Christensen.

Implement the spec change from <a href="https://github.com/whatwg/html/pull/9756.">https://github.com/whatwg/html/pull/9756.</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=utf8-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=windows-1252-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-relative-url-utf8_encoding=x-cp1251-expected.txt: Added.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::navigate):

Canonical link: <a href="https://commits.webkit.org/282890@main">https://commits.webkit.org/282890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a949d3c6b303ee38ef0b11437c012fa2ad39e46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51906 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10430 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13991 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59230 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59403 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14240 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/672 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->