### PR TITLE
Revamp handling of notificationclick and notificationclose

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h
@@ -42,6 +42,9 @@
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 @interface UNNotification ()
 + (instancetype)notificationWithRequest:(UNNotificationRequest *)request date:(NSDate *)date;
+
+@property (readonly) NSString *sourceIdentifier;
+
 @end
 
 @interface UNNotificationIcon : NSObject <NSCopying, NSSecureCoding>

--- a/Source/WebKit/Platform/spi/ios/BaseBoardSPI.h
+++ b/Source/WebKit/Platform/spi/ios/BaseBoardSPI.h
@@ -25,6 +25,7 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
+#import <BaseBoard/BSAction.h>
 #import <BaseBoard/BSInvalidatable.h>
 
 #else
@@ -43,6 +44,7 @@
 
 @interface BSActionResponse : NSObject
 + (instancetype)response;
++ (instancetype)responseForError:(NSError *)error;
 @property (nonatomic, retain, readonly) NSError *error;
 @end
 
@@ -54,9 +56,20 @@ typedef void(^BSActionResponseHandler)(BSActionResponse *response);
 
 @interface BSAction : NSObject
 - (instancetype)initWithInfo:(BSSettings *)info responder:(BSActionResponder *)responder;
+- (BOOL)canSendResponse;
 - (void)sendResponse:(BSActionResponse *)response;
 @property (nonatomic, copy, readonly) BSSettings *info;
 @end
 
-
 #endif // USE(APPLE_INTERNAL_SDK)
+
+typedef NS_ENUM(NSInteger, UIActionType) {
+    UIActionTypeNotificationResponse = 26,
+};
+
+@class UNNotificationResponse;
+
+@interface BSAction ()
+@property (nonatomic, readonly) UIActionType UIActionType;
+- (UNNotificationResponse *)response;
+@end

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1253,6 +1253,10 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @class UITextInputArrowKeyHistory;
 
+@interface UIApplication (InternalBSAction)
+- (void)_registerInternalBSActionHandler:(id<_UIApplicationBSActionHandler>)handler;
+@end
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushActionInternal.h
@@ -23,27 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
+#import "_WKWebPushAction.h"
+#import <WebCore/NotificationData.h>
 
-NS_ASSUME_NONNULL_BEGIN
+@interface _WKWebPushAction (Internal)
 
-@class UNNotificationResponse;
-
-WK_EXTERN NSString * const _WKWebPushActionTypePushEvent;
-WK_EXTERN NSString * const _WKWebPushActionTypeNotificationClick;
-WK_EXTERN NSString * const _WKWebPushActionTypeNotificationClose;
-
-WK_EXTERN
-@interface _WKWebPushAction : NSObject
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (_WKWebPushAction *)webPushActionWithDictionary:(NSDictionary *)dictionary;
-+ (_WKWebPushAction *)_webPushActionWithNotificationResponse:(UNNotificationResponse *)response;
-
-@property (nonatomic, readonly) NSNumber *version;
-@property (nonatomic, readonly) NSString *pushPartition;
-@property (nonatomic, readonly) NSString *type;
+@property (nonatomic, readonly) std::optional<WebCore::NotificationData> coreNotificationData;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1302,6 +1302,7 @@
 		518ACF1112B015F800B04B83 /* WKCredentialTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 518ACF1012B015F800B04B83 /* WKCredentialTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		518D2CAE12D5153B003BB93B /* WebBackForwardListItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 518D2CAC12D5153B003BB93B /* WebBackForwardListItem.h */; };
 		518E8EF916B2091C00E91429 /* AuthenticationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 518E8EF416B2091C00E91429 /* AuthenticationManager.h */; };
+		51909C5E2C801B5A009D2E0E /* _WKWebPushActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51909C5D2C801B5A009D2E0E /* _WKWebPushActionInternal.h */; };
 		519261782950EA3F00A975D1 /* WKSecurityOriginPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 519261772950EA3E00A975D1 /* WKSecurityOriginPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5192DDB92AB54ED700E88DE7 /* WebPushMessageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */; };
 		51933DEF1965EB31008AC3EA /* MenuUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51933DEB1965EB24008AC3EA /* MenuUtilities.h */; };
