### PR TITLE
[visionOS] add support for MV-HEVC spatial video playback

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9859,19 +9859,6 @@ void HTMLMediaElement::watchtimeTimerFired()
     }();
 }
 
-std::optional<SpatialVideoMetadata> HTMLMediaElement::spatialVideoMetadata() const
-{
-    RefPtr videoTracks = this->videoTracks();
-    if (!videoTracks)
-        return { };
-
-    RefPtr selectedVideoTrack = videoTracks->selectedItem();
-    if (!selectedVideoTrack)
-        return { };
-
-    return selectedVideoTrack->configuration().spatialVideoMetadata();
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -112,7 +112,6 @@ class ScriptController;
 class ScriptExecutionContext;
 class SleepDisabler;
 class SourceBuffer;
-struct SpatialVideoMetadata;
 class SpeechSynthesis;
 class TextTrackList;
 class TimeRanges;
@@ -695,7 +694,6 @@ public:
     const String& spatialTrackingLabel() const;
     void setSpatialTrackingLabel(const String&);
 #endif
-    WEBCORE_EXPORT std::optional<SpatialVideoMetadata> spatialVideoMetadata() const;
 
     void mediaSourceWasDetached();
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -27,9 +27,9 @@
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 
+#include "NowPlayingMetadataObserver.h"
 #include "PlatformMediaSession.h"
 #include "VideoReceiverEndpoint.h"
-#include <WebCore/NowPlayingMetadataObserver.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
@@ -46,6 +46,7 @@ namespace WebCore {
 class TimeRanges;
 class PlaybackSessionModelClient;
 struct MediaSelectionOption;
+struct SpatialVideoMetadata;
 
 enum class AudioSessionSoundStageSize : uint8_t;
 
@@ -179,6 +180,7 @@ public:
     virtual void isInWindowFullscreenActiveChanged(bool) { }
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     virtual void supportsLinearMediaPlayerChanged(bool) { }
+    virtual void spatialVideoMetadataChanged(const std::optional<SpatialVideoMetadata>&) { };
 #endif
     virtual void ensureControlsManager() { }
     virtual void modelDestroyed() { }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -30,6 +30,9 @@
 #include "EventListener.h"
 #include "HTMLMediaElementEnums.h"
 #include "PlaybackSessionModel.h"
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+#include "SpatialVideoMetadata.h"
+#endif
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
@@ -147,6 +150,9 @@ private:
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     AudioSessionSoundStageSize m_soundStageSize;
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    std::optional<SpatialVideoMetadata> m_spatialVideoMetadata;
+#endif
 
     double playbackStartedTime() const;
     void updateMediaSelectionOptions();

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -41,6 +41,9 @@
 #import "PageGroup.h"
 #import "TextTrackList.h"
 #import "TimeRanges.h"
+#import "VideoTrack.h"
+#import "VideoTrackConfiguration.h"
+#import "VideoTrackList.h"
 #import <QuartzCore/CoreAnimation.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/SoftLinking.h>
@@ -490,6 +493,17 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionOptions()
         client->audioMediaSelectionOptionsChanged(audioOptions, audioIndex);
         client->legibleMediaSelectionOptionsChanged(legibleOptions, legibleIndex);
     }
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    RefPtr videoTracks = mediaElement->videoTracks();
+    auto* selectedItem = videoTracks ? videoTracks->selectedItem() : nullptr;
+    auto spatialVideoMetadata = selectedItem ? selectedItem->configuration().spatialVideoMetadata() : std::nullopt;
+    if (spatialVideoMetadata != m_spatialVideoMetadata) {
+        for (auto& client : m_clients)
+            client->spatialVideoMetadataChanged(spatialVideoMetadata);
+        m_spatialVideoMetadata = WTFMove(spatialVideoMetadata);
+    }
+#endif
 }
 
 void PlaybackSessionModelMediaElement::updateMediaSelectionIndices()

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -83,7 +83,7 @@ public:
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
     WEBCORE_EXPORT virtual void hasVideoChanged(bool) = 0;
     WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&);
