### PR TITLE
[IFC][SVG text] SVGTextLayoutEngine should use inline iterator

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -151,6 +151,21 @@ public:
     LeafBoxIterator& traversePreviousOnLineIgnoringLineBreak();
 };
 
+template<class IteratorType>
+class BoxRange {
+public:
+    BoxRange(IteratorType begin)
+        : m_begin(begin)
+    {
+    }
+
+    IteratorType begin() const { return m_begin; }
+    EndIterator end() const { return { }; }
+
+private:
+    IteratorType m_begin;
+};
+
 LeafBoxIterator boxFor(const RenderLineBreak&);
 LeafBoxIterator boxFor(const RenderBox&);
 LeafBoxIterator boxFor(const LayoutIntegration::InlineContent&, size_t boxIndex);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
@@ -44,7 +44,7 @@ FloatRect SVGTextBox::calculateBoundariesIncludingSVGTransform() const
     return visualRectIgnoringBlockDirection();
 }
 
-const Vector<SVGTextFragment>& SVGTextBox::svgTextFragments() const
+const Vector<SVGTextFragment>& SVGTextBox::textFragments() const
 {
     if (auto* svgText = dynamicDowncast<SVGInlineTextBox>(legacyInlineBox()))
         return svgText->textFragments();
@@ -69,7 +69,7 @@ SVGTextBoxIterator::SVGTextBoxIterator(const Box& box)
 {
 }
 
-SVGTextBoxIterator firstTextBoxFor(const RenderSVGInlineText& text)
+SVGTextBoxIterator firstSVGTextBoxFor(const RenderSVGInlineText& text)
 {
     if (auto* lineLayout = LayoutIntegration::LineLayout::containing(text))
         return { *lineLayout->textBoxesFor(text) };
@@ -77,10 +77,16 @@ SVGTextBoxIterator firstTextBoxFor(const RenderSVGInlineText& text)
     return { BoxLegacyPath { text.firstLegacyTextBox() } };
 }
 
-SVGTextBoxRange textBoxesFor(const RenderSVGInlineText& text)
+BoxRange<SVGTextBoxIterator> svgTextBoxesFor(const RenderSVGInlineText& text)
 {
-    return { firstTextBoxFor(text) };
+    return { firstSVGTextBoxFor(text) };
 }
+
+SVGTextBoxIterator svgTextBoxFor(const SVGInlineTextBox* box)
+{
+    return { BoxLegacyPath { box } };
+}
+
 
 }
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
@@ -40,7 +40,7 @@ public:
     SVGTextBox(PathVariant&&);
 
     FloatRect calculateBoundariesIncludingSVGTransform() const;
-    const Vector<SVGTextFragment>& svgTextFragments() const;
+    const Vector<SVGTextFragment>& textFragments() const;
 
     const RenderSVGInlineText& renderer() const { return downcast<RenderSVGInlineText>(TextBox::renderer()); }
 
@@ -76,8 +76,9 @@ private:
     SVGTextBoxIterator m_begin;
 };
 
-SVGTextBoxIterator firstTextBoxFor(const RenderSVGInlineText&);
-SVGTextBoxRange textBoxesFor(const RenderSVGInlineText&);
+SVGTextBoxIterator firstSVGTextBoxFor(const RenderSVGInlineText&);
+BoxRange<SVGTextBoxIterator> svgTextBoxesFor(const RenderSVGInlineText&);
+SVGTextBoxIterator svgTextBoxFor(const SVGInlineTextBox*);
 
 }
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -92,7 +92,7 @@ TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent& content, size
     return { BoxModernPath { content, boxIndex } };
 }
 
-TextBoxRange textBoxesFor(const RenderText& text)
+BoxRange<TextBoxIterator> textBoxesFor(const RenderText& text)
 {
     return { firstTextBoxFor(text) };
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -81,25 +81,11 @@ private:
     const TextBox& get() const { return downcast<TextBox>(m_box); }
 };
 
-class TextBoxRange {
-public:
-    TextBoxRange(TextBoxIterator begin)
-        : m_begin(begin)
-    {
-    }
-
-    TextBoxIterator begin() const { return m_begin; }
-    EndIterator end() const { return { }; }
-
-private:
-    TextBoxIterator m_begin;
-};
-
 TextBoxIterator firstTextBoxFor(const RenderText&);
 TextBoxIterator textBoxFor(const LegacyInlineTextBox*);
 TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent&, const InlineDisplay::Box&);
 TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent&, size_t boxIndex);
