### PR TITLE
[TZone] WebCore/rendering Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -34,8 +34,11 @@
 #include "RenderStyleInlines.h"
 #include "RenderText.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AccessibilityRegionContext);
 
 AccessibilityRegionContext::~AccessibilityRegionContext()
 {

--- a/Source/WebCore/rendering/AccessibilityRegionContext.h
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.h
@@ -28,6 +28,7 @@
 #include "InlineIteratorTextBox.h"
 #include "LayoutRect.h"
 #include "RegionContext.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -37,7 +38,7 @@ class RenderText;
 class RenderView;
 
 class AccessibilityRegionContext final : public RegionContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AccessibilityRegionContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AccessibilityRegionContext);
 public:
     AccessibilityRegionContext() = default;

--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -29,8 +29,12 @@
 #include "BaselineAlignmentInlines.h"
 #include "RenderBox.h"
 #include "RenderStyleInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BaselineGroup);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BaselineAlignmentState);
 
 BaselineGroup::BaselineGroup(BlockFlowDirection blockFlow, ItemPosition childPreference)
     : m_maxAscent(0), m_items()

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -27,6 +27,7 @@
 #include "LayoutUnit.h"
 #include "RenderStyleConstants.h"
 #include "WritingMode.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -48,6 +49,7 @@ class RenderBox;
 // (first/last baseline), it's ready to collect the items that will participate in the Baseline Alignment logic.
 //
 class BaselineGroup {
+    WTF_MAKE_TZONE_ALLOCATED(BaselineGroup);
 public:
     // It stores an item (if not already present) and update the max_ascent associated to this
     // baseline-sharing group.
@@ -94,7 +96,7 @@ private:
 // if there is one that is compatible with such item. Otherwise, a new baseline-sharing group is created,
 // compatible with the new item.
 class BaselineAlignmentState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BaselineAlignmentState);
 public:
     BaselineAlignmentState(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
     const BaselineGroup& sharedGroup(const RenderBox& child, ItemPosition preference) const;

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -39,8 +39,11 @@
 #include "SVGFilter.h"
 #include "SVGFilterElement.h"
 #include "SourceGraphic.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFilter);
 
 RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperations& operations, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
 {

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -27,6 +27,7 @@
 
 #include "Filter.h"
 #include "LengthBox.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class GraphicsContext;
 class RenderElement;
 
 class CSSFilter final : public Filter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CSSFilter);
 public:
     static RefPtr<CSSFilter> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     WEBCORE_EXPORT static Ref<CSSFilter> create(Vector<Ref<FilterFunction>>&&);

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -35,9 +35,12 @@
 #include "RenderStyleInlines.h"
 #include "SimpleRange.h"
 #include "WindRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventRegionContext);
 
 EventRegionContext::EventRegionContext(EventRegion& eventRegion)
     : m_eventRegion(eventRegion)

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -38,6 +38,7 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -48,7 +49,7 @@ class RenderObject;
 class RenderStyle;
 
 class EventRegionContext final : public RegionContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(EventRegionContext, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventRegionContext);
 public:
     WEBCORE_EXPORT explicit EventRegionContext(EventRegion&);

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -29,8 +29,15 @@
 #include "RenderBox.h"
 #include "RenderView.h"
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
+
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(FloatingObjectTree);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FloatingObject);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FloatingObjects);
+
 
 struct SameSizeAsFloatingObject {
     SingleThreadWeakPtr<RenderBox> renderer;

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -25,6 +25,7 @@
 
 #include "LegacyRootInlineBox.h"
 #include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -37,7 +38,8 @@ template<typename, typename> class PODInterval;
 template<typename, typename> class PODIntervalTree;
 
 class FloatingObject {
-    WTF_MAKE_NONCOPYABLE(FloatingObject); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FloatingObject);
+    WTF_MAKE_NONCOPYABLE(FloatingObject);
 public:
     // Note that Type uses bits so you can use FloatLeftRight as a mask to query for both left and right.
     enum Type { FloatLeft = 1, FloatRight = 2, FloatLeftRight = 3 };
@@ -144,7 +146,8 @@ typedef PODIntervalTree<LayoutUnit, FloatingObject*> FloatingObjectTree;
 // FIXME: This is really the same thing as FloatingObjectSet.
 // Change clients to use that set directly, and replace the moveAllToFloatInfoMap function with a takeSet function.
 class FloatingObjects {
-    WTF_MAKE_NONCOPYABLE(FloatingObjects); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FloatingObjects);
+    WTF_MAKE_NONCOPYABLE(FloatingObjects);
 public:
     explicit FloatingObjects(const RenderBlockFlow&);
     ~FloatingObjects();

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -32,8 +32,12 @@
 #include "PaintInfo.h"
 #include "RenderLayer.h"
 #include "RenderStyleInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GlyphDisplayListCacheEntry);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GlyphDisplayListCache);
 
 struct GlyphDisplayListCacheKey {
     GlyphDisplayListCacheKey(const TextRun& textRun, const FontCascade& font, const GraphicsContext& context)

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -34,6 +34,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ struct Box;
 }
 
 class GlyphDisplayListCacheEntry : public RefCounted<GlyphDisplayListCacheEntry>, public CanMakeSingleThreadWeakPtr<GlyphDisplayListCacheEntry> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GlyphDisplayListCacheEntry);
     friend struct GlyphDisplayListCacheKeyTranslator;
     friend void add(Hasher&, const GlyphDisplayListCacheEntry&);
 public:
@@ -101,7 +102,7 @@ struct GlyphDisplayListCacheEntryHash {
 };
 
 class GlyphDisplayListCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GlyphDisplayListCache);
     friend class GlyphDisplayListCacheEntry;
 public:
     GlyphDisplayListCache() = default;

