### PR TITLE
[TZone] WebCore/workers Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -32,9 +32,12 @@
 #include <JavaScriptCore/ScriptArguments.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerConsoleClient);
 
 WorkerConsoleClient::WorkerConsoleClient(WorkerOrWorkletGlobalScope& globalScope)
     : m_globalScope(globalScope)

--- a/Source/WebCore/workers/WorkerConsoleClient.h
+++ b/Source/WebCore/workers/WorkerConsoleClient.h
@@ -28,6 +28,7 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include <JavaScriptCore/ConsoleClient.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class CallFrame;
@@ -38,7 +39,7 @@ using JSC::MessageType;
 namespace WebCore {
 
 class WorkerConsoleClient final : public JSC::ConsoleClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerConsoleClient);
 public:
     explicit WorkerConsoleClient(WorkerOrWorkletGlobalScope&);
     virtual ~WorkerConsoleClient();

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -37,8 +37,11 @@
 #include "WOFFFileFormat.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerThreadableLoader.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerFontLoadRequest);
 
 WorkerFontLoadRequest::WorkerFontLoadRequest(URL&& url, LoadedFromOpaqueSource loadedFromOpaqueSource)
     : m_url(WTFMove(url))

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -30,6 +30,7 @@
 #include "ResourceLoaderOptions.h"
 #include "SharedBuffer.h"
 #include "ThreadableLoaderClient.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,7 +43,7 @@ class WorkerGlobalScope;
 struct FontCustomPlatformData;
 
 class WorkerFontLoadRequest final : public FontLoadRequest, public ThreadableLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerFontLoadRequest);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerFontLoadRequest);
 public:
     WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -34,9 +34,12 @@
 #include "WorkerThread.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <wtf/NeverDestroyed.h>
-
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerInspectorProxy);
+
 using namespace Inspector;
 
 static Lock proxiesLock;

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -27,6 +27,7 @@
 
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
@@ -42,8 +43,8 @@ class WorkerThread;
 enum class WorkerThreadStartMode;
 
 class WorkerInspectorProxy : public RefCounted<WorkerInspectorProxy>, public CanMakeWeakPtr<WorkerInspectorProxy, WeakPtrFactoryInitialization::Eager> {
+    WTF_MAKE_TZONE_ALLOCATED(WorkerInspectorProxy);
     WTF_MAKE_NONCOPYABLE(WorkerInspectorProxy);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<WorkerInspectorProxy> create(const String& identifier)
     {

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -53,8 +53,11 @@
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerMessagingProxy);
 
 // WorkerUserGestureForwarder is a ThreadSafeRefCounted utility class indended for
 // holding a non-thread-safe RefCounted UserGestureToken. Because UserGestureToken

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -31,6 +31,7 @@
 #include "WorkerLoaderProxy.h"
 #include "WorkerObjectProxy.h"
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
@@ -40,7 +41,7 @@ class WorkerInspectorProxy;
 class WorkerUserGestureForwarder;
 
 class WorkerMessagingProxy final : public ThreadSafeRefCounted<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerMessagingProxy);
 public:
     explicit WorkerMessagingProxy(Worker&);
     virtual ~WorkerMessagingProxy();

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -63,8 +63,11 @@
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerOrWorkletScriptController);
 
 using namespace JSC;
 

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -35,6 +35,7 @@
 #include <wtf/Lock.h>
 #include <wtf/MessageQueue.h>
 #include <wtf/NakedPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class AbstractModuleRecord;
