### PR TITLE
WKWebView _obscuredInsets sometimes incorrectly applied in element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1076,6 +1076,14 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         [webView _overrideZoomScaleParametersWithMinimumZoomScale:WebKit::baseScale maximumZoomScale:WebKit::baseScale allowUserScaling:NO];
         [webView _resetContentOffset];
         [_window insertSubview:webView.get() atIndex:0];
+
+        // _obscuredInsets and _unobscuredSafeAreaInsets were already reset by
+        // WKWebViewState::applyTo(), but inserting webView into _window may change its
+        // safeAreaInsets, which may cause the client to set new (un)obscured insets.
+        // Therefore we need to reset them again.
+        [webView _resetObscuredInsets];
+        [webView _resetUnobscuredSafeAreaInsets];
+
         [webView setNeedsLayout];
         [webView layoutIfNeeded];
 


### PR DESCRIPTION
#### 14ac3c34ea68a5a108f2a0687b35473da0f4bab2
<pre>
WKWebView _obscuredInsets sometimes incorrectly applied in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=278842">https://bugs.webkit.org/show_bug.cgi?id=278842</a>
<a href="https://rdar.apple.com/131878433">rdar://131878433</a>

Reviewed by Wenson Hsieh.

When entering element fullscreen, WKFullScreenWindowController saves the state of various WKWebView
properties then resets them to values appropriate for presenting the web view in the element
fullscreen window. Later, it restores the saved properties when exiting element fullscreen.
However, nothing prevents clients from modifying these properties *during* element fullscreen,
overwriting the values previously set by WKFullScreenWindowController and potentially invalidating
the element fullscreen presentation.

While this is an general problem with the design of element fullscreen that this change doesn&apos;t
fully address, there is a scenario where _obscuredInsets and _unobscuredSafeAreaInsets are likely
to change at a known time: when WKFullScreenWindowController inserts the web view into the element
fullscreen window the web view&apos;s safeAreaInsets may change, and if the client has subclassed
WKWebView and overrode -safeAreaInsetsDidChange then it may choose to modify _obscuredInsets and
_unobscuredSafeAreaInsets (since these values are often derived from safeAreaInsets). The result is
that the content in element fullscreen may be inset even though there are no views obscuring the
web view.

To address this scenario, this changes WKFullScreenWindowController to specifically reset
_obscuredInsets and _unobscuredSafeAreaInsets after the call to -insertSubview:atIndex: in case the
client synchronously modified these properties in response to the web view being reparented.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:]):

Canonical link: <a href="https://commits.webkit.org/282915@main">https://commits.webkit.org/282915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a74c4a2fb02ba559d484b6071a54b6eac11fcb3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15193 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51951 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10482 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37327 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70307 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8532 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13096 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59278 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55976 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59457 "Found 190 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close, /WebKitGTK/TestAutocleanups:/webkit/Autocleanups/web-process-autocleanups, /WebKitGTK/TestNetworkProcessMemoryPressure:/webkit/WebKitWebsiteData/memory-pressure, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-storage, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-alternate-html-for-local-page, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/default-content-security-policy, /WebKitGTK/TestBackForwardList:/webkit/WebKitWebView/session-state, /WebKitGTK/TestDownloads:/webkit/Downloads/user-agent ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/726 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39763 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40841 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->