-    WEBCORE_EXPORT virtual void setSpatialVideoMetadata(const std::optional<SpatialVideoMetadata>&);
+    virtual void setSpatialImmersive(bool) { }
     WEBCORE_EXPORT virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
     WEBCORE_EXPORT virtual void setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     WEBCORE_EXPORT virtual void externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName);

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -161,10 +161,6 @@ std::optional<MediaPlayerIdentifier>VideoPresentationInterfaceIOS::playerIdentif
     return m_playbackSessionInterface->playerIdentifier();
 }
 
-void VideoPresentationInterfaceIOS::setSpatialVideoMetadata(const std::optional<SpatialVideoMetadata>&)
-{
-}
-
 void VideoPresentationInterfaceIOS::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
 {
     m_playbackSessionInterface->setPlayerIdentifier(WTFMove(identifier));

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -60,6 +60,7 @@ public:
     void mutedChanged(bool) final;
     void volumeChanged(double) final;
     void supportsLinearMediaPlayerChanged(bool) final;
+    void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&) final;
     void startObservingNowPlayingMetadata() final;
     void stopObservingNowPlayingMetadata() final;
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -34,6 +34,7 @@
 #import <WebCore/NowPlayingInfo.h>
 #import <WebCore/PlaybackSessionModel.h>
 #import <WebCore/SharedBuffer.h>
+#import <WebCore/SpatialVideoMetadata.h>
 #import <WebCore/TimeRanges.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -363,6 +364,14 @@ void PlaybackSessionInterfaceLMK::supportsLinearMediaPlayerChanged(bool supports
     }
 
     ASSERT_NOT_REACHED();
+}
+
+void PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+{
+    RetainPtr<WKSLinearMediaSpatialVideoMetadata> spatialVideoMetadata;
+    if (metadata)
+        spatialVideoMetadata = [allocWKSLinearMediaSpatialVideoMetadataInstance() initWithWidth:metadata->size.width() height:metadata->size.height() horizontalFOVDegrees:metadata->horizontalFOVDegrees baseline:metadata->baseline disparityAdjustment:metadata->disparityAdjustment];
+    [m_player setSpatialVideoMetadata:spatialVideoMetadata.get()];
 }
 
 void PlaybackSessionInterfaceLMK::startObservingNowPlayingMetadata()

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -78,7 +78,7 @@ private:
     CALayer *captionsLayer() final;
     void setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize&) final;
     LMPlayableViewController *playableViewController() final;
-    void setSpatialVideoMetadata(const std::optional<WebCore::SpatialVideoMetadata>&) final;
+    void setSpatialImmersive(bool) final;
 
     WKSLinearMediaPlayer *linearMediaPlayer() const;
     void ensurePlayableViewController();

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -91,10 +91,9 @@ WKSLinearMediaPlayer *VideoPresentationInterfaceLMK::linearMediaPlayer() const
     return playbackSessionInterface().linearMediaPlayer();
 }
 
