### PR TITLE
[TZone] WebCore/dom Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/dom/ConstantPropertyMap.cpp
+++ b/Source/WebCore/dom/ConstantPropertyMap.cpp
@@ -33,8 +33,11 @@
 #include "Document.h"
 #include "Page.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ConstantPropertyMap);
 
 ConstantPropertyMap::ConstantPropertyMap(Document& document)
     : m_document(document)

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
@@ -53,7 +54,7 @@ enum class ConstantProperty {
 };
 
 class ConstantPropertyMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ConstantPropertyMap);
 public:
     explicit ConstantPropertyMap(Document&);
 

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -39,8 +39,11 @@
 #include "SimpleRange.h"
 #include "StyleOriginatedAnimation.h"
 #include "VisibleSelection.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentVisibilityDocumentState);
 
 class ContentVisibilityIntersectionObserverCallback final : public IntersectionObserverCallback {
 public:

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.h
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntersectionObserver.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ enum class ViewportProximity : bool { Far, Near };
 enum class HadInitialVisibleContentVisibilityDetermination : bool { No, Yes };
 
 class ContentVisibilityDocumentState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentVisibilityDocumentState);
 public:
     static void observe(Element&);
     static void unobserve(Element&);

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -39,8 +39,13 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomElementReactionQueueItem);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomElementQueue);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomElementReactionQueue);
 
 inline CustomElementReactionQueueItem::AdoptedPayload::~AdoptedPayload() = default;
 inline CustomElementReactionQueueItem::FormAssociatedPayload::~FormAssociatedPayload() = default;

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
@@ -51,7 +52,7 @@ class HTMLFormElement;
 class JSCustomElementInterface;
 
 class CustomElementReactionQueueItem {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CustomElementReactionQueueItem);
     WTF_MAKE_NONCOPYABLE(CustomElementReactionQueueItem);
 public:
     enum class Type : uint8_t {
@@ -97,7 +98,7 @@ private:
 
 // https://html.spec.whatwg.org/multipage/custom-elements.html#element-queue
 class CustomElementQueue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CustomElementQueue);
     WTF_MAKE_NONCOPYABLE(CustomElementQueue);
 public:
     CustomElementQueue() = default;
@@ -117,7 +118,7 @@ private:
 };
 
 class CustomElementReactionQueue final : public CanMakeCheckedPtr<CustomElementReactionQueue> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CustomElementReactionQueue);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CustomElementReactionQueue);
     WTF_MAKE_NONCOPYABLE(CustomElementReactionQueue);
 public:

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -49,6 +49,7 @@
 #include "WebContentReader.h"
 #include "WebCorePasteboardFileReader.h"
 #include "markup.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URLParser.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -57,7 +58,8 @@ namespace WebCore {
 #if ENABLE(DRAG_SUPPORT)
 
 class DragImageLoader final : private CachedImageClient {
-    WTF_MAKE_NONCOPYABLE(DragImageLoader); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DragImageLoader);
+    WTF_MAKE_NONCOPYABLE(DragImageLoader);
 public:
     explicit DragImageLoader(DataTransfer&);
     void startLoading(CachedResourceHandle<CachedImage>&);

--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -32,8 +32,11 @@
 #include "DeviceMotionEvent.h"
 #include "EventNames.h"
 #include "Page.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceMotionController);
 
 DeviceMotionController::DeviceMotionController(DeviceMotionClient& client)
     : DeviceController(client)

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -28,6 +28,7 @@
 
 #include "DeviceController.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,8 +36,8 @@ class DeviceMotionClient;
 class DeviceMotionData;
 
 class DeviceMotionController : public DeviceController {
+    WTF_MAKE_TZONE_ALLOCATED(DeviceMotionController);
     WTF_MAKE_NONCOPYABLE(DeviceMotionController);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceMotionController);
 public:
     explicit DeviceMotionController(DeviceMotionClient&);

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -36,8 +36,11 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "UserGestureIndicator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationAndMotionAccessController);
 
 DeviceOrientationAndMotionAccessController::DeviceOrientationAndMotionAccessController(Document& topDocument)
     : m_topDocument(topDocument)

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
@@ -32,6 +32,7 @@
 #include "ExceptionOr.h"
 #include "SecurityOriginData.h"
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -50,7 +51,7 @@ class Document;
 class Page;
 
 class DeviceOrientationAndMotionAccessController : public CanMakeWeakPtr<DeviceOrientationAndMotionAccessController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationAndMotionAccessController);
 public:
     explicit DeviceOrientationAndMotionAccessController(Document& topDocument);
 

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -32,8 +32,11 @@
 #include "DeviceOrientationEvent.h"
 #include "EventNames.h"
 #include "Page.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationController);
 
 DeviceOrientationController::DeviceOrientationController(DeviceOrientationClient& client)
     : DeviceController(client)

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -28,6 +28,7 @@
 
 #include "DeviceController.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,8 +37,8 @@ class DeviceOrientationData;
 class Page;
 
 class DeviceOrientationController final : public DeviceController {
+    WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationController);
     WTF_MAKE_NONCOPYABLE(DeviceOrientationController);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationController);
 public:
     explicit DeviceOrientationController(DeviceOrientationClient&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -403,6 +403,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Document);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentParserYieldToken);
 
 using namespace HTMLNames;
 using namespace WTF::Unicode;
