### PR TITLE
[TZone] WebCore/html Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -32,8 +32,11 @@
 #include "ImageBitmap.h"
 #include "PaintRenderingContext2D.h"
 #include "ScriptExecutionContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomPaintCanvas);
 
 Ref<CustomPaintCanvas> CustomPaintCanvas::create(ScriptExecutionContext& context, unsigned width, unsigned height)
 {

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -36,6 +36,7 @@
 #include "ScriptWrappable.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ class DrawingContext;
 }
 
 class CustomPaintCanvas final : public RefCounted<CustomPaintCanvas>, public CanvasBase, private ContextDestructionObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CustomPaintCanvas);
 public:
 
     static Ref<CustomPaintCanvas> create(ScriptExecutionContext&, unsigned width, unsigned height);

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -29,10 +29,13 @@
 #include "SpaceSplitString.h"
 #include <wtf/HashSet.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMTokenList);
 
 DOMTokenList::DOMTokenList(Element& element, const QualifiedName& attributeName, IsSupportedTokenFunction&& isSupportedToken)
     : m_element(element)

--- a/Source/WebCore/html/DOMTokenList.h
+++ b/Source/WebCore/html/DOMTokenList.h
@@ -27,11 +27,12 @@
 
 #include "Element.h"
 #include <wtf/FixedVector.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class DOMTokenList final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DOMTokenList);
 public:
     using IsSupportedTokenFunction = Function<bool(Document&, StringView)>;
     DOMTokenList(Element&, const QualifiedName& attributeName, IsSupportedTokenFunction&& isSupportedToken = { });

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -37,6 +37,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FormAssociatedCustomElement);
+
 using namespace HTMLNames;
 
 FormAssociatedCustomElement::FormAssociatedCustomElement(HTMLMaybeFormAssociatedCustomElement& element)

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -29,12 +29,13 @@
 #include "HTMLMaybeFormAssociatedCustomElement.h"
 #include "ValidatedFormListedElement.h"
 #include "ValidityStateFlags.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class FormAssociatedCustomElement final : public ValidatedFormListedElement {
