### PR TITLE
[ iOS ] editing/selection/ios/look-up-selected-text.html is a constant timeout

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7533,9 +7533,6 @@ media/remove-video-best-media-element-in-main-frame-crash.html [ Pass Timeout ]
 # webkit.org/b/278325 New-test(282375@main): [ iOS ] http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html is a constant text failure
 http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html [ Failure ]
 
-# webkit.org/b/278324 [ iOS ] editing/selection/ios/look-up-selected-text.html is a constant timeout
-editing/selection/ios/look-up-selected-text.html [ Timeout ]
-
 # webkit.org/b/278340 [ iOS ] compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html is a flaky image failure
 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11408,7 +11408,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 #endif
 
     if (auto menu = self.scrollToTextFragmentGenerationMenu)
-        [builder insertSiblingMenu:menu afterMenuForIdentifier:UIMenuStandardEdit];
+        [builder insertSiblingMenu:menu beforeMenuForIdentifier:UIMenuShare];
 }
 
 - (UIMenu *)menuWithInlineAction:(NSString *)title image:(UIImage *)image identifier:(NSString *)identifier handler:(Function<void(WKContentView *)>&&)handler


### PR DESCRIPTION
#### 0587c4d7e320d7442fc30bd361af664fece9e9d0
<pre>
[ iOS ] editing/selection/ios/look-up-selected-text.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=278324">https://bugs.webkit.org/show_bug.cgi?id=278324</a>
<a href="https://rdar.apple.com/134271844">rdar://134271844</a>

Reviewed by Wenson Hsieh.

Shift STTF generation a little further down the callout bar (which we want
to do anyway, but also happens to fix this test).

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView buildMenuForWebViewWithBuilder:]):

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/282913@main">https://commits.webkit.org/282913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f2e1016a4f78c3b8d11470a7015acd1edc3efae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15210 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51959 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8549 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13107 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59288 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55985 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59474 "Found 197 new API test failures: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-no-credential, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/next, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/cookies-changed, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-redirect-to-http, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-bytes, /WebKitGTK/TestDOMNode:/webkit/WebKitDOMNode/hierarchy-navigation, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-alternate-html-for-local-page, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestDOMNodeFilter:/webkit/WebKitDOMNodeFilter/node-iterator, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7066 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/734 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9802 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39780 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->