@@ -54,8 +55,8 @@ class WorkerOrWorkletGlobalScope;
 class WorkerScriptFetcher;
 
 class WorkerOrWorkletScriptController final : public CanMakeCheckedPtr<WorkerOrWorkletScriptController> {
+    WTF_MAKE_TZONE_ALLOCATED(WorkerOrWorkletScriptController);
     WTF_MAKE_NONCOPYABLE(WorkerOrWorkletScriptController);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerOrWorkletScriptController);
 public:
     WorkerOrWorkletScriptController(WorkerThreadType, Ref<JSC::VM>&&, WorkerOrWorkletGlobalScope*);

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -46,12 +46,17 @@
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSRunLoopTimer.h>
 #include <wtf/AutodrainedPool.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(GLIB)
 #include <glib.h>
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerRunLoop);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerDedicatedRunLoop);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WorkerDedicatedRunLoopTask, WorkerDedicatedRunLoop::Task);
 
 class WorkerSharedTimer final : public SharedTimer {
 public:

--- a/Source/WebCore/workers/WorkerRunLoop.h
+++ b/Source/WebCore/workers/WorkerRunLoop.h
@@ -34,6 +34,7 @@
 #include "ScriptExecutionContext.h"
 #include <memory>
 #include <wtf/MessageQueue.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class WorkerMainRunLoop;
@@ -52,7 +53,7 @@ class WorkerOrWorkletGlobalScope;
 class WorkerSharedTimer;
 
 class WorkerRunLoop {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerRunLoop);
 public:
     enum class Type : bool { WorkerDedicatedRunLoop, WorkerMainRunLoop };
 
@@ -77,6 +78,7 @@ private:
 };
 
 class WorkerDedicatedRunLoop final : public WorkerRunLoop {
+    WTF_MAKE_TZONE_ALLOCATED(WorkerDedicatedRunLoop);
 public:
     WorkerDedicatedRunLoop();
     ~WorkerDedicatedRunLoop();
@@ -96,7 +98,8 @@ public:
     WEBCORE_EXPORT void postTaskForMode(ScriptExecutionContext::Task&&, const String& mode) final;
 
     class Task {
-        WTF_MAKE_NONCOPYABLE(Task); WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Task);
+        WTF_MAKE_NONCOPYABLE(Task);
     public:
         Task(ScriptExecutionContext::Task&&, const String& mode);
         const String& mode() const { return m_mode; }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -45,9 +45,12 @@
 #include "WorkerScriptLoaderClient.h"
 #include "WorkerThreadableLoader.h"
 #include <wtf/Ref.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerScriptLoader);
 
 static Lock workerScriptLoaderControlledCallbackMapLock;
 static void accessWorkerScriptLoaderMap(CompletionHandler<void(HashMap<ScriptExecutionContextIdentifier, Ref<WorkerScriptLoader::ServiceWorkerDataManager>>&)>&& callback)

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -40,10 +40,10 @@
 #include "ThreadableLoader.h"
 #include "ThreadableLoaderClient.h"
 #include <memory>
-#include <wtf/FastMalloc.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -58,7 +58,7 @@ struct WorkerFetchResult;
 enum class CertificateInfoPolicy : uint8_t;
 
 class WorkerScriptLoader final : public RefCounted<WorkerScriptLoader>, public ThreadableLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerScriptLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerScriptLoader);
 public:
     static Ref<WorkerScriptLoader> create()

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -36,6 +36,7 @@
 #include "WorkerScriptFetcher.h"
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 
 namespace WebCore {
@@ -74,7 +75,8 @@ WorkerParameters WorkerParameters::isolatedCopy() const
 }
 
 struct WorkerThreadStartupData {
-    WTF_MAKE_NONCOPYABLE(WorkerThreadStartupData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WorkerThreadStartupData);
+    WTF_MAKE_NONCOPYABLE(WorkerThreadStartupData);
 public:
     WorkerThreadStartupData(const WorkerParameters& params, const ScriptBuffer& sourceCode, WorkerThreadStartMode, const SecurityOrigin& topOrigin);
 

--- a/Source/WebCore/workers/service/NavigationPreloadManager.cpp
+++ b/Source/WebCore/workers/service/NavigationPreloadManager.cpp
@@ -28,8 +28,11 @@
 
 #include "ServiceWorkerContainer.h"
 #include "ServiceWorkerRegistration.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationPreloadManager);
 
 void NavigationPreloadManager::enable(Promise&& promise)
 {

--- a/Source/WebCore/workers/service/NavigationPreloadManager.h
+++ b/Source/WebCore/workers/service/NavigationPreloadManager.h
@@ -27,11 +27,12 @@
 
 #include "NavigationPreloadState.h"
 #include "ServiceWorkerRegistration.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class NavigationPreloadManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NavigationPreloadManager);
 public:
     friend class ServiceWorkerRegistration;
 

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -37,9 +37,12 @@
 #include "ServiceWorkerRegistration.h"
 #include "WorkerFetchResult.h"
 #include "WorkerRunLoop.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerJob);
 
 ServiceWorkerJob::ServiceWorkerJob(ServiceWorkerJobClient& client, RefPtr<DeferredPromise>&& promise, ServiceWorkerJobData&& jobData)
     : m_client(client)

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -36,6 +36,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 
@@ -48,7 +49,7 @@ enum class ServiceWorkerJobType : uint8_t;
 struct ServiceWorkerRegistrationData;
 
 class ServiceWorkerJob : public WorkerScriptLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ServiceWorkerJob, WEBCORE_EXPORT);
 public:
     ServiceWorkerJob(ServiceWorkerJobClient&, RefPtr<DeferredPromise>&&, ServiceWorkerJobData&&);
     WEBCORE_EXPORT ~ServiceWorkerJob();

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -36,9 +36,13 @@
 #include "RetrieveRecordsOptions.h"
 #include "SWServerRegistration.h"
 #include "WebCorePersistentCoders.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/persistence/PersistentCoders.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetch);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(BackgroundFetchRecord, BackgroundFetch::Record);
 
 static const unsigned backgroundFetchCurrentVersion = 1;
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -37,6 +37,7 @@
 #include "ServiceWorkerRegistrationKey.h"
 #include "ServiceWorkerTypes.h"
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -58,7 +59,7 @@ struct BackgroundFetchRequest;
 struct CacheQueryOptions;
 
 class BackgroundFetch : public CanMakeWeakPtr<BackgroundFetch> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackgroundFetch);
 public:
     using NotificationCallback = Function<void(BackgroundFetch&)>;
     BackgroundFetch(SWServerRegistration&, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, Ref<BackgroundFetchStore>&&, NotificationCallback&&);