+    WTF_MAKE_TZONE_ALLOCATED(FormAssociatedCustomElement);
     WTF_MAKE_NONCOPYABLE(FormAssociatedCustomElement);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<FormAssociatedCustomElement> create(HTMLMaybeFormAssociatedCustomElement&);
 

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -28,12 +28,15 @@
 #include "ScriptDisallowedScope.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FormController);
 
 HTMLFormElement* FormController::ownerForm(const FormListedElement& control)
 {
@@ -158,9 +161,12 @@ void FormController::SavedFormState::appendReferencedFilePaths(Vector<String>& v
 
 // ----------------------------------------------------------------------------
 
+
 class FormController::FormKeyGenerator {
+    typedef FormController::FormKeyGenerator FormControllerFormKeyGenerator;
+
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FormControllerFormKeyGenerator);
     WTF_MAKE_NONCOPYABLE(FormKeyGenerator);
-    WTF_MAKE_FAST_ALLOCATED;
 
 public:
     FormKeyGenerator() = default;

--- a/Source/WebCore/html/FormController.h
+++ b/Source/WebCore/html/FormController.h
@@ -23,6 +23,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class ValidatedFormListedElement;
 using FormControlState = Vector<AtomString>;
 
 class FormController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FormController);
 
 public:
     FormController();

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -36,13 +36,16 @@
 #include "IdTargetObserver.h"
 #include "LocalFrame.h"
 #include "TreeScopeInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FormListedElement);
 
 using namespace HTMLNames;
 
 class FormAttributeTargetObserver final : private IdTargetObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FormAttributeTargetObserver);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FormAttributeTargetObserver);
 public:
     FormAttributeTargetObserver(const AtomString& id, FormListedElement&);

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -25,6 +25,7 @@
 
 #include "FormAssociatedElement.h"
 #include "Node.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,8 +41,8 @@ class ValidityState;
 
 // https://html.spec.whatwg.org/multipage/forms.html#category-listed
 class FormListedElement : public FormAssociatedElement {
+    WTF_MAKE_TZONE_ALLOCATED(FormListedElement);
     WTF_MAKE_NONCOPYABLE(FormListedElement);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~FormListedElement();
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -27,11 +27,13 @@
 #include "HTMLNames.h"
 #include "LiveNodeList.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class CollectionNamedElementCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CollectionNamedElementCache);
 public:
     inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* findElementsWithId(const AtomString& id) const;
     inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* findElementsWithName(const AtomString& name) const;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -99,7 +99,7 @@ using namespace HTMLNames;
 
 #if ENABLE(DATALIST_ELEMENT)
 class ListAttributeTargetObserver final : public IdTargetObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ListAttributeTargetObserver);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ListAttributeTargetObserver);
 public:
     ListAttributeTargetObserver(const AtomString& id, HTMLInputElement&);

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -88,7 +88,7 @@ static LinkEventSender& linkLoadEventSender()
 }
 
 class ExpectIdTargetObserver final : public IdTargetObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ExpectIdTargetObserver);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ExpectIdTargetObserver);
 public:
     ExpectIdTargetObserver(const AtomString& id, HTMLLinkElement&);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -233,7 +233,10 @@ struct LogArgument<URL> {
 
 namespace WebCore {
 
+typedef PODIntervalTree<MediaTime, TextTrackCue*> TextTrackCueIntervalTree;
+
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLMediaElement);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(TextTrackCueIntervalTree);
 
 static const Seconds SeekRepeatDelay { 100_ms };
 static const double SeekTime = 0.2;
@@ -472,7 +475,7 @@ static bool isInWindowOrStandardFullscreen(HTMLMediaElementEnums::VideoFullscree
 
 struct HTMLMediaElement::CueData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    PODIntervalTree<MediaTime, TextTrackCue*> cueTree;
+    TextTrackCueIntervalTree cueTree;
     CueList currentlyActiveCues;
 };
 

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -736,7 +736,7 @@ private:
 };
 
 class PendingImageBitmap final : public RefCounted<PendingImageBitmap>, public ActiveDOMObject, public FileReaderLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PendingImageBitmap);
 public:
     // ActiveDOMObject.
     void ref() const final { RefCounted::ref(); }

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -82,10 +82,13 @@
 #include <limits>
 #include <wtf/Assertions.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/TextBreakIterator.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -35,11 +35,11 @@
 #include "HTMLInputElement.h"
 #include "HTMLTextFormControlElement.h"
 #include "RenderPtr.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -70,7 +70,7 @@ enum class DateComponentsType : uint8_t;
 // Do not expose instances of InputType and classes derived from it to classes
 // other than HTMLInputElement.
 class InputType : public RefCounted<InputType> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InputType);
 public:
     enum class Type : uint32_t {
         Button          = 1 << 0,

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -34,8 +34,11 @@
 #include "RenderStyle.h"
 
 #include <limits>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LazyLoadFrameObserver);
 
 class LazyFrameLoadIntersectionObserverCallback final : public IntersectionObserverCallback {
 public:

--- a/Source/WebCore/html/LazyLoadFrameObserver.h
+++ b/Source/WebCore/html/LazyLoadFrameObserver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntersectionObserver.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class Element;
 class HTMLIFrameElement;
 
 class LazyLoadFrameObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LazyLoadFrameObserver);
 public:
     LazyLoadFrameObserver(HTMLIFrameElement&);
 

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -32,8 +32,11 @@
 #include "IntersectionObserverEntry.h"
 #include "LocalFrame.h"
 #include <limits>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LazyLoadImageObserver);
 
 class LazyImageLoadIntersectionObserverCallback final : public IntersectionObserverCallback {
 public:

--- a/Source/WebCore/html/LazyLoadImageObserver.h
+++ b/Source/WebCore/html/LazyLoadImageObserver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntersectionObserver.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class Document;
 class Element;
 
 class LazyLoadImageObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LazyLoadImageObserver);
 public:
     static void observe(Element&);
     static void unobserve(Element&, Document&);

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -63,6 +63,7 @@
 #include "VideoTrack.h"
 #include "VideoTrackConfiguration.h"
 #include "VideoTrackList.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 #if ENABLE(MEDIA_SESSION)
@@ -80,6 +81,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaElementSession);
 
 static const Seconds clientDataBufferingTimerThrottleDelay { 100_ms };
 static const Seconds elementMainContentCheckInterval { 250_ms };
