### PR TITLE
[TZone] Remaining WebCore files - Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -28,7 +28,6 @@
 #include "ExceptionOr.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <span>
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
@@ -29,7 +29,6 @@
 #include "RTCDataChannelHandler.h"
 #include "RTCDataChannelIdentifier.h"
 #include "RTCDataChannelState.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -31,7 +31,6 @@
 #include "SharedBuffer.h"
 #include "ThreadableLoader.h"
 #include <wtf/CompletionHandler.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -32,7 +32,6 @@
 #include "SQLiteStatementAutoResetScope.h"
 #include <span>
 #include <wtf/CompletionHandler.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -34,7 +34,6 @@
 #include "Logging.h"
 #include <array>
 #include <wtf/CheckedArithmetic.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <zlib.h>

--- a/Source/WebCore/PAL/pal/HysteresisActivity.h
+++ b/Source/WebCore/PAL/pal/HysteresisActivity.h
@@ -27,6 +27,7 @@
 
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace PAL {
 
@@ -35,7 +36,7 @@ static const Seconds defaultHysteresisDuration { 5_s };
 enum class HysteresisState : bool { Started, Stopped };
 
 class HysteresisActivity {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(HysteresisActivity);
 public:
     explicit HysteresisActivity(Function<void(HysteresisState)>&& callback = [](HysteresisState) { }, Seconds hysteresisSeconds = defaultHysteresisDuration)
         : m_callback(WTFMove(callback))

--- a/Source/WebCore/PAL/pal/ThreadGlobalData.cpp
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.cpp
@@ -29,11 +29,14 @@
 
 #include "TextCodecICU.h"
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSpecific.h>
 #include <wtf/Threading.h>
 #include <wtf/text/StringImpl.h>
 
 namespace PAL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadGlobalData);
 
 ThreadGlobalData::ThreadGlobalData()
     : m_cachedConverterICU(makeUnique<ICUConverterWrapper>())

--- a/Source/WebCore/PAL/pal/ThreadGlobalData.h
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/text/StringHash.h>
@@ -35,8 +36,8 @@ namespace PAL {
 struct ICUConverterWrapper;
 
 class ThreadGlobalData : public WTF::Thread::ClientData {
+    WTF_MAKE_TZONE_ALLOCATED(ThreadGlobalData);
     WTF_MAKE_NONCOPYABLE(ThreadGlobalData);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     PAL_EXPORT virtual ~ThreadGlobalData();
 

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,8 +35,8 @@ namespace PAL {
 struct CryptoDigestContext;
 
 class CryptoDigest {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CryptoDigest);
     WTF_MAKE_NONCOPYABLE(CryptoDigest);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Algorithm {
         SHA_1,

--- a/Source/WebCore/PAL/pal/system/Clock.h
+++ b/Source/WebCore/PAL/pal/system/Clock.h
@@ -27,11 +27,12 @@
 #pragma once
 
 #include <memory>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace PAL {
 
 class Clock {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Clock);
 public:
     static std::unique_ptr<Clock> create();
     virtual ~Clock() = default;

--- a/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h
+++ b/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h
@@ -28,6 +28,7 @@
 #if PLATFORM(MAC)
 
 #include <pal/system/SystemSleepListener.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace PAL {
@@ -42,7 +43,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<PAL::SystemSleepListe
 namespace PAL {
 
 class SystemSleepListenerMac : public SystemSleepListener, public CanMakeWeakPtr<SystemSleepListenerMac> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SystemSleepListenerMac);
 protected:
     SystemSleepListenerMac(Client&);
     virtual ~SystemSleepListenerMac();

--- a/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.mm
+++ b/Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.mm
@@ -30,8 +30,11 @@
 
 #import <AppKit/AppKit.h>
 #import <wtf/MainThread.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace PAL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SystemSleepListenerMac);
 
 std::unique_ptr<SystemSleepListener> SystemSleepListener::create(Client& client)
 {

--- a/Source/WebCore/PAL/pal/text/KillRing.cpp
+++ b/Source/WebCore/PAL/pal/text/KillRing.cpp
@@ -25,10 +25,13 @@
 
 #include "config.h"
 #include "KillRing.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if !PLATFORM(MAC)
 
 namespace PAL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(KillRing);
 
 void KillRing::append(const String&)
 {

--- a/Source/WebCore/PAL/pal/text/KillRing.h
+++ b/Source/WebCore/PAL/pal/text/KillRing.h
@@ -25,12 +25,13 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace PAL {
 
 class KillRing {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(KillRing, PAL_EXPORT);
 public:
     PAL_EXPORT void append(const String&);
     PAL_EXPORT void prepend(const String&);

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "TextCodec.h"
 #include <unicode/uchar.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -34,6 +35,8 @@
 #include <cstdio>
 
 namespace PAL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodec);
 
 int TextCodec::getUnencodableReplacement(char32_t codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement)
 {

--- a/Source/WebCore/PAL/pal/text/TextCodec.h
+++ b/Source/WebCore/PAL/pal/text/TextCodec.h
@@ -33,6 +33,7 @@
 #include <unicode/umachine.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace PAL {
 
@@ -41,7 +42,8 @@ class TextEncoding;
 using UnencodableReplacementArray = std::array<char, 32>;
 
 class TextCodec {
-    WTF_MAKE_NONCOPYABLE(TextCodec); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextCodec);
+    WTF_MAKE_NONCOPYABLE(TextCodec);
 public:
     TextCodec() = default;
     virtual ~TextCodec() = default;

--- a/Source/WebCore/PAL/pal/text/mac/KillRingMac.mm
+++ b/Source/WebCore/PAL/pal/text/mac/KillRingMac.mm
@@ -25,10 +25,13 @@
 
 #import "config.h"
 #import "KillRing.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(MAC)
 
 namespace PAL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(KillRing);
 
 extern "C" {
 

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "AccessibilityObject.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -208,7 +209,7 @@ private:
 };
 
 class AXTextMarkerRange {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AXTextMarkerRange);
     friend bool operator==(const AXTextMarkerRange&, const AXTextMarkerRange&);
     friend bool operator<(const AXTextMarkerRange&, const AXTextMarkerRange&);
     friend bool operator>(const AXTextMarkerRange&, const AXTextMarkerRange&);

--- a/Source/WebCore/accessibility/AXTreeStore.h
+++ b/Source/WebCore/accessibility/AXTreeStore.h
@@ -31,6 +31,7 @@
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -58,8 +59,8 @@ WEBCORE_EXPORT AXTreePtr findAXTree(Function<bool(AXTreePtr)>&&);
 
 template<typename T>
 class AXTreeStore {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AXTreeStore);
     WTF_MAKE_NONCOPYABLE(AXTreeStore);
-    WTF_MAKE_FAST_ALLOCATED;
     friend WEBCORE_EXPORT AXTreePtr findAXTree(Function<bool(AXTreePtr)>&&);
 public:
     AXID treeID() const { return m_id; }

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -35,7 +35,6 @@
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/VM.h>
 #include <pal/Logging.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/bridge/Bridge.h
+++ b/Source/WebCore/bridge/Bridge.h
@@ -27,15 +27,16 @@
 #ifndef Bridge_h
 #define Bridge_h
 
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC  {
 
 namespace Bindings {
 
 class Method {
-    WTF_MAKE_NONCOPYABLE(Method); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Method);
+    WTF_MAKE_NONCOPYABLE(Method);
 public:
     Method() = default;
     virtual int numParameters() const = 0;

--- a/Source/WebCore/bridge/IdentifierRep.cpp
+++ b/Source/WebCore/bridge/IdentifierRep.cpp
@@ -30,10 +30,13 @@
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IdentifierRep);
 
 typedef HashSet<IdentifierRep*> IdentifierSet;
 

--- a/Source/WebCore/bridge/IdentifierRep.h
+++ b/Source/WebCore/bridge/IdentifierRep.h
@@ -25,14 +25,14 @@
 
 #pragma once
 
-#include <wtf/Assertions.h>
-#include <wtf/FastMalloc.h>
 #include <string.h>
+#include <wtf/Assertions.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
     
 class IdentifierRep {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IdentifierRep);
 public:
     WEBCORE_EXPORT static IdentifierRep* get(int);
     WEBCORE_EXPORT static IdentifierRep* get(const char*);

--- a/Source/WebCore/bridge/jsc/BridgeJSC.cpp
+++ b/Source/WebCore/bridge/jsc/BridgeJSC.cpp
@@ -34,10 +34,14 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/ObjectPrototype.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 namespace Bindings {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Field);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Class);
 
 Array::Array(RefPtr<RootObject>&& rootObject)
     : m_rootObject(WTFMove(rootObject))

--- a/Source/WebCore/bridge/jsc/BridgeJSC.h
+++ b/Source/WebCore/bridge/jsc/BridgeJSC.h
@@ -29,6 +29,7 @@
 #include "Bridge.h"
 #include <JavaScriptCore/JSString.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC  {
@@ -47,7 +48,7 @@ class RootObject;
 class RuntimeObject;
 
 class Field {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Field);
 public:
     virtual JSValue valueFromInstance(JSGlobalObject*, const Instance*) const = 0;
     virtual bool setValueToInstance(JSGlobalObject*, const Instance*, JSValue) const = 0;
@@ -56,7 +57,8 @@ public:
 };
 
 class Class {
-    WTF_MAKE_NONCOPYABLE(Class); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Class);
+    WTF_MAKE_NONCOPYABLE(Class);
 public:
     Class() = default;
     virtual Method* methodNamed(PropertyName, Instance*) const = 0;

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -49,10 +49,13 @@
 #include <wtf/URL.h>
 #include "UserContentController.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore::ContentExtensions {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentExtensionsBackend);
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/ContentRuleListAdditions.mm>

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -30,6 +30,7 @@
 #include "ContentExtension.h"
 #include "ContentExtensionRule.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -51,7 +52,7 @@ struct ResourceLoadInfo;
 // 1) It stores the rules for each content extension.
 // 2) It provides APIs for the WebCore interfaces to use those rules efficiently.
 class ContentExtensionsBackend {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContentExtensionsBackend, WEBCORE_EXPORT);
 public:
     // - Rule management interface. This can be used by upper layer.
 

--- a/Source/WebCore/crypto/CryptoAlgorithmParameters.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmParameters.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "CryptoAlgorithmIdentifier.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class CryptoAlgorithmParameters {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CryptoAlgorithmParameters);
 public:
     enum class Class : uint8_t {
         None,

--- a/Source/WebCore/css/CSSRuleList.h
+++ b/Source/WebCore/css/CSSRuleList.h
@@ -23,6 +23,7 @@
 
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -72,7 +73,7 @@ private:
 // The rule owns the live list.
 template <class Rule>
 class LiveCSSRuleList final : public CSSRuleList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(LiveCSSRuleList);
 public:
     LiveCSSRuleList(Rule& rule)
         : m_rule(rule)

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -36,6 +36,7 @@
 #include <queue>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/MakeString.h>
@@ -43,6 +44,8 @@
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSSelector);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -26,6 +26,7 @@
 #include "RenderStyleConstants.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/FixedVector.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -50,7 +51,7 @@ enum class SelectorSpecificityIncrement {
 // Selector for a StyleRule.
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelectorRareData);
 class CSSSelector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CSSSelector);
 public:
     CSSSelector() = default;
     CSSSelector(const CSSSelector&);

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -29,9 +29,12 @@
 
 #include "CommonAtomStrings.h"
 #include "MutableCSSSelector.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSSelectorList);
 
 CSSSelectorList::CSSSelectorList(const CSSSelectorList& other)
 {

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -28,6 +28,7 @@
 #include "CSSSelector.h"
 #include <iterator>
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueArray.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ class MutableCSSSelector;
 using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
 
 class CSSSelectorList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CSSSelectorList);
 public:
     CSSSelectorList() = default;
     CSSSelectorList(const CSSSelectorList&);

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -31,6 +31,7 @@
 #include "CalculationTree.h"
 #include <variant>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -208,7 +209,7 @@ struct Tree {
 };
 
 struct Sum {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sum);
 public:
     using Base = Calculation::Sum;
 
@@ -218,7 +219,7 @@ public:
 };
 
 struct Product {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Product);
 public:
     using Base = Calculation::Product;
 
@@ -228,7 +229,7 @@ public:
 };
 
 struct Negate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Negate);
 public:
     using Base = Calculation::Negate;
 
@@ -238,7 +239,7 @@ public:
 };
 
 struct Invert {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Invert);
 public:
     using Base = Calculation::Invert;
 
@@ -251,7 +252,7 @@ public:
 
 // Comparison Functions - https://drafts.csswg.org/css-values-4/#comp-func
 struct Min {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Min);
 public:
     using Base = Calculation::Min;
     static constexpr auto id = CSSValueMin;
@@ -269,7 +270,7 @@ public:
 };
 
 struct Max {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Max);
 public:
     using Base = Calculation::Max;
     static constexpr auto id = CSSValueMax;