-TextBoxRange textBoxesFor(const RenderText&);
+BoxRange<TextBoxIterator> textBoxesFor(const RenderText&);
 
 inline bool TextBox::hasHyphen() const
 {

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -216,8 +216,7 @@ static LayoutRect selectionRectForTextBox(const InlineIterator::TextBox& textBox
             // For last text box in a InlineTextBox chain, we allow the caret to move to a position 'after' the end of the last text box.
             bool isCaretWithinLastTextBox = rangeStart >= textBox.start() && rangeStart <= textBox.end();
 
-            auto itEnd = InlineIterator::TextBoxRange { InlineIterator::TextBoxIterator(textBox) }.end();
-            auto isLastTextBox = textBox.nextTextBox() == itEnd;
+            auto isLastTextBox = !textBox.nextTextBox();
 
             if ((isLastTextBox && !isCaretWithinLastTextBox) || (!isLastTextBox && !isCaretWithinTextBox))
                 return { };

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<LegacyInlineTextBox> RenderSVGInlineText::createTextBox()
 FloatRect RenderSVGInlineText::floatLinesBoundingBox() const
 {
     FloatRect boundingBox;
-    for (auto& box : InlineIterator::textBoxesFor(*this))
+    for (auto& box : InlineIterator::svgTextBoxesFor(*this))
         boundingBox.unite(box.calculateBoundariesIncludingSVGTransform());
 
     return boundingBox;
@@ -177,8 +177,8 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
     const SVGInlineTextBox* closestDistanceBox = nullptr;
 
     AffineTransform fragmentTransform;
-    for (auto& box : InlineIterator::textBoxesFor(*this)) {
-        auto& fragments = box.svgTextFragments();
+    for (auto& box : InlineIterator::svgTextBoxesFor(*this)) {
+        auto& fragments = box.textFragments();
 
         unsigned textFragmentsSize = fragments.size();
         for (unsigned i = 0; i < textFragmentsSize; ++i) {

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -41,6 +41,7 @@ public:
 
     bool characterStartsNewTextChunk(int position) const;
     SVGTextLayoutAttributes* layoutAttributes() { return &m_layoutAttributes; }
+    const SVGTextLayoutAttributes* layoutAttributes() const { return &m_layoutAttributes; }
 
     // computeScalingFactor() returns the font-size scaling factor, ignoring the text-rendering mode.
     // scalingFactor() takes it into account, and thus returns 1 whenever text-rendering is set to 'geometricPrecision'.

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -340,7 +340,7 @@ static void writeRenderSVGTextBox(TextStream& ts, const RenderSVGText& text)
 
 static inline void writeSVGInlineTextBox(TextStream& ts, const InlineIterator::SVGTextBox& textBox)
 {
-    auto& fragments = textBox.svgTextFragments();
+    auto& fragments = textBox.textFragments();
     if (fragments.isEmpty())
         return;
 
@@ -393,7 +393,7 @@ static inline void writeSVGInlineTextBox(TextStream& ts, const InlineIterator::S
 
 static inline void writeSVGInlineTextBoxes(TextStream& ts, const RenderSVGInlineText& text)
 {
-    for (auto& box : InlineIterator::textBoxesFor(text))
+    for (auto& box : InlineIterator::svgTextBoxesFor(text))
         writeSVGInlineTextBox(ts, box);
 }
 

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
@@ -126,9 +126,9 @@ void SVGRootInlineBox::computePerCharacterLayoutInformation()
 void SVGRootInlineBox::layoutCharactersInTextBoxes(LegacyInlineFlowBox* start, SVGTextLayoutEngine& characterLayout)
 {
     for (auto* child = start->firstChild(); child; child = child->nextOnLine()) {
-        if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(*child)) {
-            ASSERT(is<RenderSVGInlineText>(textBox->renderer()));
-            characterLayout.layoutInlineTextBox(*textBox);
+        if (auto* legacyTextBox = dynamicDowncast<SVGInlineTextBox>(*child)) {
+            ASSERT(is<RenderSVGInlineText>(legacyTextBox->renderer()));
+            characterLayout.layoutInlineTextBox(InlineIterator::svgTextBoxFor(legacyTextBox));
         } else {
             // Skip generated content.
             RefPtr node = child->renderer().node();

--- a/Source/WebCore/rendering/svg/SVGTextChunk.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "InlineIteratorSVGTextBox.h"
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 
@@ -27,6 +28,11 @@ namespace WebCore {
 
 class AffineTransform;
 class SVGInlineTextBox;
+
+using SVGChunkTransformMapKey = std::pair<const RenderSVGInlineText*, unsigned>;
+using SVGChunkTransformMap = HashMap<SVGChunkTransformMapKey, AffineTransform>;
+
+SVGChunkTransformMapKey makeSVGChunkTransformMapKey(InlineIterator::SVGTextBoxIterator);
 
 // A SVGTextChunk describes a range of SVGTextFragments, see the SVG spec definition of a "text chunk".
 class SVGTextChunk {
@@ -41,16 +47,16 @@ public:
         LengthAdjustSpacingAndGlyphs = 1 << 6
     };
 
-    SVGTextChunk(const Vector<SVGInlineTextBox*>&, unsigned first, unsigned limit);
+    SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>&, unsigned first, unsigned limit);
 
     unsigned totalCharacters() const;
     float totalLength() const;
     float totalAnchorShift() const;
-    void layout(HashMap<SVGInlineTextBox*, AffineTransform>&) const;
+    void layout(SVGChunkTransformMap&) const;
 
 private:
     void processTextAnchorCorrection() const;
-    void buildBoxTransformations(HashMap<SVGInlineTextBox*, AffineTransform>&) const;
+    void buildBoxTransformations(SVGChunkTransformMap&) const;
     void processTextLengthSpacingCorrection() const;
 
     bool isVerticalText() const { return m_chunkStyle & VerticalText; }
@@ -61,11 +67,11 @@ private:
     bool hasLengthAdjustSpacing() const { return m_chunkStyle & LengthAdjustSpacing; }
     bool hasLengthAdjustSpacingAndGlyphs() const { return m_chunkStyle & LengthAdjustSpacingAndGlyphs; }
 
-    bool boxSpacingAndGlyphsTransform(const SVGInlineTextBox*, AffineTransform&) const;
+    bool boxSpacingAndGlyphsTransform(InlineIterator::SVGTextBoxIterator, AffineTransform&) const;
 
 private:
     // Contains all SVGInlineTextBoxes this chunk spans.
-    Vector<SVGInlineTextBox*> m_boxes;
+    Vector<InlineIterator::SVGTextBoxIterator> m_boxes;
 
     unsigned m_chunkStyle { DefaultStyle };
     float m_desiredTextLength { 0 };

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
@@ -56,13 +56,13 @@ float SVGTextChunkBuilder::totalAnchorShift() const
     return anchorShift;
 }
 
-AffineTransform SVGTextChunkBuilder::transformationForTextBox(SVGInlineTextBox* textBox) const
+AffineTransform SVGTextChunkBuilder::transformationForTextBox(InlineIterator::SVGTextBoxIterator textBox) const
 {
-    auto it = m_textBoxTransformations.find(textBox);
+    auto it = m_textBoxTransformations.find(makeSVGChunkTransformMapKey(textBox));
     return it == m_textBoxTransformations.end() ? AffineTransform() : it->value;
 }
 
-void SVGTextChunkBuilder::buildTextChunks(const Vector<SVGInlineTextBox*>& lineLayoutBoxes)
+void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes)
 {
     if (lineLayoutBoxes.isEmpty())
         return;
@@ -71,7 +71,7 @@ void SVGTextChunkBuilder::buildTextChunks(const Vector<SVGInlineTextBox*>& lineL
     unsigned first = limit;
 
     for (unsigned i = 0; i < limit; ++i) {
-        if (!lineLayoutBoxes[i]->startsNewTextChunk())
+        if (!lineLayoutBoxes[i]->legacyInlineBox()->startsNewTextChunk())
             continue;
 
         if (first == limit)
@@ -87,7 +87,7 @@ void SVGTextChunkBuilder::buildTextChunks(const Vector<SVGInlineTextBox*>& lineL
         m_textChunks.append(SVGTextChunk(lineLayoutBoxes, first, limit));
 }
 
-void SVGTextChunkBuilder::layoutTextChunks(const Vector<SVGInlineTextBox*>& lineLayoutBoxes)
+void SVGTextChunkBuilder::layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes)
 {
     buildTextChunks(lineLayoutBoxes);
     if (m_textChunks.isEmpty())

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -25,6 +25,7 @@
 
 namespace WebCore {
 
+class RenderSVGInlineText;
 class SVGInlineTextBox;
 struct SVGTextFragment;
 
@@ -43,14 +44,14 @@ public:
     unsigned totalCharacters() const;
     float totalLength() const;
     float totalAnchorShift() const;
-    AffineTransform transformationForTextBox(SVGInlineTextBox*) const;
+    AffineTransform transformationForTextBox(InlineIterator::SVGTextBoxIterator) const;
 
-    void buildTextChunks(const Vector<SVGInlineTextBox*>& lineLayoutBoxes);
-    void layoutTextChunks(const Vector<SVGInlineTextBox*>& lineLayoutBoxes);
+    void buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes);
+    void layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes);
 
 private:
     Vector<SVGTextChunk> m_textChunks;
-    HashMap<SVGInlineTextBox*, AffineTransform> m_textBoxTransformations;
+    SVGChunkTransformMap m_textBoxTransformations;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
@@ -56,6 +56,7 @@ public:
     const SVGCharacterDataMap& characterDataMap() const { return m_characterDataMap; }
 
     Vector<SVGTextMetrics>& textMetricsValues() { return m_textMetricsValues; }
+    const Vector<SVGTextMetrics>& textMetricsValues() const { return m_textMetricsValues; }
 
 private:
     SingleThreadWeakRef<RenderSVGInlineText> m_context;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "InlineIteratorSVGTextBox.h"
 #include "Path.h"
 #include "SVGTextChunkBuilder.h"
 #include "SVGTextFragment.h"
@@ -52,7 +53,7 @@ public:
     void beginTextPathLayout(RenderSVGTextPath&, SVGTextLayoutEngine& lineLayout);
     void endTextPathLayout();
 
-    void layoutInlineTextBox(SVGInlineTextBox&);
+    void layoutInlineTextBox(InlineIterator::SVGTextBoxIterator);
     void finishLayout();
 
 private:
@@ -60,15 +61,15 @@ private:
     void updateCurrentTextPosition(float x, float y, float glyphAdvance);
     void updateRelativePositionAdjustmentsIfNeeded(float dx, float dy);
 
-    void recordTextFragment(SVGInlineTextBox&, Vector<SVGTextMetrics>&);
+    void recordTextFragment(InlineIterator::SVGTextBoxIterator, const Vector<SVGTextMetrics>&);
     bool parentDefinesTextLength(RenderObject*) const;
 
-    void layoutTextOnLineOrPath(SVGInlineTextBox&, RenderSVGInlineText&, const RenderStyle&);
-    void finalizeTransformMatrices(Vector<SVGInlineTextBox*>&);
+    void layoutTextOnLineOrPath(InlineIterator::SVGTextBoxIterator, const RenderSVGInlineText&, const RenderStyle&);
+    void finalizeTransformMatrices(Vector<InlineIterator::SVGTextBoxIterator>&);
 
     bool currentLogicalCharacterAttributes(SVGTextLayoutAttributes*&);
     bool currentLogicalCharacterMetrics(SVGTextLayoutAttributes*&, SVGTextMetrics&);
-    bool currentVisualCharacterMetrics(const SVGInlineTextBox&, Vector<SVGTextMetrics>&, SVGTextMetrics&);
+    bool currentVisualCharacterMetrics(const InlineIterator::SVGTextBox&, const Vector<SVGTextMetrics>&, SVGTextMetrics&);
 
     void advanceToNextLogicalCharacter(const SVGTextMetrics&);
     void advanceToNextVisualCharacter(const SVGTextMetrics&);
@@ -76,8 +77,8 @@ private:
 private:
     Vector<SVGTextLayoutAttributes*>& m_layoutAttributes;
 
-    Vector<SVGInlineTextBox*> m_lineLayoutBoxes;
-    Vector<SVGInlineTextBox*> m_pathLayoutBoxes;
+    Vector<InlineIterator::SVGTextBoxIterator> m_lineLayoutBoxes;
+    Vector<InlineIterator::SVGTextBoxIterator> m_pathLayoutBoxes;
     SVGTextChunkBuilder m_chunkLayoutBuilder;
 
     SVGTextFragment m_currentTextFragment;

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -210,7 +210,7 @@ bool SVGTextContentElement::selfHasRelativeLengths() const
     return true;
 }
 
-SVGTextContentElement* SVGTextContentElement::elementFromRenderer(RenderObject* renderer)
+const SVGTextContentElement* SVGTextContentElement::elementFromRenderer(const RenderObject* renderer)
 {
     if (!renderer)
         return nullptr;

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -82,7 +82,7 @@ public:
     int getCharNumAtPosition(DOMPointInit&&);
     ExceptionOr<void> selectSubString(unsigned charnum, unsigned nchars);
 
-    static SVGTextContentElement* elementFromRenderer(RenderObject*);
+    static const SVGTextContentElement* elementFromRenderer(const RenderObject*);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextContentElement, SVGGraphicsElement>;
 


### PR DESCRIPTION
#### 30b1dab3e77f07d673ebbcce0d25aa66743b091a
<pre>
[IFC][SVG text] SVGTextLayoutEngine should use inline iterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=278851">https://bugs.webkit.org/show_bug.cgi?id=278851</a>
<a href="https://rdar.apple.com/134924182">rdar://134924182</a>

Reviewed by Alan Baradlay.

Make it independent from legacy inline boxes.

* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::BoxRange::BoxRange):
(WebCore::InlineIterator::BoxRange::begin const):
(WebCore::InlineIterator::BoxRange::end const):
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp:
(WebCore::InlineIterator::SVGTextBox::textFragments const):
(WebCore::InlineIterator::firstSVGTextBoxFor):
(WebCore::InlineIterator::svgTextBoxesFor):
(WebCore::InlineIterator::svgTextBoxFor):
(WebCore::InlineIterator::SVGTextBox::svgTextFragments const): Deleted.
(WebCore::InlineIterator::firstTextBoxFor): Deleted.
(WebCore::InlineIterator::textBoxesFor): Deleted.

Also some iterator cleanups.

* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h:
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::textBoxesFor):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
(WebCore::InlineIterator::TextBoxRange::TextBoxRange): Deleted.
(WebCore::InlineIterator::TextBoxRange::begin const): Deleted.
(WebCore::InlineIterator::TextBoxRange::end const): Deleted.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::selectionRectForTextBox):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::floatLinesBoundingBox const):
(WebCore::RenderSVGInlineText::positionForPoint):
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGInlineTextBox):
(WebCore::writeSVGInlineTextBoxes):
* Source/WebCore/rendering/svg/SVGRootInlineBox.cpp:
(WebCore::SVGRootInlineBox::layoutCharactersInTextBoxes):
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
(WebCore::makeSVGChunkTransformMapKey):
(WebCore::SVGTextChunk::SVGTextChunk):
(WebCore::SVGTextChunk::totalCharacters const):
(WebCore::SVGTextChunk::totalLength const):
(WebCore::SVGTextChunk::layout const):
(WebCore::SVGTextChunk::processTextLengthSpacingCorrection const):
(WebCore::SVGTextChunk::buildBoxTransformations const):
(WebCore::SVGTextChunk::boxSpacingAndGlyphsTransform const):
(WebCore::SVGTextChunk::processTextAnchorCorrection const):
* Source/WebCore/rendering/svg/SVGTextChunk.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp:
(WebCore::SVGTextChunkBuilder::transformationForTextBox const):
(WebCore::SVGTextChunkBuilder::buildTextChunks):
(WebCore::SVGTextChunkBuilder::layoutTextChunks):
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h:
(WebCore::SVGTextLayoutAttributes::textMetricsValues const):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::recordTextFragment):
(WebCore::SVGTextLayoutEngine::layoutInlineTextBox):
(WebCore::dumpTextBoxes):
(WebCore::SVGTextLayoutEngine::finalizeTransformMatrices):
(WebCore::SVGTextLayoutEngine::currentVisualCharacterMetrics):
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::elementFromRenderer):
* Source/WebCore/svg/SVGTextContentElement.h:

Canonical link: <a href="https://commits.webkit.org/282918@main">https://commits.webkit.org/282918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5adf1b2bfef327cd511a8be77b50ee7037737094

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51969 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14094 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70341 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55997 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59484 "Found 123 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.GeolocationBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PageLoadBasic, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7078 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/745 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39791 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->