--- a/Source/WebCore/rendering/GridLayoutState.cpp
+++ b/Source/WebCore/rendering/GridLayoutState.cpp
@@ -26,8 +26,11 @@
 
 #include "config.h"
 #include "GridLayoutState.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GridLayoutState);
 
 bool GridLayoutState::containsLayoutRequirementForGridItem(const RenderBox& gridItem, ItemLayoutRequirement layoutRequirement) const
 {

--- a/Source/WebCore/rendering/GridLayoutState.h
+++ b/Source/WebCore/rendering/GridLayoutState.h
@@ -27,6 +27,7 @@
 
 #include "RenderBox.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -37,6 +38,7 @@ enum class ItemLayoutRequirement : uint8_t {
 using ItemsLayoutRequirements = SingleThreadWeakHashMap<RenderBox, OptionSet<ItemLayoutRequirement>>;
 
 class GridLayoutState {
+    WTF_MAKE_TZONE_ALLOCATED(GridLayoutState);
 public:
     bool containsLayoutRequirementForGridItem(const RenderBox& gridItem, ItemLayoutRequirement) const;
     void setLayoutRequirementForGridItem(const RenderBox& gridItem, ItemLayoutRequirement);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -36,8 +36,13 @@
 #include "RenderStyleConstants.h"
 #include "StyleSelfAlignmentData.h"
 #include <wtf/StdMap.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GridTrack);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GridTrackSizingAlgorithm);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GridTrackSizingAlgorithmStrategy);
 
 GridTrackSizingAlgorithm::GridTrackSizingAlgorithm(const RenderGrid* renderGrid, Grid& grid)
     : m_grid(grid)

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -32,6 +32,7 @@
 #include "LayoutSize.h"
 #include "RenderBoxInlines.h"
 #include <wtf/StdMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class GridTrack;
@@ -71,6 +72,7 @@ class GridTrackSizingAlgorithmStrategy;
 class GridItemWithSpan;
 
 class GridTrack : public CanMakeWeakPtr<GridTrack> {
+    WTF_MAKE_TZONE_ALLOCATED(GridTrack);
 public:
     GridTrack() = default;
 
@@ -116,6 +118,7 @@ private:
 };
 
 class GridTrackSizingAlgorithm final {
+    WTF_MAKE_TZONE_ALLOCATED(GridTrackSizingAlgorithm);
     friend class GridTrackSizingAlgorithmStrategy;
     friend class DefiniteSizeStrategy;
 
@@ -353,7 +356,7 @@ private:
 };
 
 class GridTrackSizingAlgorithmStrategy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GridTrackSizingAlgorithmStrategy);
 public:
     virtual LayoutUnit minContentContributionForGridItem(RenderBox&, GridLayoutState&) const;
     LayoutUnit maxContentContributionForGridItem(RenderBox&, GridLayoutState&) const;

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -54,6 +54,7 @@
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
 #include "XLinkNames.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
@@ -62,6 +63,8 @@
 namespace WebCore {
 
 using namespace HTMLNames;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HitTestResult);
 
 static inline void appendToNodeSet(const HitTestResult::NodeSet& source, HitTestResult::NodeSet& destination)
 {

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -26,6 +26,7 @@
 #include "HitTestRequest.h"
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ class Scrollbar;
 enum class HitTestProgress { Stop, Continue };
 
 class HitTestResult {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(HitTestResult, WEBCORE_EXPORT);
 public:
     using NodeSet = ListHashSet<Ref<Node>>;
 

--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -32,8 +32,11 @@
 #include "RenderBoxModelObject.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageQualityController);
 
 static const double cInterpolationCutoff = 800. * 800.;
 static const Seconds lowQualityTimeThreshold { 500_ms };

--- a/Source/WebCore/rendering/ImageQualityController.h
+++ b/Source/WebCore/rendering/ImageQualityController.h
@@ -28,6 +28,7 @@
 #include "GraphicsTypes.h"
 #include "Timer.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,7 +40,8 @@ class RenderView;
 class RenderStyle;
 
 class ImageQualityController {
-    WTF_MAKE_NONCOPYABLE(ImageQualityController); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ImageQualityController);
+    WTF_MAKE_NONCOPYABLE(ImageQualityController);
 public:
     explicit ImageQualityController(const RenderView&);
 

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
@@ -29,9 +29,12 @@
 #include "GraphicsLayer.h"
 #include "ScrollingConstraints.h"
 #include "ScrollingCoordinator.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerAncestorClippingStack);
 
 LayerAncestorClippingStack::LayerAncestorClippingStack(Vector<CompositedClipData>&& clipDataStack)
     : m_stack(WTF::map(WTFMove(clipDataStack), [](CompositedClipData&& clipDataEntry) { return ClippingStackEntry { WTFMove(clipDataEntry), { }, nullptr, nullptr }; }))

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -28,6 +28,7 @@
 #include "LayoutRect.h"
 #include "RenderLayer.h"
 #include "ScrollTypes.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -58,7 +59,7 @@ struct CompositedClipData {
 // This class encapsulates the set of layers and their scrolling tree nodes representing clipping in the layer's containing block ancestry,
 // but not in its paint order ancestry.
 class LayerAncestorClippingStack {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LayerAncestorClippingStack);
 public:
     LayerAncestorClippingStack(Vector<CompositedClipData>&&);
     ~LayerAncestorClippingStack() = default;

--- a/Source/WebCore/rendering/LayerOverlapMap.cpp
+++ b/Source/WebCore/rendering/LayerOverlapMap.cpp
@@ -27,6 +27,7 @@
 #include "LayerOverlapMap.h"
 #include "Logging.h"
 #include "RenderLayer.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -72,7 +73,7 @@ static TextStream& operator<<(TextStream& ts, const RectList& rectList)
 // Checking for overlap involves finding the node for the clipping layer enclosing the given layer (or the root),
 // and comparing against the bounds of earlier siblings.
 class OverlapMapContainer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(OverlapMapContainer);
 public:
     OverlapMapContainer(const RenderLayer& rootLayer, const RenderLayer& scopeLayer)
         : m_rootScope(rootLayer)

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -50,8 +50,11 @@
 #include "SVGRootInlineBox.h"
 #include "Settings.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyLineLayout);
 
 LegacyLineLayout::LegacyLineLayout(RenderBlockFlow& flow)
     : m_flow(flow)

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -30,6 +30,7 @@
 #include "RenderLineBoxList.h"
 #include "RenderStyleConstants.h"
 #include "TrailingObjects.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -49,7 +50,7 @@ struct WordMeasurement;
 template <class Run> class BidiRunList;
 
 class LegacyLineLayout {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyLineLayout);
 public:
     LegacyLineLayout(RenderBlockFlow&);
     ~LegacyLineLayout();

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -23,7 +23,7 @@
 #include "BidiContext.h"
 #include "LegacyInlineFlowBox.h"
 #include "RenderBox.h"
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/PaintFrequencyTracker.h
+++ b/Source/WebCore/rendering/PaintFrequencyTracker.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
 
 // This class is used to detect when we are painting frequently so that - even in a painting model
@@ -32,7 +34,7 @@ namespace WebCore {
 // animating. Once we transition fully to display lists, we can probably just pull from the previous
 // paint's display list if it is still around and get rid of this code.
 class PaintFrequencyTracker {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PaintFrequencyTracker);
 
 public:
     PaintFrequencyTracker() = default;

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "SVGNames.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>

--- a/Source/WebCore/rendering/RegionContext.cpp
+++ b/Source/WebCore/rendering/RegionContext.cpp
@@ -27,8 +27,11 @@
 #include "RegionContext.h"
 
 #include "Path.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RegionContext);
 
 void RegionContext::pushTransform(const AffineTransform& transform)
 {

--- a/Source/WebCore/rendering/RegionContext.h
+++ b/Source/WebCore/rendering/RegionContext.h
@@ -28,6 +28,7 @@
 #include "AffineTransform.h"
 #include "IntRect.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ namespace WebCore {
 class Path;
 
 class RegionContext : public CanMakeCheckedPtr<RegionContext> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RegionContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RegionContext);
 public:
     virtual ~RegionContext() = default;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -246,7 +246,8 @@ using ContinuationOutlineTableMap = HashMap<SingleThreadWeakRef<RenderBlock>, st
 // Allocated only when some of these fields have non-default values
 
 struct RenderBlockRareData {
-    WTF_MAKE_NONCOPYABLE(RenderBlockRareData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RenderBlockRareData);
+    WTF_MAKE_NONCOPYABLE(RenderBlockRareData);
 public:
     RenderBlockRareData()
     {

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -77,6 +77,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderBlockFlow);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderBlockFlowRareData);
 
 bool RenderBlock::s_canPropagateFloatIntoSibling = false;
 

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -30,6 +30,7 @@
 #include "RenderLineBoxList.h"
 #include "TrailingObjects.h"
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct RenderBlockFlowRareData;
@@ -88,7 +89,8 @@ private:
 
 // Allocated only when some of these fields have non-default values
 struct RenderBlockFlowRareData {
-    WTF_MAKE_NONCOPYABLE(RenderBlockFlowRareData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderBlockFlowRareData);
+    WTF_MAKE_NONCOPYABLE(RenderBlockFlowRareData);
 public:
     RenderBlockFlowRareData(const RenderBlockFlow&);
     ~RenderBlockFlowRareData();

--- a/Source/WebCore/rendering/RenderBoxFragmentInfo.h
+++ b/Source/WebCore/rendering/RenderBoxFragmentInfo.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "RenderOverflow.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class RenderBoxFragmentInfo {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RenderBoxFragmentInfo);
     WTF_MAKE_NONCOPYABLE(RenderBoxFragmentInfo);
 public:
     RenderBoxFragmentInfo(LayoutUnit logicalLeft, LayoutUnit logicalWidth, bool isShifted)

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -53,6 +53,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderFragmentedFlow);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(FragmentIntervalTree);
 
 RenderFragmentedFlow::RenderFragmentedFlow(Type type, Document& document, RenderStyle&& style)
     : RenderBlockFlow(type, document, WTFMove(style), BlockFlowFlag::IsFragmentedFlow)

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -46,6 +46,7 @@ class LegacyRootInlineBox;
 typedef SingleThreadWeakListHashSet<RenderFragmentContainer> RenderFragmentContainerList;
 typedef Vector<SingleThreadWeakPtr<RenderLayer>> RenderLayerList;
 typedef HashMap<const LegacyRootInlineBox*, SingleThreadWeakPtr<RenderFragmentContainer>> ContainingFragmentMap;
+typedef PODIntervalTree<LayoutUnit, SingleThreadWeakPtr<RenderFragmentContainer>> FragmentIntervalTree;
 
 // RenderFragmentedFlow is used to collect all the render objects that participate in a
 // flow thread. It will also help in doing the layout. However, it will not render
@@ -250,7 +251,6 @@ protected:
     RenderBoxToFragmentMap m_breakBeforeToFragmentMap;
     RenderBoxToFragmentMap m_breakAfterToFragmentMap;
 
-    using FragmentIntervalTree = PODIntervalTree<LayoutUnit, SingleThreadWeakPtr<RenderFragmentContainer>>;
     FragmentIntervalTree m_fragmentIntervalTree;
 
     CurrentRenderFragmentContainerMaintainer* m_currentFragmentMaintainer;

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -31,6 +31,7 @@
 #include "GridMasonryLayout.h"
 #include "GridTrackSizingAlgorithm.h"
 #include "RenderBlock.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -29,7 +29,6 @@
 #include "CachedResourceHandle.h"
 #include "StyleImage.h"
 #include <wtf/CheckedPtr.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -162,7 +162,7 @@ namespace WebCore {
 using namespace HTMLNames;
 
 class ClipRects : public RefCounted<ClipRects> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ClipRects);
 public:
     static Ref<ClipRects> create()
     {
@@ -239,7 +239,7 @@ private:
 };
 
 class ClipRectsCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ClipRectsCache);
 public:
     ClipRectsCache()
     {

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -84,6 +84,7 @@
 #include "TiledBacking.h"
 #include "ViewTransition.h"
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
@@ -109,6 +110,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerBacking);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -32,6 +32,7 @@
 #include "RenderLayer.h"
 #include "RenderLayerCompositor.h"
 #include "ScrollingCoordinator.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
 
 namespace WebCore {
@@ -57,7 +58,8 @@ enum CompositingLayerType {
 // There is one RenderLayerBacking for each RenderLayer that is composited.
 
 class RenderLayerBacking final : public GraphicsLayerClient {
-    WTF_MAKE_NONCOPYABLE(RenderLayerBacking); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderLayerBacking);
+    WTF_MAKE_NONCOPYABLE(RenderLayerBacking);
 public:
     explicit RenderLayerBacking(RenderLayer&);
     ~RenderLayerBacking();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -82,6 +82,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -109,6 +110,12 @@
 #endif
 
 namespace WebCore {
+
+#if PLATFORM(IOS_FAMILY)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyWebKitScrollingLayerCoordinator);
+#endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerCompositor);
 
 #if !USE(COMPOSITING_FOR_SMALL_CANVASES)
 static const int canvasAreaThresholdRequiringCompositing = 50 * 100;

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -32,6 +32,7 @@
 #include <pal/HysteresisActivity.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -109,7 +110,7 @@ static constexpr OptionSet<ScrollCoordinationRole> allScrollCoordinationRoles()
 
 #if PLATFORM(IOS_FAMILY)
 class LegacyWebKitScrollingLayerCoordinator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyWebKitScrollingLayerCoordinator);
 public:
     LegacyWebKitScrollingLayerCoordinator(ChromeClient& chromeClient, bool coordinateViewportConstrainedLayers)
         : m_chromeClient(chromeClient)
@@ -151,7 +152,7 @@ private:
 // There is one RenderLayerCompositor per RenderView.
 
 class RenderLayerCompositor final : public GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderLayerCompositor);
     friend class LegacyWebKitScrollingLayerCoordinator;
 public:
     explicit RenderLayerCompositor(RenderView&);

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -40,8 +40,11 @@
 #include "RenderSVGShape.h"
 #include "RenderStyleInlines.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerFilters);
 
 RenderLayerFilters::RenderLayerFilters(RenderLayer& layer)
     : m_layer(layer)

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -34,6 +34,7 @@
 #include "CachedSVGDocumentClient.h"
 #include "FilterRenderingMode.h"
 #include "RenderLayer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ class FilterOperations;
 class GraphicsContextSwitcher;
 
 class RenderLayerFilters final : private CachedSVGDocumentClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderLayerFilters);
 public:
     explicit RenderLayerFilters(RenderLayer&);
     virtual ~RenderLayerFilters();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -78,9 +78,12 @@
 #include "ScrollingCoordinator.h"
 #include "ShadowRoot.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerScrollableArea);
 
 RenderLayerScrollableArea::RenderLayerScrollableArea(RenderLayer& layer)
     : m_layer(layer)

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -46,13 +46,14 @@
 
 #include "RenderLayer.h"
 #include "ScrollableArea.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderMarquee;
 
 class RenderLayerScrollableArea final : public ScrollableArea, public CanMakeCheckedPtr<RenderLayerScrollableArea> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderLayerScrollableArea);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayerScrollableArea);
 public:
     explicit RenderLayerScrollableArea(RenderLayer&);

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -34,9 +34,12 @@
 #include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayoutState);
 
 RenderLayoutState::RenderLayoutState(RenderElement& renderer)
     : m_clipped(false)

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -29,6 +29,7 @@
 #include "LocalFrameViewLayoutContext.h"
 #include "StyleTextEdge.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -41,7 +42,8 @@ class RenderMultiColumnFlow;
 class RenderObject;
 
 class RenderLayoutState {
-    WTF_MAKE_NONCOPYABLE(RenderLayoutState); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderLayoutState);
+    WTF_MAKE_NONCOPYABLE(RenderLayoutState);
 
 public:
     struct TextBoxTrim {

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -54,8 +54,11 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderMarquee);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -46,6 +46,7 @@
 #include "Length.h"
 #include "RenderStyleConstants.h"
 #include "Timer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -53,7 +54,8 @@ class RenderLayer;
 
 // This class handles the auto-scrolling for <marquee>
 class RenderMarquee final {
-    WTF_MAKE_NONCOPYABLE(RenderMarquee); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderMarquee);
+    WTF_MAKE_NONCOPYABLE(RenderMarquee);
 public:
     explicit RenderMarquee(RenderLayer*);
     ~RenderMarquee();

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -94,6 +94,7 @@ namespace WebCore {
 using namespace HTMLNames;
 
 WTF_MAKE_COMPACT_TZONE_OR_ISO_ALLOCATED_IMPL(RenderObject);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderObjectRenderObjectRareData, RenderObject::RenderObjectRareData);
 
 #if ASSERT_ENABLED
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1300,7 +1300,7 @@ private:
 
     // FIXME: This should be RenderElementRareData.
     class RenderObjectRareData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(RenderObjectRareData);
     public:
         RenderObjectRareData();
         ~RenderObjectRareData();