@@ -81,7 +82,7 @@ public:
     void resume(const CreateLoaderCallback&);
 
     class Record final : public BackgroundFetchRecordLoaderClient, public RefCounted<Record>, private Identified<BackgroundFetchRecordIdentifier> {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Record);
     public:
         static Ref<Record> create(BackgroundFetch& fetch, BackgroundFetchRequest&& request, size_t size) { return adoptRef(*new Record(fetch, WTFMove(request), size)); }
         ~Record();

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
@@ -33,8 +33,11 @@
 #include "RetrieveRecordsOptions.h"
 #include "SWServerRegistration.h"
 #include "SWServerToContextConnection.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetchEngine);
 
 BackgroundFetchEngine::BackgroundFetchEngine(SWServer& server)
     : m_server(server)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
@@ -27,6 +27,7 @@
 
 #include "BackgroundFetch.h"
 #include <span>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class BackgroundFetchEngine;
@@ -44,7 +45,7 @@ class ResourceResponse;
 class SWServer;
 
 class BackgroundFetchEngine : public CanMakeWeakPtr<BackgroundFetchEngine> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackgroundFetchEngine);
 public:
     explicit BackgroundFetchEngine(SWServer&);
 

--- a/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
+++ b/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
@@ -29,8 +29,11 @@
 #include "BackgroundFetchManager.h"
 #include "ServiceWorkerRegistration.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerRegistrationBackgroundFetchAPI);
 
 ServiceWorkerRegistrationBackgroundFetchAPI::ServiceWorkerRegistrationBackgroundFetchAPI(ServiceWorkerRegistration& serviceWorkerRegistration)
     : m_serviceWorkerRegistration(serviceWorkerRegistration)

