### PR TITLE
GraphicsLayerWC shouldn't call GraphicsLayerClient::notifyFlushRequired during layer flushing

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1204,9 +1204,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-t
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ Pass ]
 
-webkit.org/b/278847 css3/blending/background-blend-mode-crossfade-image.html [ Skip ] # Crash
-webkit.org/b/278847 css3/blending/background-blend-mode-tiled-layers.html [ Skip ] # Crash
-
 css3/blending/blend-mode-accelerated-parent-overflow-hidden.html [ Skip ] # ImageOnlyFailure
 css3/blending/blend-mode-body-child-isolate-html-background-color.html [ Skip ] # ImageOnlyFailure
 css3/blending/blend-mode-body-composited-child-background-color.html [ Skip ] # ImageOnlyFailure

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -527,6 +527,8 @@ void GraphicsLayerWC::noteLayerPropertyChanged(OptionSet<WCLayerChange> flags, S
         return;
     bool needsFlush = !m_uncommittedChanges;
     m_uncommittedChanges.add(flags);
+    if (m_isFlushing)
+        return;
     if (needsFlush && scheduleFlush == ScheduleFlush)
         client().notifyFlushRequired(this);
 }
@@ -545,6 +547,7 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
 {
     if (!m_uncommittedChanges)
         return;
+    SetForScope<bool> scopedIsFlushing(m_isFlushing, true);
     WCLayerUpdateInfo update {
         .id = *primaryLayerID(),
         .changes = std::exchange(m_uncommittedChanges, { })

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -134,6 +134,7 @@ private:
     WebCore::Color m_debugBorderColor;
     OptionSet<WCLayerChange> m_uncommittedChanges;
     float m_debugBorderWidth { 0 };
+    bool m_isFlushing { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### db9e0f6f196db5f47df07fdf374a681ef86eab15
<pre>
GraphicsLayerWC shouldn&apos;t call GraphicsLayerClient::notifyFlushRequired during layer flushing
<a href="https://bugs.webkit.org/show_bug.cgi?id=278847">https://bugs.webkit.org/show_bug.cgi?id=278847</a>

Reviewed by Don Olmstead.

An assertion failed in RenderLayerCompositor::scheduleRenderingUpdate
for some SVG image tests. The assertion ensures
GraphicsLayerClient::notifyFlushRequired isn&apos;t called during layer
flushing. However, SVGImage does layout during painting.

Added a flag m_isFlushing to GraphicsLayerWC.

* LayoutTests/platform/win/TestExpectations:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::GraphicsLayerWC::noteLayerPropertyChanged):
(WebKit::GraphicsLayerWC::flushCompositingStateForThisLayerOnly):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:

Canonical link: <a href="https://commits.webkit.org/282920@main">https://commits.webkit.org/282920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71639b15b3acb787fbdd4e104e14f0b1bf61601a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15215 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51962 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37345 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13278 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/stretch-along-block-axis-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70329 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59292 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55989 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59482 "Found 197 new API test failures: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-no-credential, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/next, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-redirect-to-http, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/cookies-changed, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-bytes, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-alternate-html-for-local-page, /WebKitGTK/TestDOMNodeFilter:/webkit/WebKitDOMNodeFilter/node-iterator, /WebKitGTK/TestDOMNode:/webkit/WebKitDOMNode/hierarchy-navigation ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/737 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9805 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->