### PR TITLE
Do more CheckedRef adoption in layout & rendering code

### DIFF
--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -241,10 +241,10 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
         if (!styleImage)
             return false;
 
-        if (!styleImage->isLoaded(&m_renderer))
+        if (!styleImage->isLoaded(m_renderer.ptr()))
             return false;
 
-        if (!styleImage->canRender(&m_renderer, style.usedZoom()))
+        if (!styleImage->canRender(m_renderer.ptr(), style.usedZoom()))
             return false;
 
         auto rectWithOutsets = rect;
@@ -255,7 +255,7 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
     if (rect.isEmpty() && !paintsBorderImage(rect, style.borderImage()))
         return;
 
-    auto rectToClipOut = const_cast<RenderElement&>(m_renderer).paintRectToClipOutFromBorder(rect);
+    auto rectToClipOut = const_cast<RenderElement&>(m_renderer.get()).paintRectToClipOutFromBorder(rect);
     bool appliedClipAlready = !rectToClipOut.isEmpty();
     GraphicsContextStateSaver stateSave(graphicsContext, appliedClipAlready);
     if (!rectToClipOut.isEmpty())
@@ -308,22 +308,22 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
 
 void BorderPainter::paintOutline(const LayoutRect& paintRect) const
 {
-    auto& styleToUse = m_renderer.style();
+    auto& styleToUse = m_renderer->style();
     auto outlineWidth = floorToDevicePixel(styleToUse.outlineWidth(), document().deviceScaleFactor());
     auto outlineOffset = floorToDevicePixel(styleToUse.outlineOffset(), document().deviceScaleFactor());
 
     // Only paint the focus ring by hand if the theme isn't able to draw it.
-    if (styleToUse.outlineStyleIsAuto() == OutlineIsAuto::On && !m_renderer.theme().supportsFocusRing(styleToUse)) {
+    if (styleToUse.outlineStyleIsAuto() == OutlineIsAuto::On && !m_renderer->theme().supportsFocusRing(styleToUse)) {
         Vector<LayoutRect> focusRingRects;
         LayoutRect paintRectToUse { paintRect };
-        if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer))
-            paintRectToUse = m_renderer.theme().adjustedPaintRect(*box, paintRectToUse);
-        m_renderer.addFocusRingRects(focusRingRects, paintRectToUse.location(), m_paintInfo.paintContainer);
-        m_renderer.paintFocusRing(m_paintInfo, styleToUse, focusRingRects);
+        if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer.get()))
+            paintRectToUse = m_renderer->theme().adjustedPaintRect(*box, paintRectToUse);
+        m_renderer->addFocusRingRects(focusRingRects, paintRectToUse.location(), m_paintInfo.paintContainer);
+        m_renderer->paintFocusRing(m_paintInfo, styleToUse, focusRingRects);
     }
 
-    if (m_renderer.hasOutlineAnnotation() && styleToUse.outlineStyleIsAuto() == OutlineIsAuto::Off && !m_renderer.theme().supportsFocusRing(styleToUse))
-        m_renderer.addPDFURLRect(m_paintInfo, paintRect.location());
+    if (m_renderer->hasOutlineAnnotation() && styleToUse.outlineStyleIsAuto() == OutlineIsAuto::Off && !m_renderer->theme().supportsFocusRing(styleToUse))
+        m_renderer->addPDFURLRect(m_paintInfo, paintRect.location());
 
     if (styleToUse.outlineStyleIsAuto() == OutlineIsAuto::On || styleToUse.outlineStyle() == BorderStyle::None)
         return;
@@ -393,7 +393,7 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
         return;
     }
 
-    auto& styleToUse = m_renderer.style();
+    auto& styleToUse = m_renderer->style();
     auto outlineOffset = styleToUse.outlineOffset();
     auto outlineWidth = styleToUse.outlineWidth();
     auto deviceScaleFactor = document().deviceScaleFactor();
