### PR TITLE
Replace CR/NL by space - don't remove altogether when xml:space=default

### DIFF
--- a/LayoutTests/fast/svg/assert-when-trying-to-construct-multiple-lines-expected.txt
+++ b/LayoutTests/fast/svg/assert-when-trying-to-construct-multiple-lines-expected.txt
@@ -1,3 +1,3 @@
 PASS if no crash or assert.
-X Y
+ X Y
 

--- a/LayoutTests/fast/svg/svg-text-segment-crash-expected.txt
+++ b/LayoutTests/fast/svg/svg-text-segment-crash-expected.txt
@@ -1,1 +1,1 @@
-[object Object]This test passes if it doesn't crash.
+[object Object] This test passes if it doesn't crash.

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-dynamic-add-svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-dynamic-add-svg-expected.txt
@@ -1,5 +1,5 @@
 Test of Dynamic Adding of Elements
-The result of this test isunknown.
+The result of this test is unknown.
 
 PASS Dynamic Adding of Elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-dynamic-remove-svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-dynamic-remove-svg-expected.txt
@@ -1,5 +1,5 @@
 Test of Dynamic Removal of Elements
-The result of this test isunknown.
+The result of this test is unknown.
 
 PASS Dynamic Removal of Elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-svg-expected.txt
@@ -1,5 +1,5 @@
 Test of childElementCount
-The result of this test isunknown.
+The result of this test is unknown.
 
 PASS childElementCount
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-firstElementChild-svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-firstElementChild-svg-expected.txt
@@ -1,5 +1,5 @@
 Test of firstElementChild
-The result of this test isunknown.
+The result of this test is unknown.
 
 PASS firstElementChild
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-previousElementSibling-svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-previousElementSibling-svg-expected.txt
@@ -1,5 +1,5 @@
 Test of previousElementSibling
-The result of this test isunknown.
+The result of this test is unknown.
 
 PASS previousElementSibling
 

--- a/LayoutTests/platform/glib/svg/custom/text-whitespace-handling-expected.txt
+++ b/LayoutTests/platform/glib/svg/custom/text-whitespace-handling-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderSVGText {text} at (10,5) size 239x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 239x18
           chunk 1 text run 1 at (10.00,20.00) startOffset 0 endOffset 36 width 238.38: "Testing xml:space=\"default\" support:"
-      RenderSVGText {text} at (10,25) size 161x19 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 161x18
-          chunk 1 text run 1 at (10.00,40.00) startOffset 0 endOffset 20 width 160.22: "NoSpacesBetweenWords"
+      RenderSVGText {text} at (10,25) size 173x19 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 173x18
+          chunk 1 text run 1 at (10.00,40.00) startOffset 0 endOffset 23 width 172.22: "No Spaces Between Words"
       RenderSVGText {text} at (10,45) size 129x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 129x18
           chunk 1 text run 1 at (10.00,60.00) startOffset 0 endOffset 18 width 128.38: "Tabs become spaces"