@@ -287,7 +288,7 @@ public:
 };
 
 struct Clamp {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Clamp);
 public:
     using Base = Calculation::Clamp;
     static constexpr auto id = CSSValueClamp;
@@ -308,7 +309,7 @@ public:
 
 // Stepped Value Functions - https://drafts.csswg.org/css-values-4/#round-func
 struct RoundNearest {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundNearest);
 public:
     using Base = Calculation::RoundNearest;
     static constexpr auto id = CSSValueNearest;
@@ -335,7 +336,7 @@ public:
 };
 
 struct RoundUp {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundUp);
 public:
     using Base = Calculation::RoundUp;
     static constexpr auto id = CSSValueUp;
@@ -362,7 +363,7 @@ public:
 };
 
 struct RoundDown {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundDown);
 public:
     using Base = Calculation::RoundDown;
     static constexpr auto id = CSSValueDown;
@@ -389,7 +390,7 @@ public:
 };
 
 struct RoundToZero {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundToZero);
 public:
     using Base = Calculation::RoundToZero;
     static constexpr auto id = CSSValueToZero;
@@ -416,7 +417,7 @@ public:
 };
 
 struct Mod {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Mod);
 public:
     using Base = Calculation::Mod;
     static constexpr auto id = CSSValueMod;
@@ -436,7 +437,7 @@ public:
 };
 
 struct Rem {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Rem);
 public:
     using Base = Calculation::Rem;
     static constexpr auto id = CSSValueRem;
@@ -457,7 +458,7 @@ public:
 
 // Trigonometric Functions - https://drafts.csswg.org/css-values-4/#trig-funcs
 struct Sin {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sin);
 public:
     using Base = Calculation::Sin;
     static constexpr auto id = CSSValueSin;
@@ -474,7 +475,7 @@ public:
 };
 
 struct Cos {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Cos);
 public:
     using Base = Calculation::Cos;
     static constexpr auto id = CSSValueCos;
@@ -491,7 +492,7 @@ public:
 };
 
 struct Tan {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Tan);
 public:
     using Base = Calculation::Tan;
     static constexpr auto id = CSSValueTan;
@@ -508,7 +509,7 @@ public:
 };
 
 struct Asin {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Asin);
 public:
     using Base = Calculation::Asin;
     static constexpr auto id = CSSValueAsin;
@@ -525,7 +526,7 @@ public:
 };
 
 struct Acos {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Acos);
 public:
     using Base = Calculation::Acos;
     static constexpr auto id = CSSValueAcos;
@@ -542,7 +543,7 @@ public:
 };
 
 struct Atan {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Atan);
 public:
     using Base = Calculation::Atan;
     static constexpr auto id = CSSValueAtan;
@@ -559,7 +560,7 @@ public:
 };
 
 struct Atan2 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Atan2);
 public:
     using Base = Calculation::Atan2;
     static constexpr auto id = CSSValueAtan2;
@@ -579,7 +580,7 @@ public:
 
 // Exponential Functions - https://drafts.csswg.org/css-values-4/#exponent-funcs
 struct Pow {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Pow);
 public:
     using Base = Calculation::Pow;
     static constexpr auto id = CSSValuePow;
@@ -598,7 +599,7 @@ public:
 };
 
 struct Sqrt {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sqrt);
 public:
     using Base = Calculation::Sqrt;
     static constexpr auto id = CSSValueSqrt;
@@ -615,7 +616,7 @@ public:
 };
 
 struct Hypot {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Hypot);
 public:
     using Base = Calculation::Hypot;
     static constexpr auto id = CSSValueHypot;
@@ -633,7 +634,7 @@ public:
 };
 
 struct Log {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Log);
 public:
     using Base = Calculation::Log;
     static constexpr auto id = CSSValueLog;
@@ -652,7 +653,7 @@ public:
 };
 
 struct Exp {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Exp);
 public:
     using Base = Calculation::Exp;
     static constexpr auto id = CSSValueExp;
@@ -670,7 +671,7 @@ public:
 
 // Sign-Related Functions - https://drafts.csswg.org/css-values-4/#sign-funcs
 struct Abs {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Abs);
 public:
     using Base = Calculation::Abs;
     static constexpr auto id = CSSValueAbs;
@@ -687,7 +688,7 @@ public:
 };
 
 struct Sign {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sign);
 public:
     using Base = Calculation::Sign;
     static constexpr auto id = CSSValueSign;