--- a/Source/WebCore/rendering/RenderOverflow.h
+++ b/Source/WebCore/rendering/RenderOverflow.h
@@ -23,6 +23,7 @@
 
 #include "LayoutRect.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore
 {
@@ -39,7 +40,8 @@ namespace WebCore
 
 // This object is allocated only when some of these fields have non-default values in the owning box.
 class RenderOverflow : public RefCounted<RenderOverflow> {
-    WTF_MAKE_NONCOPYABLE(RenderOverflow); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RenderOverflow);
+    WTF_MAKE_NONCOPYABLE(RenderOverflow);
 public:
     RenderOverflow(const LayoutRect& layoutRect, const LayoutRect& visualRect) 
         : m_layoutOverflow(layoutRect)

--- a/Source/WebCore/rendering/RenderSelectionGeometry.cpp
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.cpp
@@ -27,8 +27,11 @@
 #include "RenderSelectionGeometry.h"
 
 #include "RenderText.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderSelectionGeometryBase);
 
 RenderSelectionGeometryBase::RenderSelectionGeometryBase(RenderObject& renderer)
     : m_renderer(renderer)

--- a/Source/WebCore/rendering/RenderSelectionGeometry.h
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.h
@@ -27,11 +27,13 @@
 #include "GapRects.h"
 #include "RenderBlock.h"
 #include "RenderObject.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderSelectionGeometryBase {
-    WTF_MAKE_NONCOPYABLE(RenderSelectionGeometryBase); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderSelectionGeometryBase);
+    WTF_MAKE_NONCOPYABLE(RenderSelectionGeometryBase);
 public:
     explicit RenderSelectionGeometryBase(RenderObject& renderer);
     const RenderLayerModelObject* repaintContainer() const { return m_repaintContainer; }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -100,7 +100,7 @@ struct SameSizeAsRenderText : public RenderObject {
 static_assert(sizeof(RenderText) == sizeof(SameSizeAsRenderText), "RenderText should stay small");
 
 class SecureTextTimer final : private TimerBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SecureTextTimer);
 public:
     explicit SecureTextTimer(RenderText&);
     void restart(unsigned offsetAfterLastTypedCharacter);

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -41,8 +41,12 @@
 #include "Settings.h"
 #include "StyleResolver.h"
 #include "TextSizeAdjustment.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextAutoSizingValue);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextAutoSizing);
 
 static RenderStyle cloneRenderStyleWithState(const RenderStyle& currentStyle)
 {

--- a/Source/WebCore/rendering/TextAutoSizing.h
+++ b/Source/WebCore/rendering/TextAutoSizing.h
@@ -32,6 +32,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -92,7 +93,7 @@ struct TextAutoSizingHashTranslator {
 };
 
 class TextAutoSizingValue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextAutoSizingValue);
 public:
     TextAutoSizingValue() = default;
     ~TextAutoSizingValue();