-void VideoPresentationInterfaceLMK::setSpatialVideoMetadata(const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+void VideoPresentationInterfaceLMK::setSpatialImmersive(bool immersive)
 {
-    RetainPtr<WKSLinearMediaSpatialVideoMetadata> spatialVideoMetadata = metadata ? [allocWKSLinearMediaSpatialVideoMetadataInstance() initWithWidth:metadata->size.width() height:metadata->size.height() horizontalFOVDegrees:metadata->horizontalFOVDegrees baseline:metadata->baseline disparityAdjustment:metadata->disparityAdjustment] : nil;
-    linearMediaPlayer().spatialVideoMetadata = spatialVideoMetadata.get();
+    linearMediaPlayer().spatialImmersive = immersive;
 }
 
 void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const WebCore::FloatRect& initialRect, const WebCore::FloatSize& videoDimensions, UIView* parentView, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -42,6 +42,9 @@
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+#include <WebCore/SpatialVideoMetadata.h>
+#endif
 
 namespace WebKit {
 
@@ -92,6 +95,7 @@ public:
     void isInWindowFullscreenActiveChanged(bool);
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(bool);
+    void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&);
 #endif
 
     bool wirelessVideoPlaybackDisabled() const final { return m_wirelessVideoPlaybackDisabled; }
@@ -211,6 +215,7 @@ private:
     WebCore::AudioSessionSoundStageSize m_soundStageSize { 0 };
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool m_supportsLinearMediaPlayer { false };
+    std::optional<WebCore::SpatialVideoMetadata> m_spatialVideoMetadata;
 #endif
 
 #if !RELEASE_LOG_DISABLED
@@ -281,6 +286,7 @@ private:
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool isInWindow);
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(PlaybackSessionContextIdentifier, bool);
+    void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
 #endif
 
     // Messages to PlaybackSessionManager

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -41,6 +41,7 @@ messages -> PlaybackSessionManagerProxy {
     IsInWindowFullscreenActiveChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool isInWindow)
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     SupportsLinearMediaPlayerChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool supportsLinearMediaPlayer)
+    SpatialVideoMetadataChanged(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::SpatialVideoMetadata> metadata);
 #endif
     SetUpPlaybackControlsManagerWithID(WebKit::PlaybackSessionContextIdentifier contextId, bool isVideo)
     ClearPlaybackControlsManager()

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -469,6 +469,18 @@ void PlaybackSessionModelContext::supportsLinearMediaPlayerChanged(bool supports
     if (RefPtr manager = m_manager.get())
         manager->updateVideoControlsManager(m_contextId);
 }
+
+void PlaybackSessionModelContext::spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+{
+    if (m_spatialVideoMetadata == metadata)
+        return;
+    if (metadata)
+        ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, *metadata);
+    m_spatialVideoMetadata = metadata;
+
+    for (auto& client : m_clients)
+        client.spatialVideoMetadataChanged(m_spatialVideoMetadata);
+}
 #endif
 
 void PlaybackSessionModelContext::invalidate()
@@ -719,6 +731,12 @@ void PlaybackSessionManagerProxy::supportsLinearMediaPlayerChanged(PlaybackSessi
 {
     ensureModel(contextId)->supportsLinearMediaPlayerChanged(supportsLinearMediaPlayer);
 }
+
+void PlaybackSessionManagerProxy::spatialVideoMetadataChanged(PlaybackSessionContextIdentifier contextId, const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+{
+    ensureModel(contextId)->spatialVideoMetadataChanged(metadata);
+}
+
 #endif
 
 void PlaybackSessionManagerProxy::handleControlledElementIDResponse(PlaybackSessionContextIdentifier contextId, String identifier) const

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -225,7 +225,7 @@ private:
     RetainPtr<WKLayerHostView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
 
     // Messages from VideoPresentationManager
-    void setupFullscreenWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture, const std::optional<WebCore::SpatialVideoMetadata>&);
+    void setupFullscreenWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     void setInlineRect(PlaybackSessionContextIdentifier, const WebCore::FloatRect& inlineRect, bool visible);
     void setHasVideoContentLayer(PlaybackSessionContextIdentifier, bool value);
     void setHasVideo(PlaybackSessionContextIdentifier, bool);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -25,7 +25,7 @@ messages -> VideoPresentationManagerProxy {
     SetHasVideo(WebKit::PlaybackSessionContextIdentifier contextId, bool hasVideo)
     SetDocumentVisibility(WebKit::PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)
     SetVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize videoDimensions)
-    SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture, std::optional<WebCore::SpatialVideoMetadata> metadata)
+    SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
     SetPlayerIdentifier(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier)
 #if !PLATFORM(IOS_FAMILY)
     EnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -885,7 +885,7 @@ void VideoPresentationManagerProxy::willRemoveLayerForID(PlaybackSessionContextI
 
 #pragma mark Messages from VideoPresentationManager
 
-void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingDeviceScaleFactor, HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture, const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingDeviceScaleFactor, HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     if (!m_page)
         return;
@@ -933,12 +933,10 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 #if PLATFORM(IOS_FAMILY)
     auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*m_page->drawingArea()).remoteLayerTreeHost().rootNode();
     UIView *parentView = rootNode ? rootNode->uiView() : nil;