--- a/Source/WebCore/css/color/CSSUnresolvedColor.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.cpp
@@ -28,8 +28,11 @@
 
 #include "StyleBuilderState.h"
 #include "StyleColor.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSUnresolvedColor);
 
 CSSUnresolvedColor::~CSSUnresolvedColor() = default;
 

--- a/Source/WebCore/css/color/CSSUnresolvedColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.h
@@ -36,6 +36,7 @@
 #include "CSSUnresolvedRelativeColor.h"
 #include <variant>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ struct CSSUnresolvedColorResolutionState;
 struct CSSUnresolvedStyleColorResolutionState;
 
 class CSSUnresolvedColor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CSSUnresolvedColor);
 public:
     template<typename T> explicit CSSUnresolvedColor(T&& value)
         : m_value { std::forward<T>(value) }

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -25,6 +25,7 @@
 #include "CSSSelectorInlines.h"
 #include "CSSSelectorList.h"
 #include "SelectorPseudoTypeMap.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if COMPILER(MSVC)
 // See https://msdn.microsoft.com/en-us/library/1wea5zwe.aspx
@@ -32,6 +33,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MutableCSSSelector);
 
 std::unique_ptr<MutableCSSSelector> MutableCSSSelector::parsePagePseudoSelector(StringView pseudoTypeString)
 {

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "CSSSelector.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
@@ -31,7 +32,7 @@ class MutableCSSSelector;
 using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
 
 class MutableCSSSelector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MutableCSSSelector);
 public:
     enum class Combinator {
         Child,

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -49,9 +49,11 @@
 #include "TextIterator.h"
 #include "VisibleUnits.h"
 #include "markup.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AlternativeTextController);
 
 #if USE(DICTATION_ALTERNATIVES) || USE(AUTOCORRECTION_PANEL)
 

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -31,6 +31,7 @@
 #include "Position.h"
 #include <variant>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -67,8 +68,8 @@ struct TextCheckingResult;
 #endif
 
 class AlternativeTextController : public CanMakeWeakPtr<AlternativeTextController> {
+    WTF_MAKE_TZONE_ALLOCATED(AlternativeTextController);
     WTF_MAKE_NONCOPYABLE(AlternativeTextController);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit AlternativeTextController(Document& document) UNLESS_ENABLED(: m_document(document) { })
     ~AlternativeTextController() UNLESS_ENABLED({ })

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -77,9 +77,12 @@
 #include "VisibleUnits.h"
 #include "WrapContentsInDummySpanCommand.h"
 #include "markup.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AccessibilityUndoReplacedText);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -30,6 +30,7 @@
 #include "EditCommand.h"
 #include "CSSPropertyNames.h"
 #include "UndoStep.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,7 +44,7 @@ class StyledElement;
 class Text;
 
 class AccessibilityUndoReplacedText {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AccessibilityUndoReplacedText);
 public:
     AccessibilityUndoReplacedText() { }
     void configureRangeDeletedByReapplyWithStartingSelection(const VisibleSelection&);

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -63,6 +63,7 @@
 #include "StyleRule.h"
 #include "StyledElement.h"
 #include "VisibleUnits.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -180,7 +181,7 @@ static bool hasTransparentBackgroundColor(StyleProperties*);
 static RefPtr<CSSValue> backgroundColorInEffect(Node*);
 
 class HTMLElementEquivalent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(HTMLElementEquivalent);
 public:
     HTMLElementEquivalent(CSSPropertyID, CSSValueID primitiveValue, const QualifiedName& tagName);
     virtual ~HTMLElementEquivalent() = default;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -131,6 +131,7 @@
 #include <pal/text/KillRing.h>
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -143,6 +144,10 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TemporarySelectionChange);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IgnoreSelectionChangeForScope);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Editor);
 
 static bool dispatchBeforeInputEvent(Element& element, const AtomString& inputType, IsInputMethodComposing isInputMethodComposing, const String& data = { },
     RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<RefPtr<StaticRange>>& targetRanges = { }, Event::IsCancelable cancelable = Event::IsCancelable::Yes)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -43,6 +43,7 @@
 #include "VisibleSelection.h"
 #include "WritingDirection.h"
 #include <memory>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
@@ -137,7 +138,8 @@ enum class TemporarySelectionOption : uint16_t {
 };
 
 class TemporarySelectionChange {
-    WTF_MAKE_NONCOPYABLE(TemporarySelectionChange); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(TemporarySelectionChange, WEBCORE_EXPORT);
+    WTF_MAKE_NONCOPYABLE(TemporarySelectionChange);
 public:
     WEBCORE_EXPORT TemporarySelectionChange(Document&, std::optional<VisibleSelection> = std::nullopt, OptionSet<TemporarySelectionOption> = { });
     WEBCORE_EXPORT ~TemporarySelectionChange();
@@ -159,7 +161,8 @@ private:
 };
 
 class IgnoreSelectionChangeForScope {
-    WTF_MAKE_NONCOPYABLE(IgnoreSelectionChangeForScope); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IgnoreSelectionChangeForScope);
+    WTF_MAKE_NONCOPYABLE(IgnoreSelectionChangeForScope);
 public:
     IgnoreSelectionChangeForScope(LocalFrame& frame)
         : m_selectionChange(*frame.document(), std::nullopt, TemporarySelectionOption::IgnoreSelectionChanges)
@@ -175,7 +178,7 @@ private:
 };
 
 class Editor final : public CanMakeCheckedPtr<Editor> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(Editor, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Editor);
 public:
     explicit Editor(Document&);

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -85,6 +85,7 @@
 #include "TypingCommand.h"
 #include "VisibleUnits.h"
 #include <stdio.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/TextStream.h>
 
