### PR TITLE
Add STATIC_ASSERT_NOT_REACHED_FOR_{TYPE,VALUE}

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -546,6 +546,28 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #endif
 #endif
 
+#ifdef __cplusplus
+namespace WTF {
+template <typename T>
+static constexpr bool unreachableForType = false;
+template <auto v>
+static constexpr bool unreachableForValue = false;
+} // namespace WTF
+// This could be used in a function template, or a member function of a class template.
+// It will trigger in code that gets instantiated when it shouldn't, for example a template function invocation, or a constexpr-if/else branch that is actually taken.
+// The 1st parameter TYPE or COMPILE_TIME_VALUE is necessary as part of delaying the assertion evaluation until instantiation, and that parameter will be visible in compiler errors.
+// The 2nd parameter is an optional explanation string.
+#define STATIC_ASSERT_NOT_REACHED_FOR_TYPE(TYPE, ...) do { \
+    static_assert(WTF::unreachableForType<TYPE>, ##__VA_ARGS__); \
+    CRASH(); \
+} while (0)
+
+#define STATIC_ASSERT_NOT_REACHED_FOR_VALUE(COMPILE_TIME_VALUE, ...) do { \
+    static_assert(WTF::unreachableForValue<COMPILE_TIME_VALUE>, ##__VA_ARGS__); \
+    CRASH(); \
+} while (0)
+#endif // __cplusplus
+
 /* FATAL */
 
 #if FATAL_DISABLED

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -152,7 +152,7 @@ public:
                 delete static_cast<const T*>(this);
             });
         } else {
-            static_assert(!sizeof(T), "Unexpected destructionThread enumerator");
+            STATIC_ASSERT_NOT_REACHED_FOR_VALUE(destructionThread, "Unexpected destructionThread enumerator value");
         }
     }
 
@@ -172,7 +172,7 @@ public:
                 delete static_cast<const T*>(this);
             });
         } else {
-            static_assert(!sizeof(T), "Unexpected destructionThread enumerator");
+            STATIC_ASSERT_NOT_REACHED_FOR_VALUE(destructionThread, "Unexpected destructionThread enumerator value");
         }
     }
 


### PR DESCRIPTION
#### 221f446c995477d5ad4370bf381af7e9d58954d3
<pre>
Add STATIC_ASSERT_NOT_REACHED_FOR_{TYPE,VALUE}
<a href="https://bugs.webkit.org/show_bug.cgi?id=278821">https://bugs.webkit.org/show_bug.cgi?id=278821</a>
<a href="https://rdar.apple.com/problem/134888391">rdar://problem/134888391</a>

Reviewed by Geoffrey Garen.

This is the compile-time equivalent of RELEASE_ASSERT_NOT_REACHED.

It is necessary to provide a type or compile-time value, so that the
static_assert doesn&apos;t always trigger. See
<a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html">https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html</a>
for more information -- as part of a C++ proposal that would make
that parameter unnecessary.
That parameter will also helpfully be shown in compiler errors.

The Crash() is only there to remove warnings about missing return.

ThreadSafeRefCounted changes show how it can be used, in this case to
guard against enum changes.

* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/ThreadSafeRefCounted.h:
(WTF::ThreadSafeRefCounted::deref const):
(WTF::ThreadSafeRefCounted::derefAllowingPartiallyDestroyed const):

Canonical link: <a href="https://commits.webkit.org/283957@main">https://commits.webkit.org/283957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/741384f4db115ae3f77e2e7cc9049bf362ec9707

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71544 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54087 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15783 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16991 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60611 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73243 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66741 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61523 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61584 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2976 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88510 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42680 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15606 "Found 6 new JSC stress test failures: wasm.yaml/wasm/function-tests/many-arguments-to-function.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->