### PR TITLE
When invisible autoplay is restricted, videos with autoplay=true are blocked from using play()

### DIFF
--- a/LayoutTests/fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html
+++ b/LayoutTests/fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html
@@ -35,9 +35,6 @@
 
             async function pause2()
             {
-                // At this point, we are interrupted, calling play should be a no-op and should not confuse our interruption state tracking.
-                video.play();
-
                 run('video.style.removeProperty("visibility")');
                 waitForEventOnce('play', play3);
             }

--- a/LayoutTests/media/video-restricted-invisible-autoplay-allowed-after-play-expected.txt
+++ b/LayoutTests/media/video-restricted-invisible-autoplay-allowed-after-play-expected.txt
@@ -1,0 +1,8 @@
+Test that "invisible autoplay not allowed restriction" does not pause media after an explicit call to play().
+
+
+** setting video.src
+EVENT(play)
+Promise resolved OK
+END OF TEST
+

--- a/LayoutTests/media/video-restricted-invisible-autoplay-allowed-after-play.html
+++ b/LayoutTests/media/video-restricted-invisible-autoplay-allowed-after-play.html
@@ -1,0 +1,33 @@
+<html>
+    <head>
+        <script src="media-file.js"></script>
+        <script src="video-test.js"></script>
+        <script>
+            if (window.internals)
+                internals.settings.setInvisibleAutoplayNotPermitted(true);
+
+            async function runTest()
+            {
+                video = document.createElement('video');
+                video.muted = true;
+                video.autoplay = true;
+
+                consoleWrite('');
+                consoleWrite('** setting video.src');
+                video.src = findMediaFile('video', 'content/test');
+                await Promise.all([
+                    waitFor(video, 'play'),
+                    shouldResolve(video.play()),
+                ]);
+            }
+
+            window.addEventListener('load', event => {
+                runTest().then(endTest).catch(failTest);
+            });
+        </script>
+    </head>
+
+    <body>
+        <p>Test that "invisible autoplay not allowed restriction" does not pause media after an explicit call to play().</p>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4328,6 +4328,12 @@ void HTMLMediaElement::play(DOMPromiseDeferred<void>&& promise)
 
     if (processingUserGestureForMedia())
         removeBehaviorRestrictionsAfterFirstUserGesture();
+    else {
+        // If we are allowed to explicitly play without a user gesture, remove the restriction
+        // preventing invisible autoplay, as that will cause explicit playback to be interrupted
+        // by updateShouldAutoplay().
+        mediaSession().removeBehaviorRestriction(MediaElementSession::InvisibleAutoplayNotPermitted);
+    }
 
     m_pendingPlayPromises.append(WTFMove(promise));
     playInternal();


### PR DESCRIPTION
#### f901c971f13aea15e1b8bd09320c1962fdab0de8
<pre>
When invisible autoplay is restricted, videos with autoplay=true are blocked from using play()
<a href="https://bugs.webkit.org/show_bug.cgi?id=278862">https://bugs.webkit.org/show_bug.cgi?id=278862</a>
<a href="https://rdar.apple.com/131877227">rdar://131877227</a>

Reviewed by Mike Wyrzykowski.

Remove the InvisibleAutoplayNotPermitted restriction after play() is called, regardless of
whether a user gesture is present or not.

* LayoutTests/media/video-restricted-invisible-autoplay-allowed-after-play-expected.txt: Added.
* LayoutTests/media/video-restricted-invisible-autoplay-allowed-after-play.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::play):

Canonical link: <a href="https://commits.webkit.org/282927@main">https://commits.webkit.org/282927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03671495539311a264467e92e541156a7034a4ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15569 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10547 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70414 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13169 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56052 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/796 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39861 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->