-    interface->setSpatialVideoMetadata(metadata);
     interface->setupFullscreen(*model->layerHostView(), screenRect, videoDimensions, parentView, videoFullscreenMode, allowsPictureInPicture, standby, blocksReturnToFullscreenFromPictureInPicture);
 #else
     UNUSED_PARAM(videoDimensions);
     UNUSED_PARAM(blocksReturnToFullscreenFromPictureInPicture);
-    UNUSED_PARAM(metadata);
     IntRect initialWindowRect;
     m_page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
     interface->setupFullscreen(*model->layerHostView(), initialWindowRect, m_page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -224,6 +224,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
 #endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    [self _didCleanupFullscreen];
+#endif
+
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     _playbackClient.setParent(nullptr);
     _playbackClient.setInterface(nullptr);
@@ -365,10 +369,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)videoControlsManagerDidChange
 {
     ASSERT(_valid);
-    auto page = [self._webView _page];
-    RefPtr videoPresentationManager = page ? page->videoPresentationManager() : nullptr;
-    RefPtr videoPresentationInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
-    RefPtr playbackSessionInterface = videoPresentationInterface ? &videoPresentationInterface->playbackSessionInterface() : nullptr;
+    RefPtr playbackSessionInterface = [self _playbackSessionInterface];
 
     _playbackClient.setInterface(playbackSessionInterface.get());
 
@@ -408,8 +409,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    RefPtr playbackSessionManager = page->playbackSessionManager();
-    RefPtr playbackSessionInterface = playbackSessionManager ? playbackSessionManager->controlsManagerInterface() : nullptr;
+    RefPtr playbackSessionInterface = [self _playbackSessionInterface];
     auto* playbackSessionModel = playbackSessionInterface ? playbackSessionInterface->playbackSessionModel() : nullptr;
     if (!playbackSessionModel || !playbackSessionModel->supportsLinearMediaPlayer()) {
         [self _removeEnvironmentPickerButtonView];
@@ -418,6 +418,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     RefPtr videoPresentationManager = page->videoPresentationManager();
     RefPtr videoPresentationInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
+
+    if (videoPresentationInterface)
+        videoPresentationInterface->setSpatialImmersive(true);
+
     LMPlayableViewController *playableViewController = videoPresentationInterface ? videoPresentationInterface->playableViewController() : nil;
     UIViewController *environmentPickerButtonViewController = playableViewController.wks_environmentPickerButtonViewController;
 
@@ -452,6 +456,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self removeChildViewController:_environmentPickerButtonViewController.get()];
 
     _environmentPickerButtonViewController = nil;
+}
+
+- (void)_didCleanupFullscreen
+{
+    RefPtr page = self._webView._page.get();
+    if (!page)
+        return;
+    RefPtr videoPresentationManager = page->videoPresentationManager();
+    if (!videoPresentationManager)
+        return;
+    if (RefPtr videoPresentationInterface = videoPresentationManager->controlsManagerInterface())
+        videoPresentationInterface->setSpatialImmersive(false);
 }
 #endif // ENABLE(LINEAR_MEDIA_PLAYER)
 
@@ -838,6 +854,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return insets;
 }
 