@@ -115,7 +116,7 @@ struct TextAutoSizingTraits : HashTraits<TextAutoSizingKey> {
 };
 
 class TextAutoSizing {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextAutoSizing);
 public:
     TextAutoSizing() = default;
 

--- a/Source/WebCore/rendering/shapes/RasterShape.cpp
+++ b/Source/WebCore/rendering/shapes/RasterShape.cpp
@@ -31,8 +31,11 @@
 #include "RasterShape.h"
 
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RasterShapeIntervals);
 
 class MarginIntervalGenerator {
 public:

--- a/Source/WebCore/rendering/shapes/RasterShape.h
+++ b/Source/WebCore/rendering/shapes/RasterShape.h
@@ -33,12 +33,13 @@
 #include "Shape.h"
 #include "ShapeInterval.h"
 #include <wtf/Assertions.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class RasterShapeIntervals {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RasterShapeIntervals);
 public:
     explicit RasterShapeIntervals(unsigned size, int offset = 0)
         : m_intervals(clampTo<int>(size))

--- a/Source/WebCore/rendering/shapes/ShapeInterval.h
+++ b/Source/WebCore/rendering/shapes/ShapeInterval.h
@@ -29,13 +29,14 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 template <typename T>
 class ShapeInterval {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ShapeInterval);
 public:
     ShapeInterval()
         : m_x1(-1)

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -39,9 +39,13 @@
 #include "RenderFragmentContainer.h"
 #include "RenderImage.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ShapeOutsideDeltas);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ShapeOutsideInfo);
 
 static LayoutUnit logicalLeftOffset(const RenderBox&);
 static LayoutUnit logicalTopOffset(const RenderBox&);

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -33,6 +33,7 @@
 #include "Shape.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -44,6 +45,7 @@ class FloatingObject;
 Ref<const Shape> makeShapeForShapeOutside(const RenderBox&);
 
 class ShapeOutsideDeltas final {
+    WTF_MAKE_TZONE_ALLOCATED(ShapeOutsideDeltas);
 public:
     ShapeOutsideDeltas()
         : m_lineOverlapsShape(false)
@@ -81,7 +83,7 @@ private:
 };
 
 class ShapeOutsideInfo final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ShapeOutsideInfo);
 public:
     ShapeOutsideInfo(const RenderBox& renderer)
         : m_renderer(renderer)

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -44,10 +44,13 @@
 #include "SVGPathUtilities.h"
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TinyLRUCache.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicShape);
 
 void BasicShapeCenterCoordinate::updateComputedLength()
 {

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -35,6 +35,7 @@
 #include "WindRule.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 
@@ -55,7 +56,7 @@ enum class CoordinateAffinity : uint8_t {
 };
 
 class BasicShape : public RefCounted<BasicShape> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BasicShape);
 public:
     virtual ~BasicShape() = default;
 