@@ -98,6 +99,10 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CaretBase);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DragCaretController);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameSelection);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -38,6 +38,7 @@
 #include "VisibleSelection.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -62,8 +63,8 @@ enum class CaretVisibilitySuppressionReason : uint8_t {
 };
 
 class CaretBase {
+    WTF_MAKE_TZONE_ALLOCATED(CaretBase);
     WTF_MAKE_NONCOPYABLE(CaretBase);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static Color computeCaretColor(const RenderStyle& elementStyle, const Node*);
 protected:
@@ -91,8 +92,8 @@ private:
 };
 
 class DragCaretController : private CaretBase {
+    WTF_MAKE_TZONE_ALLOCATED(DragCaretController);
     WTF_MAKE_NONCOPYABLE(DragCaretController);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     DragCaretController();
 
@@ -118,8 +119,8 @@ private:
 };
 
 class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection> {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(FrameSelection, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(FrameSelection);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameSelection);
 public:
     enum class ShouldUpdateAppearance : bool { No, Yes };

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -76,6 +76,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -86,7 +87,7 @@ enum EFragmentType { EmptyFragment, SingleTextNodeFragment, TreeFragment };
 // --- ReplacementFragment helper class
 
 class ReplacementFragment {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ReplacementFragment);
     WTF_MAKE_NONCOPYABLE(ReplacementFragment);
 public:
     ReplacementFragment(RefPtr<DocumentFragment>&&, const VisibleSelection&);

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -34,8 +34,12 @@
 #include "LocalFrame.h"
 #include "RenderView.h"
 #include "ServicesOverlayController.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SelectionGeometryGatherer);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(SelectionGeometryGathererNotifier, SelectionGeometryGatherer::Notifier);
 
 SelectionGeometryGatherer::SelectionGeometryGatherer(RenderView& renderView)
     : m_renderView(renderView)

--- a/Source/WebCore/editing/SelectionGeometryGatherer.h
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.h
@@ -29,6 +29,7 @@
 
 #include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
 
@@ -42,6 +43,7 @@ class RenderView;
 struct GapRects;
 
 class SelectionGeometryGatherer {
+    WTF_MAKE_TZONE_ALLOCATED(SelectionGeometryGatherer);
     WTF_MAKE_NONCOPYABLE(SelectionGeometryGatherer);
 
 public:
@@ -53,7 +55,7 @@ public:
     bool isTextOnly() const { return m_isTextOnly; }
 
     class Notifier {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Notifier);
         WTF_MAKE_NONCOPYABLE(Notifier);
     public:
         Notifier(SelectionGeometryGatherer&);

--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -40,8 +40,11 @@
 #include "Settings.h"
 #include "TextCheckerClient.h"
 #include "TextIterator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpellChecker);
 
 SpellCheckRequest::SpellCheckRequest(const SimpleRange& checkingRange, const SimpleRange& automaticReplacementRange, const SimpleRange& paragraphRange, const String& text, OptionSet<TextCheckingType> options, TextCheckingProcessType type)
     : m_checkingRange(checkingRange)

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -31,6 +31,7 @@
 #include "TextChecking.h"
 #include "Timer.h"
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -77,7 +78,7 @@ private:
 };
 
 class SpellChecker : public CanMakeSingleThreadWeakPtr<SpellChecker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpellChecker);
 public:
     friend class SpellCheckRequest;
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -67,6 +67,7 @@
 #include "VisibleUnits.h"
 #include <unicode/unorm2.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -80,6 +81,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextIterator);
 
 using namespace WTF::Unicode;
 using namespace HTMLNames;

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -31,6 +31,7 @@
 #include "InlineIteratorTextBox.h"
 #include "SimpleRange.h"
 #include "TextIteratorBehavior.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -95,7 +96,7 @@ private:
 bool shouldEmitNewlinesBeforeAndAfterNode(Node&);
 
 class TextIterator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(TextIterator, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT explicit TextIterator(const SimpleRange&, TextIteratorBehaviors = { });
     WEBCORE_EXPORT ~TextIterator();

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -50,8 +50,11 @@
 #include "TextIterator.h"
 #include "TextManipulationItem.h"
 #include "VisibleUnits.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextManipulationController);
 
 inline bool TextManipulationControllerExclusionRule::match(const Element& element) const
 {

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -33,6 +33,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,7 +44,7 @@ class Element;
 class VisiblePosition;
 
 class TextManipulationController final : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr<TextManipulationController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextManipulationController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextManipulationController);
 public:
     TextManipulationController(Document&);

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.h
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.h
@@ -24,6 +24,7 @@
  */
 
 #import "AlternativeTextContextController.h"
+#import <wtf/TZoneMalloc.h>
 
 @class NSView;
 
@@ -32,7 +33,7 @@ namespace WebCore {
 class FloatRect;
 
 class AlternativeTextUIController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(AlternativeTextUIController, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT DictationContext addAlternatives(PlatformTextAlternatives *);
     WEBCORE_EXPORT void replaceAlternatives(PlatformTextAlternatives *, DictationContext);

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
@@ -27,6 +27,7 @@
 #import "AlternativeTextUIController.h"
 
 #import "FloatRect.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if USE(APPKIT)
 #import <AppKit/NSSpellChecker.h>
@@ -39,6 +40,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AlternativeTextUIController);
 
 DictationContext AlternativeTextUIController::addAlternatives(PlatformTextAlternatives *alternatives)
 {

--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -28,8 +28,11 @@
 
 #include "FocusController.h"
 #include "Page.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AutofillElements);
 
 static inline bool isAutofillableElement(Element& node)
 {

--- a/Source/WebCore/editing/cocoa/AutofillElements.h
+++ b/Source/WebCore/editing/cocoa/AutofillElements.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "HTMLInputElement.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class AutofillElements {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AutofillElements);
 public:
     WEBCORE_EXPORT static std::optional<AutofillElements> computeAutofillElements(Ref<HTMLInputElement>);
     WEBCORE_EXPORT void autofill(String, String);

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -74,6 +74,7 @@
 #import <objc/runtime.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <wtf/ASCIICType.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -131,7 +132,7 @@ static const CGFloat defaultFontSize = 12;
 static const CGFloat minimumFontSize = 1;
 
 class HTMLConverterCaches {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(HTMLConverterCaches);
 public:
     String propertyValueForNode(Node&, CSSPropertyID );
     bool floatPropertyValueForNode(Node&, CSSPropertyID, float&);

--- a/Source/WebCore/fileapi/AsyncFileStream.cpp
+++ b/Source/WebCore/fileapi/AsyncFileStream.cpp
@@ -40,10 +40,13 @@
 #include <wtf/MainThread.h>
 #include <wtf/MessageQueue.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AsyncFileStream);
 
 struct AsyncFileStream::Internals {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/WebCore/fileapi/AsyncFileStream.h
+++ b/Source/WebCore/fileapi/AsyncFileStream.h
@@ -33,6 +33,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ class FileStreamClient;
 class FileStream;
 
 class WEBCORE_EXPORT AsyncFileStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AsyncFileStream);
 public:
     explicit AsyncFileStream(FileStreamClient&);
     ~AsyncFileStream();

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -33,11 +33,12 @@
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class BlobLoader final : public FileReaderLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(BlobLoader);
 public:
     explicit BlobLoader(CompletionHandler<void(BlobLoader&)>&&);
     ~BlobLoader();

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -58,10 +58,13 @@
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackForwardCache);
 
 #define PCLOG(...) LOG(BackForwardCache, "%*s%s", indentLevel*4, "", makeString(__VA_ARGS__).utf8().data())
 

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -29,6 +29,7 @@
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,8 +40,8 @@ class Page;
 enum class PruningReason { None, ProcessSuspended, MemoryPressure, ReachedMaxSize };
 
 class BackForwardCache {
+    WTF_MAKE_TZONE_ALLOCATED(BackForwardCache);
     WTF_MAKE_NONCOPYABLE(BackForwardCache);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     // Function to obtain the global back/forward cache.
     WEBCORE_EXPORT static BackForwardCache& singleton();

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -30,8 +30,11 @@
 #include "HistoryItem.h"
 #include "Page.h"
 #include "ShouldTreatAsContinuingLoad.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackForwardController);
 
 BackForwardController::BackForwardController(Page& page, Ref<BackForwardClient>&& client)
     : m_page(page)

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -39,8 +40,8 @@ class HistoryItem;
 class Page;
 
 class BackForwardController final : public CanMakeCheckedPtr<BackForwardController> {
+    WTF_MAKE_TZONE_ALLOCATED(BackForwardController);
     WTF_MAKE_NONCOPYABLE(BackForwardController);
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BackForwardController);
 public:
     BackForwardController(Page&, Ref<BackForwardClient>&&);

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -49,6 +49,7 @@
 #include "StyleTreeResolver.h"
 #include "WindowEventLoop.h"
 #include <wtf/RefCountedLeakCounter.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 
 #if PLATFORM(IOS_FAMILY) || ENABLE(TOUCH_EVENTS)
@@ -57,6 +58,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedFrame);
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, cachedFrameCounter, ("CachedFrame"));
 

--- a/Source/WebCore/history/CachedFrame.h
+++ b/Source/WebCore/history/CachedFrame.h
@@ -29,6 +29,7 @@
 #include <wtf/URL.h>
 #include "ScriptCachedFrameData.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
@@ -74,7 +75,7 @@ private:
 };
 
 class CachedFrame : private CachedFrameBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CachedFrame);
 public:
     explicit CachedFrame(Frame&);
 

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -47,6 +47,7 @@
 #include "VisitedLinkState.h"
 #include <wtf/RefCountedLeakCounter.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "FrameSelection.h"
@@ -55,6 +56,8 @@
 
 namespace WebCore {
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedPage);
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, cachedPageCounter, ("CachedPage"));
 

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -28,6 +28,7 @@
 #include "CachedFrame.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class DocumentLoader;
 class Page;
 
 class CachedPage final : public CanMakeCheckedPtr<CachedPage> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(CachedPage, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedPage);
 public:
     explicit CachedPage(Page&);

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -37,11 +37,14 @@
 #include <stdio.h>
 #include <wtf/DateMath.h>
 #include <wtf/DebugUtilities.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HistoryItemClient);
 
 int64_t HistoryItem::generateSequenceNumber()
 {

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -37,6 +37,7 @@
 #include "SerializedScriptValue.h"
 #include <memory>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -61,7 +62,7 @@ class ResourceRequest;
 enum class PruningReason;
 
 class HistoryItemClient : public RefCounted<HistoryItemClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(HistoryItemClient, WEBCORE_EXPORT);
 public:
     virtual ~HistoryItemClient() = default;
     virtual void historyItemChanged(const HistoryItem&) = 0;

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -32,7 +32,6 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorEnvironment.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
@@ -45,8 +45,8 @@ namespace WebCore {
 class Page;
 
 class InspectorIndexedDBAgent final : public InspectorAgentBase, public Inspector::IndexedDBBackendDispatcherHandler {
-    WTF_MAKE_NONCOPYABLE(InspectorIndexedDBAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorIndexedDBAgent);
+    WTF_MAKE_NONCOPYABLE(InspectorIndexedDBAgent);
 public:
     InspectorIndexedDBAgent(PageAgentContext&);
     ~InspectorIndexedDBAgent();

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -66,8 +66,8 @@ class WebSocket;
 struct WebSocketFrame;
 
 class InspectorNetworkAgent : public InspectorAgentBase, public Inspector::NetworkBackendDispatcherHandler {
-    WTF_MAKE_NONCOPYABLE(InspectorNetworkAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorNetworkAgent);
+    WTF_MAKE_NONCOPYABLE(InspectorNetworkAgent);
 public:
     ~InspectorNetworkAgent() override;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
@@ -31,9 +31,12 @@
 #include "LayoutBoxGeometry.h"
 #include "LayoutElementBox.h"
 #include "RenderStyleInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Layout {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LineBox);
 
 LineBox::LineBox(const Box& rootLayoutBox, InlineLayoutUnit contentLogicalLeft, InlineLayoutUnit contentLogicalWidth, size_t lineIndex, size_t nonSpanningInlineLevelBoxCount)
     : m_lineIndex(lineIndex)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -29,7 +29,7 @@
 #include "InlineLine.h"
 #include "InlineRect.h"
 #include "LayoutElementBox.h"
-#include <wtf/TZoneMallocInlines.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
@@ -57,7 +57,7 @@ class RubyFormattingContext;
 // The resulting rectangular area that contains the boxes that form a single line of inline-level content is called a line box.
 // https://www.w3.org/TR/css-inline-3/#model
 class LineBox {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LineBox);
 public:
     LineBox(const Box& rootLayoutBox, InlineLayoutUnit contentLogicalLeft, InlineLayoutUnit contentLogicalWidth, size_t lineIndex, size_t nonSpanningInlineLevelBoxCount);
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
@@ -29,12 +29,13 @@
 #include "InlineRect.h"
 #include "TextRun.h"
 #include "TextUtil.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace InlineDisplay {
 
 class Line {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Line);
 public:
     struct EnclosingTopAndBottom {
         // This values encloses the root inline box and any other inline level box's border box.

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
@@ -28,9 +28,12 @@
 
 #include "RenderStyle.h"
 #include "RenderStyleInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Layout {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextBreakingPositionCache);
 
 static constexpr size_t evictionSoftThreshold = 500000; // At this amount of content (string + breaking position list) we should start evicting
 static constexpr size_t evictionHardCapMultiplier = 5; // Do not let the cache grow beyond this

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
@@ -36,7 +36,7 @@ namespace WebCore {
 namespace Layout {
 
 class TextBreakingPositionCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextBreakingPositionCache);
 public:
     static constexpr size_t minimumRequiredTextLengthForContentBreakCache = 5;
     static constexpr size_t minimumRequiredContentBreaks = 3;

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -37,9 +37,12 @@
 #include "RenderBoxInlines.h"
 #include "RenderFlexibleBox.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace LayoutIntegration {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FlexLayout);
 
 FlexLayout::FlexLayout(RenderFlexibleBox& flexBoxRenderer)
     : m_boxTree(flexBoxRenderer)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -29,6 +29,7 @@
 #include "LayoutState.h"
 #include "RenderObjectEnums.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ struct PaintInfo;
 namespace LayoutIntegration {
 
 class FlexLayout final : public CanMakeCheckedPtr<FlexLayout> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FlexLayout);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FlexLayout);
 public:
     FlexLayout(RenderFlexibleBox&);

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -42,6 +42,8 @@ namespace WebCore {
 namespace Layout {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Box);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(BoxBoxRareData, Box::BoxRareData);
+
 
 Box::Box(ElementAttributes&& elementAttributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle, OptionSet<BaseTypeFlag> baseTypeFlags)
     : m_nodeType(elementAttributes.nodeType)

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -206,7 +206,7 @@ private:
     friend class LayoutState;
 
     class BoxRareData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(BoxRareData);
     public:
         BoxRareData() = default;
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -86,6 +86,7 @@
 #include <JavaScriptCore/HeapInlines.h>
 #include <pal/SessionID.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
 #include "CompiledContentExtension.h"
@@ -100,6 +101,9 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyChromeClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyCryptoClient);
 
 class UserMessageHandlerDescriptor;
 
@@ -116,7 +120,7 @@ class EmptyBackForwardClient final : public BackForwardClient {
 #if ENABLE(CONTEXT_MENUS)
 
 class EmptyContextMenuClient final : public ContextMenuClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyContextMenuClient);
 
     void downloadURL(const URL&) final { }
     void searchWithGoogle(const LocalFrame*) final { }
@@ -225,7 +229,7 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
 };
 
 class EmptyDiagnosticLoggingClient final : public DiagnosticLoggingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyDiagnosticLoggingClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyDiagnosticLoggingClient);
 
     void logDiagnosticMessage(const String&, const String&, ShouldSample) final { }
@@ -248,7 +252,7 @@ class EmptyDragClient final : public DragClient {
 #endif // ENABLE(DRAG_SUPPORT)
 
 class EmptyEditorClient final : public EditorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyEditorClient);
 
 public:
     EmptyEditorClient() = default;
@@ -406,7 +410,7 @@ private:
 };
 
 class EmptyInspectorClient final : public InspectorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyInspectorClient);
     void inspectedPageDestroyed() final { }
     Inspector::FrontendChannel* openLocalFrontend(InspectorController*) final { return nullptr; }
     void bringFrontendToFront() final { }
@@ -417,7 +421,7 @@ class EmptyInspectorClient final : public InspectorClient {
 #if ENABLE(APPLE_PAY)
 
 class EmptyPaymentCoordinatorClient final : public PaymentCoordinatorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyPaymentCoordinatorClient);
     std::optional<String> validatedPaymentNetwork(const String&) const final { return std::nullopt; }
     bool canMakePayments() final { return false; }
     void canMakePaymentsWithActiveCard(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler) final { callOnMainThread([completionHandler = WTFMove(completionHandler)]() mutable { completionHandler(false); }); }

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -30,6 +30,7 @@
 
 #include "ChromeClient.h"
 #include "CryptoClient.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 // Empty client classes for use by WebCore.
@@ -45,7 +46,7 @@ class HTMLImageElement;
 class PageConfiguration;
 
 class EmptyChromeClient : public ChromeClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EmptyChromeClient);
 
     void chromeDestroyed() override { }
 
