### PR TITLE
[css-view-transitions-2] no-view-transition-with-cross-origin-redirect.sub.html fails.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7490,8 +7490,10 @@ imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-m
 
 # View transitions Level 2 - cross document transitions.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html [ ImageOnlyFailure ]
+# Fuzzy failure, pixel rounding in <iframe>?
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html [ ImageOnlyFailure ]
+# https://github.com/w3c/csswg-drafts/issues/10800
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay.html [ Failure ]
 
 # prerender not supported.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/prerender-removed-during-navigation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html
@@ -24,7 +24,7 @@
 </style>
 <script>
   function runTest() {
-    let crossOriginPath = "http://{{hosts[][www]}}:{{ports[http][1]}}";
+    let crossOriginPath = "http://{{hosts[alt][]}}:{{ports[http][1]}}";
     let newUrl = crossOriginPath + "/common/redirect.py?location=" + location.href.split('?')[0] + "?new";
     location.href = newUrl;
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View transitions: long delay in pageswap aborts the transition assert_equals: viewTransition must have been skipped. expected null but got object "[object ViewTransition]"
+PASS View transitions: long delay in pageswap aborts the transition
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2507,7 +2507,10 @@ bool DocumentLoader::navigationCanTriggerCrossDocumentViewTransition(Document& o
     if (!newOrigin->isSameOriginAs(oldDocument.securityOrigin()))
         return false;
 
-    // FIXME: If newDocument was created via cross-origin redirects, then return false.
+    if (const auto* metrics = response().deprecatedNetworkLoadMetricsOrNull()) {
+        if (metrics->crossOriginRedirect())
+            return false;
+    }
 
     if (*m_triggeringAction.navigationAPIType() == NavigationNavigationType::Traverse)
         return true;


### PR DESCRIPTION
#### 798529e297cf544acc9dcf47c849463e9ed22cf4
<pre>
[css-view-transitions-2] no-view-transition-with-cross-origin-redirect.sub.html fails.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278837">https://bugs.webkit.org/show_bug.cgi?id=278837</a>
&lt;<a href="https://rdar.apple.com/134908686">rdar://134908686</a>&gt;

Reviewed by Alex Christensen.

Cross-origin redirects should prevent the view transition from being allowed

This changes the test a bit, since &apos;hosts[][www]}&apos; was resolving to
&apos;www.localhost&apos;. I&apos;m not sure if that&apos;s a WebKit bug, or a test harness issue,
but using hosts[alt] should be a valid version of the test (where the initial
request is cross origin, but the post-redirect response is not).

It also moves the failure annotation for pageswap-long-delay.html into the
TestExpectations file, so that a URL to the spec issue can be added.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::navigationCanTriggerCrossDocumentViewTransition):

Canonical link: <a href="https://commits.webkit.org/283004@main">https://commits.webkit.org/283004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d1c7beb1b700e8cf8e40def0cf3df7fbc5a05a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52070 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10612 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13416 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59399 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56125 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59597 "Found 122 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.GeolocationBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PageLoadBasic, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/872 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39950 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->