@@ -413,7 +414,7 @@ static const Seconds maxIntervalForUserGestureForwardingAfterMediaFinishesPlayin
 
 // Defined here to avoid including GCReachableRef.h in Document.h
 struct Document::PendingScrollEventTargetList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PendingScrollEventTargetList);
 
 public:
     Vector<GCReachableRef<ContainerNode>> targets;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -61,6 +61,7 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/Observer.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TriState.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashCountedSet.h>
@@ -406,7 +407,7 @@ using RenderingContext = std::variant<
 using StartViewTransitionCallbackOptions = std::optional<std::variant<RefPtr<JSViewTransitionUpdateCallback>, StartViewTransitionOptions>>;
 
 class DocumentParserYieldToken {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(DocumentParserYieldToken, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT DocumentParserYieldToken(Document&);
     WEBCORE_EXPORT ~DocumentParserYieldToken();

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -37,8 +37,11 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "LocalFrame.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentFontLoader);
 
 DocumentFontLoader::DocumentFontLoader(Document& document)
     : m_document(document)

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -29,6 +29,7 @@
 #include "CachedResourceHandle.h"
 #include "Document.h"
 #include "Timer.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
 
@@ -37,7 +38,7 @@ namespace WebCore {
 class CachedFont;
 
 class DocumentFontLoader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DocumentFontLoader);
 public:
     DocumentFontLoader(Document&);
     ~DocumentFontLoader();

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -40,8 +40,11 @@
 #include "RenderedDocumentMarker.h"
 #include "TextIterator.h"
 #include <stdio.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentMarkerController);
 
 constexpr Seconds markerFadeAnimationDuration = 200_ms;
 

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -30,6 +30,7 @@
 #include "Timer.h"
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
 
@@ -48,8 +49,8 @@ enum class RemovePartiallyOverlappingMarker : bool { No, Yes };
 enum class FilterMarkerResult : bool { Keep, Remove };
 
 class DocumentMarkerController final : public CanMakeCheckedPtr<DocumentMarkerController> {
+    WTF_MAKE_TZONE_ALLOCATED(DocumentMarkerController);
     WTF_MAKE_NONCOPYABLE(DocumentMarkerController);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentMarkerController);
 public:
     enum class IterationDirection : bool {

--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -29,9 +29,12 @@
 
 #include "Element.h"
 #include "ElementData.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UnalignedAccess.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentSharedObjectPool);
 
 // Do comparisons 8 bytes-at-a-time on architectures where it's safe.
 #if (CPU(X86_64) || CPU(ARM64)) && !ASAN_ENABLED

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class Attribute;
 class ShareableElementData;
 
 class DocumentSharedObjectPool {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DocumentSharedObjectPool);
 public:
     Ref<ShareableElementData> cachedShareableElementDataWithAttributes(std::span<const Attribute>);
 

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -42,8 +42,11 @@
 #include "SecurityOrigin.h"
 #include "Settings.h"
 #include "UserGestureIndicator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentStorageAccess);
 
 DocumentStorageAccess::DocumentStorageAccess(Document& document)
     : m_document(document)

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -27,6 +27,7 @@
 
 #include "RegistrableDomain.h"
 #include "Supplementable.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -70,7 +71,7 @@ struct RequestStorageAccessResult {
 const unsigned maxNumberOfTimesExplicitlyDeniedStorageAccess = 2;
 
 class DocumentStorageAccess final : public Supplement<Document>, public CanMakeWeakPtr<DocumentStorageAccess> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DocumentStorageAccess);
 public:
     explicit DocumentStorageAccess(Document&);
     ~DocumentStorageAccess();

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -36,8 +36,11 @@
 #include "LocalDOMWindow.h"
 #include "MouseEvent.h"
 #include "TouchEvent.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventContext);
 
 void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
 {

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -29,11 +29,12 @@
 
 #include "HTMLFormElement.h"
 #include "TouchList.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class EventContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EventContext);
 public:
     using EventInvokePhase = EventTarget::EventInvokePhase;
 

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -28,11 +28,16 @@
 
 #include "Microtasks.h"
 #include "ScriptExecutionContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventLoopTask);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventLoopTimerHandle);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventLoopTaskGroup);
+
 class EventLoopTimer final : public RefCounted<EventLoopTimer>, public TimerBase, public CanMakeWeakPtr<EventLoopTimer> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EventLoopTimer);
 public:
     enum class Type : bool { OneShot, Repeating };
     static Ref<EventLoopTimer> create(Type type, std::unique_ptr<EventLoopTask>&& task) { return adoptRef(*new EventLoopTimer(type, WTFMove(task))); }

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -34,6 +34,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -48,8 +49,8 @@ class ScriptExecutionContext;
 class TimerAlignment;
 
 class EventLoopTask {
+    WTF_MAKE_TZONE_ALLOCATED(EventLoopTask);
     WTF_MAKE_NONCOPYABLE(EventLoopTask);
-    WTF_MAKE_FAST_ALLOCATED;
 
 public:
     virtual ~EventLoopTask() = default;
@@ -68,7 +69,7 @@ private:
 };
 
 class EventLoopTimerHandle {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EventLoopTimerHandle);
 public:
     EventLoopTimerHandle();
     EventLoopTimerHandle(EventLoopTimer&);
@@ -154,8 +155,8 @@ private:
 };
 
 class EventLoopTaskGroup final : public CanMakeWeakPtr<EventLoopTaskGroup>, public CanMakeCheckedPtr<EventLoopTaskGroup> {
+    WTF_MAKE_TZONE_ALLOCATED(EventLoopTaskGroup);
     WTF_MAKE_NONCOPYABLE(EventLoopTaskGroup);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventLoopTaskGroup);
 public:
     EventLoopTaskGroup(EventLoop& eventLoop)

--- a/Source/WebCore/dom/EventSender.h
+++ b/Source/WebCore/dom/EventSender.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Timer.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -35,7 +36,8 @@ class Page;
 class WeakPtrImplWithEventTargetData;
 
 template<typename T, typename WeakPtrImpl> class EventSender {
-    WTF_MAKE_NONCOPYABLE(EventSender); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EventSender);
+    WTF_MAKE_NONCOPYABLE(EventSender);
 public:
     EventSender();
 

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -56,6 +56,7 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventTargetData);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EventTarget);
 
 struct SameSizeAsEventTarget : ScriptWrappable, CanMakeWeakPtrWithBitField<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData> {

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -55,7 +55,8 @@ class EventTarget;
 class JSEventListener;
 
 struct EventTargetData {
-    WTF_MAKE_NONCOPYABLE(EventTargetData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EventTargetData);
+    WTF_MAKE_NONCOPYABLE(EventTargetData);
 public:
     EventTargetData() = default;
 

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -44,8 +44,11 @@
 #include "UserContentController.h"
 #include "UserContentURLPattern.h"
 #include "UserStyleSheet.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExtensionStyleSheets);
 
 #if ENABLE(CONTENT_EXTENSIONS)
 using namespace ContentExtensions;

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -30,9 +30,9 @@
 #include "UserStyleSheet.h"
 #include <memory>
 #include <wtf/CheckedRef.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
@@ -52,7 +52,7 @@ class StyleSheetList;
 class WeakPtrImplWithEventTargetData;
 
 class ExtensionStyleSheets final : public CanMakeCheckedPtr<ExtensionStyleSheets> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ExtensionStyleSheets);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ExtensionStyleSheets);
 public:
     explicit ExtensionStyleSheets(Document&);

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -50,8 +50,11 @@
 #include "RenderBlock.h"
 #include "Settings.h"
 #include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FullscreenManager);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -35,6 +35,7 @@
 #include "LayoutRect.h"
 #include "Page.h"
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ class DeferredPromise;
 class RenderStyle;
 
 class FullscreenManager final : public CanMakeWeakPtr<FullscreenManager>, public CanMakeCheckedPtr<FullscreenManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FullscreenManager);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FullscreenManager);
 public:
     FullscreenManager(Document&);