@@ -233,7 +234,7 @@ DiagnosticLoggingClient& emptyDiagnosticLoggingClient();
 WEBCORE_EXPORT PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier>, PAL::SessionID);
 
 class EmptyCryptoClient: public CryptoClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EmptyCryptoClient);
 public:
     EmptyCryptoClient() = default;
     ~EmptyCryptoClient() = default;

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -33,6 +33,7 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -64,7 +64,6 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/VM.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/ResourceUsage.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -96,7 +96,7 @@ class VisitedLinkStore;
 class WebRTCProvider;
 
 class PageConfiguration {
-    WTF_MAKE_TZONE_ALLOCATED(PageConfiguration);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PageConfiguration, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(PageConfiguration);
 public:
 

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -56,7 +56,7 @@ class DOMTimer;
 class Element;
 
 class ContentChangeObserver : public CanMakeWeakPtr<ContentChangeObserver> {
-    WTF_MAKE_TZONE_ALLOCATED(ContentChangeObserver);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContentChangeObserver, WEBCORE_EXPORT);
 public:
     ContentChangeObserver(Document&);
 

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -28,6 +28,7 @@
 #include <optional>
 #include <tuple>
 #include <variant>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -184,7 +185,7 @@ struct Tree {
 // Math Operators.
 
 struct Sum {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sum);
 public:
     static constexpr auto op = Operator::Sum;
 
@@ -194,7 +195,7 @@ public:
 };
 
 struct Product {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Product);
 public:
     static constexpr auto op = Operator::Product;
 
@@ -204,7 +205,7 @@ public:
 };
 
 struct Negate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Negate);
 public:
     static constexpr auto op = Operator::Negate;
 
@@ -214,7 +215,7 @@ public:
 };
 
 struct Invert {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Invert);
 public:
     static constexpr auto op = Operator::Invert;
 
@@ -227,7 +228,7 @@ public:
 
 // Comparison Functions - https://drafts.csswg.org/css-values-4/#comp-func
 struct Min {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Min);
 public:
     static constexpr auto op = Operator::Min;
 
@@ -237,7 +238,7 @@ public:
 };
 
 struct Max {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Max);
 public:
     static constexpr auto op = Operator::Max;
 
@@ -247,7 +248,7 @@ public:
 };
 
 struct Clamp {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Clamp);
 public:
     static constexpr auto op = Operator::Clamp;
 
@@ -260,7 +261,7 @@ public:
 
 // Stepped Value Functions - https://drafts.csswg.org/css-values-4/#round-func
 struct RoundNearest {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundNearest);
 public:
     static constexpr auto op = Operator::Nearest;
 
@@ -271,7 +272,7 @@ public:
 };
 
 struct RoundUp {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundUp);
 public:
     static constexpr auto op = Operator::Up;
 