@@ -588,13 +588,13 @@ bool BorderPainter::paintNinePieceImage(const LayoutRect& rect, const RenderStyl
     if (!styleImage)
         return false;
 
-    if (!styleImage->isLoaded(&m_renderer))
+    if (!styleImage->isLoaded(m_renderer.ptr()))
         return true; // Never paint a nine-piece image incrementally, but don't paint the fallback borders either.
 
-    if (!styleImage->canRender(&m_renderer, style.usedZoom()))
+    if (!styleImage->canRender(m_renderer.ptr(), style.usedZoom()))
         return false;
 
-    CheckedPtr modelObject = dynamicDowncast<RenderBoxModelObject>(m_renderer);
+    CheckedPtr modelObject = dynamicDowncast<RenderBoxModelObject>(m_renderer.get());
     if (!modelObject)
         return false;
 
@@ -611,7 +611,7 @@ bool BorderPainter::paintNinePieceImage(const LayoutRect& rect, const RenderStyl
     // If both values are ‘auto’ then the intrinsic width and/or height of the image should be used, if any.
     styleImage->setContainerContextForRenderer(m_renderer, source, style.usedZoom());
 
-    ninePieceImage.paint(m_paintInfo.context(), &m_renderer, style, destination, source, deviceScaleFactor, op);
+    ninePieceImage.paint(m_paintInfo.context(), m_renderer.ptr(), style, destination, source, deviceScaleFactor, op);
     return true;
 }
 
@@ -1441,7 +1441,7 @@ Color BorderPainter::calculateBorderStyleColor(const BorderStyle& style, const B
 
 const Document& BorderPainter::document() const
 {
-    return m_renderer.document();
+    return m_renderer->document();
 }
 
 }

--- a/Source/WebCore/rendering/BorderPainter.h
+++ b/Source/WebCore/rendering/BorderPainter.h
@@ -62,7 +62,7 @@ private:
 
     const Document& document() const;
 
-    const RenderElement& m_renderer;
+    CheckedRef<const RenderElement> m_renderer;
     const PaintInfo& m_paintInfo;
 };
 