--- a/Source/WebCore/dom/IdTargetObserver.cpp
+++ b/Source/WebCore/dom/IdTargetObserver.cpp
@@ -27,8 +27,11 @@
 #include "IdTargetObserver.h"
 
 #include "IdTargetObserverRegistry.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IdTargetObserver);
 
 IdTargetObserver::IdTargetObserver(IdTargetObserverRegistry& registry, const AtomString& id)
     : m_registry(&registry)

--- a/Source/WebCore/dom/IdTargetObserver.h
+++ b/Source/WebCore/dom/IdTargetObserver.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/CheckedPtr.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -34,7 +34,7 @@ namespace WebCore {
 class IdTargetObserverRegistry;
 
 class IdTargetObserver : public CanMakeCheckedPtr<IdTargetObserver> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IdTargetObserver);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IdTargetObserver);
 public:
     virtual ~IdTargetObserver();

--- a/Source/WebCore/dom/IdTargetObserverRegistry.cpp
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.cpp
@@ -27,8 +27,11 @@
 #include "IdTargetObserverRegistry.h"
 
 #include "IdTargetObserver.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IdTargetObserverRegistry);
 
 IdTargetObserverRegistry::IdTargetObserverRegistry() = default;
 

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -38,7 +39,7 @@ namespace WebCore {
 class IdTargetObserver;
 
 class IdTargetObserverRegistry final : public CanMakeCheckedPtr<IdTargetObserverRegistry> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IdTargetObserverRegistry);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IdTargetObserverRegistry);
     friend class IdTargetObserver;
 public:

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -32,8 +32,11 @@
 #include "Page.h"
 #include "Timer.h"
 #include "WindowEventLoop.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IdleCallbackController);
 
 IdleCallbackController::IdleCallbackController(Document& document)
     : m_document(document)

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -29,6 +29,7 @@
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 
 class IdleCallbackController : public CanMakeWeakPtr<IdleCallbackController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IdleCallbackController);
 
 public:
     IdleCallbackController(Document&);

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -32,8 +32,11 @@
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MicrotaskQueue);
 
 MicrotaskQueue::MicrotaskQueue(JSC::VM& vm, EventLoop& eventLoop)
     : m_vm(vm)

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -35,7 +36,7 @@ class EventLoop;
 class EventLoopTask;
 
 class MicrotaskQueue final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(MicrotaskQueue, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT MicrotaskQueue(JSC::VM&, EventLoop&);
     WEBCORE_EXPORT ~MicrotaskQueue();

--- a/Source/WebCore/dom/MutationObserverInterestGroup.cpp
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.cpp
@@ -34,8 +34,11 @@
 
 #include "MutationObserverRegistration.h"
 #include "MutationRecord.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MutationObserverInterestGroup);
 
 inline MutationObserverInterestGroup::MutationObserverInterestGroup(HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&& observers, MutationRecordDeliveryOptions oldValueFlag)
     : m_observers(WTFMove(observers))

--- a/Source/WebCore/dom/MutationObserverInterestGroup.h
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.h
@@ -34,13 +34,14 @@
 #include "MutationObserver.h"
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class QualifiedName;
 
 class MutationObserverInterestGroup {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MutationObserverInterestGroup);
 public:
     MutationObserverInterestGroup(HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&&, MutationRecordDeliveryOptions);
 

--- a/Source/WebCore/dom/MutationObserverRegistration.cpp
+++ b/Source/WebCore/dom/MutationObserverRegistration.cpp
@@ -36,8 +36,11 @@
 #include "JSNodeCustom.h"
 #include "QualifiedName.h"
 #include "WebCoreOpaqueRootInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MutationObserverRegistration);
 
 MutationObserverRegistration::MutationObserverRegistration(MutationObserver& observer, Node& node, MutationObserverOptions options, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter)
     : m_observer(observer)

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -34,6 +34,7 @@
 #include "MutationObserver.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
@@ -56,7 +57,7 @@ namespace WebCore {
 class QualifiedName;
 
 class MutationObserverRegistration : public CanMakeWeakPtr<MutationObserverRegistration> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MutationObserverRegistration);
 public:
     MutationObserverRegistration(MutationObserver&, Node&, MutationObserverOptions, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter);
     ~MutationObserverRegistration();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -109,7 +109,7 @@ WTF_MAKE_COMPACT_TZONE_OR_ISO_ALLOCATED_IMPL(Node);
 using namespace HTMLNames;
 
 struct SameSizeAsNode : EventTarget, CanMakeCheckedPtr<SameSizeAsNode> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SameSizeAsNode);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SameSizeAsNode);
 public:
 #if ASSERT_ENABLED