--- a/Source/WebCore/rendering/style/ContentData.cpp
+++ b/Source/WebCore/rendering/style/ContentData.cpp
@@ -30,8 +30,11 @@
 #include "RenderStyle.h"
 #include "RenderTextFragment.h"
 #include "StyleInheritedData.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentData);
 
 std::unique_ptr<ContentData> ContentData::clone() const
 {

--- a/Source/WebCore/rendering/style/ContentData.h
+++ b/Source/WebCore/rendering/style/ContentData.h
@@ -27,6 +27,7 @@
 #include "CounterContent.h"
 #include "StyleImage.h"
 #include "RenderPtr.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ class RenderObject;
 class RenderStyle;
 
 class ContentData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentData);
 public:
     enum Type {
         CounterDataType,

--- a/Source/WebCore/rendering/style/CounterContent.h
+++ b/Source/WebCore/rendering/style/CounterContent.h
@@ -26,12 +26,13 @@
 
 #include "ListStyleType.h"
 #include "RenderStyleConstants.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class CounterContent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CounterContent);
 public:
     CounterContent(const AtomString& identifier, ListStyleType style, const AtomString& separator)
         : m_identifier(identifier)

--- a/Source/WebCore/rendering/style/FillLayer.cpp
+++ b/Source/WebCore/rendering/style/FillLayer.cpp
@@ -23,9 +23,12 @@
 #include "FillLayer.h"
 
 #include <wtf/PointerComparison.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FillLayer);
 
 struct SameSizeAsFillLayer : RefCounted<SameSizeAsFillLayer> {
     RefPtr<FillLayer> next;

--- a/Source/WebCore/rendering/style/FillLayer.h
+++ b/Source/WebCore/rendering/style/FillLayer.h
@@ -29,6 +29,7 @@
 #include "RenderStyleConstants.h"
 #include "StyleImage.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -60,7 +61,7 @@ struct FillRepeatXY {
 };
 
 class FillLayer : public RefCounted<FillLayer> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FillLayer);
 public:
     static Ref<FillLayer> create(FillLayerType);
     static Ref<FillLayer> create(const FillLayer&);

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -33,6 +33,7 @@
 
 #include "GridPosition.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -207,7 +208,7 @@ private:
 
 // This represents a grid area that spans in both rows' and columns' direction.
 class GridArea {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(GridArea);
 public:
     // HashMap requires a default constuctor.
     GridArea()

--- a/Source/WebCore/rendering/style/ShadowData.cpp
+++ b/Source/WebCore/rendering/style/ShadowData.cpp
@@ -23,9 +23,12 @@
 #include "ShadowData.h"
 
 #include <wtf/PointerComparison.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ShadowData);
 
 ShadowData::ShadowData(const ShadowData& o)
     : m_location(o.m_location.x(), o.m_location.y())

--- a/Source/WebCore/rendering/style/ShadowData.h
+++ b/Source/WebCore/rendering/style/ShadowData.h
@@ -30,6 +30,7 @@
 #include "LengthBox.h"
 #include "LengthPoint.h"
 #include "StyleColor.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ enum class ShadowStyle : uint8_t { Normal, Inset };
 // This class holds information about shadows for the text-shadow and box-shadow properties.
 
 class ShadowData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ShadowData);
 public:
     ShadowData() = default;
 

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -35,8 +35,11 @@
 #include "SVGResourceImage.h"
 #include "SVGSVGElement.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleCachedImage);
 
 Ref<StyleCachedImage> StyleCachedImage::create(Ref<CSSImageValue> cssValue, float scaleFactor)
 {

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -25,6 +25,7 @@
 
 #include "CachedResourceHandle.h"
 #include "StyleImage.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ class RenderSVGResourceContainer;
 class TreeScope;
 
 class StyleCachedImage final : public StyleImage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StyleCachedImage);
 public:
     static Ref<StyleCachedImage> create(Ref<CSSImageValue>, float scaleFactor = 1);
     static Ref<StyleCachedImage> copyOverridingScaleFactor(StyleCachedImage&, float scaleFactor);

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -37,8 +37,11 @@
 #include "StyleBuilderState.h"
 #include "StyleCachedImage.h"
 #include "StyleImageSet.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleCursorImage);
 
 Ref<StyleCursorImage> StyleCursorImage::create(Ref<StyleImage>&& image, const std::optional<IntPoint>& hotSpot, const URL& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
 { 

--- a/Source/WebCore/rendering/style/StyleCursorImage.h
+++ b/Source/WebCore/rendering/style/StyleCursorImage.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "StyleMultiImage.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class SVGCursorElement;
 enum class LoadedFromOpaqueSource : bool;
 
 class StyleCursorImage final : public StyleMultiImage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StyleCursorImage);
 public:
     static Ref<StyleCursorImage> create(Ref<StyleImage>&&, const std::optional<IntPoint>&, const URL&, LoadedFromOpaqueSource);
     virtual ~StyleCursorImage();

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
@@ -27,6 +27,7 @@
 #include "GeneratedImage.h"
 #include "RenderElement.h"
 #include "StyleResolver.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ static const Seconds timeToKeepCachedGeneratedImages { 3_s };
 // MARK: - CachedGeneratedImage
 
 class StyleGeneratedImage::CachedGeneratedImage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CachedGeneratedImage);
 public:
     CachedGeneratedImage(StyleGeneratedImage&, FloatSize, GeneratedImage&);
     GeneratedImage& image() const { return m_image; }