--- a/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
+++ b/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
@@ -27,6 +27,7 @@
 
 #include "Supplementable.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class BackgroundFetchManager;
 class ServiceWorkerRegistration;
 
 class ServiceWorkerRegistrationBackgroundFetchAPI : public Supplement<ServiceWorkerRegistration> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerRegistrationBackgroundFetchAPI);
 public:
     explicit ServiceWorkerRegistrationBackgroundFetchAPI(ServiceWorkerRegistration&);
     ~ServiceWorkerRegistrationBackgroundFetchAPI();

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -32,9 +32,12 @@
 #include "NotificationPayload.h"
 #include "ServiceWorkerContainer.h"
 #include "ServiceWorkerGlobalScope.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WTFProcess.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(SWContextManagerServiceWorkerTerminationRequest, SWContextManager::ServiceWorkerTerminationRequest);
 
 SWContextManager& SWContextManager::singleton()
 {

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -36,6 +36,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 
 namespace WebCore {
@@ -151,7 +152,7 @@ private:
     ServiceWorkerCreationCallback* m_serviceWorkerCreationCallback { nullptr };
 
     class ServiceWorkerTerminationRequest {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerTerminationRequest);
     public:
         ServiceWorkerTerminationRequest(SWContextManager&, ServiceWorkerIdentifier, Seconds timeout);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
@@ -30,8 +30,11 @@
 
 #include "ServiceWorkerInspectorProxy.h"
 #include "ServiceWorkerThreadProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerDebuggable);
 
 using namespace Inspector;
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
@@ -30,13 +30,14 @@
 #include "ServiceWorkerContextData.h"
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ServiceWorkerThreadProxy;
 
 class ServiceWorkerDebuggable final : public Inspector::RemoteInspectionTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerDebuggable);
     WTF_MAKE_NONCOPYABLE(ServiceWorkerDebuggable);
 public:
     ServiceWorkerDebuggable(ServiceWorkerThreadProxy&, const ServiceWorkerContextData&);

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
@@ -34,10 +34,13 @@
 #include "WorkerRunLoop.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerInspectorProxy);
 
 ServiceWorkerInspectorProxy::ServiceWorkerInspectorProxy(ServiceWorkerThreadProxy& serviceWorkerThreadProxy)
     : m_serviceWorkerThreadProxy(serviceWorkerThreadProxy)

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 // All of these methods should be called on the Main Thread.
 // Used to send messages to the WorkerInspector on the WorkerThread.
@@ -40,8 +41,8 @@ namespace WebCore {
 class ServiceWorkerThreadProxy;
 
 class ServiceWorkerInspectorProxy {
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerInspectorProxy);
     WTF_MAKE_NONCOPYABLE(ServiceWorkerInspectorProxy);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ServiceWorkerInspectorProxy(ServiceWorkerThreadProxy&);
     ~ServiceWorkerInspectorProxy();

--- a/Source/WebCore/workers/service/server/SWOriginStore.cpp
+++ b/Source/WebCore/workers/service/server/SWOriginStore.cpp
@@ -27,8 +27,11 @@
 #include "SWOriginStore.h"
 
 #include "SecurityOrigin.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWOriginStore);
 
 void SWOriginStore::add(const SecurityOriginData& origin)
 {

--- a/Source/WebCore/workers/service/server/SWOriginStore.h
+++ b/Source/WebCore/workers/service/server/SWOriginStore.h
@@ -27,11 +27,12 @@
 
 #include "SecurityOriginData.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SWOriginStore {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SWOriginStore, WEBCORE_EXPORT);
 public:
     virtual ~SWOriginStore() = default;
 

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -40,11 +40,14 @@
 #include "ServiceWorkerRegistrationKey.h"
 #include "WebCorePersistentCoders.h"
 #include "WorkerType.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/persistence/PersistentCoders.h>
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWRegistrationDatabase);
 
 static constexpr auto scriptVersion = "V1"_s;
 #define RECORDS_TABLE_SCHEMA_PREFIX "CREATE TABLE "

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -27,6 +27,7 @@
 
 #include "ServiceWorkerTypes.h"
 #include "ServiceWorkerUpdateViaCache.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ class SWScriptStorage;
 struct ServiceWorkerContextData;
 
 class SWRegistrationDatabase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SWRegistrationDatabase, WEBCORE_EXPORT);
 public:
     static constexpr uint64_t schemaVersion = 8;
 

--- a/Source/WebCore/workers/service/server/SWRegistrationStore.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationStore.h
@@ -27,6 +27,7 @@
 
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class ServiceWorkerRegistrationKey;
 struct ServiceWorkerContextData;
 
 class SWRegistrationStore {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SWRegistrationStore);
 public:
     virtual ~SWRegistrationStore() = default;
     virtual void clearAll(CompletionHandler<void()>&&) = 0;

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -32,9 +32,12 @@
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/MainThread.h>
 #include <wtf/PageBlock.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWScriptStorage);
 
 static bool shouldUseFileMapping(uint64_t fileSize)
 {

--- a/Source/WebCore/workers/service/server/SWScriptStorage.h
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.h
@@ -27,6 +27,7 @@
 
 #include <wtf/FileSystem.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ class ServiceWorkerRegistrationKey;
 class ScriptBuffer;
 
 class SWScriptStorage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SWScriptStorage);
 public:
     explicit SWScriptStorage(const String& directory);
 

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -52,9 +52,13 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWServer);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(SWServerConnection, SWServer::Connection);
 
 static const unsigned defaultMaxRegistrationCount = 3;
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -49,6 +49,7 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/URLHash.h>
@@ -82,10 +83,10 @@ struct ServiceWorkerRegistrationData;
 struct WorkerFetchResult;
 
 class SWServer : public RefCounted<SWServer>, public CanMakeWeakPtr<SWServer> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SWServer, WEBCORE_EXPORT);
 public:
     class Connection : public CanMakeWeakPtr<Connection>, public CanMakeCheckedPtr<Connection> {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_EXPORT(Connection, WEBCORE_EXPORT);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Connection);
         friend class SWServer;
     public:

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -36,9 +36,12 @@
 #include "ServiceWorkerUpdateViaCache.h"
 #include "WorkerFetchResult.h"
 #include "WorkerType.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWServerJobQueue);
 
 SWServerJobQueue::SWServerJobQueue(SWServer& server, const ServiceWorkerRegistrationKey& key)
     : m_jobTimer(*this, &SWServerJobQueue::runNextJobSynchronously)

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -31,6 +31,7 @@
 #include "WorkerFetchResult.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,7 +40,7 @@ class ServiceWorkerJob;
 struct WorkerFetchResult;
 
 class SWServerJobQueue final : public CanMakeCheckedPtr<SWServerJobQueue> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SWServerJobQueue);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SWServerJobQueue);
 public:
     explicit SWServerJobQueue(SWServer&, const ServiceWorkerRegistrationKey&);

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -33,9 +33,12 @@
 #include "SWServerWorker.h"
 #include "ServiceWorkerTypes.h"
 #include "ServiceWorkerUpdateViaCache.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWServerRegistration);
 
 Ref<SWServerRegistration> SWServerRegistration::create(SWServer& server, const ServiceWorkerRegistrationKey& key, ServiceWorkerUpdateViaCache updateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&& navigationPreloadState)
 {

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -37,6 +37,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Identified.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakPtr.h>
 
@@ -52,7 +53,7 @@ struct ServiceWorkerContextData;
 enum class IsAppInitiated : bool { No, Yes };
 
 class SWServerRegistration : public RefCounted<SWServerRegistration>, public CanMakeWeakPtr<SWServerRegistration>, public Identified<ServiceWorkerRegistrationIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SWServerRegistration, WEBCORE_EXPORT);
 public:
     static Ref<SWServerRegistration> create(SWServer&, const ServiceWorkerRegistrationKey&, ServiceWorkerUpdateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&&);
     WEBCORE_EXPORT ~SWServerRegistration();

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -30,8 +30,11 @@
 #include "SWServerWorker.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SWServerToContextConnection);
 
 SWServerToContextConnection::SWServerToContextConnection(SWServer& server, RegistrableDomain&& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier)
     : m_server(server)

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -37,6 +37,7 @@
 #include "ServiceWorkerTypes.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
 
