### PR TITLE
AX: Implement [WebAccessibilityObjectWrapper misspellingTextMarkerRange:forward:] on iOS using new AXSearchManager functionality.

### DIFF
--- a/LayoutTests/accessibility/misspelling-range.html
+++ b/LayoutTests/accessibility/misspelling-range.html
@@ -12,9 +12,9 @@ wrods is misspelled aab lotsi nowadays. euep.
 
 <script>
 let output = "This tests that misspelling ranges are properly retrieved in the fashion that a spell checker would.\n\n";
-jsTestIsAsync = true;
 
 if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
     var content = document.getElementById("content");
     content.focus();
     var text = accessibilityController.focusedElement;
@@ -37,9 +37,9 @@ if (window.accessibilityController && window.internals) {
         startMarker = null;
         await waitFor(() => {
             misspellingRange = text.misspellingTextMarkerRange(startRange, true);
-            startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
-            return text.indexForTextMarker(startMarker) >= 0;
+            return text.stringForTextMarkerRange(misspellingRange) == "wrods";
         });
+        startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
         output += `misspelling start: ${text.indexForTextMarker(startMarker)}\n`;
         endMarker = text.endTextMarkerForTextMarkerRange(misspellingRange);
         output += `misspelling end: ${text.indexForTextMarker(endMarker)}\n`;

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -236,6 +236,11 @@ public:
 #if PLATFORM(MAC)
     RetainPtr<AXTextMarkerRangeRef> platformData() const;
     operator AXTextMarkerRangeRef() const { return platformData().autorelease(); }
+#elif PLATFORM(IOS_FAMILY)
+    // There is no iOS native type for a TextMarkerRange analogous to AXTextMarkerRangeRef on Mac.
+    // Instead, an NSArray of 2 elements is used.
+    AXTextMarkerRange(NSArray *);
+    RetainPtr<NSArray> platformData() const;
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
@@ -30,6 +30,10 @@
 #import "WebAccessibilityObjectWrapperBase.h"
 #import "WAKView.h"
 
+namespace WebCore {
+class VisiblePosition;
+}
+
 // NSAttributedStrings support.
 
 static NSString * const UIAccessibilityTextAttributeContext = @"UIAccessibilityTextAttributeContext";
@@ -70,6 +74,19 @@ static NSString * const UIAccessibilityTextualContextSourceCode = @"UIAccessibil
 // This is called by the Accessibility system to relay back to the chrome.
 - (void)handleNotificationRelayToChrome:(NSString *)notificationName notificationData:(NSData *)notificationData;
 
+@end
+
+@interface WebAccessibilityTextMarker : NSObject {
+    WebCore::AXObjectCache* _cache;
+    WebCore::TextMarkerData _textMarkerData;
+}
+
++ (WebAccessibilityTextMarker *)textMarkerWithVisiblePosition:(WebCore::VisiblePosition&)visiblePos cache:(WebCore::AXObjectCache*)cache;
++ (WebAccessibilityTextMarker *)textMarkerWithCharacterOffset:(WebCore::CharacterOffset&)characterOffset cache:(WebCore::AXObjectCache*)cache;
++ (WebAccessibilityTextMarker *)startOrEndTextMarkerForRange:(const std::optional<WebCore::SimpleRange>&)range isStart:(BOOL)isStart cache:(WebCore::AXObjectCache*)cache;
+
+- (id)initWithTextMarker:(const WebCore::TextMarkerData *)data cache:(WebCore::AXObjectCache*)cache;
+- (WebCore::TextMarkerData)textMarkerData;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "AXLogger.h"
 #import "AXSearchManager.h"
 #import "AccessibilityAttachment.h"
 #import "AccessibilityMediaObject.h"
@@ -56,6 +57,7 @@
 #import "SelectionGeometry.h"
 #import "SimpleRange.h"
 #import "TextIterator.h"
+#import "VisiblePosition.h"
 #import "WAKScrollView.h"
 #import "WAKWindow.h"
 #import "WebCoreThread.h"
@@ -124,22 +126,9 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
 #pragma mark Accessibility Text Marker
 
-@interface WebAccessibilityTextMarker : NSObject
-{
-    AXObjectCache* _cache;
-    TextMarkerData _textMarkerData;
-}
-
-+ (WebAccessibilityTextMarker *)textMarkerWithVisiblePosition:(VisiblePosition&)visiblePos cache:(AXObjectCache*)cache;
-+ (WebAccessibilityTextMarker *)textMarkerWithCharacterOffset:(CharacterOffset&)characterOffset cache:(AXObjectCache*)cache;
-+ (WebAccessibilityTextMarker *)startOrEndTextMarkerForRange:(const std::optional<SimpleRange>&)range isStart:(BOOL)isStart cache:(AXObjectCache*)cache;
-
-- (TextMarkerData)textMarkerData;
-@end
-
 @implementation WebAccessibilityTextMarker
 
-- (id)initWithTextMarker:(TextMarkerData *)data cache:(AXObjectCache*)cache
+- (id)initWithTextMarker:(const TextMarkerData *)data cache:(AXObjectCache*)cache
 {
     if (!(self = [super init]))
         return nil;
@@ -2210,10 +2199,13 @@ static RenderObject* rendererForView(WAKView* view)
 {
     if (![self _prepareAccessibilityCall])
         return nil;
-    auto range = [self rangeForTextMarkers:markers];
-    if (!range)
+
+    AXTextMarkerRange axRange { markers };
+    if (!axRange)
         return nil;
-    return self.axBackingObject->stringForRange(*range);
+
+    auto range = axRange.simpleRange();
+    return range ? self.axBackingObject->stringForRange(*range) : String();
 }
 
 // This method is intended to return an array of strings and accessibility elements that
@@ -2546,16 +2538,32 @@ static RenderObject* rendererForView(WAKView* view)
     return [WebAccessibilityTextMarker textMarkerWithVisiblePosition:lineStart cache:self.axBackingObject->axObjectCache()];
 }
 
-- (NSArray *)misspellingTextMarkerRange:(NSArray *)startTextMarkerRange forward:(BOOL)forward
+- (NSArray *)misspellingTextMarkerRange:(NSArray *)startMarkers forward:(BOOL)forward
 {
+    AXTRACE("misspellingTextMarkerRange:forward:"_s);
+
     if (![self _prepareAccessibilityCall])
         return nil;
-    auto startRange = [self rangeForTextMarkers:startTextMarkerRange];
+
+    AXTextMarkerRange startRange { startMarkers };
     if (!startRange)
         return nil;
-    auto misspellingRange = self.axBackingObject->misspellingRange(*startRange,
-        forward ? AccessibilitySearchDirection::Next : AccessibilitySearchDirection::Previous);
-    return [self textMarkersForRange:misspellingRange];
+    AXLOG(makeString("start range: "_s, startRange.debugDescription()));
+
+    auto characterRange = startRange.characterRange();
+    if (!characterRange)
+        return nil;
+
+    RefPtr startObject = forward ? startRange.end().object() : startRange.start().object();
+    auto misspellingRange = AXSearchManager().findMatchingRange(AccessibilitySearchCriteria {
+        self.axBackingObject, startObject.get(), *characterRange,
+        forward ? AccessibilitySearchDirection::Next : AccessibilitySearchDirection::Previous,
+        { AccessibilitySearchKey::MisspelledWord }, { }, 1
+    });
+    AXLOG(makeString("misspellingRange: "_s, misspellingRange ? misspellingRange->debugDescription() : "null"_s));
+    if (misspellingRange)
+        return misspellingRange->platformData().autorelease();
+    return nil;
 }
 
 - (WebAccessibilityTextMarker *)nextMarkerForMarker:(WebAccessibilityTextMarker *)marker


### PR DESCRIPTION
#### c2423ee74d49d167d457795485801bdd03bc8a33
<pre>
AX: Implement [WebAccessibilityObjectWrapper misspellingTextMarkerRange:forward:] on iOS using new AXSearchManager functionality.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278876">https://bugs.webkit.org/show_bug.cgi?id=278876</a>
&lt;<a href="https://rdar.apple.com/problem/134957919">rdar://problem/134957919</a>&gt;

Reviewed by Tyler Wilcock.

This unifies the code paths for iOS and Mac to obtain the range of a misspelling. It also improves this functionality on iOS since now misspellingTextMarkerRange:forward: is not confined to the misspellings in the current object.

As a required byproduct of this changes, we added the conversion between AXTextMarkerRanges and NSArrays of TextMarkers used on iOS to represent ranges.

* LayoutTests/accessibility/misspelling-range.html:
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::AXTextMarkerRange::platformData const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityTextMarker initWithTextMarker:cache:]):
(-[WebAccessibilityObjectWrapper stringForTextMarkers:]):
(-[WebAccessibilityObjectWrapper misspellingTextMarkerRange:forward:]):

Canonical link: <a href="https://commits.webkit.org/282959@main">https://commits.webkit.org/282959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e41c84e02dd51f966e24a73421b39d12e546815

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15312 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52025 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10557 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70435 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59354 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56072 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59543 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/816 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39882 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->