--- a/Source/WebCore/rendering/LayoutRepainter.cpp
+++ b/Source/WebCore/rendering/LayoutRepainter.cpp
@@ -33,15 +33,15 @@ namespace WebCore {
 
 LayoutRepainter::LayoutRepainter(RenderElement& renderer, std::optional<CheckForRepaint> checkForRepaintOverride, std::optional<ShouldAlwaysIssueFullRepaint> shouldAlwaysIssueFullRepaint, RepaintOutlineBounds repaintOutlineBounds)
     : m_renderer(renderer)
-    , m_checkForRepaint(checkForRepaintOverride ? *checkForRepaintOverride == CheckForRepaint::Yes : m_renderer.checkForRepaintDuringLayout())
+    , m_checkForRepaint(checkForRepaintOverride ? *checkForRepaintOverride == CheckForRepaint::Yes : m_renderer->checkForRepaintDuringLayout())
     , m_forceFullRepaint(shouldAlwaysIssueFullRepaint && *shouldAlwaysIssueFullRepaint == ShouldAlwaysIssueFullRepaint::Yes)
     , m_repaintOutlineBounds(repaintOutlineBounds)
 {
     if (!m_checkForRepaint)
         return;
 
-    m_repaintContainer = m_renderer.containerForRepaint().renderer.get();
-    m_oldRects = m_renderer.rectsForRepaintingAfterLayout(m_repaintContainer, m_repaintOutlineBounds);
+    m_repaintContainer = m_renderer->containerForRepaint().renderer.get();
+    m_oldRects = m_renderer->rectsForRepaintingAfterLayout(m_repaintContainer, m_repaintOutlineBounds);
 }
 
 bool LayoutRepainter::repaintAfterLayout()
@@ -49,10 +49,10 @@ bool LayoutRepainter::repaintAfterLayout()
     if (!m_checkForRepaint)
         return false;
 
-    auto requiresFullRepaint = m_forceFullRepaint || m_renderer.selfNeedsLayout() ? RequiresFullRepaint::Yes : RequiresFullRepaint::No;
+    auto requiresFullRepaint = m_forceFullRepaint || m_renderer->selfNeedsLayout() ? RequiresFullRepaint::Yes : RequiresFullRepaint::No;
     // Outline bounds are not used if we're doing a full repaint.
-    auto newRects = m_renderer.rectsForRepaintingAfterLayout(m_repaintContainer, (requiresFullRepaint == RequiresFullRepaint::Yes) ? RepaintOutlineBounds::No : m_repaintOutlineBounds);
-    return m_renderer.repaintAfterLayoutIfNeeded(m_repaintContainer, requiresFullRepaint, m_oldRects, newRects);
+    auto newRects = m_renderer->rectsForRepaintingAfterLayout(m_repaintContainer, (requiresFullRepaint == RequiresFullRepaint::Yes) ? RepaintOutlineBounds::No : m_repaintOutlineBounds);
+    return m_renderer->repaintAfterLayoutIfNeeded(m_repaintContainer, requiresFullRepaint, m_oldRects, newRects);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/LayoutRepainter.h
+++ b/Source/WebCore/rendering/LayoutRepainter.h
@@ -42,7 +42,7 @@ public:
     bool repaintAfterLayout();
 
 private:
-    RenderElement& m_renderer;
+    CheckedRef<RenderElement> m_renderer;
     const RenderLayerModelObject* m_repaintContainer { nullptr };
     // We store these values as LayoutRects, but the final invalidations will be pixel snapped
     RenderObject::RepaintRects m_oldRects;

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -54,21 +54,21 @@ public:
 
     void resourceChanged(SVGElement&) final;
 
-    const RenderElement& renderer() const final { return m_clientRenderer; }
+    const RenderElement& renderer() const final { return m_clientRenderer.get(); }
 
 private:
-    RenderElement& m_clientRenderer;
+    CheckedRef<RenderElement> m_clientRenderer;
 };
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSSVGResourceElementClient);
 
 void CSSSVGResourceElementClient::resourceChanged(SVGElement& element)
 {
-    if (m_clientRenderer.renderTreeBeingDestroyed())
+    if (m_clientRenderer->renderTreeBeingDestroyed())
         return;
 
-    if (!m_clientRenderer.document().settings().layerBasedSVGEngineEnabled()) {
-        m_clientRenderer.repaint();
+    if (!m_clientRenderer->document().settings().layerBasedSVGEngineEnabled()) {
+        m_clientRenderer->repaint();
         return;
     }
 
@@ -76,10 +76,10 @@ void CSSSVGResourceElementClient::resourceChanged(SVGElement& element)
     // once during layout, or if the shape itself changes. Here we manually update the marker positions without
     // requiring a relayout. Instead we can simply repaint the path - via the updateLayerPosition() logic, properly
     // repainting the old repaint boundaries and the new ones (after the marker change).
-    if (auto* pathClientRenderer = dynamicDowncast<RenderSVGPath>(m_clientRenderer); pathClientRenderer && is<SVGMarkerElement>(element))
+    if (auto* pathClientRenderer = dynamicDowncast<RenderSVGPath>(m_clientRenderer.get()); pathClientRenderer && is<SVGMarkerElement>(element))
         pathClientRenderer->updateMarkerPositions();
 
-    m_clientRenderer.repaintOldAndNewPositionsForSVGRenderer();
+    m_clientRenderer->repaintOldAndNewPositionsForSVGRenderer();
 }
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ReferencedSVGResources);
@@ -91,7 +91,7 @@ ReferencedSVGResources::ReferencedSVGResources(RenderElement& renderer)
 
 ReferencedSVGResources::~ReferencedSVGResources()
 {
-    Ref treeScope = m_renderer.treeScopeForSVGReferences();
+    Ref treeScope = m_renderer->treeScopeForSVGReferences();
     for (auto& targetID : copyToVector(m_elementClients.keys()))
         removeClientForTarget(treeScope, targetID);
 }

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -83,7 +83,7 @@ private:
     void addClientForTarget(SVGElement& targetElement, const AtomString&);
     void removeClientForTarget(TreeScope&, const AtomString&);
 