@@ -53,7 +54,7 @@ struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
 class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr<SWServerToContextConnection>, public Identified<SWServerToContextConnectionIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SWServerToContextConnection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SWServerToContextConnection);
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -33,8 +33,11 @@
 #include "WorkerInitializationData.h"
 #include "WorkerRunLoop.h"
 #include "WorkerScriptLoader.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedWorkerScriptLoader);
 
 SharedWorkerScriptLoader::SharedWorkerScriptLoader(URL&& url, SharedWorker& worker, WorkerOptions&& options)
     : m_options(WTFMove(options))

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
@@ -33,6 +33,7 @@
 #include "WorkerScriptLoaderClient.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ struct WorkerFetchResult;
 struct WorkerInitializationData;
 
 class SharedWorkerScriptLoader : private WorkerScriptLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SharedWorkerScriptLoader);
 public:
     SharedWorkerScriptLoader(URL&&, SharedWorker&, WorkerOptions&&);
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
@@ -31,8 +31,12 @@
 #include "SharedWorkerThread.h"
 #include "SharedWorkerThreadProxy.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedWorkerContextManager);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(SharedWorkerContextManagerConnection, SharedWorkerContextManager::Connection);
 
 SharedWorkerContextManager& SharedWorkerContextManager::singleton()
 {

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
@@ -28,6 +28,7 @@
 #include "SharedWorkerIdentifier.h"
 #include "TransferredMessagePort.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,6 +36,7 @@ class ScriptExecutionContext;
 class SharedWorkerThreadProxy;
 
 class SharedWorkerContextManager {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SharedWorkerContextManager, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static SharedWorkerContextManager& singleton();
 
@@ -45,7 +47,7 @@ public:
     WEBCORE_EXPORT void stopAllSharedWorkers();
 
     class Connection {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_EXPORT(Connection, WEBCORE_EXPORT);
     public:
         virtual ~Connection() { }
         virtual void establishConnection(CompletionHandler<void()>&&) = 0;


### PR DESCRIPTION
#### 0cb6e6093777e85289e337b2b1cd75a9db15ff16
<pre>
[TZone] WebCore/workers Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278840">https://bugs.webkit.org/show_bug.cgi?id=278840</a>
<a href="https://rdar.apple.com/134910091">rdar://134910091</a>

Reviewed by Yijia Huang.

Converted WebCore/workers classes from WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED
(and related macros) in preparation for enabling TZone (not yet enabled).

* Source/WebCore/workers/WorkerConsoleClient.cpp:
* Source/WebCore/workers/WorkerConsoleClient.h:
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
* Source/WebCore/workers/WorkerFontLoadRequest.h:
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
* Source/WebCore/workers/WorkerInspectorProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebCore/workers/WorkerRunLoop.cpp:
* Source/WebCore/workers/WorkerRunLoop.h:
* Source/WebCore/workers/WorkerScriptLoader.cpp:
* Source/WebCore/workers/WorkerScriptLoader.h:
* Source/WebCore/workers/WorkerThread.cpp:
* Source/WebCore/workers/service/NavigationPreloadManager.cpp:
* Source/WebCore/workers/service/NavigationPreloadManager.h:
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
* Source/WebCore/workers/service/ServiceWorkerJob.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h:
* Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp:
* Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h:
* Source/WebCore/workers/service/context/SWContextManager.cpp:
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp:
* Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h:
* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp:
* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h:
* Source/WebCore/workers/service/server/SWOriginStore.cpp:
* Source/WebCore/workers/service/server/SWOriginStore.h:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:
* Source/WebCore/workers/service/server/SWRegistrationStore.h:
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
* Source/WebCore/workers/service/server/SWScriptStorage.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
* Source/WebCore/workers/service/server/SWServerRegistration.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.h:
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp:
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.h:

Canonical link: <a href="https://commits.webkit.org/282904@main">https://commits.webkit.org/282904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0947b86403084d8ea0aeeb5500efc0b425ff42b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51947 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10476 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13258 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59274 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59450 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/718 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39755 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->