--- a/Source/WebCore/dom/NodeRareData.cpp
+++ b/Source/WebCore/dom/NodeRareData.cpp
@@ -32,8 +32,11 @@
 #include "NodeRareData.h"
 
 #include "Page.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NodeMutationObserverData);
 
 struct SameSizeAsNodeRareData {
     void* m_pointer[2];

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -31,6 +31,7 @@
 #include <new>
 #include <wtf/HashSet.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -213,7 +214,8 @@ private:
 };
 
 class NodeMutationObserverData {
-    WTF_MAKE_NONCOPYABLE(NodeMutationObserverData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NodeMutationObserverData);
+    WTF_MAKE_NONCOPYABLE(NodeMutationObserverData);
 public:
     Vector<std::unique_ptr<MutationObserverRegistration>> registry;
     WeakHashSet<MutationObserverRegistration> transientRegistry;

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -28,6 +28,7 @@
 #include "Element.h"
 #include "HTMLElement.h"
 #include "HTMLFormControlElement.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ struct PopoverToggleEventData {
 };
 
 class PopoverData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PopoverData);
 public:
     PopoverData() = default;
 

--- a/Source/WebCore/dom/QualifiedNameCache.cpp
+++ b/Source/WebCore/dom/QualifiedNameCache.cpp
@@ -29,8 +29,11 @@
 
 #include "Namespace.h"
 #include "NodeName.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(QualifiedNameCache);
 
 struct QNameComponentsTranslator {
     static unsigned hash(const QualifiedNameComponents& components)

--- a/Source/WebCore/dom/QualifiedNameCache.h
+++ b/Source/WebCore/dom/QualifiedNameCache.h
@@ -34,6 +34,7 @@
 #include "XMLNames.h"
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(MATHML)
 #include "MathMLNames.h"
@@ -45,7 +46,7 @@ enum class NodeName : uint16_t;
 namespace WebCore {
 
 class QualifiedNameCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(QualifiedNameCache);
 public:
     QualifiedNameCache() = default;
 

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -24,12 +24,15 @@
 #include "HTMLInputElement.h"
 #include "Range.h"
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RadioButtonGroups);
+
 class RadioButtonGroup {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RadioButtonGroup);
 public:
     bool isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
     bool isRequired() const { return m_requiredCount; }

--- a/Source/WebCore/dom/RadioButtonGroups.h
+++ b/Source/WebCore/dom/RadioButtonGroups.h
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -31,7 +32,7 @@ class HTMLInputElement;
 class RadioButtonGroup;
 
 class RadioButtonGroups {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RadioButtonGroups);
 public:
     RadioButtonGroups();
     ~RadioButtonGroups();

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -42,7 +42,7 @@ class TrustedHTML;
 struct SimpleRange;
 
 class Range final : public AbstractRange, public CanMakeSingleThreadWeakPtr<Range> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Range);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(Range, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(Range);
 public:
     WEBCORE_EXPORT static Ref<Range> create(Document&);

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -46,10 +46,13 @@
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
 #include <JavaScriptCore/WeakInlines.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 using namespace JSC;
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RejectedPromiseTracker);
 
 class UnhandledPromise {
     WTF_MAKE_NONCOPYABLE(UnhandledPromise);

--- a/Source/WebCore/dom/RejectedPromiseTracker.h
+++ b/Source/WebCore/dom/RejectedPromiseTracker.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
 
@@ -46,8 +47,8 @@ class ScriptExecutionContext;
 class UnhandledPromise;
 
 class RejectedPromiseTracker final : public CanMakeCheckedPtr<RejectedPromiseTracker> {
+    WTF_MAKE_TZONE_ALLOCATED(RejectedPromiseTracker);
     WTF_MAKE_NONCOPYABLE(RejectedPromiseTracker);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RejectedPromiseTracker);
 public:
     explicit RejectedPromiseTracker(ScriptExecutionContext&, JSC::VM&);

--- a/Source/WebCore/dom/ScopedEventQueue.cpp
+++ b/Source/WebCore/dom/ScopedEventQueue.cpp
@@ -34,8 +34,11 @@
 #include "Event.h"
 #include "Node.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScopedEventQueue);
 
 ScopedEventQueue& ScopedEventQueue::singleton()
 {

--- a/Source/WebCore/dom/ScopedEventQueue.h
+++ b/Source/WebCore/dom/ScopedEventQueue.h
@@ -34,6 +34,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -42,7 +43,8 @@ class Event;
 class EventQueueScope;
 
 class ScopedEventQueue {
-    WTF_MAKE_NONCOPYABLE(ScopedEventQueue); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScopedEventQueue);
+    WTF_MAKE_NONCOPYABLE(ScopedEventQueue);
 public:
     static ScopedEventQueue& singleton();
 

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -85,6 +85,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/Ref.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -101,7 +102,7 @@ static HashMap<ScriptExecutionContextIdentifier, ScriptExecutionContext*>& allSc
 }
 
 struct ScriptExecutionContext::PendingException {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PendingException);
 public:
     PendingException(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, RefPtr<ScriptCallStack>&& callStack)
         : m_errorMessage(errorMessage)

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -46,6 +46,7 @@
 #include <wtf/NativePromise.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -213,7 +214,7 @@ public:
     WEBCORE_EXPORT void derefAllowingPartiallyDestroyed();
 
     class Task {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(Task);
     public:
         enum CleanupTaskTag { CleanupTask };
 

--- a/Source/WebCore/dom/ScriptRunner.cpp
+++ b/Source/WebCore/dom/ScriptRunner.cpp
@@ -31,8 +31,11 @@
 #include "Element.h"
 #include "PendingScript.h"
 #include "ScriptElement.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScriptRunner);
 
 ScriptRunner::ScriptRunner(Document& document)
     : m_document(document)

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -30,6 +30,7 @@
 #include "Timer.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
 
@@ -41,8 +42,8 @@ class LoadableScript;
 class WeakPtrImplWithEventTargetData;
 
 class ScriptRunner final : public PendingScriptClient, public CanMakeCheckedPtr<ScriptRunner> {
+    WTF_MAKE_TZONE_ALLOCATED(ScriptRunner);
     WTF_MAKE_NONCOPYABLE(ScriptRunner);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScriptRunner);
 public:
     explicit ScriptRunner(Document&);

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -40,8 +40,12 @@
 #include "StyledElement.h"
 #include "TreeScopeInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SelectorQuery);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SelectorQueryCache);
 
 #if ASSERT_ENABLED
 static bool isSingleTagNameSelector(const CSSSelector& selector)

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -32,6 +32,7 @@
 #include "SecurityOriginData.h"
 #include "SelectorCompiler.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -97,8 +98,8 @@ private:
 };
 
 class SelectorQuery {
+    WTF_MAKE_TZONE_ALLOCATED(SelectorQuery);
     WTF_MAKE_NONCOPYABLE(SelectorQuery);
-    WTF_MAKE_FAST_ALLOCATED;
 
 public:
     explicit SelectorQuery(CSSSelectorList&&);
@@ -116,7 +117,7 @@ private:
 };
 
 class SelectorQueryCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SelectorQueryCache);
 public:
     static SelectorQueryCache& singleton();
 

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -31,8 +31,13 @@
 #include "RenderTreeUpdater.h"
 #include "ShadowRoot.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SlotAssignment);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NamedSlotAssignment);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NamedSlotAssignmentSlot, NamedSlotAssignment::Slot);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -28,6 +28,7 @@
 #include "ShadowRoot.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -42,7 +43,8 @@ class HTMLSlotElement;
 class Node;
 
 class SlotAssignment {
-    WTF_MAKE_NONCOPYABLE(SlotAssignment); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SlotAssignment);
+    WTF_MAKE_NONCOPYABLE(SlotAssignment);
 public:
     SlotAssignment() = default;
     virtual ~SlotAssignment() = default;