@@ -132,7 +135,7 @@ static bool pageExplicitlyAllowsElementToAutoplayInline(const HTMLMediaElement& 
 
 #if ENABLE(MEDIA_SESSION)
 class MediaElementSessionObserver : public MediaSessionObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MediaElementSessionObserver);
 
 public:
     MediaElementSessionObserver(MediaElementSession& session, const Ref<MediaSession>& mediaSession)

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -33,6 +33,7 @@
 #include "PlatformMediaSession.h"
 #include "Timer.h"
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
@@ -68,7 +69,7 @@ struct MediaPositionState;
 enum class MediaSessionPlaybackState : uint8_t;
 
 class MediaElementSession final : public PlatformMediaSession {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MediaElementSession);
 public:
     explicit MediaElementSession(HTMLMediaElement&);
     virtual ~MediaElementSession();

--- a/Source/WebCore/html/NavigatorUserActivation.cpp
+++ b/Source/WebCore/html/NavigatorUserActivation.cpp
@@ -29,8 +29,11 @@
 #include "Navigator.h"
 #include "UserActivation.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigatorUserActivation);
 
 NavigatorUserActivation::NavigatorUserActivation(Navigator& navigator)
     : m_userActivation(UserActivation::create(navigator))

--- a/Source/WebCore/html/NavigatorUserActivation.h
+++ b/Source/WebCore/html/NavigatorUserActivation.h
@@ -27,6 +27,7 @@
 
 #include "Supplementable.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class UserActivation;
 class Navigator;
 
 class NavigatorUserActivation final : public Supplement<Navigator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NavigatorUserActivation);
 public:
     explicit NavigatorUserActivation(Navigator&);
     ~NavigatorUserActivation();

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -65,6 +65,7 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DetachedOffscreenCanvas);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OffscreenCanvas);
 
 DetachedOffscreenCanvas::DetachedOffscreenCanvas(const IntSize& size, bool originClean, RefPtr<PlaceholderRenderingContextSource>&& placeholderSource)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -40,6 +40,7 @@
 #include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -77,8 +78,8 @@ class PlaceholderRenderingContext;
 class PlaceholderRenderingContextSource;
 
 class DetachedOffscreenCanvas {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(DetachedOffscreenCanvas, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(DetachedOffscreenCanvas);
-    WTF_MAKE_FAST_ALLOCATED;
     friend class OffscreenCanvas;
 
 public:

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -35,9 +35,12 @@
 #include "LocalDOMWindow.h"
 #include "Quirks.h"
 #include "SecurityOrigin.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PermissionsPolicy);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/PermissionsPolicy.h
+++ b/Source/WebCore/html/PermissionsPolicy.h
@@ -28,6 +28,7 @@
 #include "Allowlist.h"
 #include <wtf/HashSet.h>
 #include <wtf/HashTraits.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -39,7 +40,7 @@ class HTMLIFrameElement;
 struct OwnerPermissionsPolicyData;
 
 class PermissionsPolicy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PermissionsPolicy);
 public:
     PermissionsPolicy();
     PermissionsPolicy(const Document&);

--- a/Source/WebCore/html/PublicURLManager.cpp
+++ b/Source/WebCore/html/PublicURLManager.cpp
@@ -30,10 +30,13 @@
 #include "ContextDestructionObserverInlines.h"
 #include "SecurityOrigin.h"
 #include "URLRegistry.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PublicURLManager);
 
 Ref<PublicURLManager> PublicURLManager::create(ScriptExecutionContext* context)
 {

--- a/Source/WebCore/html/PublicURLManager.h
+++ b/Source/WebCore/html/PublicURLManager.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -38,7 +39,7 @@ class URLRegistry;
 class URLRegistrable;
 
 class PublicURLManager final : public RefCounted<PublicURLManager>, public ActiveDOMObject {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PublicURLManager);
 public:
     static Ref<PublicURLManager> create(ScriptExecutionContext*);
 

--- a/Source/WebCore/html/StepRange.cpp
+++ b/Source/WebCore/html/StepRange.cpp
@@ -25,8 +25,12 @@
 #include "HTMLParserIdioms.h"
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StepRange);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(StepRangeStepDescription, StepRange::StepDescription);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/StepRange.h
+++ b/Source/WebCore/html/StepRange.h
@@ -22,6 +22,7 @@
 
 #include "Decimal.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -30,6 +31,7 @@ enum class AnyStepHandling : bool { Reject, Default };
 enum class RangeLimitations : bool { Valid, Invalid };
 
 class StepRange {
+    WTF_MAKE_TZONE_ALLOCATED(StepRange);
 public:
     enum StepValueShouldBe {
         StepValueShouldBeReal,
@@ -38,7 +40,7 @@ public:
     };
 
     struct StepDescription {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(StepDescription);
     public:
         int defaultStep { 1 };
         int defaultStepBase { 0 };

--- a/Source/WebCore/html/URLRegistry.cpp
+++ b/Source/WebCore/html/URLRegistry.cpp
@@ -28,9 +28,12 @@
 
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(URLRegistry);
 
 static Lock allRegistriesLock;
 static Vector<URLRegistry*>& allRegistries() WTF_REQUIRES_LOCK(allRegistriesLock)

--- a/Source/WebCore/html/URLRegistry.h
+++ b/Source/WebCore/html/URLRegistry.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ public:
 };
 
 class URLRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(URLRegistry);
 public:
     static void forEach(const Function<void(URLRegistry&)>&);
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -50,10 +50,13 @@
 #include "ValidationMessage.h"
 #include <wtf/Ref.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ValidatedFormListedElement);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -33,6 +33,7 @@
 #include "FormListedElement.h"
 #include "HTMLElement.h"
 #include "ValidationMessage.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TriState.h>
 
 namespace WebCore {
@@ -40,8 +41,8 @@ namespace WebCore {
 class HTMLMaybeFormAssociatedCustomElement;
 
 class ValidatedFormListedElement : public FormListedElement {
+    WTF_MAKE_TZONE_ALLOCATED(ValidatedFormListedElement);
     WTF_MAKE_NONCOPYABLE(ValidatedFormListedElement);
-    WTF_MAKE_FAST_ALLOCATED;
     friend class DelayedUpdateValidityScope;
     friend class HTMLMaybeFormAssociatedCustomElement;
 public:

--- a/Source/WebCore/html/ValidationMessage.cpp
+++ b/Source/WebCore/html/ValidationMessage.cpp
@@ -49,9 +49,12 @@
 #include "Text.h"
 #include "UserAgentParts.h"
 #include "ValidationMessageClient.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ValidationMessage);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/ValidationMessage.h
+++ b/Source/WebCore/html/ValidationMessage.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -56,7 +57,8 @@ class ValidationMessageClient;
 // FIXME: We should remove the code for !validationMessageClient() when all
 // ports supporting interactive validation switch to ValidationMessageClient.
 class ValidationMessage : public CanMakeWeakPtr<ValidationMessage> {
-    WTF_MAKE_NONCOPYABLE(ValidationMessage); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ValidationMessage);
+    WTF_MAKE_NONCOPYABLE(ValidationMessage);
 public:
     explicit ValidationMessage(HTMLElement&);
     ~ValidationMessage();

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
@@ -29,8 +29,11 @@
 #include "CanvasLayerContextSwitcher.h"
 #include "CanvasRenderingContext2DBase.h"
 #include "FloatRect.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CanvasFilterContextSwitcher);
 
 std::unique_ptr<CanvasFilterContextSwitcher> CanvasFilterContextSwitcher::create(CanvasRenderingContext2DBase& context, const FloatRect& bounds)
 {

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +34,7 @@ class CanvasRenderingContext2DBase;
 class FloatRect;
 
 class CanvasFilterContextSwitcher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CanvasFilterContextSwitcher);
 public:
     static std::unique_ptr<CanvasFilterContextSwitcher> create(CanvasRenderingContext2DBase&, const FloatRect& bounds);
 

--- a/Source/WebCore/html/canvas/Path2D.cpp
+++ b/Source/WebCore/html/canvas/Path2D.cpp
@@ -31,8 +31,11 @@
 #include "AffineTransform.h"
 #include "DOMMatrix2DInit.h"
 #include "DOMMatrixReadOnly.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Path2D);
 
 Path2D::~Path2D() = default;
 

--- a/Source/WebCore/html/canvas/Path2D.h
+++ b/Source/WebCore/html/canvas/Path2D.h
@@ -30,13 +30,14 @@
 #include "CanvasPath.h"
 #include "SVGPathUtilities.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 struct DOMMatrix2DInit;
 
 class WEBCORE_EXPORT Path2D final : public RefCounted<Path2D>, public CanvasPath {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Path2D);
 public:
     virtual ~Path2D();
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaceholderRenderingContextSource);
+
 #if !USE(NICOSIA)
 namespace {
 // FIXME: Once NICOSIA PlaceholderRenderingContextSource is reimplemented with delegated display compositor interface,

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -28,6 +28,7 @@
 #if ENABLE(OFFSCREEN_CANVAS)
 
 #include "CanvasRenderingContext.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -37,7 +38,7 @@ class PlaceholderRenderingContext;
 
 // Thread-safe interface to submit frames from worker to the placeholder rendering context.
 class PlaceholderRenderingContextSource : public ThreadSafeRefCounted<PlaceholderRenderingContextSource> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PlaceholderRenderingContextSource);
     WTF_MAKE_NONCOPYABLE(PlaceholderRenderingContextSource);
 public:
     static Ref<PlaceholderRenderingContextSource> create(PlaceholderRenderingContext&);

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -27,8 +27,11 @@
 
 #if ENABLE(WEBGL)
 #include "WebGLDefaultFramebuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLDefaultFramebuffer);
 
 std::unique_ptr<WebGLDefaultFramebuffer> WebGLDefaultFramebuffer::create(WebGLRenderingContextBase& context, IntSize size)
 {

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
@@ -28,12 +28,13 @@
 #if ENABLE(WEBGL)
 
 #include "WebGLRenderingContextBase.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 // Implementation for the WebGL context default framebuffer.
 class WebGLDefaultFramebuffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebGLDefaultFramebuffer);
     WTF_MAKE_NONCOPYABLE(WebGLDefaultFramebuffer);
 public:
     static std::unique_ptr<WebGLDefaultFramebuffer> create(WebGLRenderingContextBase&, IntSize);

--- a/Source/WebCore/html/forms/FileIconLoader.cpp
+++ b/Source/WebCore/html/forms/FileIconLoader.cpp
@@ -31,8 +31,11 @@
 #include "FileIconLoader.h"
 
 #include "Icon.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FileIconLoader);
 
 void FileIconLoader::invalidate()
 {

--- a/Source/WebCore/html/forms/FileIconLoader.h
+++ b/Source/WebCore/html/forms/FileIconLoader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ public:
 };
 
 class FileIconLoader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FileIconLoader);
 public:
     explicit FileIconLoader(FileIconLoaderClient&);
 

--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -32,8 +32,12 @@
 #include "HTMLOptionElement.h"
 #include "HTMLTableElement.h"
 #include "MathMLNames.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLElementStack);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(HTMLElementStackElementRecord, HTMLElementStack::ElementRecord);
 
 using namespace ElementNames;
 

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -40,13 +41,15 @@ class QualifiedName;
 // NOTE: The HTML5 spec uses a backwards (grows downward) stack.  We're using
 // more standard (grows upwards) stack terminology here.
 class HTMLElementStack {
-    WTF_MAKE_NONCOPYABLE(HTMLElementStack); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLElementStack);
+    WTF_MAKE_NONCOPYABLE(HTMLElementStack);
 public:
     HTMLElementStack() = default;
     ~HTMLElementStack();
 
     class ElementRecord {
-        WTF_MAKE_NONCOPYABLE(ElementRecord); WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(ElementRecord);
+        WTF_MAKE_NONCOPYABLE(ElementRecord);
     public:
         ElementRecord(HTMLStackItem&&, std::unique_ptr<ElementRecord>);
         ~ElementRecord();

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -30,8 +30,11 @@
 #include "HTMLNames.h"
 #include <pal/text/TextCodec.h>
 #include <pal/text/TextEncodingRegistry.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLMetaCharsetParser);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
@@ -28,6 +28,7 @@
 #include "HTMLTokenizer.h"
 #include "SegmentedString.h"
 #include <pal/text/TextEncoding.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace PAL {
 class TextCodec;
@@ -36,7 +37,8 @@ class TextCodec;
 namespace WebCore {
 
 class HTMLMetaCharsetParser {
-    WTF_MAKE_NONCOPYABLE(HTMLMetaCharsetParser); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLMetaCharsetParser);
+    WTF_MAKE_NONCOPYABLE(HTMLMetaCharsetParser);
 public:
     HTMLMetaCharsetParser();
 

--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -35,8 +35,11 @@
 #include "Page.h"
 #include "ScriptController.h"
 #include "ScriptElement.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLParserScheduler);
 
 static Seconds parserTimeLimit(Page* page)
 {

--- a/Source/WebCore/html/parser/HTMLParserScheduler.h
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.h
@@ -28,6 +28,7 @@
 #include "NestingLevelIncrementer.h"
 #include "Timer.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "WebCoreThread.h"
@@ -61,7 +62,8 @@ public:
 };
 
 class HTMLParserScheduler {
-    WTF_MAKE_NONCOPYABLE(HTMLParserScheduler); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLParserScheduler);
+    WTF_MAKE_NONCOPYABLE(HTMLParserScheduler);
 public:
     explicit HTMLParserScheduler(HTMLDocumentParser&);
     ~HTMLParserScheduler();

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -48,9 +48,13 @@
 #include "SizesAttributeParser.h"
 #include <wtf/MainThread.h>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TokenPreloadScanner);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLPreloadScanner);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.h
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.h
@@ -29,10 +29,12 @@
 #include "CSSPreloadScanner.h"
 #include "HTMLTokenizer.h"
 #include "SegmentedString.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class TokenPreloadScanner {
+    WTF_MAKE_TZONE_ALLOCATED(TokenPreloadScanner);
     WTF_MAKE_NONCOPYABLE(TokenPreloadScanner);
 public:
     explicit TokenPreloadScanner(const URL& documentURL, float deviceScaleFactor = 1.0);
@@ -82,7 +84,7 @@ private:
 };
 
 class HTMLPreloadScanner {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLPreloadScanner);
 public:
     HTMLPreloadScanner(const HTMLParserOptions&, const URL& documentURL, float deviceScaleFactor = 1.0);
 

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -35,8 +35,12 @@
 #include "NodeRenderStyle.h"
 #include "RenderView.h"
 #include "ScriptElementCachedScriptFetcher.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PreloadRequest);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLResourcePreloader);
 
 URL PreloadRequest::completeURL(Document& document)
 {

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -28,6 +28,7 @@
 #include "CachedResource.h"
 #include "CachedResourceRequest.h"
 #include "ScriptType.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::HTMLResource
 namespace WebCore {
 
 class PreloadRequest {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PreloadRequest);
 public:
     PreloadRequest(ASCIILiteral initiatorType, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ScriptType scriptType, const ReferrerPolicy& referrerPolicy, RequestPriority fetchPriorityHint = RequestPriority::Auto)
         : m_initiatorType(initiatorType)
@@ -86,7 +87,8 @@ private:
 typedef Vector<std::unique_ptr<PreloadRequest>> PreloadRequestStream;
 
 class HTMLResourcePreloader : public CanMakeWeakPtr<HTMLResourcePreloader> {
-    WTF_MAKE_NONCOPYABLE(HTMLResourcePreloader); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLResourcePreloader);
+    WTF_MAKE_NONCOPYABLE(HTMLResourcePreloader);
 public:
     explicit HTMLResourcePreloader(Document& document)
         : m_document(document)

--- a/Source/WebCore/html/parser/HTMLScriptRunner.cpp
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.cpp
@@ -42,8 +42,11 @@
 #include "NestingLevelIncrementer.h"
 #include "ScriptElement.h"
 #include "ScriptSourceCode.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLScriptRunner);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/parser/HTMLScriptRunner.h
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.h
@@ -28,6 +28,7 @@
 
 #include "PendingScript.h"
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/TextPosition.h>
 
@@ -40,7 +41,7 @@ class ScriptSourceCode;
 class WeakPtrImplWithEventTargetData;
 
 class HTMLScriptRunner {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLScriptRunner);
 public:
     HTMLScriptRunner(Document&, HTMLScriptRunnerHost&);
     ~HTMLScriptRunner();

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -27,11 +27,12 @@
 #pragma once
 
 #include "Attribute.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 struct DoctypeData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DoctypeData);
 public:
     Vector<UChar> publicIdentifier;
     Vector<UChar> systemIdentifier;
@@ -41,7 +42,7 @@ public:
 };
 
 class HTMLToken {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(HTMLToken);
 public:
     enum class Type : uint8_t {
         Uninitialized,

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -51,6 +51,7 @@
 #include "XMLNames.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -59,6 +60,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTreeBuilder);
 
 using namespace ElementNames;
 using namespace HTMLNames;

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -28,6 +28,7 @@
 
 #include "HTMLConstructionSite.h"
 #include "HTMLParserOptions.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextPosition.h>
 
@@ -51,7 +52,7 @@ struct CustomElementConstructionData {
 };
 
 class HTMLTreeBuilder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HTMLTreeBuilder);
 public:
     HTMLTreeBuilder(HTMLDocumentParser&, HTMLDocument&, OptionSet<ParserContentPolicy>, const HTMLParserOptions&);
     HTMLTreeBuilder(HTMLDocumentParser&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy>, const HTMLParserOptions&);

--- a/Source/WebCore/html/track/AudioTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.cpp
@@ -29,8 +29,11 @@
 #if ENABLE(VIDEO)
 
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackConfiguration);
 
 Ref<JSON::Object> AudioTrackConfiguration::toJSON() const
 {

--- a/Source/WebCore/html/track/AudioTrackConfiguration.h
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include "PlatformAudioTrackConfiguration.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ namespace WebCore {
 using AudioTrackConfigurationInit = PlatformAudioTrackConfiguration;
 
 class AudioTrackConfiguration : public RefCounted<AudioTrackConfiguration> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AudioTrackConfiguration);
 public:
     static Ref<AudioTrackConfiguration> create(AudioTrackConfigurationInit&& init) { return adoptRef(*new AudioTrackConfiguration(WTFMove(init))); }
     static Ref<AudioTrackConfiguration> create() { return adoptRef(*new AudioTrackConfiguration()); }

--- a/Source/WebCore/html/track/VideoTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.cpp
@@ -29,8 +29,11 @@
 #if ENABLE(VIDEO)
 
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackConfiguration);
 
 Ref<JSON::Object> VideoTrackConfiguration::toJSON() const
 {

--- a/Source/WebCore/html/track/VideoTrackConfiguration.h
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.h
@@ -29,6 +29,7 @@
 
 #include "PlatformVideoTrackConfiguration.h"
 #include "VideoColorSpace.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ namespace WebCore {
 using VideoTrackConfigurationInit = PlatformVideoTrackConfiguration;
 
 class VideoTrackConfiguration : public RefCounted<VideoTrackConfiguration> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VideoTrackConfiguration);
 public:
     static Ref<VideoTrackConfiguration> create(VideoTrackConfigurationInit&& init) { return adoptRef(*new VideoTrackConfiguration(WTFMove(init))); }
     static Ref<VideoTrackConfiguration> create() { return adoptRef(*new VideoTrackConfiguration()); }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -46,8 +46,12 @@
 #include "VTTScanner.h"
 #include "WebVTTElement.h"
 #include "WebVTTTokenizer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebVTTCueData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebVTTParser);
 
 constexpr double secondsPerHour = 3600;
 constexpr double secondsPerMinute = 60;

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -41,6 +41,7 @@
 #include "VTTRegion.h"
 #include <memory>
 #include <wtf/MediaTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -62,6 +63,7 @@ public:
 };
 
 class WebVTTCueData final : public RefCounted<WebVTTCueData> {
+    WTF_MAKE_TZONE_ALLOCATED(WebVTTCueData);
 public:
 
     static Ref<WebVTTCueData> create() { return adoptRef(*new WebVTTCueData()); }
@@ -97,7 +99,7 @@ private:
 };
 
 class WEBCORE_EXPORT WebVTTParser final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebVTTParser);
 public:
     enum ParseState {
         Initial,


### PR DESCRIPTION
#### ed6a62906bf1e00f285497c6301b740b3f0715ea
<pre>
[TZone] WebCore/html Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278838">https://bugs.webkit.org/show_bug.cgi?id=278838</a>
<a href="https://rdar.apple.com/134908928">rdar://134908928</a>

Reviewed by Yijia Huang.

Converted WebCore/html classes from WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED
(and related macros) in preparation for enabling TZone (not yet enabled).

* Source/WebCore/html/CustomPaintCanvas.cpp:
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/DOMTokenList.cpp:
* Source/WebCore/html/DOMTokenList.h:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
* Source/WebCore/html/FormAssociatedCustomElement.h:
* Source/WebCore/html/FormController.cpp:
* Source/WebCore/html/FormController.h:
* Source/WebCore/html/FormListedElement.cpp:
* Source/WebCore/html/FormListedElement.h:
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/html/HTMLLinkElement.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/InputType.cpp:
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/LazyLoadFrameObserver.cpp:
* Source/WebCore/html/LazyLoadFrameObserver.h:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
* Source/WebCore/html/LazyLoadImageObserver.h:
* Source/WebCore/html/MediaElementSession.cpp:
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/NavigatorUserActivation.cpp:
* Source/WebCore/html/NavigatorUserActivation.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/PermissionsPolicy.cpp:
* Source/WebCore/html/PermissionsPolicy.h:
* Source/WebCore/html/PublicURLManager.cpp:
* Source/WebCore/html/PublicURLManager.h:
* Source/WebCore/html/StepRange.cpp:
* Source/WebCore/html/StepRange.h:
* Source/WebCore/html/URLRegistry.cpp:
* Source/WebCore/html/URLRegistry.h:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
* Source/WebCore/html/ValidatedFormListedElement.h:
* Source/WebCore/html/ValidationMessage.cpp:
* Source/WebCore/html/ValidationMessage.h:
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp:
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h:
* Source/WebCore/html/canvas/Path2D.cpp:
* Source/WebCore/html/canvas/Path2D.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(): Deleted.
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h:
* Source/WebCore/html/forms/FileIconLoader.cpp:
* Source/WebCore/html/forms/FileIconLoader.h:
* Source/WebCore/html/parser/HTMLElementStack.cpp:
* Source/WebCore/html/parser/HTMLElementStack.h:
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
* Source/WebCore/html/parser/HTMLMetaCharsetParser.h:
* Source/WebCore/html/parser/HTMLParserScheduler.cpp:
* Source/WebCore/html/parser/HTMLParserScheduler.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
* Source/WebCore/html/parser/HTMLPreloadScanner.h:
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
* Source/WebCore/html/parser/HTMLScriptRunner.cpp:
* Source/WebCore/html/parser/HTMLScriptRunner.h:
* Source/WebCore/html/parser/HTMLToken.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
* Source/WebCore/html/parser/HTMLTreeBuilder.h:
* Source/WebCore/html/track/AudioTrackConfiguration.cpp:
* Source/WebCore/html/track/AudioTrackConfiguration.h:
* Source/WebCore/html/track/VideoTrackConfiguration.cpp:
* Source/WebCore/html/track/VideoTrackConfiguration.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
* Source/WebCore/html/track/WebVTTParser.h:

Canonical link: <a href="https://commits.webkit.org/282905@main">https://commits.webkit.org/282905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca30ba1db951d75d900ce50ad6b9ba814226befd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51948 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10479 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13262 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59275 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7048 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/722 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->