@@ -5686,6 +5687,7 @@
 		518E8EF316B2091C00E91429 /* AuthenticationManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AuthenticationManager.cpp; sourceTree = "<group>"; };
 		518E8EF416B2091C00E91429 /* AuthenticationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationManager.h; sourceTree = "<group>"; };
 		518E8EF516B2091C00E91429 /* AuthenticationManager.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AuthenticationManager.messages.in; sourceTree = "<group>"; };
+		51909C5D2C801B5A009D2E0E /* _WKWebPushActionInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebPushActionInternal.h; sourceTree = "<group>"; };
 		519261772950EA3E00A975D1 /* WKSecurityOriginPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSecurityOriginPrivate.h; sourceTree = "<group>"; };
 		51933DEB1965EB24008AC3EA /* MenuUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuUtilities.h; sourceTree = "<group>"; };
 		51933DEC1965EB24008AC3EA /* MenuUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MenuUtilities.mm; sourceTree = "<group>"; };
@@ -11561,6 +11563,7 @@
 				028D308D2C63E3B3004F4FC6 /* _WKWebExtensionSidebarInternal.h */,
 				51E0BD9B2C7471110048411B /* _WKWebPushAction.h */,
 				51E0BD9C2C7471110048411B /* _WKWebPushAction.mm */,
+				51909C5D2C801B5A009D2E0E /* _WKWebPushActionInternal.h */,
 				1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */,
 				1AE286751C7E76510069AC4F /* _WKWebsiteDataSize.mm */,
 				1AE2867F1C7F92BF0069AC4F /* _WKWebsiteDataSizeInternal.h */,
@@ -16121,6 +16124,7 @@
 				1CC5CA712C5ACB8500DF3B94 /* _WKWebExtensionWindow.h in Headers */,
 				1CC5CA7D2C5ACB8500DF3B94 /* _WKWebExtensionWindowCreationOptions.h in Headers */,
 				51E0BD9D2C74711A0048411B /* _WKWebPushAction.h in Headers */,
+				51909C5E2C801B5A009D2E0E /* _WKWebPushActionInternal.h in Headers */,
 				1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */,
 				1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */,
 				5120C8351E5B74B90025B250 /* _WKWebsiteDataStoreConfiguration.h in Headers */,


### PR DESCRIPTION
#### 135df2fc81755218135e1a49886e6efe74a30a99
<pre>
Revamp handling of notificationclick and notificationclose
<a href="https://rdar.apple.com/131365403">rdar://131365403</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278825">https://bugs.webkit.org/show_bug.cgi?id=278825</a>

Reviewed by Ben Nham.

This reworks some logic in webpushd and in the WebKit UIProcess to properly
capture and route &quot;notificationclick&quot; and &quot;notificationclose&quot; events for
clients using built-in notifications.

* Source/WebKit/Platform/spi/ios/BaseBoardSPI.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClick:completionHandler:]):
(-[WKWebsiteDataStore _processPersistentNotificationClick:completionHandler:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClose:completionHandler:]):
(-[WKWebsiteDataStore _processPersistentNotificationClose:completionHandler:]):
(+[WKWebsiteDataStore _setWebPushActionHandler:]):
(-[WKWebsiteDataStore _handleNextPushMessage]):
(-[WKWebsiteDataStore _handleWebPushAction:]):
(-[_WKWebsiteDataStoreBSActionHandler _respondToApplicationActions:fromTransitionContext:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(+[_WKWebPushAction _webPushActionWithNotificationResponse:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushActionInternal.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformDefaultActionBundleIdentifier):
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):
(WebPushD::WebPushDaemon::showNotification):

Canonical link: <a href="https://commits.webkit.org/282885@main">https://commits.webkit.org/282885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c436688630b7a71dc7ff30556d5daebe65e3ec8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64577 "5 style errors") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43942 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15183 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15462 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37319 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14056 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13586 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70297 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13087 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55966 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14238 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/716 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39753 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->