@@ -282,7 +283,7 @@ public:
 };
 
 struct RoundDown {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundDown);
 public:
     static constexpr auto op = Operator::Down;
 
@@ -293,7 +294,7 @@ public:
 };
 
 struct RoundToZero {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RoundToZero);
 public:
     static constexpr auto op = Operator::ToZero;
 
@@ -304,7 +305,7 @@ public:
 };
 
 struct Mod {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Mod);
 public:
     static constexpr auto op = Operator::Mod;
 
@@ -315,7 +316,7 @@ public:
 };
 
 struct Rem {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Rem);
 public:
     static constexpr auto op = Operator::Rem;
 
@@ -327,7 +328,7 @@ public:
 
 // Trigonometric Functions - https://drafts.csswg.org/css-values-4/#trig-funcs
 struct Sin {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sin);
 public:
     static constexpr auto op = Operator::Sin;
 
@@ -337,7 +338,7 @@ public:
 };
 
 struct Cos {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Cos);
 public:
     static constexpr auto op = Operator::Cos;
 
@@ -347,7 +348,7 @@ public:
 };
 
 struct Tan {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Tan);
 public:
     static constexpr auto op = Operator::Tan;
 
@@ -357,7 +358,7 @@ public:
 };
 
 struct Asin {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Asin);
 public:
     static constexpr auto op = Operator::Asin;
 
@@ -367,7 +368,7 @@ public:
 };
 
 struct Acos {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Acos);
 public:
     static constexpr auto op = Operator::Acos;
 
@@ -377,7 +378,7 @@ public:
 };
 
 struct Atan {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Atan);
 public:
     static constexpr auto op = Operator::Atan;
 
@@ -387,7 +388,7 @@ public:
 };
 
 struct Atan2 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Atan2);
 public:
     static constexpr auto op = Operator::Atan2;
 
@@ -399,7 +400,7 @@ public:
 
 // Exponential Functions - https://drafts.csswg.org/css-values-4/#exponent-funcs
 struct Pow {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Atan2);
 public:
     static constexpr auto op = Operator::Pow;
 
@@ -410,7 +411,7 @@ public:
 };
 
 struct Sqrt {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sqrt);
 public:
     static constexpr auto op = Operator::Sqrt;
 
@@ -420,7 +421,7 @@ public:
 };
 
 struct Hypot {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Hypot);
 public:
     static constexpr auto op = Operator::Hypot;
 
@@ -430,7 +431,7 @@ public:
 };
 
 struct Log {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Log);
 public:
     static constexpr auto op = Operator::Log;
 
@@ -441,7 +442,7 @@ public:
 };
 
 struct Exp {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Exp);
 public:
     static constexpr auto op = Operator::Exp;
 
@@ -452,7 +453,7 @@ public:
 
 // Sign-Related Functions - https://drafts.csswg.org/css-values-4/#sign-funcs
 struct Abs {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Abs);
 public:
     static constexpr auto op = Operator::Abs;
 
@@ -462,7 +463,7 @@ public:
 };
 
 struct Sign {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Sign);
 public:
     static constexpr auto op = Operator::Sign;
 
@@ -473,7 +474,7 @@ public:
 
 // Non-standard
 struct Blend {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Blend);
 public:
     static constexpr auto op = Operator::Blend;
 

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.h
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.h
@@ -21,6 +21,7 @@
 
 #include <optional>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,7 +35,8 @@ typedef unsigned EGLenum;
 namespace WebCore {
 
 class GLDisplay {
-    WTF_MAKE_NONCOPYABLE(GLDisplay); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(GLDisplay);
+    WTF_MAKE_NONCOPYABLE(GLDisplay);
 public:
     static std::unique_ptr<GLDisplay> create(EGLDisplay);
     explicit GLDisplay(EGLDisplay);

--- a/Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
@@ -21,7 +21,6 @@
 #include "GstAllocatorFastMalloc.h"
 
 #include <gst/gst.h>
-#include <wtf/FastMalloc.h>
 
 typedef struct {
     GstMemory base;

--- a/Source/WebCore/platform/graphics/win/FullScreenController.cpp
+++ b/Source/WebCore/platform/graphics/win/FullScreenController.cpp
@@ -37,13 +37,14 @@
 #include "Timer.h"
 #include "WebCoreInstanceHandle.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 static const int kFullScreenAnimationDuration = 500; // milliseconds 
 
 class FullScreenController::Private : public FullScreenClient  {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Private);
 public:
     Private(FullScreenController* controller, FullScreenControllerClient* client) 
         : m_controller(controller)

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRCocoa.mm
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRCocoa.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "PlatformXRCocoa.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
 
@@ -36,7 +37,7 @@ using namespace WebCore;
 namespace PlatformXR {
 
 struct Instance::Impl {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Impl);
 public:
     Impl() = default;
     ~Impl() = default;

--- a/Source/WebCore/storage/StorageMap.cpp
+++ b/Source/WebCore/storage/StorageMap.cpp
@@ -28,8 +28,11 @@
 
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageMap);
 
 StorageMap::StorageMap(unsigned quota)
     : m_impl(Impl::create())

--- a/Source/WebCore/storage/StorageMap.h
+++ b/Source/WebCore/storage/StorageMap.h
@@ -27,6 +27,7 @@
 
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,7 +35,7 @@ namespace WebCore {
 
 // This class uses copy-on-write semantics.
 class StorageMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(StorageMap, WEBCORE_EXPORT);
 public:
     // Quota size measured in bytes.
     WEBCORE_EXPORT explicit StorageMap(unsigned quotaSize);

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -43,9 +43,12 @@
 #include "WritingMode.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore::Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AnchorPositionedState);
 
 static BoxAxis mapInsetPropertyToPhysicalAxis(CSSPropertyID id, const RenderStyle& style)
 {

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -28,6 +28,7 @@
 #include "EventTarget.h"
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 
@@ -47,7 +48,7 @@ enum class AnchorPositionResolutionStage : uint8_t {
 };
 
 struct AnchorPositionedState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AnchorPositionedState);
 public:
     HashMap<String, WeakRef<Element, WeakPtrImplWithEventTargetData>> anchorElements;
     HashSet<String> anchorNames;

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -36,9 +36,12 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "WebAnimation.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomPropertyRegistry);
 
 CustomPropertyRegistry::CustomPropertyRegistry(Scope& scope)
     : m_scope(scope)

--- a/Source/WebCore/style/CustomPropertyRegistry.h
+++ b/Source/WebCore/style/CustomPropertyRegistry.h
@@ -27,6 +27,7 @@
 #include "CSSRegisteredCustomProperty.h"
 #include "StyleRule.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -37,7 +38,7 @@ namespace Style {
 class Scope;
 
 class CustomPropertyRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CustomPropertyRegistry);
 public:
     CustomPropertyRegistry(Scope&);
 

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -30,8 +30,11 @@
 #include "SelectorFilter.h"
 #include "StyleRule.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore::Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HasSelectorFilter);
 
 // FIXME: Support additional pseudo-classes.
 static constexpr unsigned HoverSalt = 101;

--- a/Source/WebCore/style/HasSelectorFilter.h
+++ b/Source/WebCore/style/HasSelectorFilter.h
@@ -26,6 +26,7 @@
 
 #include "CSSSelector.h"
 #include <wtf/BloomFilter.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ namespace Style {
 enum class MatchElement : uint8_t;
 
 class HasSelectorFilter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HasSelectorFilter);
 public:
     enum class Type : uint8_t { Children, Descendants };
     HasSelectorFilter(const Element&, Type);

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -37,10 +37,13 @@
 #include "RenderStyleInlines.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
 namespace Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MatchedDeclarationsCache);
 
 MatchedDeclarationsCache::MatchedDeclarationsCache(const Resolver& owner)
     : m_owner(owner)

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -28,6 +28,7 @@
 #include "MatchResult.h"
 #include "RenderStyle.h"
 #include "Timer.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ namespace Style {
 class Resolver;
 
 class MatchedDeclarationsCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MatchedDeclarationsCache);
 public:
     explicit MatchedDeclarationsCache(const Resolver&);
     ~MatchedDeclarationsCache();

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -34,9 +34,12 @@
 #include "PropertyAllowlist.h"
 #include "StyleBuilderGenerated.h"
 #include "StylePropertyShorthand.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PropertyCascade);
 
 PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, OptionSet<PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties)
     : m_matchResult(matchResult)

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -29,6 +29,7 @@
 #include "MatchResult.h"
 #include "WebAnimationTypes.h"
 #include <wtf/BitSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -37,7 +38,7 @@ class StyleResolver;
 namespace Style {
 
 class PropertyCascade {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PropertyCascade);
 public:
     using PropertyBitSet = WTF::BitSet<lastLowPriorityProperty + 1>;
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -51,9 +51,12 @@
 #include "StylePropertyShorthand.h"
 
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Builder);
 
 static const CSSPropertyID firstLowPriorityProperty = static_cast<CSSPropertyID>(lastHighPriorityProperty + 1);
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -27,6 +27,7 @@
 
 #include "PropertyCascade.h"
 #include "StyleBuilderState.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ struct CSSRegisteredCustomProperty;
 namespace Style {
 
 class Builder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
     Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -62,12 +62,15 @@
 #include "UserContentURLPattern.h"
 #include "UserStyleSheet.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace HTMLNames;
 
 namespace Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Scope);
 
 Scope::Scope(Document& document)
     : m_document(document)

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -33,11 +33,11 @@
 #include "Timer.h"
 #include <memory>
 #include <wtf/CheckedPtr.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