@@ -76,7 +78,8 @@ protected:
 };
 
 class NamedSlotAssignment : public SlotAssignment {
-    WTF_MAKE_NONCOPYABLE(NamedSlotAssignment); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NamedSlotAssignment);
+    WTF_MAKE_NONCOPYABLE(NamedSlotAssignment);
 public:
     NamedSlotAssignment();
     virtual ~NamedSlotAssignment();
@@ -105,7 +108,7 @@ private:
     void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue, ShadowRoot&) final;
 
     struct Slot {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Slot);
     public:
         bool hasSlotElements() { return !!elementCount; }
         bool hasDuplicatedSlotElements() { return elementCount > 1; }

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -23,9 +23,12 @@
 
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpaceSplitStringData);
 
 static_assert(!(sizeof(SpaceSplitStringData) % sizeof(uintptr_t)), "SpaceSplitStringDataTail is aligned to WordSize");
 

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -21,13 +21,14 @@
 #pragma once
 
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class SpaceSplitStringData {
+    WTF_MAKE_TZONE_ALLOCATED(SpaceSplitStringData);
     WTF_MAKE_NONCOPYABLE(SpaceSplitStringData);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     static RefPtr<SpaceSplitStringData> create(const AtomString&);
 

--- a/Source/WebCore/dom/TransformSource.h
+++ b/Source/WebCore/dom/TransformSource.h
@@ -22,9 +22,9 @@
 #if ENABLE(XSLT)
 
 #include <libxml/tree.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -32,7 +32,8 @@ namespace WebCore {
 typedef xmlDocPtr PlatformTransformSource;
 
 class TransformSource {
-    WTF_MAKE_NONCOPYABLE(TransformSource); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(TransformSource);
+    WTF_MAKE_NONCOPYABLE(TransformSource);
 public:
     explicit TransformSource(const PlatformTransformSource&);
     ~TransformSource();

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -39,8 +39,11 @@
 #include "HTMLNameCollection.h"
 #include "TreeScopeInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TreeScopeOrderedMap);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -33,6 +33,7 @@
 #include "Element.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -45,7 +46,7 @@ class HTMLMapElement;
 class TreeScope;
 
 class TreeScopeOrderedMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TreeScopeOrderedMap);
 public:
     void add(const AtomString&, Element&, const TreeScope&);
     void remove(const AtomString&, Element&);

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -34,8 +34,11 @@
 #include "SecurityOrigin.h"
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserGestureIndicator);
 
 static RefPtr<UserGestureToken>& currentToken()
 {

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -30,6 +30,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
@@ -125,7 +126,7 @@ private:
 };
 
 class UserGestureIndicator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(UserGestureIndicator, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(UserGestureIndicator);
 public:
     WEBCORE_EXPORT static RefPtr<UserGestureToken> currentUserGesture();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -50,9 +50,14 @@
 #include "StyleScope.h"
 #include "Styleable.h"
 #include "WebAnimation.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CapturedElement);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewTransitionParams);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewTransition);
 
 static std::pair<Ref<DOMPromise>, Ref<DeferredPromise>> createPromiseAndWrapper(Document& document)
 {

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -37,6 +37,7 @@
 #include "ViewTransitionUpdateCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -56,7 +57,7 @@ enum class ViewTransitionPhase : uint8_t {
 };
 
 struct CapturedElement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CapturedElement);
 public:
     // std::nullopt represents an non-capturable element.
     // nullptr represents an absent snapshot on an capturable element.
