### PR TITLE
[css-animations] css/css-animations/jump-start-animation-before-phase.html is a failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8152,8 +8152,6 @@ webkit.org/b/275663 imported/w3c/web-platform-tests/webrtc-encoded-transform/scr
 # https://bugs.webkit.org/show_bug.cgi?id=266843 flakey tests with racey promise console.logs
 imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.html [ Skip ]
 
-webkit.org/b/278855 imported/w3c/web-platform-tests/css/css-animations/jump-start-animation-before-phase.html [ ImageOnlyFailure ]
-
 # Dump `rendertree` rather than proper test expectation as `testharness` test
 imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-mutable-prototype.any.html [ Skip ]
 imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-mutable-prototype.any.worker.html [ Skip ]

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -125,6 +125,7 @@ ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<Seconds> s
     computedTiming.progress = resolvedTiming.transformedProgress;
     computedTiming.currentIteration = resolvedTiming.currentIteration;
     computedTiming.phase = resolvedTiming.phase;
+    computedTiming.before = resolvedTiming.before;
     return computedTiming;
 }
 

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -41,6 +41,7 @@ struct ResolvedEffectTiming {
     AnimationEffectPhase phase { AnimationEffectPhase::Idle };
     MarkableDouble transformedProgress;
     MarkableDouble simpleIterationProgress;
+    TimingFunction::Before before;
 };
 
 struct AnimationEffectTiming {

--- a/Source/WebCore/animation/ComputedEffectTiming.h
+++ b/Source/WebCore/animation/ComputedEffectTiming.h
@@ -27,6 +27,7 @@
 
 #include "AnimationEffectPhase.h"
 #include "EffectTiming.h"
+#include "TimingFunction.h"
 #include "WebAnimationTypes.h"
 
 namespace WebCore {
@@ -39,6 +40,7 @@ struct ComputedEffectTiming : EffectTiming {
     MarkableDouble currentIteration;
     double endTime;
     double activeDuration;
+    TimingFunction::Before before { TimingFunction::Before::No };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -226,7 +226,7 @@ private:
     void addPendingAcceleratedAction(AcceleratedAction);
     bool isCompletelyAccelerated() const { return m_acceleratedPropertiesState == AcceleratedProperties::All; }
     void updateAcceleratedActions();
-    void setAnimatedPropertiesInStyle(RenderStyle&, double iterationProgress, double currentIteration);
+    void setAnimatedPropertiesInStyle(RenderStyle&, const ComputedEffectTiming&);
     const TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;
     const TimingFunction* timingFunctionForBlendingKeyframe(const BlendingKeyframe&) const;
     Ref<const Animation> backingAnimationForCompositedRenderer() const;

--- a/Source/WebCore/animation/KeyframeInterpolation.cpp
+++ b/Source/WebCore/animation/KeyframeInterpolation.cpp
@@ -121,7 +121,7 @@ const KeyframeInterpolation::KeyframeInterval KeyframeInterpolation::interpolati
     return { intervalEndpoints, hasImplicitZeroKeyframe, hasImplicitOneKeyframe };
 }
 
-void KeyframeInterpolation::interpolateKeyframes(Property property, const KeyframeInterval& interval, double iterationProgress, double currentIteration, Seconds iterationDuration, const CompositionCallback& compositionCallback, const AccumulationCallback& accumulationCallback, const InterpolationCallback& interpolationCallback, const RequiresBlendingForAccumulativeIterationCallback& requiresBlendingForAccumulativeIterationCallback) const
+void KeyframeInterpolation::interpolateKeyframes(Property property, const KeyframeInterval& interval, double iterationProgress, double currentIteration, Seconds iterationDuration, TimingFunction::Before before, const CompositionCallback& compositionCallback, const AccumulationCallback& accumulationCallback, const InterpolationCallback& interpolationCallback, const RequiresBlendingForAccumulativeIterationCallback& requiresBlendingForAccumulativeIterationCallback) const
 {
     auto& intervalEndpoints = interval.endpoints;
     if (intervalEndpoints.isEmpty())
@@ -197,7 +197,7 @@ void KeyframeInterpolation::interpolateKeyframes(Property property, const Keyfra
     if (iterationDuration) {
         auto rangeDuration = (endOffset - startOffset) * iterationDuration.seconds();
         if (auto* timingFunction = timingFunctionForKeyframe(startKeyframe))
-            transformedDistance = timingFunction->transformProgress(intervalDistance, rangeDuration);
+            transformedDistance = timingFunction->transformProgress(intervalDistance, rangeDuration, before);
     }
 
     // 18. Return the result of applying the interpolation procedure defined by the animation type of the target property, to the values of the target

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -69,7 +69,7 @@ public:
     using AccumulationCallback = Function<void(const Keyframe&)>;
     using InterpolationCallback = Function<void(double intervalProgress, double currentIteration, IterationCompositeOperation)>;
     using RequiresBlendingForAccumulativeIterationCallback = Function<bool()>;
-    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, Seconds iterationDuration, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
+    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, Seconds iterationDuration, TimingFunction::Before, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
 
     virtual ~KeyframeInterpolation() = default;
 };

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -412,7 +412,7 @@ void AcceleratedEffect::apply(Seconds currentTime, AcceleratedEffectValues& valu
             return false;
         };
 
-        interpolateKeyframes(animatedProperty, interval, progress, *resolvedTiming.currentIteration, m_timing.iterationDuration, composeProperty, accumulateProperty, interpolateProperty, requiresBlendingForAccumulativeIterationCallback);
+        interpolateKeyframes(animatedProperty, interval, progress, *resolvedTiming.currentIteration, m_timing.iterationDuration, resolvedTiming.before, composeProperty, accumulateProperty, interpolateProperty, requiresBlendingForAccumulativeIterationCallback);
     }
 }
 

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -102,7 +102,7 @@ TextStream& operator<<(TextStream& ts, const TimingFunction& timingFunction)
     return ts;
 }
 
