### PR TITLE
Do not use strlen unnecessarily for dtoa result

### DIFF
--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -164,8 +164,8 @@ ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName
 
     double index = jsToNumber(propertyName);
     NumberToStringBuffer buffer;
-    const char* indexString = WTF::numberToString(index, buffer);
-    return equal(propertyName, indexString);
+    size_t length = WTF::numberToStringAndSize(index, buffer);
+    return equal(propertyName, std::span { bitwise_cast<const LChar*>(buffer.data()), length });
 }
 
 } // namespace JSC

--- a/Source/WTF/wtf/dtoa.cpp
+++ b/Source/WTF/wtf/dtoa.cpp
@@ -24,18 +24,18 @@
 
 namespace WTF {
 
-const char* numberToString(float number, NumberToStringBuffer& buffer)
+size_t numberToStringAndSize(float number, NumberToStringBuffer& buffer)
 {
-    double_conversion::StringBuilder builder(&buffer[0], sizeof(buffer));
-    dragonbox::ToShortest(number, &builder);
-    return builder.Finalize();
+    static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary32>() + 1));
+    auto* result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, buffer.data());
+    return result - buffer.data();
 }
 
-const char* numberToString(double d, NumberToStringBuffer& buffer)
+size_t numberToStringAndSize(double number, NumberToStringBuffer& buffer)
 {
-    double_conversion::StringBuilder builder(&buffer[0], sizeof(buffer));
-    dragonbox::ToShortest(d, &builder);
-    return builder.Finalize();
+    static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary64>() + 1));
+    auto* result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, buffer.data());
+    return result - buffer.data();
 }
 
 const char* numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer)

--- a/Source/WTF/wtf/dtoa.h
+++ b/Source/WTF/wtf/dtoa.h
@@ -36,14 +36,15 @@ using NumberToStringBuffer = std::array<char, 124>;
 // <-> + <320 digits> + decimal point + <6 digits> + null char = 329
 using NumberToCSSStringBuffer = std::array<char, 329>;
 
-WTF_EXPORT_PRIVATE const char* numberToString(float, NumberToStringBuffer&);
 WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(float, unsigned significantFigures, NumberToStringBuffer&, bool truncateTrailingZeros = false);
 WTF_EXPORT_PRIVATE const char* numberToFixedWidthString(float, unsigned decimalPlaces, NumberToStringBuffer&);
 
-WTF_EXPORT_PRIVATE const char* numberToString(double, NumberToStringBuffer&);
 WTF_EXPORT_PRIVATE const char* numberToStringWithTrailingPoint(double, NumberToStringBuffer&);
 WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(double, unsigned significantFigures, NumberToStringBuffer&, bool truncateTrailingZeros = false);
 WTF_EXPORT_PRIVATE const char* numberToFixedWidthString(double, unsigned decimalPlaces, NumberToStringBuffer&);
+
+WTF_EXPORT_PRIVATE size_t numberToStringAndSize(float, NumberToStringBuffer&);
+WTF_EXPORT_PRIVATE size_t numberToStringAndSize(double, NumberToStringBuffer&);
 
 // Fixed width with up to 6 decimal places, trailing zeros truncated.
 WTF_EXPORT_PRIVATE const char* numberToCSSString(double, NumberToCSSStringBuffer&);
@@ -58,8 +59,8 @@ inline double parseDouble(StringView string, size_t& parsedLength)
 } // namespace WTF
 
 using WTF::NumberToStringBuffer;
-using WTF::numberToString;
 using WTF::numberToStringWithTrailingPoint;
+using WTF::numberToStringAndSize;
 using WTF::numberToFixedPrecisionString;
 using WTF::numberToFixedWidthString;
 using WTF::parseDouble;

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -108,13 +108,15 @@ AtomString AtomString::number(unsigned long long number)
 AtomString AtomString::number(float number)
 {
     NumberToStringBuffer buffer;
-    return AtomString::fromLatin1(numberToString(number, buffer));
+    size_t length = numberToStringAndSize(number, buffer);
+    return AtomString { std::span { bitwise_cast<const LChar*>(buffer.data()), length } };
 }
 
 AtomString AtomString::number(double number)
 {
     NumberToStringBuffer buffer;
-    return AtomString::fromLatin1(numberToString(number, buffer));
+    size_t length = numberToStringAndSize(number, buffer);
+    return AtomString { std::span { bitwise_cast<const LChar*>(buffer.data()), length } };
 }
 
 AtomString AtomString::fromUTF8Internal(std::span<const char> characters)

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -71,8 +71,7 @@ class StringTypeAdapter<FloatingPoint, typename std::enable_if_t<std::is_floatin
 public:
     StringTypeAdapter(FloatingPoint number)
     {
-        numberToString(number, m_buffer);
-        m_length = std::strlen(&m_buffer[0]);
+        m_length = numberToStringAndSize(number, m_buffer);
     }
 
     unsigned length() const { return m_length; }

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -241,13 +241,15 @@ String String::numberToStringFixedPrecision(double number, unsigned precision, T
 String String::number(float number)
 {
     NumberToStringBuffer buffer;
-    return String { numberToString(number, buffer) };
+    size_t length = numberToStringAndSize(number, buffer);
+    return String { std::span { buffer.data(), length } };
 }
 
 String String::number(double number)
 {
     NumberToStringBuffer buffer;
-    return String { numberToString(number, buffer) };
+    size_t length = numberToStringAndSize(number, buffer);
+    return String { std::span { buffer.data(), length } };
 }
 
 String String::numberToStringFixedWidth(double number, unsigned decimalPlaces)

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -547,8 +547,8 @@ Decimal Decimal::fromDouble(double doubleValue)
 {
     if (std::isfinite(doubleValue)) {
         NumberToStringBuffer buffer;
-        auto* result = numberToString(doubleValue, buffer);
-        return fromString(span8(result));
+        size_t length = numberToStringAndSize(doubleValue, buffer);
+        return fromString(StringView { std::span { buffer.data(), length } });
     }
 
     if (std::isinf(doubleValue))


### PR DESCRIPTION
#### 866cbaee79e9007c85214ddd28275d4f43f7cca5
<pre>
Do not use strlen unnecessarily for dtoa result
<a href="https://bugs.webkit.org/show_bug.cgi?id=278830">https://bugs.webkit.org/show_bug.cgi?id=278830</a>
<a href="https://rdar.apple.com/134898507">rdar://134898507</a>

Reviewed by Keith Miller.

Add numberToStringAndSize to return the size of generated string so that we do not need to strlen repeatedly.
We change String::number / AtomString(double) etc. with this.

* Source/WTF/wtf/dtoa.cpp:
(WTF::numberToStringAndSize):
(WTF::numberToString):
* Source/WTF/wtf/dtoa.h:
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::number):
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::number):

Canonical link: <a href="https://commits.webkit.org/282883@main">https://commits.webkit.org/282883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc27ff295c79494b23171233b52c8aac6879a8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15454 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32563 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14048 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57678 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70289 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63811 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13083 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55963 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7038 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85572 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9790 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39745 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15096 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->