@@ -141,7 +142,7 @@ private:
 };
 
 struct ViewTransitionParams {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ViewTransitionParams);
 public:
 
     OrderedNamedElementsMap namedElements;
@@ -150,6 +151,7 @@ public:
 };
 
 class ViewTransition : public RefCounted<ViewTransition>, public CanMakeWeakPtr<ViewTransition>, public ActiveDOMObject {
+    WTF_MAKE_TZONE_ALLOCATED(ViewTransition);
 public:
     static Ref<ViewTransition> createSamePage(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     static RefPtr<ViewTransition> resolveInboundCrossDocumentViewTransition(Document&, std::unique_ptr<ViewTransitionParams>);

--- a/Source/WebCore/dom/VisitedLinkState.cpp
+++ b/Source/WebCore/dom/VisitedLinkState.cpp
@@ -40,8 +40,11 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "VisitedLinkStore.h"
 #include "XLinkNames.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VisitedLinkState);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -33,6 +33,7 @@
 #include "SharedStringHash.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -40,7 +41,7 @@ namespace WebCore {
 class Document;
 
 class VisitedLinkState final : public CanMakeCheckedPtr<VisitedLinkState> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VisitedLinkState);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VisitedLinkState);
 public:
     explicit VisitedLinkState(Document&);

--- a/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
+++ b/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
@@ -32,6 +32,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "Supplementable.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/ASCIILiteral.h>
 #include "TrustedTypePolicyFactory.h"
 #include "WorkerGlobalScope.h"