-double TimingFunction::transformProgress(double progress, double duration, bool before) const
+double TimingFunction::transformProgress(double progress, double duration, Before before) const
 {
     switch (type()) {
     case Type::CubicBezierFunction: {
@@ -128,7 +128,7 @@ double TimingFunction::transformProgress(double progress, double duration, bool 
         //    - the before flag is set, and
         //    - input progress value × steps mod 1 equals zero (that is, if input progress value × steps is integral), then
         //    decrement current step by one.
-        if (before && !fmod(progress * steps, 1))
+        if (before == Before::Yes && !fmod(progress * steps, 1))
             currentStep--;
         // 4. If input progress value ≥ 0 and current step < 0, let current step be zero.
         if (progress >= 0 && currentStep < 0)

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -54,7 +54,8 @@ public:
 
     static ExceptionOr<RefPtr<TimingFunction>> createFromCSSText(const String&);
     static RefPtr<TimingFunction> createFromCSSValue(const CSSValue&);
-    double transformProgress(double progress, double duration, bool before = false) const;
+    enum class Before : bool { No, Yes };
+    double transformProgress(double progress, double duration, Before = Before::No) const;
     String cssText() const;
 };
 


### PR DESCRIPTION
#### b782138edb7f3058d4a9b7a38a2439db6cd7c7bf
<pre>
[css-animations] css/css-animations/jump-start-animation-before-phase.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=278855">https://bugs.webkit.org/show_bug.cgi?id=278855</a>

Reviewed by Simon Fraser.

The `steps()` easing takes a &quot;before&quot; flag [0] that we only passed when calling
`TimingFunction::transformProgress()` when resolving the overall effect progress in
`AnimationEffectTiming::resolve()`.

But a `steps()` easing may be specified for a given keyframe interval, and as such
the `TimingFunction::transformProgress()` call site in `KeyframeInterpolation::interpolateKeyframes()`
needs to pass that flag in as well. We now expose that flag through `ResolvedEffectTiming`
and `ComputedEffectTiming` such that we may ultimately pass it over to the appropriate
method both in the non-accelerated codepath (`KeyframeEffect::setAnimatedPropertiesInStyle()`)
and the accelerated codepath (`AcceleratedEffect::apply()`).

This makes the recently-added WPT test `css/css-animations/jump-start-animation-before-phase.html`
pass since it used a `steps(1, jump-start)` easing in the before phase of a CSS Animation.

[0] <a href="https://www.w3.org/TR/css-easing-1/#before-flag">https://www.w3.org/TR/css-easing-1/#before-flag</a>

* LayoutTests/TestExpectations:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getComputedTiming const):
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::resolve const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/animation/ComputedEffectTiming.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::apply):
(WebCore::KeyframeEffect::getAnimatedStyle):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeInterpolation.cpp:
(WebCore::KeyframeInterpolation::interpolateKeyframes const):
* Source/WebCore/animation/KeyframeInterpolation.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::apply):
* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::TimingFunction::transformProgress const):
* Source/WebCore/platform/animation/TimingFunction.h:

Canonical link: <a href="https://commits.webkit.org/282933@main">https://commits.webkit.org/282933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc1ecacb160d5f838428a106a5dad788bf56e8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17307 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/68734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/15318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15596 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/68734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/15318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67777 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/68734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14190 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70441 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/8656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/8690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9810 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/40709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->