+- (RefPtr<WebCore::PlatformPlaybackSessionInterface>) _playbackSessionInterface
+{
+    auto page = [self._webView _page];
+    if (!page)
+        return nullptr;
+
+    WebKit::PlaybackSessionManagerProxy* playbackSessionManager = page->playbackSessionManager();
+    if (!playbackSessionManager)
+        return nullptr;
+
+    return playbackSessionManager->controlsManagerInterface();
+}
+
 - (void)_cancelAction:(id)sender
 {
     ASSERT(_valid);
@@ -847,15 +876,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_togglePiPAction:(id)sender
 {
     ASSERT(_valid);
-    auto page = [self._webView _page];
-    if (!page)
-        return;
 
-    WebKit::PlaybackSessionManagerProxy* playbackSessionManager = page->playbackSessionManager();
-    if (!playbackSessionManager)
-        return;
-
-    RefPtr playbackSessionInterface = playbackSessionManager->controlsManagerInterface();
+    RefPtr playbackSessionInterface = [self _playbackSessionInterface];
     if (!playbackSessionInterface)
         return;
 

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -40,7 +40,7 @@ private class SwiftOnlyData: NSObject {
     @Published var thumbnailMaterial: VideoMaterial?
     @Published var videoMaterial: VideoMaterial?
     @Published var peculiarEntity: PeculiarEntity?
-    
+
     // FIXME: It should be possible to store these directly on WKSLinearMediaPlayer since they are
     // bridged to NSDate, but a bug prevents that from compiling (rdar://121877511).
     @Published var startDate: Date?
@@ -48,6 +48,9 @@ private class SwiftOnlyData: NSObject {
 
     @Published var presentationMode: PresentationMode = .inline
     @Published var presentationState: WKSLinearMediaPresentationState = .inline
+
+    var spatialVideoMetadata: WKSLinearMediaSpatialVideoMetadata?
+    var videoReceiverEndpointObserver: Cancellable?
 }
 
 enum LinearMediaPlayerErrors: Error {
@@ -111,7 +114,16 @@ enum LinearMediaPlayerErrors: Error {
     var fullscreenSceneBehaviors: WKSLinearMediaFullscreenBehaviors = []
     var startTime: Double = .nan
     var endTime: Double = .nan
-    var spatialVideoMetadata: WKSLinearMediaSpatialVideoMetadata?
+    var spatialImmersive = false
+    var spatialVideoMetadata: WKSLinearMediaSpatialVideoMetadata? {
+        get { swiftOnlyData.spatialVideoMetadata }
+        set {
+            swiftOnlyData.spatialVideoMetadata = newValue
+#if canImport(LinearMediaKit, _version: 211.60.3)
+            swiftOnlyData.peculiarEntity?.setVideoMetaData(to: swiftOnlyData.spatialVideoMetadata?.metadata)
+#endif
+        }
+    }
 
     // FIXME: These should be stored properties on WKSLinearMediaPlayer, but a bug prevents that from compiling (rdar://121877511).
     var startDate: Date? {
@@ -171,6 +183,8 @@ enum LinearMediaPlayerErrors: Error {
             self.enterFullscreenCompletionHandler = nil
         }
 
+        maybeCreateSpatialEntity();
+
         switch presentationState {
         case .inline, .enteringFullscreen, .exitingFullscreen:
             enterFullscreenCompletionHandler = completionHandler
@@ -219,6 +233,29 @@ extension WKSLinearMediaPlayer {
         @unknown default:
             fatalError()
         }
+    }
+
+    private func maybeCreateSpatialEntity() {
+#if canImport(LinearMediaKit, _version: 211.60.3)
+        if swiftOnlyData.peculiarEntity != nil { return }
+        guard let metadata = swiftOnlyData.spatialVideoMetadata else { return }
+        swiftOnlyData.peculiarEntity = ContentType.makeSpatialEntity(videoMetadata: metadata.metadata, extruded: true)
+        swiftOnlyData.peculiarEntity?.screenMode = spatialImmersive ? .immersive : .portal;
+        swiftOnlyData.videoReceiverEndpointObserver = swiftOnlyData.peculiarEntity?.videoReceiverEndpointPublisher.sink {
+            [weak self] in guard let endpoint = $0 else { return }
+            self?.setVideoReceiverEndpoint(endpoint)
+        }
+        contentType = .spatial
+#endif
+    }
+
+    private func maybeClearSpatialEntity() {
+#if canImport(LinearMediaKit, _version: 211.60.3)
+        if swiftOnlyData.peculiarEntity == nil { return }
+        swiftOnlyData.videoReceiverEndpointObserver = nil;
+        swiftOnlyData.peculiarEntity = nil;
+        contentType = .none; // this causes a call to makeDefaultEntity
+#endif
     }
 }
 
@@ -635,6 +672,8 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
         let completionHandler = exitFullscreenCompletionHandler
         exitFullscreenCompletionHandler = nil
 
+        maybeClearSpatialEntity();
+
         switch result {
         case .success():
             Logger.linearMediaPlayer.log("\(#function): success")
@@ -648,11 +687,16 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     public func makeDefaultEntity() -> Entity? {
         Logger.linearMediaPlayer.log("\(#function)")
 
-        if let captionLayer = captionLayer {
+#if canImport(LinearMediaKit, _version: 211.60.3)
+        if swiftOnlyData.spatialVideoMetadata != nil {
+            return swiftOnlyData.peculiarEntity;
+        }
+#endif
+        if let captionLayer {
             return ContentType.makeEntity(captionLayer: captionLayer)
         }
 
-        Logger.linearMediaPlayer.error("\(#function): failed to find captionLayer")
+        Logger.linearMediaPlayer.error("\(#function): failed to find spatialVideoMetadata and captionLayer")
         return nil
     }
 

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -233,4 +233,12 @@ extension WKSLinearMediaTrack: @retroactive Track {
 }
 #endif
 
+extension WKSLinearMediaSpatialVideoMetadata {
+#if canImport(LinearMediaKit, _version: 211.60.3)
+    var metadata: SpatialVideoMetadata {
+        return SpatialVideoMetadata(width: self.width, height: self.height, horizontalFOVDegrees: self.horizontalFOVDegrees, baseline: self.baseline, disparityAdjustment: self.disparityAdjustment, isRecommendedForImmersive: true)
+    }
+#endif
+}
+
 #endif // os(visionOS)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -157,6 +157,7 @@ API_AVAILABLE(visionos(1.0))
 @property (nonatomic) double endTime;
 @property (nonatomic, strong, nullable) NSDate *startDate;
 @property (nonatomic, strong, nullable) NSDate *endDate;
+@property (nonatomic) BOOL spatialImmersive;
 @property (nonatomic, strong, nullable) WKSLinearMediaSpatialVideoMetadata *spatialVideoMetadata;
 
 - (LMPlayableViewController *)makeViewController;

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -100,6 +100,9 @@ private:
     void volumeChanged(double) final;
     void isPictureInPictureSupportedChanged(bool) final;
     void isInWindowFullscreenActiveChanged(bool) final;
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&) final;
+#endif
 
     PlaybackSessionInterfaceContext(PlaybackSessionManager&, PlaybackSessionContextIdentifier);
 
@@ -160,6 +163,7 @@ private:
     void volumeChanged(PlaybackSessionContextIdentifier, double);
     void isPictureInPictureSupportedChanged(PlaybackSessionContextIdentifier, bool);
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool);
+    void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
 
     // Messages from PlaybackSessionManagerProxy
     void play(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -167,6 +167,14 @@ void PlaybackSessionInterfaceContext::isInWindowFullscreenActiveChanged(bool isI
         m_manager->isInWindowFullscreenActiveChanged(m_contextId, isInWindow);
 }
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+void PlaybackSessionInterfaceContext::spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+{
+    if (m_manager)
+        m_manager->spatialVideoMetadataChanged(m_contextId, metadata);
+}
+#endif
+
 #pragma mark - PlaybackSessionManager
 
 Ref<PlaybackSessionManager> PlaybackSessionManager::create(WebPage& page)
@@ -444,6 +452,13 @@ void PlaybackSessionManager::isInWindowFullscreenActiveChanged(PlaybackSessionCo
 {
     m_page->send(Messages::PlaybackSessionManagerProxy::IsInWindowFullscreenActiveChanged(contextId, inWindow));
 }
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+void PlaybackSessionManager::spatialVideoMetadataChanged(PlaybackSessionContextIdentifier contextId, const std::optional<WebCore::SpatialVideoMetadata>& metadata)
+{
+    m_page->send(Messages::PlaybackSessionManagerProxy::SpatialVideoMetadataChanged(contextId, metadata));
+}
+#endif
 
 #pragma mark Messages from PlaybackSessionManagerProxy:
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -397,7 +397,7 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     auto setupFullscreen = [protectedThis = Ref { *this }, page = WeakPtr { m_page }, contextId = contextId, initialSize = initialSize, videoRect = videoRect, videoElement = WeakPtr { videoElement }, allowsPictureInPicture = allowsPictureInPicture, standby = standby, fullscreenMode = interface->fullscreenMode()] (LayerHostingContextID contextID, const FloatSize& size) {
         if (!page || !videoElement)
             return;
-        page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(contextId, contextID, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, videoElement->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), videoElement->spatialVideoMetadata()));
+        page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(contextId, contextID, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, videoElement->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
 
         if (RefPtr player = videoElement->player()) {
             if (auto identifier = player->identifier())


### PR DESCRIPTION
#### d6a54a7d8abb19778f8e29b7ea22535eb0b38ec4
<pre>
[visionOS] add support for MV-HEVC spatial video playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=278827">https://bugs.webkit.org/show_bug.cgi?id=278827</a>
<a href="https://rdar.apple.com/134896614">rdar://134896614</a>

Reviewed by Jer Noble.

Following 282641@main, to support entering spatial mode in element fullscreen
we needed the UI process to determine if the video contained spatial metadata
prior entering fullscreen.
As such, we stop passing the metadata to the VideoPresentationManager when entering
fullscreen, and instead synchronise the information through the PlaybackSessionInterface
similar to how we synchronise other media&apos;s related data (such as the duration).
When entering spatial mode from element fullscreen, we will go straight to immersive mode
while when entered from native video fullscreen we will enter &quot;portal&quot; mode instead.

As there is no infrastructure in place for the video to determine if when
it entered native fullscreen it came from element fullscreen, we use the
same mechanism that sets the &quot;docking&quot; menu on the current view and assume
that if the button is displayed, we were in element fullscreen first.

Manually tested.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::spatialVideoMetadata const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModelClient::spatialVideoMetadataChanged):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionOptions):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::setSpatialImmersive):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::setSpatialVideoMetadata): Deleted.
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::setSpatialImmersive):
(WebKit::VideoPresentationInterfaceLMK::setSpatialVideoMetadata): Deleted.
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::spatialVideoMetadataChanged):
(WebKit::PlaybackSessionManagerProxy::spatialVideoMetadataChanged):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController invalidate]):
(-[WKFullScreenViewController videoControlsManagerDidChange]): Add convenience method to retrieve the attached PlaybackSessionInterface and use it wherever needed.
(-[WKFullScreenViewController configureEnvironmentPickerButtonView]):
(-[WKFullScreenViewController _didCleanupFullscreen]):
(-[WKFullScreenViewController _playbackSessionInterface]):
(-[WKFullScreenViewController _togglePiPAction:]):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(SwiftOnlyData.spatialVideoMetadata):
(SwiftOnlyData.videoReceiverEndpointObserver):
(WKSLinearMediaPlayer.spatialVideoMetadata):
(WKSLinearMediaPlayer.enterFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.maybeCreateSpatialEntity):
(WKSLinearMediaPlayer.maybeClearSpatialEntity):
(WKSLinearMediaPlayer.didCompleteExitFullscreen(_:any:)):
(WKSLinearMediaPlayer.makeDefaultEntity):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSLinearMediaSpatialVideoMetadata.metadata):
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionInterfaceContext::spatialVideoMetadataChanged):
(WebKit::PlaybackSessionManager::spatialVideoMetadataChanged):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):

Canonical link: <a href="https://commits.webkit.org/282893@main">https://commits.webkit.org/282893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/685126320568e8611a9fe7d4c434a85e26b97a31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51960 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10491 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37340 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13277 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/stretch-along-block-axis-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59267 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13608 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59289 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55988 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/736 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40857 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->