@@ -39,7 +40,7 @@
 namespace WebCore {
 
 class DOMWindowTrustedTypes : public Supplement<LocalDOMWindow>, public LocalDOMWindowProperty {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMWindowTrustedTypes);
 public:
     explicit DOMWindowTrustedTypes(LocalDOMWindow&);
     virtual ~DOMWindowTrustedTypes() = default;
@@ -85,7 +86,7 @@ TrustedTypePolicyFactory* WindowOrWorkerGlobalScopeTrustedTypes::trustedTypes(DO
 }
 
 class WorkerGlobalScopeTrustedTypes : public Supplement<WorkerGlobalScope> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WorkerGlobalScopeTrustedTypes);
 public:
     explicit WorkerGlobalScopeTrustedTypes(WorkerGlobalScope&);
     virtual ~WorkerGlobalScopeTrustedTypes() = default;

--- a/Source/WebCore/dom/WritingSuggestionData.h
+++ b/Source/WebCore/dom/WritingSuggestionData.h
@@ -25,12 +25,13 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class WritingSuggestionData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WritingSuggestionData);
 public:
     WritingSuggestionData(String&& content, String&& currentText, uint64_t&& offset, String&& originalPrefix, String&& originalSuffix, bool supportsSuffix)
         : m_content(WTFMove(content))

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
@@ -29,8 +29,11 @@
 #include "Logging.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MessagePortChannelRegistry);
 
 MessagePortChannelRegistry::MessagePortChannelRegistry() = default;
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -30,14 +30,14 @@
 #include "MessagePortIdentifier.h"
 #include "ProcessIdentifier.h"
 #include <wtf/CheckedRef.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class MessagePortChannelRegistry final : public CanMakeWeakPtr<MessagePortChannelRegistry>, public CanMakeCheckedPtr<MessagePortChannelRegistry> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(MessagePortChannelRegistry, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MessagePortChannelRegistry);
 public:
     WEBCORE_EXPORT MessagePortChannelRegistry();

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp
@@ -31,8 +31,11 @@
 #include "WorkerThread.h"
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerMessagePortChannelProvider);
 
 WorkerMessagePortChannelProvider::WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope& scope)
     : m_scope(scope)

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -28,6 +28,7 @@
 #include "MessagePortChannelProvider.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ namespace WebCore {
 class WorkerOrWorkletGlobalScope;
 
 class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public CanMakeCheckedPtr<WorkerMessagePortChannelProvider> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerMessagePortChannelProvider);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerMessagePortChannelProvider);
 public:
     explicit WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope&);