--- a/LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt
@@ -30,6 +30,7 @@ layer at (0,0) size 800x600
         chunk 1 text run 1 at (35.63,10.00) startOffset 0 endOffset 1 width 4.06: " "
       RenderSVGTSpan {tspan} at (-10,4) size 0x1
         RenderSVGInlineText {#text} at (-10,4) size 0x0
+      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGText {text} at (65,42) size 120x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 120x10
         chunk 1 (middle anchor) text run 1 at (65.31,50.00) startOffset 0 endOffset 36 width 119.38: "Font size should decrease monotonic."

--- a/LayoutTests/platform/glib/svg/text/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 800x600
       RenderSVGInlineText {#text} at (0,0) size 320x45
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 319.20: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 800x600 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/glib/svg/text/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/text-ws-01-t-expected.txt
@@ -19,9 +19,10 @@ layer at (0,0) size 800x600
       RenderSVGText {text} at (28,139) size 340x45 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 340x45
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 339.60: "xml:space='default'"
-      RenderSVGText {text} at (15,189) size 414x45 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 414x45
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 414.00: "WS non-indented lines."
+      RenderSVGText {text} at (15,189) size 415x45 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 415x45
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 75.60: "WS "
+          chunk 1 text run 1 at (90.60,225.00) startOffset 0 endOffset 19 width 338.40: "non-indented lines."
       RenderSVGText {text} at (15,224) size 414x45 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 414.00: "WS non-indented lines."

--- a/LayoutTests/platform/glib/svg/text/textPathBoundsBug-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/textPathBoundsBug-expected.txt
@@ -10,5 +10,6 @@ layer at (0,0) size 800x600
           chunk 1 (middle anchor) text run 2 at (110.50,100.00) startOffset 5 endOffset 6 width 7.00: "6"
           chunk 1 (middle anchor) text run 3 at (117.50,100.00) startOffset 6 endOffset 7 width 7.00: "7"
           chunk 1 (middle anchor) text run 4 at (124.50,100.00) startOffset 7 endOffset 8 width 7.00: "8"
+      RenderSVGInlineText {#text} at (0,0) size 0x0
 selection start: position 0 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document
 selection end:   position 8 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document

--- a/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,6 +13,7 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (339,96) size 45x30
           RenderSVGInlineText {#text} at (339,96) size 45x30
             chunk 1 text run 1 at (389.00,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
+        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 480x360
       RenderSVGInlineText {#text} at (0,0) size 264x45
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 264.00: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 480x360 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
@@ -21,7 +21,8 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 337.00: "xml:space='default'"
       RenderSVGText {text} at (15,189) size 411x44 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 411x44
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 411.00: "WS non-indented lines."
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 76.00: "WS "
+          chunk 1 text run 1 at (91.00,225.00) startOffset 0 endOffset 19 width 335.00: "non-indented lines."
       RenderSVGText {text} at (15,224) size 411x44 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 411x44
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 411.00: "WS non-indented lines."

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
@@ -9,7 +9,8 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 33 width 184.13: "Rectangle should be red not green"
       RenderSVGText {text} at (40,25) size 330x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 330x14
-          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 64 width 329.70: "This tests id selectors: <rect id=\"one\" /> and the selector #one"
+          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 54.68: "This tests "
+          chunk 1 text run 1 at (94.68,36.00) startOffset 0 endOffset 53 width 275.02: "id selectors: <rect id=\"one\" /> and the selector #one"
       RenderSVGContainer {g} at (130,70) size 260x60
         RenderSVGEllipse {circle} at (130,70) size 60x60 [fill={[type=SOLID] [color=#008000]}] [cx=160.00] [cy=100.00] [r=30.00]
         RenderSVGRect {rect} at (220,80) size 60x40 [fill={[type=SOLID] [color=#FF0000]}] [x=220.00] [y=80.00] [width=60.00] [height=40.00]
@@ -20,7 +21,8 @@ layer at (0,0) size 480x360
             chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 51 width 258.14: "Circle should be red not green; rectangle still red"
         RenderSVGText {text} at (40,25) size 317x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 317x14
-            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 63 width 316.96: "This tests attribute selectors: <circle transform=\"scale(2)\" />"
+            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 54.68: "This tests "
+            chunk 1 text run 1 at (94.68,36.00) startOffset 0 endOffset 52 width 262.28: "attribute selectors: <circle transform=\"scale(2)\" />"
         RenderSVGText {text} at (40,47) size 205x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 205x14
             chunk 1 text run 1 at (40.00,58.00) startOffset 0 endOffset 39 width 204.28: "and the selector [transform=\"scale(2)\"]"

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,6 +13,7 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (337,96) size 46x30
           RenderSVGInlineText {#text} at (337,96) size 45x30
             chunk 1 text run 1 at (387.50,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
+        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
@@ -11,22 +11,30 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (5.00,90.00) startOffset 0 endOffset 32 width 460.21: "and many-to-many chars to glyphs"
       RenderSVGHiddenContainer {defs} at (0,0) size 0x0
       RenderSVGContainer {g} at (45,125) size 428x165
-        RenderSVGText {text} at (140,130) size 199x75 contains 1 chunk(s)
+        RenderSVGText {text} at (140,130) size 266x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 44x75
             RenderSVGInlineText {#text} at (0,0) size 44x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.33: "H"
-          RenderSVGTSpan {altGlyph} at (43,0) size 38x75
-            RenderSVGInlineText {#text} at (43,0) size 38x75
-              chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 37.50: "A"
-          RenderSVGTSpan {altGlyph} at (80,0) size 41x75
-            RenderSVGInlineText {#text} at (80,0) size 41x75
-              chunk 1 text run 1 at (220.83,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGTSpan {altGlyph} at (120,0) size 41x75
-            RenderSVGInlineText {#text} at (120,0) size 41x75
-              chunk 1 text run 1 at (260.85,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGTSpan {altGlyph} at (160,0) size 39x75
-            RenderSVGInlineText {#text} at (160,0) size 38x75
-              chunk 1 text run 1 at (300.87,190.00) startOffset 0 endOffset 1 width 37.50: "Y"
+          RenderSVGInlineText {#text} at (43,0) size 17x75
+            chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (60,0) size 38x75
+            RenderSVGInlineText {#text} at (60,0) size 38x75
+              chunk 1 text run 1 at (200.00,190.00) startOffset 0 endOffset 1 width 37.50: "A"
+          RenderSVGInlineText {#text} at (97,0) size 17x75
+            chunk 1 text run 1 at (237.50,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (114,0) size 41x75
+            RenderSVGInlineText {#text} at (114,0) size 41x75
+              chunk 1 text run 1 at (254.17,190.00) startOffset 0 endOffset 1 width 40.02: "P"
+          RenderSVGInlineText {#text} at (154,0) size 17x75
+            chunk 1 text run 1 at (294.19,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (170,0) size 41x75
+            RenderSVGInlineText {#text} at (170,0) size 41x75
+              chunk 1 text run 1 at (310.86,190.00) startOffset 0 endOffset 1 width 40.02: "P"
+          RenderSVGInlineText {#text} at (210,0) size 17x75
+            chunk 1 text run 1 at (350.88,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (227,0) size 39x75
+            RenderSVGInlineText {#text} at (227,0) size 38x75
+              chunk 1 text run 1 at (367.55,190.00) startOffset 0 endOffset 1 width 37.50: "Y"
           RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGText {text} at (50,210) size 113x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 38x75

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 480x360
       RenderSVGInlineText {#text} at (0,0) size 264x45
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.34: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 480x360 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
@@ -21,7 +21,8 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 338.79: "xml:space='default'"
       RenderSVGText {text} at (15,188) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 75.55: "WS "
+          chunk 1 text run 1 at (90.55,225.00) startOffset 0 endOffset 19 width 338.03: "non-indented lines."
       RenderSVGText {text} at (15,223) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."

--- a/LayoutTests/platform/ios/svg/custom/text-whitespace-handling-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/text-whitespace-handling-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderSVGText {text} at (10,5) size 240x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 240x18
           chunk 1 text run 1 at (10.00,20.00) startOffset 0 endOffset 36 width 239.81: "Testing xml:space=\"default\" support:"
-      RenderSVGText {text} at (10,25) size 163x19 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 163x18
-          chunk 1 text run 1 at (10.00,40.00) startOffset 0 endOffset 20 width 162.62: "NoSpacesBetweenWords"
+      RenderSVGText {text} at (10,25) size 175x19 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 175x18
+          chunk 1 text run 1 at (10.00,40.00) startOffset 0 endOffset 23 width 174.62: "No Spaces Between Words"
       RenderSVGText {text} at (10,45) size 131x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 131x18
           chunk 1 text run 1 at (10.00,60.00) startOffset 0 endOffset 18 width 130.61: "Tabs become spaces"

--- a/LayoutTests/platform/ios/svg/text/font-size-below-point-five-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/font-size-below-point-five-expected.txt
@@ -31,6 +31,7 @@ layer at (0,0) size 800x600
       RenderSVGTSpan {tspan} at (28,14) size 2x1
         RenderSVGInlineText {#text} at (28,14) size 1x1
           chunk 1 text run 1 at (38.99,10.00) startOffset 0 endOffset 1 width 0.05: "6"
+      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGText {text} at (64,42) size 122x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 121x10
         chunk 1 (middle anchor) text run 1 at (64.90,50.00) startOffset 0 endOffset 36 width 120.20: "Font size should decrease monotonic."

--- a/LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt
@@ -11,22 +11,30 @@ layer at (0,0) size 800x600
           chunk 1 text run 1 at (5.00,90.00) startOffset 0 endOffset 32 width 460.21: "and many-to-many chars to glyphs"
       RenderSVGHiddenContainer {defs} at (0,0) size 0x0
       RenderSVGContainer {g} at (75,208) size 713x276
-        RenderSVGText {text} at (140,130) size 199x75 contains 1 chunk(s)
+        RenderSVGText {text} at (140,130) size 266x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 44x75
             RenderSVGInlineText {#text} at (0,0) size 44x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 43.33: "H"
-          RenderSVGTSpan {altGlyph} at (43,0) size 38x75
-            RenderSVGInlineText {#text} at (43,0) size 38x75
-              chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 37.50: "A"
-          RenderSVGTSpan {altGlyph} at (80,0) size 41x75
-            RenderSVGInlineText {#text} at (80,0) size 41x75
-              chunk 1 text run 1 at (220.83,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGTSpan {altGlyph} at (120,0) size 41x75
-            RenderSVGInlineText {#text} at (120,0) size 41x75
-              chunk 1 text run 1 at (260.85,190.00) startOffset 0 endOffset 1 width 40.02: "P"
-          RenderSVGTSpan {altGlyph} at (160,0) size 39x75
-            RenderSVGInlineText {#text} at (160,0) size 38x75
-              chunk 1 text run 1 at (300.87,190.00) startOffset 0 endOffset 1 width 37.50: "Y"
+          RenderSVGInlineText {#text} at (43,0) size 17x75
+            chunk 1 text run 1 at (183.33,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (60,0) size 38x75
+            RenderSVGInlineText {#text} at (60,0) size 38x75
+              chunk 1 text run 1 at (200.00,190.00) startOffset 0 endOffset 1 width 37.50: "A"
+          RenderSVGInlineText {#text} at (97,0) size 17x75
+            chunk 1 text run 1 at (237.50,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (114,0) size 41x75
+            RenderSVGInlineText {#text} at (114,0) size 41x75
+              chunk 1 text run 1 at (254.17,190.00) startOffset 0 endOffset 1 width 40.02: "P"
+          RenderSVGInlineText {#text} at (154,0) size 17x75
+            chunk 1 text run 1 at (294.19,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (170,0) size 41x75
+            RenderSVGInlineText {#text} at (170,0) size 41x75
+              chunk 1 text run 1 at (310.86,190.00) startOffset 0 endOffset 1 width 40.02: "P"
+          RenderSVGInlineText {#text} at (210,0) size 17x75
+            chunk 1 text run 1 at (350.88,190.00) startOffset 0 endOffset 1 width 16.67: " "
+          RenderSVGTSpan {altGlyph} at (227,0) size 39x75
+            RenderSVGInlineText {#text} at (227,0) size 38x75
+              chunk 1 text run 1 at (367.55,190.00) startOffset 0 endOffset 1 width 37.50: "Y"
           RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGText {text} at (50,210) size 113x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 38x75

--- a/LayoutTests/platform/ios/svg/text/text-hkern-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/text-hkern-expected.txt
@@ -22,3 +22,4 @@ layer at (0,0) size 800x600
           chunk 1 text run 2 at (7.50,70.00) startOffset 1 endOffset 2 width 5.00: "2"
           chunk 1 text run 3 at (13.75,70.00) startOffset 2 endOffset 3 width 7.50: "3"
           chunk 1 text run 4 at (22.50,70.00) startOffset 3 endOffset 4 width 10.00: "4"
+      RenderSVGInlineText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/svg/text/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 800x600
       RenderSVGInlineText {#text} at (0,0) size 264x45
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.34: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 800x600 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/ios/svg/text/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/text-ws-01-t-expected.txt
@@ -21,7 +21,8 @@ layer at (0,0) size 800x600
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 338.79: "xml:space='default'"
       RenderSVGText {text} at (15,188) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 75.55: "WS "
+          chunk 1 text run 1 at (90.55,225.00) startOffset 0 endOffset 19 width 338.03: "non-indented lines."
       RenderSVGText {text} at (15,223) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."

--- a/LayoutTests/platform/mac-sonoma/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 480x360
       RenderSVGInlineText {#text} at (0,0) size 264x46
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.34: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 480x360 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
@@ -9,7 +9,8 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 33 width 184.13: "Rectangle should be red not green"
       RenderSVGText {text} at (40,25) size 330x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 330x14
-          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 64 width 329.70: "This tests id selectors: <rect id=\"one\" /> and the selector #one"
+          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 54.68: "This tests "
+          chunk 1 text run 1 at (94.68,36.00) startOffset 0 endOffset 53 width 275.02: "id selectors: <rect id=\"one\" /> and the selector #one"
       RenderSVGContainer {g} at (130,70) size 260x60
         RenderSVGEllipse {circle} at (130,70) size 60x60 [fill={[type=SOLID] [color=#008000]}] [cx=160.00] [cy=100.00] [r=30.00]
         RenderSVGRect {rect} at (220,80) size 60x40 [fill={[type=SOLID] [color=#FF0000]}] [x=220.00] [y=80.00] [width=60.00] [height=40.00]
@@ -20,7 +21,8 @@ layer at (0,0) size 480x360
             chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 51 width 258.14: "Circle should be red not green; rectangle still red"
         RenderSVGText {text} at (40,25) size 317x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 317x14
-            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 63 width 316.96: "This tests attribute selectors: <circle transform=\"scale(2)\" />"
+            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 54.68: "This tests "
+            chunk 1 text run 1 at (94.68,36.00) startOffset 0 endOffset 52 width 262.28: "attribute selectors: <circle transform=\"scale(2)\" />"
         RenderSVGText {text} at (40,47) size 205x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 205x14
             chunk 1 text run 1 at (40.00,58.00) startOffset 0 endOffset 39 width 204.28: "and the selector [transform=\"scale(2)\"]"

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,6 +13,7 @@ layer at (0,0) size 480x360
         RenderSVGTSpan {tspan} at (337,96) size 46x31
           RenderSVGInlineText {#text} at (337,96) size 45x31
             chunk 1 text run 1 at (387.50,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
+        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (50,199) size 383x2 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (50,229) size 383x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (50,94) size 383x2 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
@@ -8,13 +8,13 @@ layer at (0,0) size 480x360
         RenderSVGText {text} at (10,56) size 177x18 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 177x18
             chunk 1 text run 1 at (10.00,70.00) startOffset 0 endOffset 26 width 176.87: "StartIndex: 0. NumChars: 9"
-        RenderSVGText {text} at (10,85) size 366x55 contains 1 chunk(s)
-          RenderSVGInlineText {#text} at (0,0) size 366x55
+        RenderSVGText {text} at (10,85) size 400x55 contains 1 chunk(s)
+          RenderSVGInlineText {#text} at (0,0) size 400x55
             chunk 1 text run 1 at (10.00,128.00) startOffset 0 endOffset 4 width 78.61: "abc "
-            chunk 1 text run 1 at (88.61,128.00) startOffset 0 endOffset 4 width 68.11 RTL: " \x{5D3}\x{5D4}\x{5D5}"
-            chunk 1 text run 1 at (156.72,128.00) startOffset 0 endOffset 3 width 72.00: "123"
-            chunk 1 text run 1 at (228.72,128.00) startOffset 0 endOffset 4 width 73.05 RTL: "\x{5D0}\x{5D1}\x{5D2} "
-            chunk 1 text run 1 at (301.77,128.00) startOffset 0 endOffset 4 width 73.29: " def"
+            chunk 1 text run 1 at (88.61,128.00) startOffset 0 endOffset 4 width 85.57 RTL: " \x{5D3}\x{5D4}\x{5D5}"
+            chunk 1 text run 1 at (174.18,128.00) startOffset 0 endOffset 3 width 72.00: "123"
+            chunk 1 text run 1 at (246.18,128.00) startOffset 0 endOffset 4 width 90.49 RTL: "\x{5D0}\x{5D1}\x{5D2} "
+            chunk 1 text run 1 at (336.67,128.00) startOffset 0 endOffset 4 width 73.29: " def"
         RenderSVGContainer {g} at (10,220) size 430x20
           RenderSVGRect {rect} at (10,220) size 100x20 [fill={[type=SOLID] [color=#0000FF]}] [x=10.00] [y=160.00] [width=100.00] [height=20.00]
           RenderSVGText {text} at (18,161) size 84x18 contains 1 chunk(s)
@@ -36,5 +36,5 @@ layer at (0,0) size 480x360
       RenderSVGInlineText {#text} at (0,0) size 264x46
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.34: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 480x360 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
@@ -21,7 +21,8 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 338.79: "xml:space='default'"
       RenderSVGText {text} at (15,188) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 75.55: "WS "
+          chunk 1 text run 1 at (90.55,225.00) startOffset 0 endOffset 19 width 338.03: "non-indented lines."
       RenderSVGText {text} at (15,223) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."

--- a/LayoutTests/platform/mac/svg/custom/text-whitespace-handling-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/text-whitespace-handling-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderSVGText {text} at (10,5) size 240x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 240x19
           chunk 1 text run 1 at (10.00,20.00) startOffset 0 endOffset 36 width 239.81: "Testing xml:space=\"default\" support:"
-      RenderSVGText {text} at (10,25) size 163x19 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 163x19
-          chunk 1 text run 1 at (10.00,40.00) startOffset 0 endOffset 20 width 162.62: "NoSpacesBetweenWords"
+      RenderSVGText {text} at (10,25) size 175x19 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 175x19
+          chunk 1 text run 1 at (10.00,40.00) startOffset 0 endOffset 23 width 174.62: "No Spaces Between Words"
       RenderSVGText {text} at (10,45) size 131x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 131x19
           chunk 1 text run 1 at (10.00,60.00) startOffset 0 endOffset 18 width 130.61: "Tabs become spaces"

--- a/LayoutTests/platform/mac/svg/text/font-size-below-point-five-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/font-size-below-point-five-expected.txt
@@ -31,6 +31,7 @@ layer at (0,0) size 800x600
       RenderSVGTSpan {tspan} at (28,14) size 2x1
         RenderSVGInlineText {#text} at (28,14) size 1x1
           chunk 1 text run 1 at (38.99,10.00) startOffset 0 endOffset 1 width 0.05: "6"
+      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGText {text} at (64,42) size 122x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 121x10
         chunk 1 (middle anchor) text run 1 at (64.90,50.00) startOffset 0 endOffset 36 width 120.20: "Font size should decrease monotonic."

--- a/LayoutTests/platform/mac/svg/text/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 800x600
       RenderSVGInlineText {#text} at (0,0) size 264x46
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.34: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 800x600 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/mac/svg/text/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/text-ws-01-t-expected.txt
@@ -21,7 +21,8 @@ layer at (0,0) size 800x600
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 338.79: "xml:space='default'"
       RenderSVGText {text} at (15,188) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 75.55: "WS "
+          chunk 1 text run 1 at (90.55,225.00) startOffset 0 endOffset 19 width 338.03: "non-indented lines."
       RenderSVGText {text} at (15,223) size 414x46 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 413.57: "WS non-indented lines."

--- a/LayoutTests/platform/mac/svg/zoom/page/zoom-mask-with-percentages-expected.txt
+++ b/LayoutTests/platform/mac/svg/zoom/page/zoom-mask-with-percentages-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 933x1037
   RenderSVGRoot {svg} at (186,73) size 551x765
     RenderSVGContainer {g} at (186,73) size 551x765
       RenderSVGText {text} at (179,35) size 92x19 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 93x19
+        RenderSVGInlineText {#text} at (0,0) size 92x19
           chunk 1 (middle anchor) text run 1 at (179.00,50.00) startOffset 0 endOffset 12 width 92.00: "Mask Regions"
       RenderSVGHiddenContainer {defs} at (0,0) size 0x0
         RenderSVGResourceLinearGradient {linearGradient} [id="maskedGradient"] [gradientUnits=objectBoundingBox] [start=(0,0)] [end=(1,1)]

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/interact-order-01-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/interact-order-01-b-expected.txt
@@ -10,18 +10,18 @@ layer at (0,0) size 800x600
       RenderSVGContainer {g} at (15,99) size 770x402
         RenderSVGRect {rect} at (15,99) size 770x202 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#EEEEEE]}] [x=10.00] [y=60.00] [width=460.00] [height=120.00]
         RenderSVGRect {rect} at (15,299) size 770x202 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#FFFFFF]}] [x=10.00] [y=180.00] [width=460.00] [height=120.00]
-      RenderSVGContainer {g} at (33,116) size 693x368
+      RenderSVGContainer {g} at (33,116) size 692x368
         RenderSVGContainer {g} at (33,116) size 167x368
           RenderSVGEllipse {circle} at (33,116) size 167x168 [fill={[type=SOLID] [color=#000000]}] [cx=70.00] [cy=120.00] [r=50.00]
           RenderSVGEllipse {circle} at (33,316) size 167x168 [fill={[type=SOLID] [color=#000000]}] [cx=70.00] [cy=240.00] [r=50.00]
-        RenderSVGText {text} at (150,74) size 286x45 contains 1 chunk(s)
-          RenderSVGInlineText {#text} at (0,0) size 286x45
+        RenderSVGText {text} at (150,74) size 285x45 contains 1 chunk(s)
+          RenderSVGInlineText {#text} at (0,0) size 285x45
             chunk 1 text run 1 at (150.00,110.00) startOffset 0 endOffset 18 width 285.00: "Pointer in circle,"
         RenderSVGText {text} at (150,114) size 263x45 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 263x45
             chunk 1 text run 1 at (150.00,150.00) startOffset 0 endOffset 16 width 262.20: "circle turns red"
-        RenderSVGText {text} at (150,194) size 286x45 contains 1 chunk(s)
-          RenderSVGInlineText {#text} at (0,0) size 286x45
+        RenderSVGText {text} at (150,194) size 285x45 contains 1 chunk(s)
+          RenderSVGInlineText {#text} at (0,0) size 285x45
             chunk 1 text run 1 at (150.00,230.00) startOffset 0 endOffset 18 width 285.00: "Pointer in circle,"
         RenderSVGText {text} at (150,234) size 281x45 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 281x45

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
@@ -9,7 +9,8 @@ layer at (0,0) size 800x600
           chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 33 width 184.20: "Rectangle should be red not green"
       RenderSVGText {text} at (40,25) size 333x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 333x14
-          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 64 width 332.40: "This tests id selectors: <rect id=\"one\" /> and the selector #one"
+          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 55.20: "This tests "
+          chunk 1 text run 1 at (95.20,36.00) startOffset 0 endOffset 53 width 277.20: "id selectors: <rect id=\"one\" /> and the selector #one"
       RenderSVGContainer {g} at (216,116) size 434x101
         RenderSVGEllipse {circle} at (216,116) size 101x101 [fill={[type=SOLID] [color=#008000]}] [cx=160.00] [cy=100.00] [r=30.00]
         RenderSVGRect {rect} at (366,133) size 101x67 [fill={[type=SOLID] [color=#FF0000]}] [x=220.00] [y=80.00] [width=60.00] [height=40.00]
@@ -20,7 +21,8 @@ layer at (0,0) size 800x600
             chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 51 width 258.60: "Circle should be red not green; rectangle still red"
         RenderSVGText {text} at (40,25) size 321x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 321x14
-            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 63 width 320.40: "This tests attribute selectors: <circle transform=\"scale(2)\" />"
+            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 55.20: "This tests "
+            chunk 1 text run 1 at (95.20,36.00) startOffset 0 endOffset 52 width 265.20: "attribute selectors: <circle transform=\"scale(2)\" />"
         RenderSVGText {text} at (40,47) size 207x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 207x14
             chunk 1 text run 1 at (40.00,58.00) startOffset 0 endOffset 39 width 206.40: "and the selector [transform=\"scale(2)\"]"

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-align-08-b-expected.txt
@@ -13,6 +13,7 @@ layer at (0,0) size 800x600
         RenderSVGTSpan {tspan} at (338,96) size 46x30
           RenderSVGInlineText {#text} at (338,96) size 45x30
             chunk 1 text run 1 at (388.40,200.00) startOffset 0 endOffset 3 width 45.00: "a\x{729C}\x{923}"
+        RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGPath {line} at (83,332) size 639x3 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=200.00] [x2=433.00] [y2=200.00]
       RenderSVGPath {line} at (83,382) size 639x3 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=230.00] [x2=433.00] [y2=230.00]
       RenderSVGPath {line} at (83,157) size 639x3 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#000000]}] [x1=50.00] [y1=95.00] [x2=433.00] [y2=95.00]

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt
@@ -11,22 +11,30 @@ layer at (0,0) size 800x600
           chunk 1 text run 1 at (5.00,90.00) startOffset 0 endOffset 32 width 463.20: "and many-to-many chars to glyphs"
       RenderSVGHiddenContainer {defs} at (0,0) size 0x0
       RenderSVGContainer {g} at (75,208) size 662x276
-        RenderSVGText {text} at (140,130) size 192x75 contains 1 chunk(s)
+        RenderSVGText {text} at (140,130) size 269x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 45x75
             RenderSVGInlineText {#text} at (0,0) size 45x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 45.00: "H"
-          RenderSVGTSpan {altGlyph} at (45,0) size 38x75
-            RenderSVGInlineText {#text} at (45,0) size 38x75
-              chunk 1 text run 1 at (185.00,190.00) startOffset 0 endOffset 1 width 37.20: "A"
-          RenderSVGTSpan {altGlyph} at (82,0) size 37x75
-            RenderSVGInlineText {#text} at (82,0) size 36x75
-              chunk 1 text run 1 at (222.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGTSpan {altGlyph} at (118,0) size 37x75
-            RenderSVGInlineText {#text} at (118,0) size 36x75
-              chunk 1 text run 1 at (258.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGTSpan {altGlyph} at (154,0) size 38x75
-            RenderSVGInlineText {#text} at (154,0) size 38x75
-              chunk 1 text run 1 at (294.20,190.00) startOffset 0 endOffset 1 width 37.20: "Y"
+          RenderSVGInlineText {#text} at (45,0) size 20x75
+            chunk 1 text run 1 at (185.00,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (64,0) size 38x75
+            RenderSVGInlineText {#text} at (64,0) size 38x75
+              chunk 1 text run 1 at (204.20,190.00) startOffset 0 endOffset 1 width 37.20: "A"
+          RenderSVGInlineText {#text} at (101,0) size 20x75
+            chunk 1 text run 1 at (241.40,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (120,0) size 37x75
+            RenderSVGInlineText {#text} at (120,0) size 36x75
+              chunk 1 text run 1 at (260.60,190.00) startOffset 0 endOffset 1 width 36.00: "P"
+          RenderSVGInlineText {#text} at (156,0) size 20x75
+            chunk 1 text run 1 at (296.60,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (175,0) size 37x75
+            RenderSVGInlineText {#text} at (175,0) size 36x75
+              chunk 1 text run 1 at (315.80,190.00) startOffset 0 endOffset 1 width 36.00: "P"
+          RenderSVGInlineText {#text} at (211,0) size 20x75
+            chunk 1 text run 1 at (351.80,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (231,0) size 38x75
+            RenderSVGInlineText {#text} at (231,0) size 38x75
+              chunk 1 text run 1 at (371.00,190.00) startOffset 0 endOffset 1 width 37.20: "Y"
           RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGText {text} at (50,210) size 112x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 38x75

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt
@@ -36,5 +36,5 @@ layer at (0,0) size 800x600
       RenderSVGInlineText {#text} at (0,0) size 264x44
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.40: "$Revision: 1.2 $"
     RenderSVGRect {rect} at (0,0) size 800x600 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
-selection start: position 3 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
-selection end:   position 12 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection start: position 4 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document
+selection end:   position 13 of child 0 {#text} of child 3 {text} of child 3 {g} of child 35 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt
@@ -19,9 +19,10 @@ layer at (0,0) size 800x600
       RenderSVGText {text} at (28,139) size 340x45 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 340x45
           chunk 1 text run 1 at (28.00,175.00) startOffset 0 endOffset 19 width 339.60: "xml:space='default'"
-      RenderSVGText {text} at (15,189) size 414x45 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 414x45
-          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 22 width 414.00: "WS non-indented lines."
+      RenderSVGText {text} at (15,189) size 415x45 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 415x45
+          chunk 1 text run 1 at (15.00,225.00) startOffset 0 endOffset 3 width 75.60: "WS "
+          chunk 1 text run 1 at (90.60,225.00) startOffset 0 endOffset 19 width 338.40: "non-indented lines."
       RenderSVGText {text} at (15,224) size 414x45 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 414x45
           chunk 1 text run 1 at (15.00,260.00) startOffset 0 endOffset 22 width 414.00: "WS non-indented lines."

--- a/LayoutTests/platform/wpe/svg/text/text-altglyph-01-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/text/text-altglyph-01-b-expected.txt
@@ -11,22 +11,30 @@ layer at (0,0) size 800x600
           chunk 1 text run 1 at (5.00,90.00) startOffset 0 endOffset 32 width 463.20: "and many-to-many chars to glyphs"
       RenderSVGHiddenContainer {defs} at (0,0) size 0x0
       RenderSVGContainer {g} at (75,208) size 662x276
-        RenderSVGText {text} at (140,130) size 192x75 contains 1 chunk(s)
+        RenderSVGText {text} at (140,130) size 269x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 45x75
             RenderSVGInlineText {#text} at (0,0) size 45x75
               chunk 1 text run 1 at (140.00,190.00) startOffset 0 endOffset 1 width 45.00: "H"
-          RenderSVGTSpan {altGlyph} at (45,0) size 38x75
-            RenderSVGInlineText {#text} at (45,0) size 38x75
-              chunk 1 text run 1 at (185.00,190.00) startOffset 0 endOffset 1 width 37.20: "A"
-          RenderSVGTSpan {altGlyph} at (82,0) size 37x75
-            RenderSVGInlineText {#text} at (82,0) size 36x75
-              chunk 1 text run 1 at (222.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGTSpan {altGlyph} at (118,0) size 37x75
-            RenderSVGInlineText {#text} at (118,0) size 36x75
-              chunk 1 text run 1 at (258.20,190.00) startOffset 0 endOffset 1 width 36.00: "P"
-          RenderSVGTSpan {altGlyph} at (154,0) size 38x75
-            RenderSVGInlineText {#text} at (154,0) size 38x75
-              chunk 1 text run 1 at (294.20,190.00) startOffset 0 endOffset 1 width 37.20: "Y"
+          RenderSVGInlineText {#text} at (45,0) size 20x75
+            chunk 1 text run 1 at (185.00,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (64,0) size 38x75
+            RenderSVGInlineText {#text} at (64,0) size 38x75
+              chunk 1 text run 1 at (204.20,190.00) startOffset 0 endOffset 1 width 37.20: "A"
+          RenderSVGInlineText {#text} at (101,0) size 20x75
+            chunk 1 text run 1 at (241.40,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (120,0) size 37x75
+            RenderSVGInlineText {#text} at (120,0) size 36x75
+              chunk 1 text run 1 at (260.60,190.00) startOffset 0 endOffset 1 width 36.00: "P"
+          RenderSVGInlineText {#text} at (156,0) size 20x75
+            chunk 1 text run 1 at (296.60,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (175,0) size 37x75
+            RenderSVGInlineText {#text} at (175,0) size 36x75
+              chunk 1 text run 1 at (315.80,190.00) startOffset 0 endOffset 1 width 36.00: "P"
+          RenderSVGInlineText {#text} at (211,0) size 20x75
+            chunk 1 text run 1 at (351.80,190.00) startOffset 0 endOffset 1 width 19.20: " "
+          RenderSVGTSpan {altGlyph} at (231,0) size 38x75
+            RenderSVGInlineText {#text} at (231,0) size 38x75
+              chunk 1 text run 1 at (371.00,190.00) startOffset 0 endOffset 1 width 37.20: "Y"
           RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGText {text} at (50,210) size 112x75 contains 1 chunk(s)
           RenderSVGTSpan {altGlyph} at (0,0) size 38x75

--- a/LayoutTests/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
+++ b/LayoutTests/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt
@@ -9,7 +9,8 @@ layer at (0,0) size 480x360
           chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 33 width 189.00: "Rectangle should be red not green"
       RenderSVGText {text} at (40,25) size 332x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 332x14
-          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 64 width 332.00: "This tests id selectors: <rect id=\"one\" /> and the selector #one"
+          chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 54.00: "This tests "
+          chunk 1 text run 1 at (94.00,36.00) startOffset 0 endOffset 53 width 278.00: "id selectors: <rect id=\"one\" /> and the selector #one"
       RenderSVGContainer {g} at (130,70) size 260x60
         RenderSVGEllipse {circle} at (130,70) size 60x60 [fill={[type=SOLID] [color=#008000]}] [cx=160.00] [cy=100.00] [r=30.00]
         RenderSVGRect {rect} at (220,80) size 60x40 [fill={[type=SOLID] [color=#FF0000]}] [x=220.00] [y=80.00] [width=60.00] [height=40.00]
@@ -20,7 +21,8 @@ layer at (0,0) size 480x360
             chunk 1 text run 1 at (40.00,14.00) startOffset 0 endOffset 51 width 264.00: "Circle should be red not green; rectangle still red"
         RenderSVGText {text} at (40,25) size 318x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 318x14
-            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 63 width 318.00: "This tests attribute selectors: <circle transform=\"scale(2)\" />"
+            chunk 1 text run 1 at (40.00,36.00) startOffset 0 endOffset 11 width 54.00: "This tests "
+            chunk 1 text run 1 at (94.00,36.00) startOffset 0 endOffset 52 width 264.00: "attribute selectors: <circle transform=\"scale(2)\" />"
         RenderSVGText {text} at (40,47) size 206x14 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 206x14
             chunk 1 text run 1 at (40.00,58.00) startOffset 0 endOffset 39 width 206.00: "and the selector [transform=\"scale(2)\"]"

--- a/LayoutTests/svg/custom/invalid-text-content-expected.txt
+++ b/LayoutTests/svg/custom/invalid-text-content-expected.txt
@@ -15,4 +15,5 @@ layer at (0,0) size 800x600
         RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGInlineText {#text} at (0,0) size 0x0
         RenderSVGInlineText {#text} at (0,0) size 0x0
+      RenderSVGInlineText {#text} at (0,0) size 0x0
     RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]

--- a/LayoutTests/svg/dom/altGlyph-dom-expected.txt
+++ b/LayoutTests/svg/dom/altGlyph-dom-expected.txt
@@ -1,4 +1,4 @@
-一&M000076; 丁
+一 &M000076; 丁
 This test checks that SVG altGlyph elements create the appropriate DOM object.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/svg/text/textPathBoundsBug-expected.txt
+++ b/LayoutTests/svg/text/textPathBoundsBug-expected.txt
@@ -10,5 +10,6 @@ layer at (0,0) size 800x600
           chunk 1 (middle anchor) text run 2 at (110.01,100.00) startOffset 5 endOffset 6 width 6.67: "6"
           chunk 1 (middle anchor) text run 3 at (116.68,100.00) startOffset 6 endOffset 7 width 6.67: "7"
           chunk 1 (middle anchor) text run 4 at (123.36,100.00) startOffset 7 endOffset 8 width 6.67: "8"
+      RenderSVGInlineText {#text} at (0,0) size 0x0
 selection start: position 0 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document
 selection end:   position 8 of child 0 {#text} of child 1 {textPath} of child 3 {text} of child 0 {svg} of document


### PR DESCRIPTION
#### f72d408426f224e444edf05d298801aa0227146b
<pre>
Replace CR/NL by space - don&apos;t remove altogether when xml:space=default

<a href="https://bugs.webkit.org/show_bug.cgi?id=278524">https://bugs.webkit.org/show_bug.cgi?id=278524</a>
<a href="https://rdar.apple.com/134545958">rdar://134545958</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/0c39a6f29e59594a7b9c412a8203af9fc43e4ecd">https://chromium.googlesource.com/chromium/src.git/+/0c39a6f29e59594a7b9c412a8203af9fc43e4ecd</a>

This moves handling of xml:space=default closer to the more generic
white-space handling, by not removing CR and NL characters, but rather
just replacing them with a regular space.

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::normalizeWhitespace): Renamed from `applySVGWhitespaceRules`
(WebCore::RenderSVGInlineText::RenderSVGInlineText):
(WebCore::RenderSVGInlineText::styleDidChange):
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-dynamic-add-svg-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-dynamic-remove-svg-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-childElementCount-svg-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-firstElementChild-svg-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-previousElementSibling-svg-expected.txt:
* LayoutTests/platform/glib/svg/custom/text-whitespace-handling-expected.txt:
* LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt:
* LayoutTests/platform/glib/svg/text/text-tselect-02-f-expected.txt:
* LayoutTests/platform/glib/svg/text/text-ws-01-t-expected.txt:
* LayoutTests/platform/glib/svg/text/textPathBoundsBug-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/ios/svg/text/text-ws-01-t-expected.txt:
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt:
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt:
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt:
* LayoutTests/platform/mac/svg/custom/text-whitespace-handling-expected.txt:
* LayoutTests/platform/mac/svg/text/font-size-below-point-five-expected.txt:
* LayoutTests/platform/mac/svg/text/text-tselect-02-f-expected.txt:
* LayoutTests/platform/mac/svg/text/text-ws-01-t-expected.txt:
* LayoutTests/platform/mac/svg/zoom/page/zoom-mask-with-percentages-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt:
* LayoutTests/platform/wpe/svg/text/text-altglyph-01-b-expected.txt:
* LayoutTests/svg/custom/invalid-text-content-expected.txt:
* LayoutTests/svg/dom/altGlyph-dom-expected.txt:
* LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-align-08-b-expected.txt:
* LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt:
* LayoutTests/platform/gtk/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt:
* LayoutTests/platform/ios/svg/custom/text-whitespace-handling-expected.txt:
* LayoutTests/platform/ios/svg/text/font-size-below-point-five-expected.txt:
* LayoutTests/platform/ios/svg/text/text-align-01-b-expected.txt:
* LayoutTests/platform/ios/svg/text/text-hkern-expected.txt:
* LayoutTests/platform/ios/svg/text/text-tselect-02-f-expected.txt:
* LayoutTests/platform/ios/svg/text/text-ws-01-t-expected.txt:
* LayoutTests/platform/mac-sonoma/svg/W3C-SVG-1.1/text-tselect-02-f-expected.txt:
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/interact-order-01-b-expected.txt:
* LayoutTests/svg/text/textPathBoundsBug-expected.txt:
* LayoutTests/platform/ios/svg/text/text-align-01-b-expected.txt:
* LayoutTests/platform/ios/svg/text/text-altglyph-01-b-expected.txt:
* LayoutTests/platform/ios/svg/text/text-ws-01-t-expected.txt:
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/text-ws-01-t-expected.txt:
* LayoutTests/svg/W3C-SVG-1.1/styling-css-02-b-expected.txt:
* LayoutTests/fast/svg/assert-when-trying-to-construct-multiple-lines-expected.txt:
* LayoutTests/fast/svg/svg-text-segment-crash-expected.txt:
* LayoutTests/platform/glib/svg/text/font-size-below-point-five-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f72d408426f224e444edf05d298801aa0227146b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85840 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36512 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122219 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39873 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29721 "Found 1 new test failure: svg/W3C-SVG-1.1/text-tselect-02-f.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94440 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39564 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17379 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35976 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45257 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->