### PR TITLE
[GTK] Remove usage of GtkSettings from WebProcess

### DIFF
--- a/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.h
+++ b/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.h
@@ -27,7 +27,6 @@
 
 #include "GtkSettingsState.h"
 #include "MessageReceiver.h"
-#include <gtk/gtk.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
@@ -50,7 +49,7 @@ private:
     void applyHintingSettings();
     void applyAntialiasSettings();
 
-    GtkSettings* m_settings;
+    GtkSettingsState m_settings;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 55ea13bcac8bd071033b2a5ec2e9f40eb39b733f
<pre>
[GTK] Remove usage of GtkSettings from WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=278875">https://bugs.webkit.org/show_bug.cgi?id=278875</a>

Reviewed by NOBODY (OOPS!).

The UIProcess uses GtkSettings on the host and sends that
to the WebProcess. There isn&apos;t any reason to use GtkSettings
in the WebProcess to store these values.

* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp:
(WebKit::GtkSettingsManagerProxy::GtkSettingsManagerProxy):
(WebKit::GtkSettingsManagerProxy::applySettings):
(WebKit::GtkSettingsManagerProxy::applyHintingSettings):
(WebKit::GtkSettingsManagerProxy::applyAntialiasSettings):
* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55ea13bcac8bd071033b2a5ec2e9f40eb39b733f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52017 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37422 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14164 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13170 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59343 "Failure limit exceed. At least found 296 new test failures: accessibility/native-text-control-attributed-string.html accessibility/node-only-object-element-rect.html css2.1/20110323/replaced-elements-001.htm css3/flexbox/button.html editing/input/caret-at-the-edge-of-input.html editing/input/reveal-caret-of-multiline-input.html editing/inserting/4960120-1.html editing/inserting/before-after-input-element.html editing/pasteboard/4641033.html editing/pasteboard/4806874.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56055 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59539 "Found 123 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.GeolocationBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PageLoadBasic, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/799 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39862 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40939 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->