-    RenderElement& m_renderer;
+    CheckedRef<RenderElement> m_renderer;
     MemoryCompactRobinHoodHashMap<AtomString, std::unique_ptr<CSSSVGResourceElementClient>> m_elementClients;
 };
 

--- a/Source/WebCore/rendering/RenderChildIterator.h
+++ b/Source/WebCore/rendering/RenderChildIterator.h
@@ -55,7 +55,7 @@ public:
     T* last();
 
 private:
-    RenderElement& m_parent;
+    CheckedRef<RenderElement> m_parent;
 };
 
 template <typename T>
@@ -68,7 +68,7 @@ public:
     const T* last() const;
 
 private:
-    const RenderElement& m_parent;
+    CheckedRef<const RenderElement> m_parent;
 };
 
 template <typename T> RenderChildIteratorAdapter<T> childrenOfType(RenderElement&);
@@ -125,25 +125,25 @@ inline RenderChildIteratorAdapter<T>::RenderChildIteratorAdapter(RenderElement& 
 template <typename T>
 inline RenderChildIterator<T> RenderChildIteratorAdapter<T>::begin()
 {
-    return RenderChildIterator<T>(m_parent, RenderTraversal::firstChild<T>(m_parent));
+    return RenderChildIterator<T>(m_parent, RenderTraversal::firstChild<T>(m_parent.get()));
 }
 
 template <typename T>
 inline RenderChildIterator<T> RenderChildIteratorAdapter<T>::end()
 {
-    return RenderChildIterator<T>(m_parent);
+    return RenderChildIterator<T>(m_parent.get());
 }
 
 template <typename T>
 inline T* RenderChildIteratorAdapter<T>::first()
 {
-    return RenderTraversal::firstChild<T>(m_parent);
+    return RenderTraversal::firstChild<T>(m_parent.get());
 }
 
 template <typename T>
 inline T* RenderChildIteratorAdapter<T>::last()
 {
-    return RenderTraversal::lastChild<T>(m_parent);
+    return RenderTraversal::lastChild<T>(m_parent.get());
 }
 
 // RenderChildConstIteratorAdapter
@@ -157,25 +157,25 @@ inline RenderChildConstIteratorAdapter<T>::RenderChildConstIteratorAdapter(const
 template <typename T>
 inline RenderChildConstIterator<T> RenderChildConstIteratorAdapter<T>::begin() const
 {
-    return RenderChildConstIterator<T>(m_parent, RenderTraversal::firstChild<T>(m_parent));
+    return RenderChildConstIterator<T>(m_parent.get(), RenderTraversal::firstChild<T>(m_parent.get()));
 }
 
 template <typename T>
 inline RenderChildConstIterator<T> RenderChildConstIteratorAdapter<T>::end() const
 {
-    return RenderChildConstIterator<T>(m_parent);
+    return RenderChildConstIterator<T>(m_parent.get());
 }
 
 template <typename T>
 inline const T* RenderChildConstIteratorAdapter<T>::first() const
 {
-    return RenderTraversal::firstChild<T>(m_parent);
+    return RenderTraversal::firstChild<T>(m_parent.get());
 }
 
 template <typename T>
 inline const T* RenderChildConstIteratorAdapter<T>::last() const
 {
-    return RenderTraversal::lastChild<T>(m_parent);
+    return RenderTraversal::lastChild<T>(m_parent.get());
 }
 
 // Standalone functions

--- a/Source/WebCore/rendering/updating/RenderTreePosition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.cpp
@@ -40,7 +40,7 @@ void RenderTreePosition::computeNextSibling(const Node& node)
     if (m_hasValidNextSibling) {
 #if ASSERT_ENABLED
         const unsigned oNSquaredAvoidanceLimit = 20;
-        bool skipAssert = m_parent.isRenderView() || ++m_assertionLimitCounter > oNSquaredAvoidanceLimit;
+        bool skipAssert = m_parent->isRenderView() || ++m_assertionLimitCounter > oNSquaredAvoidanceLimit;
         ASSERT(skipAssert || nextSiblingRenderer(node) == m_nextSibling);
 #endif
         return;
@@ -61,7 +61,7 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
 {
     ASSERT(!node.renderer());
 
-    auto* parentElement = m_parent.element();
+    auto* parentElement = m_parent->element();
     if (!parentElement)
         return nullptr;
     // FIXME: PlugingReplacement shadow trees are very wrong.

--- a/Source/WebCore/rendering/updating/RenderTreePosition.h
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.h
@@ -42,7 +42,7 @@ public:
     {
     }
 
-    RenderElement& parent() const { return m_parent; }
+    RenderElement& parent() const { return m_parent.get(); }
     RenderObject* nextSibling() const { ASSERT(m_hasValidNextSibling); return m_nextSibling.get(); }
 
     void computeNextSibling(const Node&);
@@ -53,7 +53,7 @@ public:
     RenderObject* nextSiblingRenderer(const Node&) const;
 
 private:
-    RenderElement& m_parent;
+    CheckedRef<RenderElement> m_parent;
     SingleThreadWeakPtr<RenderObject> m_nextSibling;
     bool m_hasValidNextSibling { false };
 #if ASSERT_ENABLED


### PR DESCRIPTION
#### 14c065c7926fe80794c47e367fa6f02b851a8a20
<pre>
Do more CheckedRef adoption in layout &amp; rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=278857">https://bugs.webkit.org/show_bug.cgi?id=278857</a>

Reviewed by Sihui Liu.

This tested as performance neutral on Speedometer 3.

* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintBorder const):
(WebCore::BorderPainter::paintOutline const):
(WebCore::BorderPainter::paintNinePieceImage const):
(WebCore::BorderPainter::document const):
* Source/WebCore/rendering/BorderPainter.h:
* Source/WebCore/rendering/LayoutRepainter.cpp:
(WebCore::LayoutRepainter::LayoutRepainter):
(WebCore::LayoutRepainter::repaintAfterLayout):
* Source/WebCore/rendering/LayoutRepainter.h:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::CSSSVGResourceElementClient::resourceChanged):
(WebCore::ReferencedSVGResources::~ReferencedSVGResources):
* Source/WebCore/rendering/ReferencedSVGResources.h:
* Source/WebCore/rendering/RenderChildIterator.h:
(WebCore::RenderChildIteratorAdapter&lt;T&gt;::begin):
(WebCore::RenderChildIteratorAdapter&lt;T&gt;::end):
(WebCore::RenderChildIteratorAdapter&lt;T&gt;::first):
(WebCore::RenderChildIteratorAdapter&lt;T&gt;::last):
(WebCore::RenderChildConstIteratorAdapter&lt;T&gt;::begin const):
(WebCore::RenderChildConstIteratorAdapter&lt;T&gt;::end const):
(WebCore::RenderChildConstIteratorAdapter&lt;T&gt;::first const):
(WebCore::RenderChildConstIteratorAdapter&lt;T&gt;::last const):
* Source/WebCore/rendering/updating/RenderTreePosition.cpp:
(WebCore::RenderTreePosition::computeNextSibling):
(WebCore::RenderTreePosition::nextSiblingRenderer const):
* Source/WebCore/rendering/updating/RenderTreePosition.h:
(WebCore::RenderTreePosition::parent const):

Canonical link: <a href="https://commits.webkit.org/282941@main">https://commits.webkit.org/282941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83ad70e87a21f01634d22620fef3d89b429e599f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51991 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32613 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13304 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59499 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/762 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9813 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39809 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->