@@ -70,7 +70,7 @@ class RuleSet;
 struct MatchResult;
 
 class Scope final : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Scope);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Scope);
 public:
     explicit Scope(Document&);

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -33,9 +33,12 @@
 #include "RenderElement.h"
 #include "SVGElement.h"
 #include "Text.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Style {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Update);
 
 Update::Update(Document& document)
     : m_document(document)

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -29,6 +29,7 @@
 #include "StyleChange.h"
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -56,7 +57,7 @@ struct TextUpdate {
 };
 
 class Update final : public CanMakeCheckedPtr<Update> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Update);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Update);
 public:
     Update(Document&);

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -40,6 +40,7 @@
 #include "RenderTheme.h"
 #include "Supplementable.h"
 #include <wtf/Language.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEB_AUDIO)
 #include "AudioContext.h"
@@ -128,7 +129,7 @@ void InternalSettings::Backup::restoreTo(Settings& settings)
 }
 
 class InternalSettingsWrapper : public Supplement<Page> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InternalSettingsWrapper);
 public:
     explicit InternalSettingsWrapper(Page* page)
         : m_internalSettings(InternalSettings::create(page)) { }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -262,6 +262,7 @@
 #include <wtf/NativePromise.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URLHelpers.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -414,10 +415,13 @@ using JSC::StackVisitor;
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Internals);
+
 using namespace Inspector;
 using namespace HTMLNames;
 
 class InspectorStubFrontend final : public InspectorFrontendClientLocal, public FrontendChannel {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorStubFrontend);
 public:
     InspectorStubFrontend(Page& inspectedPage, RefPtr<LocalDOMWindow>&& frontendWindow);
     virtual ~InspectorStubFrontend();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -48,6 +48,7 @@
 #include "VP9Utilities.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(VIDEO)
 #include "MediaElementSession.h"
@@ -194,7 +195,7 @@ class Internals final
     , private RealtimeMediaSource::VideoFrameObserver
 #endif
     {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Internals);
 #if ENABLE(MEDIA_STREAM)
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Internals);
 #endif

--- a/Source/WebCore/testing/LegacyMockCDM.cpp
+++ b/Source/WebCore/testing/LegacyMockCDM.cpp
@@ -34,11 +34,14 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <JavaScriptCore/Uint8Array.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyMockCDM);
+
 class MockCDMSession : public LegacyCDMSession {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MockCDMSession);
 public:
     MockCDMSession(LegacyCDMSessionClient&);
     virtual ~MockCDMSession() = default;

--- a/Source/WebCore/testing/LegacyMockCDM.h
+++ b/Source/WebCore/testing/LegacyMockCDM.h
@@ -28,13 +28,14 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #include "LegacyCDMPrivate.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class LegacyCDM;
 
 class LegacyMockCDM : public CDMPrivateInterface {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyMockCDM);
 public:
     explicit LegacyMockCDM(LegacyCDM* cdm)
         : m_cdm(cdm)

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -33,11 +33,14 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/Algorithms.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockCDM);
 
 MockCDMFactory::MockCDMFactory()
     : m_supportedSessionTypes({ MediaKeySessionType::Temporary, MediaKeySessionType::PersistentUsageRecord, MediaKeySessionType::PersistentLicense })

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -36,6 +36,7 @@
 #include "MediaKeysRequirement.h"
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -109,7 +110,7 @@ private:
 };
 
 class MockCDM : public CDMPrivate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MockCDM);
 public:
     MockCDM(WeakPtr<MockCDMFactory>);
 

--- a/Source/WebCore/testing/MockMediaSessionCoordinator.cpp
+++ b/Source/WebCore/testing/MockMediaSessionCoordinator.cpp
@@ -34,11 +34,14 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockMediaSessionCoordinator);
 
 Ref<MockMediaSessionCoordinator> MockMediaSessionCoordinator::create(ScriptExecutionContext& context, RefPtr<StringCallback>&& listener)
 {

--- a/Source/WebCore/testing/MockMediaSessionCoordinator.h
+++ b/Source/WebCore/testing/MockMediaSessionCoordinator.h
@@ -29,6 +29,7 @@
 
 #include "MediaSessionCoordinatorPrivate.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class ScriptExecutionContext;
 class StringCallback;
 
 class MockMediaSessionCoordinator : public MediaSessionCoordinatorPrivate, public CanMakeWeakPtr<MockMediaSessionCoordinator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MockMediaSessionCoordinator);
 public:
     static Ref<MockMediaSessionCoordinator> create(ScriptExecutionContext&, RefPtr<StringCallback>&&);
 

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -46,9 +46,13 @@
 #include "PaymentSessionError.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
+
 #include <wtf/URL.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockPaymentCoordinator);
 
 MockPaymentCoordinator::MockPaymentCoordinator(Page& page)
     : m_page { page }

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -38,6 +38,7 @@
 #include "MockPaymentError.h"
 #include "PaymentCoordinatorClient.h"
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -48,7 +49,7 @@ struct ApplePayDetailsUpdateBase;
 struct ApplePayPaymentMethod;
 
 class MockPaymentCoordinator final : public PaymentCoordinatorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MockPaymentCoordinator);
 public:
     explicit MockPaymentCoordinator(Page&);
     ~MockPaymentCoordinator();

--- a/Source/WebCore/testing/TypeConversions.h
+++ b/Source/WebCore/testing/TypeConversions.h
@@ -27,7 +27,6 @@
 
 #include "Node.h"
 #include <variant>
-#include <wtf/FastMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -35,9 +35,12 @@
 #include "WebFakeXRInputController.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SimulatedXRDevice);
 
 static constexpr Seconds FakeXRFrameTime = 15_ms;
 

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -39,6 +39,7 @@
 #include "WebFakeXRInputController.h"
 #include "XRVisibilityState.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -72,7 +73,7 @@ private:
 };
 
 class SimulatedXRDevice final : public PlatformXR::Device {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SimulatedXRDevice);
 public:
     SimulatedXRDevice();
     virtual ~SimulatedXRDevice();

--- a/Source/WebCore/xml/XMLErrors.cpp
+++ b/Source/WebCore/xml/XMLErrors.cpp
@@ -41,8 +41,11 @@
 #include "LocalFrame.h"
 #include "SVGNames.h"
 #include "Text.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XMLErrors);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/xml/XMLErrors.h
+++ b/Source/WebCore/xml/XMLErrors.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <libxml/parser.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextPosition.h>
 