### PR DESCRIPTION
#### 5cea2110013432776c168f43d114b14449ac0c61
<pre>
[TZone] WebCore/dom Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278835">https://bugs.webkit.org/show_bug.cgi?id=278835</a>
<a href="https://rdar.apple.com/134908276">rdar://134908276</a>

Reviewed by Yijia Huang.

Converted WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED (and related macros) in
preparation for enabling TZone (not yet enabled).

* Source/WebCore/dom/ConstantPropertyMap.cpp:
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
* Source/WebCore/dom/ContentVisibilityDocumentState.h:
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/dom/DeviceMotionController.cpp:
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h:
* Source/WebCore/dom/DeviceOrientationController.cpp:
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFontLoader.cpp:
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/DocumentMarkerController.cpp:
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
* Source/WebCore/dom/DocumentSharedObjectPool.h:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/EventContext.cpp:
* Source/WebCore/dom/EventContext.h:
* Source/WebCore/dom/EventLoop.cpp:
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/EventSender.h:
* Source/WebCore/dom/EventTarget.cpp:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/ExtensionStyleSheets.cpp:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/FullscreenManager.cpp:
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/IdTargetObserver.cpp:
* Source/WebCore/dom/IdTargetObserver.h:
* Source/WebCore/dom/IdTargetObserverRegistry.cpp:
* Source/WebCore/dom/IdTargetObserverRegistry.h:
* Source/WebCore/dom/IdleCallbackController.cpp:
* Source/WebCore/dom/IdleCallbackController.h:
* Source/WebCore/dom/Microtasks.cpp:
* Source/WebCore/dom/Microtasks.h:
* Source/WebCore/dom/MutationObserverInterestGroup.cpp:
* Source/WebCore/dom/MutationObserverInterestGroup.h:
* Source/WebCore/dom/MutationObserverRegistration.cpp:
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/dom/NodeRareData.cpp:
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/dom/PopoverData.h:
* Source/WebCore/dom/QualifiedNameCache.cpp:
* Source/WebCore/dom/QualifiedNameCache.h:
* Source/WebCore/dom/RadioButtonGroups.cpp:
* Source/WebCore/dom/RadioButtonGroups.h:
* Source/WebCore/dom/Range.h:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
* Source/WebCore/dom/RejectedPromiseTracker.h:
* Source/WebCore/dom/ScopedEventQueue.cpp:
* Source/WebCore/dom/ScopedEventQueue.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptRunner.cpp:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/SelectorQuery.cpp:
* Source/WebCore/dom/SelectorQuery.h:
* Source/WebCore/dom/SlotAssignment.cpp:
* Source/WebCore/dom/SlotAssignment.h:
* Source/WebCore/dom/SpaceSplitString.cpp:
* Source/WebCore/dom/SpaceSplitString.h:
* Source/WebCore/dom/TransformSource.h:
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
* Source/WebCore/dom/TreeScopeOrderedMap.h:
* Source/WebCore/dom/UserGestureIndicator.cpp:
* Source/WebCore/dom/UserGestureIndicator.h:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/dom/VisitedLinkState.cpp:
* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp:
* Source/WebCore/dom/WritingSuggestionData.h:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/282910@main">https://commits.webkit.org/282910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092ed21f9ee7bbdcb97be067e604b7bc33009b18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51945 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10473 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13257 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14055 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59245 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13587 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70296 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59272 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55967 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59448 "Found 2 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14254 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/717 "Passed tests") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/9796 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->