--- a/Source/WebCore/rendering/style/StyleImageSet.cpp
+++ b/Source/WebCore/rendering/style/StyleImageSet.cpp
@@ -32,8 +32,11 @@
 #include "MIMETypeRegistry.h"
 #include "Page.h"
 #include "StyleInvalidImage.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleImageSet);
 
 Ref<StyleImageSet> StyleImageSet::create(Vector<ImageWithScale>&& images, Vector<size_t>&& sortedIndices)
 {

--- a/Source/WebCore/rendering/style/StyleImageSet.h
+++ b/Source/WebCore/rendering/style/StyleImageSet.h
@@ -25,11 +25,12 @@
 #pragma once
 
 #include "StyleMultiImage.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class StyleImageSet final : public StyleMultiImage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StyleImageSet);
 public:
     static Ref<StyleImageSet> create(Vector<ImageWithScale>&&, Vector<size_t>&&);
     virtual ~StyleImageSet();

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -42,8 +42,11 @@
 #include "StyleGradientImage.h"
 #include "StyleNamedImage.h"
 #include "StylePaintImage.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleMultiImage);
 
 StyleMultiImage::StyleMultiImage(Type type)
     : StyleImage { type }

--- a/Source/WebCore/rendering/style/StyleMultiImage.h
+++ b/Source/WebCore/rendering/style/StyleMultiImage.h
@@ -26,6 +26,7 @@
 
 #include "StyleImage.h"
 #include "StyleInvalidImage.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ inline bool operator==(const ImageWithScale& a, const ImageWithScale& b)
 }
 
 class StyleMultiImage : public StyleImage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StyleMultiImage);
 public:
     virtual ~StyleMultiImage();
 

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "WillChangeData.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WillChangeData);
 
 bool WillChangeData::operator==(const WillChangeData& other) const
 {

--- a/Source/WebCore/rendering/style/WillChangeData.h
+++ b/Source/WebCore/rendering/style/WillChangeData.h
@@ -27,12 +27,13 @@
 
 #include "CSSPropertyNames.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class WillChangeData : public RefCounted<WillChangeData> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WillChangeData);
 public:
     static Ref<WillChangeData> create()
     {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 struct PatternData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PatternData);
 public:
     RefPtr<Pattern> pattern;
     AffineTransform transform;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
@@ -28,8 +28,11 @@
 #include "RenderView.h"
 #include "SVGRenderStyle.h"
 #include "SVGRenderSupport.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGResourceSolidColor);
 
 LegacyRenderSVGResourceSolidColor::LegacyRenderSVGResourceSolidColor() = default;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
@@ -22,13 +22,14 @@
 #include "Color.h"
 #include "FloatRect.h"
 #include "LegacyRenderSVGResource.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderObject;
 
 class LegacyRenderSVGResourceSolidColor final : public LegacyRenderSVGResource {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyRenderSVGResourceSolidColor);
 public:
     LegacyRenderSVGResourceSolidColor();
     virtual ~LegacyRenderSVGResourceSolidColor();

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -37,12 +37,15 @@
 #include "SVGURIReference.h"
 #include "StyleCachedImage.h"
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(TREE_DEBUGGING)
 #include <stdio.h>
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGResources);
 
 SVGResources::SVGResources()
 {

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.h
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.h
@@ -26,6 +26,8 @@
 #include <memory>
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -40,7 +42,8 @@ class SVGRenderStyle;
 
 // Holds a set of resources associated with a RenderObject
 class SVGResources {
-    WTF_MAKE_NONCOPYABLE(SVGResources); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGResources);
+    WTF_MAKE_NONCOPYABLE(SVGResources);
 public:
     SVGResources();
 
@@ -109,7 +112,7 @@ private:
     // masker:  'container elements' and 'graphics elements'
     // -> a, circle, defs, ellipse, glyph, g, image, line, marker, mask, missing-glyph, path, pattern, polygon, polyline, rect, svg, switch, symbol, text, use
     struct ClipperFilterMaskerData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(ClipperFilterMaskerData);
     public:
         ClipperFilterMaskerData() = default;
         SingleThreadWeakPtr<LegacyRenderSVGResourceClipper> clipper;
@@ -120,7 +123,7 @@ private:
     // From SVG 1.1 2nd Edition
     // marker: line, path, polygon, polyline
     struct MarkerData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(MarkerData);
     public:
         MarkerData() = default;
         SingleThreadWeakPtr<LegacyRenderSVGResourceMarker> markerStart;
@@ -133,7 +136,7 @@ private:
     // stroke:     'shapes' and 'text content elements'
     // -> altGlyph, circle, ellipse, line, path, polygon, polyline, rect, text, textPath, tref, tspan
     struct FillStrokeData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(FillStrokeData);
     public:
         FillStrokeData() = default;
         SingleThreadWeakPtr<LegacyRenderSVGResourceContainer> fill;

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -25,8 +25,11 @@
 #include "SVGRenderStyle.h"
 #include "SVGResources.h"
 #include "SVGResourcesCycleSolver.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGResourcesCache);
 
 SVGResourcesCache::SVGResourcesCache() = default;
 

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.h
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -34,7 +35,8 @@ class RenderStyle;
 class SVGResources;
 
 class SVGResourcesCache {
-    WTF_MAKE_NONCOPYABLE(SVGResourcesCache); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGResourcesCache);
+    WTF_MAKE_NONCOPYABLE(SVGResourcesCache);
 public:
     SVGResourcesCache();
     ~SVGResourcesCache();

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -32,8 +32,11 @@
 #include "RenderStyleInlines.h"
 #include "RenderTextControl.h"
 #include "RenderTreeBuilderMultiColumn.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderBlock, RenderTreeBuilder::Block);
 
 static void moveAllChildrenToInternal(RenderBoxModelObject& from, RenderElement& newParent)
 {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderBlockFlow;
 
 class RenderTreeBuilder::Block {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Block);
 public:
     Block(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlockFlow.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlockFlow.cpp
@@ -29,8 +29,11 @@
 #include "RenderMultiColumnFlow.h"
 #include "RenderTreeBuilderBlock.h"
 #include "RenderTreeBuilderMultiColumn.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderBlockFlow, RenderTreeBuilder::BlockFlow);
 
 RenderTreeBuilder::BlockFlow::BlockFlow(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlockFlow.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlockFlow.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderBlockFlow;
 
 class RenderTreeBuilder::BlockFlow {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BlockFlow);
 public:
     BlockFlow(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderContinuation.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderContinuation.cpp
@@ -27,8 +27,11 @@
 #include "RenderTreeBuilderContinuation.h"
 
 #include "RenderBoxModelObject.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderContinuation, RenderTreeBuilder::Continuation);
 
 RenderTreeBuilder::Continuation::Continuation(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderContinuation.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderContinuation.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderBoxModelObject;
 
 class RenderTreeBuilder::Continuation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Continuation);
 public:
     Continuation(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -35,8 +35,11 @@
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
 #include "StyleChange.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderFirstLetter, RenderTreeBuilder::FirstLetter);
 
 static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& firstLetterContainer)
 {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class RenderText;
 class RenderTextFragment;
 
 class RenderTreeBuilder::FirstLetter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FirstLetter);
 public:
     explicit FirstLetter(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -29,8 +29,11 @@
 #include "RenderButton.h"
 #include "RenderMenuList.h"
 #include "RenderTreeBuilderBlock.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderFormControls, RenderTreeBuilder::FormControls);
 
 RenderTreeBuilder::FormControls::FormControls(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class RenderButton;
 class RenderMenuList;
 
 class RenderTreeBuilder::FormControls {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FormControls);
 public:
     FormControls(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -33,8 +33,11 @@
 #include "RenderTreeBuilderMultiColumn.h"
 #include "RenderTreeBuilderTable.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderInline, RenderTreeBuilder::Inline);
 
 static bool canUseAsParentForContinuation(const RenderObject* renderer)
 {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderTreeBuilder::Inline {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Inline);
 public:
     Inline(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -31,8 +31,11 @@
 #include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderTable.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderList, RenderTreeBuilder::List);
 
 // FIXME: This shouldn't need LegacyInlineIterator
 static bool generatesLineBoxesForInlineChild(RenderBlock& current, RenderObject* inlineObj)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
@@ -27,11 +27,12 @@
 
 #include "RenderListItem.h"
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class RenderTreeBuilder::List {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(List);
 public:
     List(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
@@ -32,8 +32,11 @@
 #include "RenderMathMLFencedOperator.h"
 #include "RenderStyleSetters.h"
 #include "RenderTreeBuilderBlock.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderMathML, RenderTreeBuilder::MathML);
 
 RenderTreeBuilder::MathML::MathML(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.h
@@ -29,6 +29,7 @@
 
 #include "MathMLOperatorDictionary.h"
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class RenderMathMLFenced;
 class RenderMathMLFencedOperator;
 
 class RenderTreeBuilder::MathML {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MathML);
 public:
     MathML(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -35,8 +35,11 @@
 #include "RenderTreeBuilderBlock.h"
 #include "RenderView.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderMultiColumn, RenderTreeBuilder::MultiColumn);
 
 static RenderMultiColumnSet* findSetRendering(const RenderMultiColumnFlow& fragmentedFlow, const RenderObject& renderer)
 {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class RenderBlockFlow;
 class RenderMultiColumnFlow;
 
 class RenderTreeBuilder::MultiColumn {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MultiColumn);
 public:
     MultiColumn(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -33,8 +33,11 @@
 #include "RenderTreeBuilderBlockFlow.h"
 #include "RenderTreeBuilderInline.h"
 #include "UnicodeBidi.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderRuby, RenderTreeBuilder::Ruby);
 
 RenderTreeBuilder::Ruby::Ruby(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderTreeUpdater.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class RenderObject;
 class RenderTreeBuilder;
 
 class RenderTreeBuilder::Ruby {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Ruby);
 public:
     Ruby(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp
@@ -38,8 +38,11 @@
 #include "RenderTreeBuilderBlockFlow.h"
 #include "RenderTreeBuilderInline.h"
 #include "SVGResourcesCache.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderSVG, RenderTreeBuilder::SVG);
 
 RenderTreeBuilder::SVG::SVG(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ class RenderSVGRoot;
 class RenderSVGText;
 
 class RenderTreeBuilder::SVG {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVG);
 public:
     SVG(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
@@ -31,8 +31,11 @@
 #include "RenderTableCol.h"
 #include "RenderTableRow.h"
 #include "RenderTreeBuilder.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeBuilderTable, RenderTreeBuilder::Table);
 
 RenderTreeBuilder::Table::Table(RenderTreeBuilder& builder)
     : m_builder(builder)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderTable.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderTable.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderTreeUpdater.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ class RenderTableRow;
 class RenderTreeBuilder;
 
 class RenderTreeBuilder::Table {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Table);
 public:
     Table(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -42,8 +42,11 @@
 #include "RenderView.h"
 #include "StyleTreeResolver.h"
 #include "WritingSuggestionData.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeUpdaterGeneratedContent, RenderTreeUpdater::GeneratedContent);
 
 RenderTreeUpdater::GeneratedContent::GeneratedContent(RenderTreeUpdater& updater)
     : m_updater(updater)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -27,6 +27,7 @@
 
 #include "RenderStyleConstants.h"
 #include "RenderTreeUpdater.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class Element;
 class RenderQuote;
 
 class RenderTreeUpdater::GeneratedContent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GeneratedContent);
 public:
     GeneratedContent(RenderTreeUpdater&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -35,8 +35,11 @@
 #include "RenderViewTransitionCapture.h"
 #include "StyleTreeResolver.h"
 #include "ViewTransition.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RenderTreeUpdaterViewTransition, RenderTreeUpdater::ViewTransition);
 
 RenderTreeUpdater::ViewTransition::ViewTransition(RenderTreeUpdater& updater)
     : m_updater(updater)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
@@ -27,6 +27,7 @@
 
 #include "RenderStyleConstants.h"
 #include "RenderTreeUpdater.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class Element;
 class RenderQuote;
 
 class RenderTreeUpdater::ViewTransition {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ViewTransition);
 public:
     ViewTransition(RenderTreeUpdater&);
 


### PR DESCRIPTION
#### f7b79a1c34b350323ced396adae93a4bf9411837
<pre>
[TZone] WebCore/rendering Convert FastMalloc to TZone
<a href="https://rdar.apple.com/134908928">rdar://134908928</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278838">https://bugs.webkit.org/show_bug.cgi?id=278838</a>

Reviewed by Yijia Huang.

Converted WebCore/rendering classes from WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED
(and related macros) in preparation for enabling TZone (not yet enabled).

* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
* Source/WebCore/rendering/AccessibilityRegionContext.h:
* Source/WebCore/rendering/BaselineAlignment.cpp:
* Source/WebCore/rendering/BaselineAlignment.h:
* Source/WebCore/rendering/CSSFilter.cpp:
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/rendering/EventRegion.cpp:
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/FloatingObjects.cpp:
* Source/WebCore/rendering/FloatingObjects.h:
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
* Source/WebCore/rendering/GlyphDisplayListCache.h:
* Source/WebCore/rendering/GridLayoutState.cpp:
* Source/WebCore/rendering/GridLayoutState.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/HitTestResult.cpp:
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/ImageQualityController.cpp:
* Source/WebCore/rendering/ImageQualityController.h:
* Source/WebCore/rendering/LayerAncestorClippingStack.cpp:
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
* Source/WebCore/rendering/LayerOverlapMap.cpp:
* Source/WebCore/rendering/LegacyLineLayout.cpp:
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/PaintFrequencyTracker.h:
* Source/WebCore/rendering/ReferencedSVGResources.h:
* Source/WebCore/rendering/RegionContext.cpp:
* Source/WebCore/rendering/RegionContext.h:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBoxFragmentInfo.h:
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderLayoutState.cpp:
* Source/WebCore/rendering/RenderLayoutState.h:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/RenderMarquee.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderOverflow.h:
* Source/WebCore/rendering/RenderSelectionGeometry.cpp:
* Source/WebCore/rendering/RenderSelectionGeometry.h:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/TextAutoSizing.h:
* Source/WebCore/rendering/shapes/RasterShape.cpp:
* Source/WebCore/rendering/shapes/RasterShape.h:
* Source/WebCore/rendering/shapes/ShapeInterval.h:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:
* Source/WebCore/rendering/style/BasicShapes.cpp:
* Source/WebCore/rendering/style/BasicShapes.h:
* Source/WebCore/rendering/style/ContentData.cpp:
* Source/WebCore/rendering/style/ContentData.h:
* Source/WebCore/rendering/style/CounterContent.h:
* Source/WebCore/rendering/style/FillLayer.cpp:
* Source/WebCore/rendering/style/FillLayer.h:
* Source/WebCore/rendering/style/GridArea.h:
* Source/WebCore/rendering/style/ShadowData.cpp:
* Source/WebCore/rendering/style/ShadowData.h:
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
* Source/WebCore/rendering/style/StyleCachedImage.h:
* Source/WebCore/rendering/style/StyleCursorImage.cpp:
* Source/WebCore/rendering/style/StyleCursorImage.h:
* Source/WebCore/rendering/style/StyleGeneratedImage.cpp:
* Source/WebCore/rendering/style/StyleImageSet.cpp:
* Source/WebCore/rendering/style/StyleImageSet.h:
* Source/WebCore/rendering/style/StyleMultiImage.cpp:
* Source/WebCore/rendering/style/StyleMultiImage.h:
* Source/WebCore/rendering/style/WillChangeData.cpp:
* Source/WebCore/rendering/style/WillChangeData.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResources.h:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlockFlow.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlockFlow.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderContinuation.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderContinuation.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderMathML.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderTable.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h:

Canonical link: <a href="https://commits.webkit.org/282900@main">https://commits.webkit.org/282900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ee2c1cc6021fea8257c8ea4a13abd5bbf79b2a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51953 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13265 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55975 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59458 "Found 196 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestAutocleanups:/webkit/Autocleanups/web-process-autocleanups, /WebKitGTK/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close, /WebKitGTK/TestNetworkProcessMemoryPressure:/webkit/WebKitWebsiteData/memory-pressure, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-storage, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-alternate-html-for-local-page, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm, /WebKitGTK/TestBackForwardList:/webkit/WebKitWebView/session-state, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/default-content-security-policy, /WebKitGTK/TestDownloads:/webkit/Downloads/user-agent ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/725 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39760 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->