@@ -37,7 +38,7 @@ namespace WebCore {
 class Document;
 
 class XMLErrors {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(XMLErrors);
 public:
     explicit XMLErrors(Document&);
 

--- a/Source/WebCore/xml/XPathExpressionNode.cpp
+++ b/Source/WebCore/xml/XPathExpressionNode.cpp
@@ -29,9 +29,12 @@
 
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace XPath {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Expression);
 
 EvaluationContext& Expression::evaluationContext()
 {

--- a/Source/WebCore/xml/XPathExpressionNode.h
+++ b/Source/WebCore/xml/XPathExpressionNode.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "XPathValue.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 namespace XPath {
@@ -41,7 +42,8 @@ struct EvaluationContext {
 };
 
 class Expression {
-    WTF_MAKE_NONCOPYABLE(Expression); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Expression);
+    WTF_MAKE_NONCOPYABLE(Expression);
 public:
     static EvaluationContext& evaluationContext();
 

--- a/Source/WebCore/xml/XPathStep.cpp
+++ b/Source/WebCore/xml/XPathStep.cpp
@@ -37,9 +37,13 @@
 #include "XMLNSNames.h"
 #include "XPathParser.h"
 #include "XPathUtil.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace XPath {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Step);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(StepNodeTest, Step::NodeTest);
 
 Step::Step(Axis axis, NodeTest nodeTest)
     : m_axis(axis)

--- a/Source/WebCore/xml/XPathStep.h
+++ b/Source/WebCore/xml/XPathStep.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
@@ -39,7 +40,7 @@ class Expression;
 class NodeSet;
 
 class Step {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Step);
 public:
     enum Axis {
         AncestorAxis, AncestorOrSelfAxis, AttributeAxis,
@@ -50,7 +51,7 @@ public:
     };
 
     class NodeTest {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(NodeTest);
     public:
         enum Kind { TextNodeTest, CommentNodeTest, ProcessingInstructionNodeTest, AnyNodeTest, NameTest };
 

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -28,8 +28,11 @@
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
 #include "Document.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XSLImportRule);
 
 XSLImportRule::XSLImportRule(XSLStyleSheet& parent, const String& href)
     : m_parentStyleSheet(parent)

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -27,13 +27,14 @@
 #include "CachedResourceHandle.h"
 #include "CachedStyleSheetClient.h"
 #include "XSLStyleSheet.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class CachedXSLStyleSheet;
 
 class XSLImportRule : private CachedStyleSheetClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(XSLImportRule);
 public:
     XSLImportRule(XSLStyleSheet& parentSheet, const String& href);
     virtual ~XSLImportRule();

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -55,10 +55,13 @@
 #include "TextResourceDecoder.h"
 #include "XMLNSNames.h"
 #include <wtf/Ref.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XMLDocumentParser);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -34,6 +34,7 @@
 #include <libxml/xmlstring.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/CString.h>
 
@@ -63,7 +64,7 @@ private:
 };
 
 class XMLDocumentParser final : public ScriptableDocumentParser, public PendingScriptClient, public CanMakeCheckedPtr<XMLDocumentParser> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(XMLDocumentParser);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLDocumentParser);
 public:
     enum class IsInFrameView : bool { No, Yes };

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -69,6 +69,7 @@
 #include "XMLDocumentParserScope.h"
 #include <libxml/parser.h>
 #include <libxml/parserInternals.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/UTF8Conversion.h>
@@ -106,7 +107,7 @@ static inline bool shouldRenderInXMLTreeViewerMode(Document& document)
 #endif
 
 class PendingCallbacks {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PendingCallbacks);
 public:
     void appendStartElementNSCallback(const xmlChar* xmlLocalName, const xmlChar* xmlPrefix, const xmlChar* xmlURI, int numNamespaces, const xmlChar** namespaces, int numAttributes, int numDefaulted, const xmlChar** attributes)
     {
@@ -368,7 +369,7 @@ static int matchFunc(const char*)
 }
 
 class OffsetBuffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(OffsetBuffer);
 public:
     OffsetBuffer(Vector<uint8_t>&& buffer)
         : m_buffer(WTFMove(buffer))

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3943,8 +3943,9 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         return;
 
     class InspectorExtensionClient : public API::InspectorExtensionClient {
+        IGNORE_CLANG_WARNINGS_BEGIN("unused-local-typedef")
         WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorExtensionClient);
-
+        IGNORE_CLANG_WARNINGS_END
     public:
         explicit InspectorExtensionClient(API::InspectorExtension& inspectorExtension, WebExtensionContext& extensionContext)
             : m_inspectorExtension(&inspectorExtension)


### PR DESCRIPTION
#### 7b532fff8f7438cf9a7d38381986cc332e0d6f14
<pre>
[TZone] Remaining WebCore files - Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278841">https://bugs.webkit.org/show_bug.cgi?id=278841</a>
<a href="https://rdar.apple.com/134910489">rdar://134910489</a>

Reviewed by Yijia Huang.

Converted various WebCore classes from WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED
(and related macros) in preparation for enabling TZone.
Also made some fixes to make sure building with TZones enabled works.
TZones are not enabled with the change.

* Source/WebCore/Modules/fetch/FormDataConsumer.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h:
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.h:
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebCore/Modules/websockets/WebSocketDeflater.cpp:
* Source/WebCore/PAL/pal/HysteresisActivity.h:
* Source/WebCore/PAL/pal/ThreadGlobalData.cpp:
* Source/WebCore/PAL/pal/ThreadGlobalData.h:
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
* Source/WebCore/PAL/pal/system/Clock.h:
* Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.h:
* Source/WebCore/PAL/pal/system/mac/SystemSleepListenerMac.mm:
* Source/WebCore/PAL/pal/text/KillRing.cpp:
* Source/WebCore/PAL/pal/text/KillRing.h:
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
* Source/WebCore/PAL/pal/text/TextCodec.h:
* Source/WebCore/PAL/pal/text/mac/KillRingMac.mm:
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AXTreeStore.h:
* Source/WebCore/bindings/js/GCController.cpp:
* Source/WebCore/bridge/Bridge.h:
* Source/WebCore/bridge/IdentifierRep.cpp:
* Source/WebCore/bridge/IdentifierRep.h:
* Source/WebCore/bridge/jsc/BridgeJSC.cpp:
* Source/WebCore/bridge/jsc/BridgeJSC.h:
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
* Source/WebCore/crypto/CryptoAlgorithmParameters.h:
* Source/WebCore/css/CSSRuleList.h:
* Source/WebCore/css/CSSSelector.cpp:
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/color/CSSUnresolvedColor.cpp:
* Source/WebCore/css/color/CSSUnresolvedColor.h:
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
* Source/WebCore/css/parser/MutableCSSSelector.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/editing/CompositeEditCommand.cpp:
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/EditingStyle.cpp:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.cpp:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/SelectionGeometryGatherer.cpp:
* Source/WebCore/editing/SelectionGeometryGatherer.h:
* Source/WebCore/editing/SpellChecker.cpp:
* Source/WebCore/editing/SpellChecker.h:
* Source/WebCore/editing/TextIterator.cpp:
* Source/WebCore/editing/TextIterator.h:
* Source/WebCore/editing/TextManipulationController.cpp:
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/editing/cocoa/AlternativeTextUIController.h:
* Source/WebCore/editing/cocoa/AlternativeTextUIController.mm:
* Source/WebCore/editing/cocoa/AutofillElements.cpp:
* Source/WebCore/editing/cocoa/AutofillElements.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
* Source/WebCore/fileapi/AsyncFileStream.cpp:
* Source/WebCore/fileapi/AsyncFileStream.h:
* Source/WebCore/fileapi/BlobLoader.h:
* Source/WebCore/history/BackForwardCache.cpp:
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/BackForwardController.cpp:
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedFrame.cpp:
* Source/WebCore/history/CachedFrame.h:
* Source/WebCore/history/CachedPage.cpp:
* Source/WebCore/history/CachedPage.h:
* Source/WebCore/history/HistoryItem.cpp:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp:
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h:
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/page/MemoryRelease.cpp:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/ios/ContentChangeObserver.h:
* Source/WebCore/platform/calc/CalculationTree.h:
* Source/WebCore/platform/graphics/egl/GLDisplay.h:
* Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp:
* Source/WebCore/platform/graphics/win/FullScreenController.cpp:
* Source/WebCore/platform/xr/cocoa/PlatformXRCocoa.mm:
* Source/WebCore/storage/StorageMap.cpp:
* Source/WebCore/storage/StorageMap.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
* Source/WebCore/style/CustomPropertyRegistry.h:
* Source/WebCore/style/HasSelectorFilter.cpp:
* Source/WebCore/style/HasSelectorFilter.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/PropertyCascade.cpp:
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleBuilder.cpp:
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleScope.cpp:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleUpdate.cpp:
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/testing/InternalSettings.cpp:
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/LegacyMockCDM.cpp:
* Source/WebCore/testing/LegacyMockCDM.h:
* Source/WebCore/testing/MockCDMFactory.cpp:
* Source/WebCore/testing/MockCDMFactory.h:
* Source/WebCore/testing/MockMediaSessionCoordinator.cpp:
* Source/WebCore/testing/MockMediaSessionCoordinator.h:
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/testing/TypeConversions.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebCore/xml/XMLErrors.cpp:
* Source/WebCore/xml/XMLErrors.h:
* Source/WebCore/xml/XPathExpressionNode.cpp:
* Source/WebCore/xml/XPathExpressionNode.h:
* Source/WebCore/xml/XPathStep.cpp:
* Source/WebCore/xml/XPathStep.h:
* Source/WebCore/xml/XSLImportRule.cpp:
* Source/WebCore/xml/XSLImportRule.h:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):

Canonical link: <a href="https://commits.webkit.org/282916@main">https://commits.webkit.org/282916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a52071eda81caa1c05250fdac033282be151a69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51988 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10518 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13298 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14108 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70357 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13134 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59318 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59497 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/756 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39805 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40627 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->