### PR TITLE
Remove reference cycle from WebExtensionAction.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -72,7 +72,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 
 - (id<WKWebExtensionTab>)associatedTab
 {
-    if (auto *tab = _webExtensionAction->tab())
+    if (RefPtr tab = _webExtensionAction->tab())
         return tab->delegate();
     return nil;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -78,8 +78,8 @@ public:
     bool operator==(const WebExtensionAction&) const;
 
     WebExtensionContext* extensionContext() const;
-    WebExtensionTab* tab() { return m_tab.get(); }
-    WebExtensionWindow* window() { return m_window.get(); }
+    RefPtr<WebExtensionTab> tab() const;
+    RefPtr<WebExtensionWindow> window() const;
 
     void clearCustomizations();
     void clearBlockedResourceCount();
@@ -149,8 +149,8 @@ private:
 #endif
 
     WeakPtr<WebExtensionContext> m_extensionContext;
-    RefPtr<WebExtensionTab> m_tab;
-    RefPtr<WebExtensionWindow> m_window;
+    std::optional<WeakPtr<WebExtensionTab>> m_tab;
+    std::optional<WeakPtr<WebExtensionWindow>> m_window;
 
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<_WKWebExtensionActionViewController> m_popupViewController;


### PR DESCRIPTION
#### fe6870e03d07b9bdf52df972d3b15214e3ce30eb
<pre>
Remove reference cycle from WebExtensionAction.
<a href="https://webkit.org/b/278800">https://webkit.org/b/278800</a>
<a href="https://rdar.apple.com/134866275">rdar://134866275</a>

Reviewed by Timothy Hatcher.

This patch removes a reference cycle previously present in
WebExtensionAction. Since actions are stored in a WeakHashMap within
WebExtensionContext where the key is either a WebExtensionWindow or
a WebExtensionTab, and since each action would store a strong reference
to whatever window or tab was used as its key, this forms a reference
cycle. This fix changes the m_tab and m_window instance variables on
WebExtensionAction to be of type std::optional&lt;WeakPtr&lt;..&gt;&gt;. This patch
also contains supporting changes within the class to handle this new
type.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm:
(-[WKWebExtensionAction associatedTab]): Take reference to an action&apos;s
tab in a RefPtr rather than a raw pointer to prevent it dropping out
while in use.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::tab const): Made method const, moved
implementation to .mm file, updated to handle optional member variable.
(WebKit::WebExtensionAction::window const): Made method const, moved
implementation to .mm file, updated to handle optional member variable.
(WebKit::WebExtensionAction::fallbackAction const): Updated to handle
new type of m_tab (optional&lt;WeakPtr&lt;..&gt;&gt;)
(WebKit::WebExtensionAction::platformMenuItems const): Use tab getter
rather than member variable
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::tab): Deleted (moved implementation to
WebExtensionActionCocoa.mm).
(WebKit::WebExtensionAction::window): Deleted (moved implementation to
WebExtensionActionCocoa.mm).

Canonical link: <a href="https://commits.webkit.org/283143@main">https://commits.webkit.org/283143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a57e26fa298fd338495c7cb3c5362edb82998a94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15918 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52449 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11002 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37952 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71041 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59773 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1306 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40491 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42749 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->