### PR TITLE
Decode CacheStorageRecord on CacheStorageDiskStore::m_ioQueue

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -321,6 +321,7 @@ MappedFileData::~MappedFileData()
 {
     if (!m_fileData)
         return;
+
     munmap(m_fileData, m_fileSize);
 }
 

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.h
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.h
@@ -59,7 +59,7 @@ WEBCORE_EXPORT bool queryCacheMatch(const ResourceRequest& request, const Resour
 WEBCORE_EXPORT bool queryCacheMatch(const ResourceRequest& request, const URL& url, bool hasVaryStar, const HashMap<String, String>& varyHeaders, const CacheQueryOptions&);
 
 using ResponseBody = std::variant<std::nullptr_t, Ref<FormData>, Ref<SharedBuffer>>;
-ResponseBody isolatedResponseBody(const ResponseBody&);
+WEBCORE_EXPORT ResponseBody isolatedResponseBody(const ResponseBody&);
 WEBCORE_EXPORT ResponseBody copyResponseBody(const ResponseBody&);
 
 struct Record {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "NetworkCacheData.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/SHA1.h>
 #include <wtf/text/WTFString.h>
 
@@ -87,12 +88,28 @@ public:
 
     static String partitionToPartitionHashAsString(const String& partition, const Salt&);
 
+    Key isolatedCopy() && { return {
+        crossThreadCopy(WTFMove(m_partition)),
+        crossThreadCopy(WTFMove(m_type)),
+        crossThreadCopy(WTFMove(m_identifier)),
+        crossThreadCopy(WTFMove(m_range)),
+        m_hash,
+        m_partitionHash
+    }; }
+
 private:
     friend struct WTF::Persistence::Coder<Key>;
     static String hashAsString(const HashType&);
     HashType computeHash(const Salt&) const;
     HashType computePartitionHash(const Salt&) const;
     static HashType partitionToPartitionHash(const String& partition, const Salt&);
+    Key(String&& partition, String&& type, String&& identifier, String&& range, HashType hash, HashType partitionHash)
+        : m_partition(WTFMove(partition))
+        , m_type(WTFMove(type))
+        , m_identifier(WTFMove(identifier))
+        , m_range(WTFMove(range))
+        , m_hash(hash)
+        , m_partitionHash(partitionHash) { }
 
     String m_partition;
     String m_type;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -54,9 +54,8 @@ private:
     String blobsDirectoryPath() const;
     String blobFilePath(const String&) const;
     std::optional<CacheStorageRecord> readRecordFromFileData(std::span<const uint8_t>, FileSystem::MappedFileData&&);
-    using FileDatas = Vector<FileSystem::MappedFileData>;
-    void readAllRecordInfosInternal(CompletionHandler<void(FileDatas&&)>&&);
-    void readRecordsInternal(Vector<String>&&, CompletionHandler<void(FileDatas&&, FileDatas&&)>&&);
+    void readAllRecordInfosInternal(ReadAllRecordInfosCallback&&);
+    void readRecordsInternal(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&);
 
     String m_cacheName;
     String m_path;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -51,6 +51,19 @@ struct CacheStorageRecordInformation {
             varyHeaders = { };
     }
 
+    CacheStorageRecordInformation isolatedCopy() && {
+        return {
+            crossThreadCopy(WTFMove(key)),
+            insertionTime,
+            identifier,
+            updateResponseCounter,
+            size,
+            crossThreadCopy(WTFMove(url)),
+            hasVaryStar,
+            crossThreadCopy(WTFMove(varyHeaders))
+        };
+    }
+
     NetworkCache::Key key;
     double insertionTime { 0 };
     uint64_t identifier { 0 };
@@ -79,6 +92,20 @@ struct CacheStorageRecord {
         , responseBodySize(responseBodySize)
         , responseBody(WTFMove(responseBody))
     {
+    }
+
+    CacheStorageRecord isolatedCopy() && {
+        return {
+            crossThreadCopy(WTFMove(info)),
+            requestHeadersGuard,
+            crossThreadCopy(WTFMove(request)),
+            options,
+            crossThreadCopy(WTFMove(referrer)),
+            responseHeadersGuard,
+            crossThreadCopy(WTFMove(responseData)),
+            responseBodySize,
+            WebCore::DOMCacheEngine::isolatedResponseBody(WTFMove(responseBody))
+        };
     }
 
     CacheStorageRecordInformation info;


### PR DESCRIPTION
#### 1f8e0f09c0b5d6a33c937a585ded7af785107e46
<pre>
Decode CacheStorageRecord on CacheStorageDiskStore::m_ioQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=278829">https://bugs.webkit.org/show_bug.cgi?id=278829</a>
<a href="https://rdar.apple.com/133253894">rdar://133253894</a>

Reviewed by Ben Nham.

We don&apos;t need to keep the files open if we could decode the record from file data right away on the IO queue.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::MappedFileData::~MappedFileData):
* Source/WebCore/Modules/cache/DOMCacheEngine.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WebKit::NetworkCache::Key::isolatedCopy):
(WebKit::NetworkCache::Key::Key):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::recordFilePathWithDirectory):
(WebKit::CacheStorageDiskStore::recordFilePath const):
(WebKit::CacheStorageDiskStore::readAllRecordInfosInternal):
(WebKit::CacheStorageDiskStore::readAllRecordInfos):
(WebKit::CacheStorageDiskStore::readRecordsInternal):
(WebKit::CacheStorageDiskStore::readRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
(WebKit::CacheStorageRecordInformation::isolatedCopy):
(WebKit::CacheStorageRecord::isolatedCopy):

Canonical link: <a href="https://commits.webkit.org/282932@main">https://commits.webkit.org/282932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f1351604f2a276270c74cf9ccdef2c7161caac9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51992 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10525 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14118 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57748 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70367 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59326 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14276 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/769 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85649 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39816 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15105 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->