### PR TITLE
[TZone] WebCore/svg Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -25,6 +25,7 @@
 #include "SVGGraphicsElement.h"
 #include "SVGURIReference.h"
 #include "SharedStringHash.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGAltGlyphElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGTextPositioningElement.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -41,10 +42,10 @@ public:
 
     bool hasValidGlyphElements(Vector<String>& glyphNames) const;
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAltGlyphElement, SVGTextPositioningElement, SVGURIReference>;
+
 private:
     SVGAltGlyphElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAltGlyphElement, SVGTextPositioningElement, SVGURIReference>;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -24,11 +24,14 @@
 
 #include "SVGParserUtilities.h"
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAngleValue);
 
 float SVGAngleValue::value() const
 {

--- a/Source/WebCore/svg/SVGAngleValue.h
+++ b/Source/WebCore/svg/SVGAngleValue.h
@@ -23,11 +23,12 @@
 
 #include "ExceptionOr.h"
 #include "SVGPropertyTraits.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SVGAngleValue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGAngleValue);
 public:
     enum Type {
         // FIXME: Change the casing style of the enum type or naming of the Angle Value (webkit.org/b/269429).

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -27,6 +27,7 @@
 #include "SVGSMILElement.h"
 #include "SVGTests.h"
 #include "UnitBezier.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -80,10 +81,10 @@ public:
     enum class AttributeType : uint8_t { CSS, XML, Auto };
     AttributeType attributeType() const { return m_attributeType; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAnimationElement, SVGElement, SVGTests>;
+
 protected:
     SVGAnimationElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAnimationElement, SVGElement, SVGTests>;
 
     virtual void resetAnimation();
 

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGeometryElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -40,10 +41,11 @@ public:
     SVGAnimatedLength& cyAnimated() { return m_cy; }
     SVGAnimatedLength& rAnimated() { return m_r; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCircleElement, SVGGeometryElement>;
+
 private:
     SVGCircleElement(const QualifiedName&, Document&);
 
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCircleElement, SVGGeometryElement>;
     friend PropertyRegistry;
 
     SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) const;

--- a/Source/WebCore/svg/SVGClipPathElement.h
+++ b/Source/WebCore/svg/SVGClipPathElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGraphicsElement.h"
 #include "SVGUnitTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,10 +44,10 @@ public:
 
     FloatRect calculateClipContentRepaintRect(RepaintRectCalculation);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGClipPathElement, SVGGraphicsElement>;
+
 private:
     SVGClipPathElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGClipPathElement, SVGGraphicsElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -25,6 +25,7 @@
 #include "NodeName.h"
 #include "SVGElement.h"
 #include <wtf/SortedArrayMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -90,10 +91,10 @@ public:
     SVGAnimatedNumber& exponentAnimated() { return m_exponent; }
     SVGAnimatedNumber& offsetAnimated() { return m_offset; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGComponentTransferFunctionElement, SVGElement>;
+
 protected:
     SVGComponentTransferFunctionElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGComponentTransferFunctionElement, SVGElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -24,6 +24,7 @@
 #include "SVGElement.h"
 #include "SVGTests.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -46,10 +47,10 @@ public:
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCursorElement, SVGElement, SVGTests, SVGURIReference>;
+
 private:
     SVGCursorElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCursorElement, SVGElement, SVGTests, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGDefsElement.h
+++ b/Source/WebCore/svg/SVGDefsElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGGraphicsElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -31,10 +32,10 @@ class SVGDefsElement final : public SVGGraphicsElement {
 public:
     static Ref<SVGDefsElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGDefsElement, SVGGraphicsElement>;
+
 private:
     SVGDefsElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGDefsElement, SVGGraphicsElement>;
 
     bool isValid() const final;
     bool supportsFocus() const final { return false; }

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -38,10 +38,13 @@
 #include "SVGUseElement.h"
 #include "ScriptableDocumentParser.h"
 #include "ShadowRoot.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGDocumentExtensions);
 
 static bool animationsPausedForDocument(Document& document)
 {

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -24,6 +24,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -39,8 +40,8 @@ class SVGUseElement;
 class WeakPtrImplWithEventTargetData;
 
 class SVGDocumentExtensions final : public CanMakeCheckedPtr<SVGDocumentExtensions> {
+    WTF_MAKE_TZONE_ALLOCATED(SVGDocumentExtensions);
     WTF_MAKE_NONCOPYABLE(SVGDocumentExtensions);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDocumentExtensions);
 public:
     explicit SVGDocumentExtensions(Document&);

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -31,6 +31,7 @@
 #include "StyledElement.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGElementRareData.h
+++ b/Source/WebCore/svg/SVGElementRareData.h
@@ -26,6 +26,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -34,7 +35,8 @@ class SVGCursorElement;
 class SVGElement;
 
 class SVGElementRareData {
-    WTF_MAKE_NONCOPYABLE(SVGElementRareData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGElementRareData);
+    WTF_MAKE_NONCOPYABLE(SVGElementRareData);
 public:
     SVGElementRareData()
         : m_instancesUpdatesBlocked(false)

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGeometryElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -42,10 +43,10 @@ public:
     SVGAnimatedLength& rxAnimated() { return m_rx; }
     SVGAnimatedLength& ryAnimated() { return m_ry; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGEllipseElement, SVGGeometryElement>;
+
 private:
     SVGEllipseElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGEllipseElement, SVGGeometryElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGFEBlendElement.h
+++ b/Source/WebCore/svg/SVGFEBlendElement.h
@@ -24,6 +24,7 @@
 
 #include "GraphicsTypes.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -61,10 +62,10 @@ public:
     SVGAnimatedString& in2Animated() { return m_in2; }
     SVGAnimatedEnumeration& modeAnimated() { return m_mode; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEBlendElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEBlendElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEBlendElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -23,6 +23,7 @@
 
 #include "FEColorMatrix.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -77,10 +78,10 @@ public:
     SVGAnimatedEnumeration& typeAnimated() { return m_type; }
     SVGAnimatedNumberList& valuesAnimated() { return m_values; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEColorMatrixElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEColorMatrixElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEColorMatrixElement, SVGFilterPrimitiveStandardAttributes>;
 
     bool isInvalidValuesLength() const;
 

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -42,10 +43,10 @@ public:
 protected:
     bool setFilterEffectAttributeFromChild(FilterEffect&, const Element&, const QualifiedName&) final;
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEComponentTransferElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEComponentTransferElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEComponentTransferElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -24,6 +24,7 @@
 #include "FEComposite.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
 #include <wtf/SortedArrayMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -97,10 +98,10 @@ public:
     SVGAnimatedNumber& k3Animated() { return m_k3; }
     SVGAnimatedNumber& k4Animated() { return m_k4; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFECompositeElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFECompositeElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFECompositeElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -23,6 +23,7 @@
 #include "CommonAtomStrings.h"
 #include "FEConvolveMatrix.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -95,10 +96,10 @@ public:
     SVGAnimatedNumber& kernelUnitLengthYAnimated() { return m_kernelUnitLengthY; }
     SVGAnimatedBoolean& preserveAlphaAnimated() { return m_preserveAlpha; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEConvolveMatrixElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEConvolveMatrixElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEConvolveMatrixElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
@@ -24,6 +24,7 @@
 
 #include "SVGFELightElement.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -49,10 +50,10 @@ public:
     SVGAnimatedNumber& kernelUnitLengthXAnimated() { return m_kernelUnitLengthX; }
     SVGAnimatedNumber& kernelUnitLengthYAnimated() { return m_kernelUnitLengthY; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDiffuseLightingElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEDiffuseLightingElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDiffuseLightingElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -22,6 +22,7 @@
 
 #include "FEDisplacementMap.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
  
@@ -82,10 +83,10 @@ public:
     SVGAnimatedEnumeration& yChannelSelectorAnimated() { return m_yChannelSelector; }
     SVGAnimatedNumber& scaleAnimated() { return m_scale; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDisplacementMapElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEDisplacementMapElement(const QualifiedName& tagName, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDisplacementMapElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "FEDropShadow.h"
+#include <wtf/TZoneMalloc.h>
 #include "SVGFilterPrimitiveStandardAttributes.h"
 
 namespace WebCore {
@@ -45,10 +46,10 @@ public:
     SVGAnimatedNumber& stdDeviationXAnimated() { return m_stdDeviationX; }
     SVGAnimatedNumber& stdDeviationYAnimated() { return m_stdDeviationY; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDropShadowElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEDropShadowElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDropShadowElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEFloodElement.h
+++ b/Source/WebCore/svg/SVGFEFloodElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -31,10 +32,10 @@ class SVGFEFloodElement final : public SVGFilterPrimitiveStandardAttributes {
 public:
     static Ref<SVGFEFloodElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEFloodElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEFloodElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEFloodElement, SVGFilterPrimitiveStandardAttributes>;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.h
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.h
@@ -24,6 +24,7 @@
 #include "FEGaussianBlur.h"
 #include "SVGFEConvolveMatrixElement.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -45,10 +46,10 @@ public:
     SVGAnimatedNumber& stdDeviationYAnimated() { return m_stdDeviationY; }
     SVGAnimatedEnumeration& edgeModeAnimated() { return m_edgeMode; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEGaussianBlurElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEGaussianBlurElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEGaussianBlurElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -25,6 +25,7 @@
 #include "CachedResourceHandle.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -41,10 +42,10 @@ public:
     const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;
+
 private:
     SVGFEImageElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFELightElement.h
+++ b/Source/WebCore/svg/SVGFELightElement.h
@@ -24,6 +24,7 @@
 
 #include "LightSource.h"
 #include "SVGElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -58,14 +59,14 @@ public:
     SVGAnimatedNumber& specularExponentAnimated() { return m_specularExponent; }
     SVGAnimatedNumber& limitingConeAngleAnimated() { return m_limitingConeAngle; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFELightElement, SVGElement>;
+
 protected:
     SVGFELightElement(const QualifiedName&, Document&);
 
     bool rendererIsNeeded(const RenderStyle&) override { return false; }
 
 private:
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFELightElement, SVGElement>;
-
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;

--- a/Source/WebCore/svg/SVGFEMergeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -31,10 +32,10 @@ class SVGFEMergeElement final : public SVGFilterPrimitiveStandardAttributes {
 public:
     static Ref<SVGFEMergeElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEMergeElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeElement, SVGFilterPrimitiveStandardAttributes>;
 
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,10 +35,10 @@ public:
     String in1() const { return m_in1->currentValue(); }
     SVGAnimatedString& in1Animated() { return m_in1; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeNodeElement, SVGElement>;
+
 private:
     SVGFEMergeNodeElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeNodeElement, SVGElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -23,6 +23,7 @@
 
 #include "FEMorphology.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -71,10 +72,10 @@ public:
     SVGAnimatedNumber& radiusXAnimated() { return m_radiusX; }
     SVGAnimatedNumber& radiusYAnimated() { return m_radiusY; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMorphologyElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEMorphologyElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMorphologyElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEOffsetElement.h
+++ b/Source/WebCore/svg/SVGFEOffsetElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,10 +40,10 @@ public:
     SVGAnimatedNumber& dxAnimated() { return m_dx; }
     SVGAnimatedNumber& dyAnimated() { return m_dy; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEOffsetElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFEOffsetElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEOffsetElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.h
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.h
@@ -25,6 +25,7 @@
 #include "FESpecularLighting.h"
 #include "SVGFELightElement.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -49,10 +50,10 @@ public:
     SVGAnimatedNumber& kernelUnitLengthXAnimated() { return m_kernelUnitLengthX; }
     SVGAnimatedNumber& kernelUnitLengthYAnimated() { return m_kernelUnitLengthY; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFESpecularLightingElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFESpecularLightingElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFESpecularLightingElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFETileElement.h
+++ b/Source/WebCore/svg/SVGFETileElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,10 +35,10 @@ public:
     String in1() const { return m_in1->currentValue(); }
     SVGAnimatedString& in1Animated() { return m_in1; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETileElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFETileElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETileElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -23,6 +23,7 @@
 
 #include "FETurbulence.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -110,10 +111,10 @@ public:
     SVGAnimatedEnumeration& stitchTilesAnimated() { return m_stitchTiles; }
     SVGAnimatedEnumeration& typeAnimated() { return m_type; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETurbulenceElement, SVGFilterPrimitiveStandardAttributes>;
+
 private:
     SVGFETurbulenceElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETurbulenceElement, SVGFilterPrimitiveStandardAttributes>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -26,6 +26,7 @@
 #include "SVGElement.h"
 #include "SVGURIReference.h"
 #include "SVGUnitTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -49,10 +50,10 @@ public:
     SVGAnimatedLength& widthAnimated() { return m_width; }
     SVGAnimatedLength& heightAnimated() { return m_height; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterElement, SVGElement, SVGURIReference>;
+
 private:
     SVGFilterElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterElement, SVGElement, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -26,6 +26,7 @@
 #include "SVGElement.h"
 #include "SVGNames.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFitToViewBox);
+
 SVGFitToViewBox::SVGFitToViewBox(SVGElement* contextElement, SVGPropertyAccess access)
     : m_viewBox(SVGAnimatedRect::create(contextElement, access))
     , m_preserveAspectRatio(SVGAnimatedPreserveAspectRatio::create(contextElement, access))

--- a/Source/WebCore/svg/SVGFitToViewBox.h
+++ b/Source/WebCore/svg/SVGFitToViewBox.h
@@ -27,12 +27,14 @@
 #include "SVGNames.h"
 #include "SVGPreserveAspectRatio.h"
 #include "SVGPropertyOwnerRegistry.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class AffineTransform;
 
 class SVGFitToViewBox {
+    WTF_MAKE_TZONE_ALLOCATED(SVGFitToViewBox);
     WTF_MAKE_NONCOPYABLE(SVGFitToViewBox);
 public:
     static AffineTransform viewBoxToViewTransform(const FloatRect& viewBoxRect, const SVGPreserveAspectRatioValue&, float viewWidth, float viewHeight);

--- a/Source/WebCore/svg/SVGFontElement.h
+++ b/Source/WebCore/svg/SVGFontElement.h
@@ -24,6 +24,7 @@
 
 #include "SVGElement.h"
 #include "SVGParserUtilities.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -45,12 +46,12 @@ class SVGFontElement final : public SVGElement {
 public:
     static Ref<SVGFontElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFontElement, SVGElement>;
+
 private:
     SVGFontElement(const QualifiedName&, Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFontElement, SVGElement>;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -22,6 +22,7 @@
 #include "SVGGraphicsElement.h"
 #include "SVGNames.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -41,10 +42,10 @@ public:
     SVGAnimatedLength& widthAnimated() { return m_width; }
     SVGAnimatedLength& heightAnimated() { return m_height; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGForeignObjectElement, SVGGraphicsElement>;
+
 private:
     SVGForeignObjectElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGForeignObjectElement, SVGGraphicsElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGGElement.h
+++ b/Source/WebCore/svg/SVGGElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGGraphicsElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -32,12 +33,12 @@ public:
     static Ref<SVGGElement> create(const QualifiedName&, Document&);
     static Ref<SVGGElement> create(Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGElement, SVGGraphicsElement>;
+
 private:
     SVGGElement(const QualifiedName&, Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGElement, SVGGraphicsElement>;
 
     bool isValid() const final { return SVGTests::isValid(); }
     bool rendererIsNeeded(const RenderStyle&) final;

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -25,6 +25,7 @@
 #include "Path.h"
 #include "SVGGraphicsElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGGlyphRefElement.h
+++ b/Source/WebCore/svg/SVGGlyphRefElement.h
@@ -22,6 +22,7 @@
 
 #include "SVGElement.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -42,10 +43,10 @@ public:
     float dy() const { return m_dy; }
     void setDy(float);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGlyphRefElement, SVGElement, SVGURIReference>;
+
 private:
     SVGGlyphRefElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGlyphRefElement, SVGElement, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -26,6 +26,7 @@
 #include "SVGNames.h"
 #include "SVGURIReference.h"
 #include "SVGUnitTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -24,6 +24,7 @@
 #include "SVGElement.h"
 #include "SVGTests.h"
 #include "SVGTransformable.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -24,6 +24,7 @@
 #include "SVGGraphicsElement.h"
 #include "SVGImageLoader.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -52,11 +53,11 @@ public:
     SVGAnimatedLength& heightAnimated() { return m_height; }
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
+
 private:
     SVGImageElement(const QualifiedName&, Document&);
     
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
-
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -26,12 +26,15 @@
 #include "SVGElement.h"
 #include "SVGLengthContext.h"
 #include "SVGParserUtilities.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGLengthValue);
 
 static inline ASCIILiteral lengthTypeToString(SVGLengthType lengthType)
 {

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -24,6 +24,7 @@
 #include "ExceptionOr.h"
 #include "SVGParsingError.h"
 #include "SVGPropertyTraits.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -59,7 +60,7 @@ enum class SVGLengthNegativeValuesMode : uint8_t {
 enum class ShouldConvertNumberToPxLength : bool { No, Yes };
 
 class SVGLengthValue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGLengthValue);
 public:
     SVGLengthValue(SVGLengthMode = SVGLengthMode::Other, const String& valueAsString = { });
     SVGLengthValue(float valueInSpecifiedUnits, SVGLengthType, SVGLengthMode = SVGLengthMode::Other);

--- a/Source/WebCore/svg/SVGLineElement.h
+++ b/Source/WebCore/svg/SVGLineElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGeometryElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGradientElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -23,6 +23,7 @@
 #include "SVGElement.h"
 #include "SVGNames.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
     
@@ -40,10 +41,10 @@ public:
 
     void targetPathChanged();
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMPathElement, SVGElement, SVGURIReference>;
+
 private:
     SVGMPathElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMPathElement, SVGElement, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -24,6 +24,7 @@
 #include "SVGElement.h"
 #include "SVGFitToViewBox.h"
 #include "SVGMarkerTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -24,6 +24,7 @@
 #include "SVGNames.h"
 #include "SVGTests.h"
 #include "SVGUnitTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -51,10 +52,10 @@ public:
 
     FloatRect calculateMaskContentRepaintRect(RepaintRectCalculation);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMaskElement, SVGElement, SVGTests>;
+
 private:
     SVGMaskElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMaskElement, SVGElement, SVGTests>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGPathBlender.cpp
+++ b/Source/WebCore/svg/SVGPathBlender.cpp
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGPathBlender);
+
 bool SVGPathBlender::addAnimatedPath(SVGPathSource& fromSource, SVGPathSource& toSource, SVGPathConsumer& consumer, unsigned repeatCount)
 {
     SVGPathBlender blender(fromSource, toSource, &consumer);

--- a/Source/WebCore/svg/SVGPathBlender.h
+++ b/Source/WebCore/svg/SVGPathBlender.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "SVGPathConsumer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -32,7 +33,8 @@ enum FloatBlendMode {
 class SVGPathSource;
 
 class SVGPathBlender {
-    WTF_MAKE_NONCOPYABLE(SVGPathBlender); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGPathBlender);
+    WTF_MAKE_NONCOPYABLE(SVGPathBlender);
 public:
 
     static bool addAnimatedPath(SVGPathSource& from, SVGPathSource& to, SVGPathConsumer&, unsigned repeatCount);

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -23,6 +23,7 @@
 #include "Path.h"
 #include "SVGPathUtilities.h"
 #include "SVGPropertyTraits.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -38,7 +39,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SVGPathByteS
 namespace WebCore {
 
 class SVGPathByteStream final : public CanMakeSingleThreadWeakPtr<SVGPathByteStream> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPathByteStream);
 public:
     class Data final : public RefCounted<Data> {
     public:

--- a/Source/WebCore/svg/SVGPathConsumer.h
+++ b/Source/WebCore/svg/SVGPathConsumer.h
@@ -24,8 +24,8 @@
 #pragma once
 
 #include "FloatPoint.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -50,7 +50,8 @@ enum PathParsingMode {
 };
 
 class SVGPathConsumer : public CanMakeSingleThreadWeakPtr<SVGPathConsumer> {
-    WTF_MAKE_NONCOPYABLE(SVGPathConsumer); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPathConsumer);
+    WTF_MAKE_NONCOPYABLE(SVGPathConsumer);
 public:
     SVGPathConsumer() = default;
     virtual void incrementPathSegmentCount() = 0;

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -26,6 +26,7 @@
 #include "SVGNames.h"
 #include "SVGPathByteStream.h"
 #include "SVGPathSegImpl.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -105,10 +106,10 @@ public:
 
     static void clearCache();
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPathElement, SVGGeometryElement>;
+
 private:
     SVGPathElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPathElement, SVGGeometryElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGPathSource.h
+++ b/Source/WebCore/svg/SVGPathSource.h
@@ -21,6 +21,7 @@
 
 #include "FloatPoint.h"
 #include "SVGPathSeg.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -35,7 +36,8 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SVGPathSourc
 namespace WebCore {
 
 class SVGPathSource : public CanMakeSingleThreadWeakPtr<SVGPathSource> {
-    WTF_MAKE_NONCOPYABLE(SVGPathSource); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPathSource);
+    WTF_MAKE_NONCOPYABLE(SVGPathSource);
 public:
     SVGPathSource() = default;
     virtual ~SVGPathSource() = default;

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -27,6 +27,7 @@
 #include "SVGTests.h"
 #include "SVGURIReference.h"
 #include "SVGUnitTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGeometryElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -37,12 +38,12 @@ public:
 
     size_t approximateMemoryCost() const override;
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPolyElement, SVGGeometryElement>;
+
 protected:
     SVGPolyElement(const QualifiedName&, Document&);
 
 private:
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPolyElement, SVGGeometryElement>;
-
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
@@ -27,11 +27,14 @@
 #include "AffineTransform.h"
 #include "FloatRect.h"
 #include "SVGParserUtilities.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGPreserveAspectRatioValue);
 
 SVGPreserveAspectRatioValue::SVGPreserveAspectRatioValue(StringView value)
 {

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
@@ -22,6 +22,7 @@
 
 #include "ExceptionOr.h"
 #include "SVGPropertyTraits.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 template<typename T, typename> struct ArgumentCoder;
@@ -33,7 +34,7 @@ class AffineTransform;
 class FloatRect;
 
 class SVGPreserveAspectRatioValue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGPreserveAspectRatioValue);
 public:
     enum SVGPreserveAspectRatioType : uint8_t {
         SVG_PRESERVEASPECTRATIO_UNKNOWN = 0,

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGradientElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -50,10 +51,10 @@ public:
     SVGAnimatedLength& fyAnimated() { return m_fy; }
     SVGAnimatedLength& frAnimated() { return m_fr; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRadialGradientElement, SVGGradientElement>;
+
 private:
     SVGRadialGradientElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRadialGradientElement, SVGGradientElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGGeometryElement.h"
 #include "SVGNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -46,10 +47,11 @@ public:
     SVGAnimatedLength& rxAnimated() { return m_rx; }
     SVGAnimatedLength& ryAnimated() { return m_ry; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRectElement, SVGGeometryElement>;
+
 private:
     SVGRectElement(const QualifiedName&, Document&);
 
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRectElement, SVGGeometryElement>;
     friend PropertyRegistry;
 
     SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) const;

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -25,6 +25,7 @@
 #include "SVGFitToViewBox.h"
 #include "SVGGraphicsElement.h"
 #include "SVGZoomAndPan.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -89,6 +90,7 @@ public:
     bool scrollToFragment(StringView fragmentIdentifier);
     void resetScrollAnchor();
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSVGElement, SVGGraphicsElement, SVGFitToViewBox>;
     using SVGGraphicsElement::ref;
     using SVGGraphicsElement::deref;
 
@@ -124,8 +126,6 @@ public:
 private:
     SVGSVGElement(const QualifiedName&, Document&);
     virtual ~SVGSVGElement();
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSVGElement, SVGGraphicsElement, SVGFitToViewBox>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -25,6 +25,7 @@
 #include "SVGURIReference.h"
 #include "ScriptElement.h"
 #include "XLinkNames.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,13 +35,12 @@ class SVGScriptElement final : public SVGElement, public SVGURIReference, public
 public:
     static Ref<SVGScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
     using SVGElement::ref;
     using SVGElement::deref;
 
 private:
     SVGScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGStopElement.h
+++ b/Source/WebCore/svg/SVGStopElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,10 +37,10 @@ public:
     float offset() const { return m_offset->currentValue(); }
     SVGAnimatedNumber& offsetAnimated() { return m_offset; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGStopElement, SVGElement>;
+
 private:
     SVGStopElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGStopElement, SVGElement>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGSwitchElement.h
+++ b/Source/WebCore/svg/SVGSwitchElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGGraphicsElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -31,10 +32,10 @@ class SVGSwitchElement final : public SVGGraphicsElement {
 public:
     static Ref<SVGSwitchElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSwitchElement, SVGGraphicsElement>;
+
 private:
     SVGSwitchElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSwitchElement, SVGGraphicsElement>;
 
     bool isValid() const final { return SVGTests::isValid(); }
 

--- a/Source/WebCore/svg/SVGSymbolElement.h
+++ b/Source/WebCore/svg/SVGSymbolElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGFitToViewBox.h"
 #include "SVGGraphicsElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -32,10 +33,10 @@ class SVGSymbolElement final : public SVGGraphicsElement, public SVGFitToViewBox
 public:
     static Ref<SVGSymbolElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSymbolElement, SVGGraphicsElement, SVGFitToViewBox>;
+
 private:
     SVGSymbolElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSymbolElement, SVGGraphicsElement, SVGFitToViewBox>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -23,6 +23,7 @@
 
 #include "SVGTextPositioningElement.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,13 +35,13 @@ class SVGTRefElement final : public SVGTextPositioningElement, public SVGURIRefe
 public:
     static Ref<SVGTRefElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTRefElement, SVGTextPositioningElement, SVGURIReference>;
+
 private:
     friend class SVGTRefTargetEventListener;
 
     SVGTRefElement(const QualifiedName&, Document&);
     virtual ~SVGTRefElement();
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTRefElement, SVGTextPositioningElement, SVGURIReference>;
 
     Ref<SVGTRefTargetEventListener> protectedTargetListener() const;
 

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -30,6 +30,7 @@
 #include "SVGStringList.h"
 #include <wtf/Language.h>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MATHML)
 #include "MathMLNames.h"
@@ -37,6 +38,7 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGConditionalProcessingAttributes);
 
 SVGConditionalProcessingAttributes::SVGConditionalProcessingAttributes(SVGElement& contextElement)
     : m_requiredExtensions(SVGStringList::create(&contextElement))

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -23,6 +23,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,7 +37,8 @@ class SVGPropertyOwnerRegistry;
 class SVGTests;
 
 class SVGConditionalProcessingAttributes {
-    WTF_MAKE_NONCOPYABLE(SVGConditionalProcessingAttributes); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGConditionalProcessingAttributes);
+    WTF_MAKE_NONCOPYABLE(SVGConditionalProcessingAttributes);
 public:
     SVGConditionalProcessingAttributes(SVGElement& contextElement);
 

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGGraphicsElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -24,6 +24,7 @@
 #include "SVGNames.h"
 #include "SVGTextContentElement.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -121,13 +122,13 @@ public:
     SVGAnimatedEnumeration& methodAnimated() { return m_method; }
     SVGAnimatedEnumeration& spacingAnimated() { return m_spacing; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPathElement, SVGTextContentElement, SVGURIReference>;
+
 private:
     SVGTextPathElement(const QualifiedName&, Document&);
     virtual ~SVGTextPathElement();
 
     void didFinishInsertingNode() override;
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPathElement, SVGTextContentElement, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGTextPositioningElement.h
+++ b/Source/WebCore/svg/SVGTextPositioningElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "SVGTextContentElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -28,9 +28,12 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGUseElement.h"
 #include "XLinkNames.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGURIReference);
 
 SVGURIReference::SVGURIReference(SVGElement* contextElement)
     : m_href(SVGAnimatedString::create(contextElement))

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -24,12 +24,14 @@
 #include "Document.h"
 #include "QualifiedName.h"
 #include "SVGPropertyOwnerRegistry.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SVGElement;
 
 class SVGURIReference {
+    WTF_MAKE_TZONE_ALLOCATED(SVGURIReference);
     WTF_MAKE_NONCOPYABLE(SVGURIReference);
 public:
     virtual ~SVGURIReference() = default;
@@ -56,7 +58,11 @@ public:
         return !equalIgnoringFragmentIdentifier(url, document.url());
     }
 
+#if 0
+    typedef SVGPropertyOwnerRegistry<SVGURIReference> PropertyRegistry;
+#else
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGURIReference>;
+#endif
 
     String href() const { return m_href->currentValue(); }
     SVGAnimatedString& hrefAnimated() { return m_href; }

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -25,6 +25,7 @@
 #include "CachedSVGDocumentClient.h"
 #include "SVGGraphicsElement.h"
 #include "SVGURIReference.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -53,6 +54,8 @@ public:
     SVGAnimatedLength& widthAnimated() { return m_width; }
     SVGAnimatedLength& heightAnimated() { return m_height; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGUseElement, SVGGraphicsElement, SVGURIReference>;
+
 private:
     SVGUseElement(const QualifiedName&, Document&);
 
@@ -60,8 +63,6 @@ private:
     void didFinishInsertingNode() final;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
     void buildPendingResource() override;
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGUseElement, SVGGraphicsElement, SVGURIReference>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -26,6 +26,7 @@
 #include "SVGSVGElement.h"
 #include "SVGStringList.h"
 #include "SVGZoomAndPan.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,6 +36,7 @@ class SVGViewElement final : public SVGElement, public SVGFitToViewBox, public S
 public:
     static Ref<SVGViewElement> create(const QualifiedName&, Document&);
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewElement, SVGElement, SVGFitToViewBox>;
     using SVGElement::ref;
     using SVGElement::deref;
 
@@ -44,8 +46,6 @@ public:
 
 private:
     SVGViewElement(const QualifiedName&, Document&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewElement, SVGElement, SVGFitToViewBox>;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGViewSpec.cpp
+++ b/Source/WebCore/svg/SVGViewSpec.cpp
@@ -28,9 +28,12 @@
 #include "SVGParserUtilities.h"
 #include "SVGTransformList.h"
 #include "SVGTransformable.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGViewSpec);
 
 SVGViewSpec::SVGViewSpec(SVGElement& contextElement)
     : SVGFitToViewBox(&contextElement, SVGPropertyAccess::ReadOnly)

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -22,6 +22,7 @@
 
 #include "SVGFitToViewBox.h"
 #include "SVGZoomAndPan.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -31,6 +32,7 @@ class SVGTransformList;
 class WeakPtrImplWithEventTargetData;
 
 class SVGViewSpec final : public RefCounted<SVGViewSpec>, public SVGFitToViewBox, public SVGZoomAndPan {
+    WTF_MAKE_TZONE_ALLOCATED(SVGViewSpec);
 public:
     static Ref<SVGViewSpec> create(SVGElement& contextElement)
     {
@@ -50,10 +52,10 @@ public:
 
     const WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>& contextElementConcurrently() const { return m_contextElement; }
 
+    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewSpec, SVGFitToViewBox>;
+
 private:
     explicit SVGViewSpec(SVGElement&);
-
-    using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewSpec, SVGFitToViewBox>;
 
     WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_contextElement;
     String m_viewTargetString;

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -28,8 +28,11 @@
 #include "LocalFrameView.h"
 #include "SVGImage.h"
 #include "SVGImageForContainer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGImageCache);
 
 SVGImageCache::SVGImageCache(SVGImage* svgImage)
     : m_svgImage(svgImage)

--- a/Source/WebCore/svg/graphics/SVGImageCache.h
+++ b/Source/WebCore/svg/graphics/SVGImageCache.h
@@ -23,6 +23,7 @@
 #include "Image.h"
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class SVGImageForContainer;
 class RenderObject;
 
 class SVGImageCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SVGImageCache, WEBCORE_EXPORT);
 public:
     explicit SVGImageCache(SVGImage*);
     ~SVGImageCache();

--- a/Source/WebCore/svg/graphics/SVGImageClients.h
+++ b/Source/WebCore/svg/graphics/SVGImageClients.h
@@ -30,12 +30,14 @@
 
 #include "EmptyClients.h"
 #include "SVGImage.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class SVGImageChromeClient final : public EmptyChromeClient {
-    WTF_MAKE_NONCOPYABLE(SVGImageChromeClient); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGImageChromeClient);
+    WTF_MAKE_NONCOPYABLE(SVGImageChromeClient);
 public:
     SVGImageChromeClient(SVGImage* image)
         : m_image(image)

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
@@ -30,8 +30,11 @@
 #include "CSSPropertyParser.h"
 #include "MutableStyleProperties.h"
 #include "SVGElementInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAttributeAnimator);
 
 bool SVGAttributeAnimator::isAnimatedStylePropertyAnimator(const SVGElement& targetElement) const
 {

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.h
@@ -29,6 +29,7 @@
 #include "QualifiedName.h"
 #include <wtf/RefCounted.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -53,7 +54,7 @@ enum class CalcMode : uint8_t {
 };
 
 class SVGAttributeAnimator : public RefCounted<SVGAttributeAnimator>, public CanMakeWeakPtr<SVGAttributeAnimator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SVGAttributeAnimator);
 public:
     SVGAttributeAnimator(const QualifiedName& attributeName)
         : m_attributeName(attributeName)

--- a/Source/WebCore/svg/properties/SVGDecoratedProperty.h
+++ b/Source/WebCore/svg/properties/SVGDecoratedProperty.h
@@ -26,12 +26,13 @@
 #pragma once
 
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 template<typename DecorationType>
 class SVGDecoratedProperty : public RefCounted<SVGDecoratedProperty<DecorationType>> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGDecoratedProperty);
 public:
     SVGDecoratedProperty() = default;
     virtual ~SVGDecoratedProperty() = default;

--- a/Source/WebCore/svg/properties/SVGMemberAccessor.h
+++ b/Source/WebCore/svg/properties/SVGMemberAccessor.h
@@ -28,6 +28,7 @@
 #include "QualifiedName.h"
 #include "SVGAnimatedProperty.h"
 #include "SVGAttributeAnimator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class SVGProperty;
 
 template<typename OwnerType>
 class SVGMemberAccessor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGMemberAccessor);
 public:
     virtual ~SVGMemberAccessor() = default;
 

--- a/Source/WebCore/svg/properties/SVGPropertyAnimatorFactory.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimatorFactory.h
@@ -31,11 +31,12 @@
 #include "SVGValuePropertyAnimatorImpl.h"
 #include "SVGValuePropertyListAnimatorImpl.h"
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class SVGPropertyAnimatorFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPropertyAnimatorFactory);
 public:
     SVGPropertyAnimatorFactory() = default;
 

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -30,6 +30,7 @@
 #include "SVGPropertyAccessorImpl.h"
 #include "SVGPropertyRegistry.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -62,7 +63,7 @@ struct SVGAttributeHashTranslator {
 
 template<typename OwnerType, typename... BaseTypes>
 class SVGPropertyOwnerRegistry : public SVGPropertyRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPropertyOwnerRegistry);
 public:
     SVGPropertyOwnerRegistry(OwnerType& owner)
         : m_owner(owner)


### PR DESCRIPTION
#### 3b7e2494b95161eadfe1948c7a8bbf49885f59f6
<pre>
[TZone] WebCore/svg Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278839">https://bugs.webkit.org/show_bug.cgi?id=278839</a>
<a href="https://rdar.apple.com/134909698">rdar://134909698</a>

Reviewed by Yijia Huang.

Converted WebCore/svg classed from WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED
(and related macros) in preparation for enabling TZone (not yet enabled).

* Source/WebCore/svg/SVGAElement.h:
* Source/WebCore/svg/SVGAltGlyphElement.h:
* Source/WebCore/svg/SVGAngleValue.cpp:
* Source/WebCore/svg/SVGAngleValue.h:
* Source/WebCore/svg/SVGAnimationElement.h:
* Source/WebCore/svg/SVGCircleElement.h:
* Source/WebCore/svg/SVGClipPathElement.h:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
* Source/WebCore/svg/SVGCursorElement.h:
* Source/WebCore/svg/SVGDefsElement.h:
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGElementRareData.h:
* Source/WebCore/svg/SVGEllipseElement.h:
* Source/WebCore/svg/SVGFEBlendElement.h:
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
* Source/WebCore/svg/SVGFEComponentTransferElement.h:
* Source/WebCore/svg/SVGFECompositeElement.h:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:
* Source/WebCore/svg/SVGFEDiffuseLightingElement.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.h:
* Source/WebCore/svg/SVGFEDropShadowElement.h:
* Source/WebCore/svg/SVGFEFloodElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.h:
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFELightElement.h:
* Source/WebCore/svg/SVGFEMergeElement.h:
* Source/WebCore/svg/SVGFEMergeNodeElement.h:
* Source/WebCore/svg/SVGFEMorphologyElement.h:
* Source/WebCore/svg/SVGFEOffsetElement.h:
* Source/WebCore/svg/SVGFESpecularLightingElement.h:
* Source/WebCore/svg/SVGFETileElement.h:
* Source/WebCore/svg/SVGFETurbulenceElement.h:
* Source/WebCore/svg/SVGFilterElement.h:
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
* Source/WebCore/svg/SVGFitToViewBox.cpp:
* Source/WebCore/svg/SVGFitToViewBox.h:
* Source/WebCore/svg/SVGFontElement.h:
* Source/WebCore/svg/SVGForeignObjectElement.h:
* Source/WebCore/svg/SVGGElement.h:
* Source/WebCore/svg/SVGGeometryElement.h:
* Source/WebCore/svg/SVGGlyphRefElement.h:
* Source/WebCore/svg/SVGGradientElement.h:
* Source/WebCore/svg/SVGGraphicsElement.h:
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
* Source/WebCore/svg/SVGLengthValue.h:
* Source/WebCore/svg/SVGLineElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.h:
* Source/WebCore/svg/SVGMPathElement.h:
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGPathBlender.cpp:
* Source/WebCore/svg/SVGPathBlender.h:
* Source/WebCore/svg/SVGPathByteStream.h:
* Source/WebCore/svg/SVGPathConsumer.h:
* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGPathSource.h:
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGPolyElement.h:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.h:
* Source/WebCore/svg/SVGRadialGradientElement.h:
* Source/WebCore/svg/SVGRectElement.h:
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGStopElement.h:
* Source/WebCore/svg/SVGSwitchElement.h:
* Source/WebCore/svg/SVGSymbolElement.h:
* Source/WebCore/svg/SVGTRefElement.h:
* Source/WebCore/svg/SVGTests.cpp:
* Source/WebCore/svg/SVGTests.h:
* Source/WebCore/svg/SVGTextContentElement.h:
* Source/WebCore/svg/SVGTextPathElement.h:
* Source/WebCore/svg/SVGTextPositioningElement.h:
* Source/WebCore/svg/SVGURIReference.cpp:
* Source/WebCore/svg/SVGURIReference.h:
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/SVGViewElement.h:
* Source/WebCore/svg/SVGViewSpec.cpp:
* Source/WebCore/svg/SVGViewSpec.h:
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
* Source/WebCore/svg/graphics/SVGImageCache.h:
* Source/WebCore/svg/graphics/SVGImageClients.h:
* Source/WebCore/svg/properties/SVGAttributeAnimator.cpp:
* Source/WebCore/svg/properties/SVGAttributeAnimator.h:
* Source/WebCore/svg/properties/SVGDecoratedProperty.h:
* Source/WebCore/svg/properties/SVGMemberAccessor.h:
* Source/WebCore/svg/properties/SVGPropertyAnimatorFactory.h:
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:

Canonical link: <a href="https://commits.webkit.org/282899@main">https://commits.webkit.org/282899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef9d685ed903073936f019880cffd75b4e6687e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51946 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10475 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14057 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59273 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59449 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/719 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39754 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->