### PR TITLE
[WPT] Sync css/css-nesting

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8126,6 +8126,10 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-js-expose.
 
 fast/canvas/image-buffer-resource-limits.html [ Slow ]
 
+# CSS Nesting interleaved declarations and rules
+# https://bugs.webkit.org/show_bug.cgi?id=275365
+imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html [ ImageOnlyFailure ]
+
 # Standardized CSS zoom tests.
 imported/w3c/web-platform-tests/css/css-viewport/width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -4054,6 +4054,7 @@
         "web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html",
         "web-platform-tests/css/css-nesting/nesting-basic-ref.html",
         "web-platform-tests/css/css-nesting/supports-is-consistent-ref.html",
+        "web-platform-tests/css/css-nesting/supports-rule-ref.html",
         "web-platform-tests/css/css-overflow/clip-001-ref.html",
         "web-platform-tests/css/css-overflow/clip-002-ref.html",
         "web-platform-tests/css/css-overflow/clip-003-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL Trailing declarations assert_equals: expected 2 but got 1
+FAIL Mixed declarations assert_equals: expected 6 but got 3
+FAIL CSSNestedDeclarations.style assert_equals: expected 2 but got 1
+FAIL Nested group rule assert_equals: expected 2 but got 1
+FAIL Nested @scope rule assert_equals: expected 2 but got 1
+FAIL Inner rule starting with an ident assert_equals: expected 4 but got 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<title>CSS Nesting: CSSNestedDeclarations CSSOM</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/#nested-declarations-rule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    let s = new CSSStyleSheet();
+    s.replaceSync(`
+      .a {
+        & { --x:1; }
+        --x:2;
+      }
+    `);
+    assert_equals(s.cssRules.length, 1);
+    let outer = s.cssRules[0];
+    assert_equals(outer.cssRules.length, 2);
+    assert_equals(outer.cssRules[0].cssText, `& { --x: 1; }`);
+    assert_equals(outer.cssRules[1].cssText, `--x: 2;`);
+  }, 'Trailing declarations');
+
+  test(() => {
+    let s = new CSSStyleSheet();
+    s.replaceSync(`
+      .a {
+        --a:1;
+        --b:1;
+        & { --c:1; }
+        --d:1;
+        --e:1;
+        & { --f:1; }
+        --g:1;
+        --h:1;
+        --i:1;
+        & { --j:1; }
+        --k:1;
+        --l:1;
+      }
+    `);
+    assert_equals(s.cssRules.length, 1);
+    let outer = s.cssRules[0];
+    assert_equals(outer.cssRules.length, 6);
+    assert_equals(outer.cssRules[0].cssText, `& { --c: 1; }`);
+    assert_equals(outer.cssRules[1].cssText, `--d: 1; --e: 1;`);
+    assert_equals(outer.cssRules[2].cssText, `& { --f: 1; }`);
+    assert_equals(outer.cssRules[3].cssText, `--g: 1; --h: 1; --i: 1;`);
+    assert_equals(outer.cssRules[4].cssText, `& { --j: 1; }`);
+    assert_equals(outer.cssRules[5].cssText, `--k: 1; --l: 1;`);
+  }, 'Mixed declarations');
+
+  test(() => {
+    let s = new CSSStyleSheet();
+    s.replaceSync(`
+      .a {
+        & { --x:1; }
+        --y:2;
+        --z:3;
+      }
+    `);
+    assert_equals(s.cssRules.length, 1);
+    let outer = s.cssRules[0];
+    assert_equals(outer.cssRules.length, 2);
+    let nested_declarations = outer.cssRules[1];
+    assert_true(nested_declarations instanceof CSSNestedDeclarations);
+    assert_equals(nested_declarations.style.length, 2);
+    assert_equals(nested_declarations.style.getPropertyValue('--x'), '');
+    assert_equals(nested_declarations.style.getPropertyValue('--y'), '2');
+    assert_equals(nested_declarations.style.getPropertyValue('--z'), '3');
+  }, 'CSSNestedDeclarations.style');
+
+  test(() => {
+    let s = new CSSStyleSheet();
+    s.replaceSync(`
+      .a {
+        @media (width > 100px) {
+          --x:1;
+          --y:1;
+          .b { }
+          --z:1;
+        }
+        --w:1;
+      }
+    `);
+    assert_equals(s.cssRules.length, 1);
+    let outer = s.cssRules[0];
+    assert_equals(outer.cssRules.length, 2);
+
+    // @media
+    let media = outer.cssRules[0];
+    assert_equals(media.cssRules.length, 3);
+    assert_true(media.cssRules[0] instanceof CSSNestedDeclarations);
+    assert_equals(media.cssRules[0].cssText, `--x: 1; --y: 1;`);
+    assert_equals(media.cssRules[1].cssText, `& .b { }`);
+    assert_true(media.cssRules[2] instanceof CSSNestedDeclarations);
+    assert_equals(media.cssRules[2].cssText, `--z: 1;`);
+
+    assert_true(outer.cssRules[1] instanceof CSSNestedDeclarations);
+    assert_equals(outer.cssRules[1].cssText, `--w: 1;`);
+  }, 'Nested group rule');
+
+  test(() => {
+    let s = new CSSStyleSheet();
+    s.replaceSync(`
+      .a {
+        @scope (.foo) {
+          --x:1;
+          --y:1;
+          .b { }
+          --z:1;
+        }
+        --w:1;
+      }
+    `);
+    assert_equals(s.cssRules.length, 1);
+    let outer = s.cssRules[0];
+    assert_equals(outer.cssRules.length, 2);
+
+    // @scope
+    let scope = outer.cssRules[0];
+    assert_equals(scope.cssRules.length, 3);
+    assert_true(scope.cssRules[0] instanceof CSSNestedDeclarations);
+    assert_equals(scope.cssRules[0].cssText, `--x: 1; --y: 1;`);
+    assert_equals(scope.cssRules[1].cssText, `.b { }`); // Implicit :scope here.
+    assert_true(scope.cssRules[2] instanceof CSSNestedDeclarations);
+    assert_equals(scope.cssRules[2].cssText, `--z: 1;`);
+
+    assert_true(outer.cssRules[1] instanceof CSSNestedDeclarations);
+    assert_equals(outer.cssRules[1].cssText, `--w: 1;`);
+  }, 'Nested @scope rule');
+
+  test(() => {
+    let s = new CSSStyleSheet();
+    s.replaceSync(`
+      a {
+        & { --x:1; }
+        width: 100px;
+        height: 200px;
+        color:hover {}
+        --y: 2;
+      }
+    `);
+    assert_equals(s.cssRules.length, 1);
+    let outer = s.cssRules[0];
+    assert_equals(outer.cssRules.length, 4);
+    assert_equals(outer.cssRules[0].cssText, `& { --x: 1; }`);
+    assert_equals(outer.cssRules[1].cssText, `width: 100px; height: 200px;`);
+    assert_equals(outer.cssRules[2].cssText, `& color:hover { }`);
+    assert_equals(outer.cssRules[3].cssText, `--y: 2;`);
+  }, 'Inner rule starting with an ident');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt
@@ -1,0 +1,15 @@
+A1
+A2
+
+FAIL Trailing declarations apply after any preceding rules assert_equals: expected "PASS" but got "FAIL"
+FAIL Trailing declarations apply after any preceding rules (no leading) assert_equals: expected "PASS" but got "FAIL"
+FAIL Trailing declarations apply after any preceding rules (multiple) assert_equals: expected "PASS" but got "FAIL"
+PASS Nested declarations rule has same specificity as outer selector
+PASS Nested declarations rule has top-level specificity behavior
+FAIL Nested declarations rule has top-level specificity behavior (max matching) assert_equals: expected "PASS" but got "FAIL"
+FAIL Bare declartaion in nested grouping rule can match pseudo-element assert_equals: expected "PASS" but got "FAIL"
+FAIL Nested group rules have top-level specificity behavior assert_equals: expected "PASS" but got "FAIL"
+FAIL Nested @scope rules behave like :where(:scope) assert_equals: expected "PASS" but got "FAIL"
+FAIL Nested @scope rules behave like :where(:scope) (trailing) assert_equals: expected "PASS" but got "FAIL"
+FAIL Nested declarations rule responds to parent selector text change assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<title>CSS Nesting: CSSNestedDeclarations matching</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/#nested-declarations-rule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .trailing {
+    --x: FAIL;
+    & { --x: FAIL; }
+    --x: PASS;
+  }
+</style>
+<div class=trailing></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.trailing');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Trailing declarations apply after any preceding rules');
+</script>
+
+
+<style>
+  .trailing_no_leading {
+    & { --x: FAIL; }
+    --x: PASS;
+  }
+</style>
+<div class=trailing_no_leading></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.trailing_no_leading');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Trailing declarations apply after any preceding rules (no leading)');
+</script>
+
+
+<style>
+  .trailing_multiple {
+    --x: FAIL;
+    --y: FAIL;
+    --z: FAIL;
+    --w: FAIL;
+    & { --x: FAIL; }
+    --x: PASS;
+    --y: PASS;
+    & { --z: FAIL; }
+    --z: PASS;
+    --w: PASS;
+  }
+</style>
+<div class=trailing_multiple></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.trailing_multiple');
+    let s = getComputedStyle(e);
+    assert_equals(s.getPropertyValue('--x'), 'PASS');
+    assert_equals(s.getPropertyValue('--y'), 'PASS');
+    assert_equals(s.getPropertyValue('--z'), 'PASS');
+    assert_equals(s.getPropertyValue('--w'), 'PASS');
+  }, 'Trailing declarations apply after any preceding rules (multiple)');
+</script>
+
+
+<style>
+  .trailing_specificity {
+    --x: FAIL;
+    :is(&, div.nomatch2) { --x: PASS; } /* Specificity: (0, 1, 1) */
+    --x: FAIL; /* Specificity: (0, 1, 0) */
+  }
+</style>
+<div class=trailing_specificity></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.trailing_specificity');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Nested declarations rule has same specificity as outer selector');
+</script>
+
+
+<style>
+  #nomatch, .specificity_top_level {
+    --x: FAIL;
+    :is(&, div.nomatch2) { --x: PASS; } /* Specificity: (0, 1, 1) */
+    --x: FAIL; /* Specificity: (0, 1, 0). In particular, this does not have
+               specificity like :is(#nomatch, .specificity_top_level). */
+  }
+</style>
+<div class=specificity_top_level></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.specificity_top_level');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Nested declarations rule has top-level specificity behavior');
+</script>
+
+
+<style>
+  #nomatch, .specificity_top_level_max, div.specificity_top_level_max {
+    --x: FAIL;
+    :is(:where(&), div.nomatch2) { --x: FAIL; } /* Specificity: (0, 1, 1) */
+    --x: PASS; /* Specificity: (0, 1, 1) (for div.specificity_top_level_max) */
+  }
+</style>
+<div class=specificity_top_level_max></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.specificity_top_level_max');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Nested declarations rule has top-level specificity behavior (max matching)');
+</script>
+
+<style>
+  .nested_pseudo::after {
+    --x: FAIL;
+    @media (width > 0px) {
+      --x: PASS;
+    }
+  }
+</style>
+<div class=nested_pseudo></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.nested_pseudo');
+    assert_equals(getComputedStyle(e, '::after').getPropertyValue('--x'), 'PASS');
+  }, 'Bare declartaion in nested grouping rule can match pseudo-element');
+</script>
+
+<style>
+  #nomatch, .nested_group_rule {
+    --x: FAIL;
+    @media (width > 0px) {
+      --x: FAIL; /* Specificity: (0, 1, 0) */
+    }
+    --x: PASS;
+  }
+</style>
+<div class=nested_group_rule></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.nested_group_rule');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Nested group rules have top-level specificity behavior');
+</script>
+
+
+<style>
+  .nested_scope_rule {
+    div:where(&) { /* Specificity: (0, 0, 1) */
+      --x: PASS;
+    }
+    @scope (&) {
+      --x: FAIL; /* Specificity: (0, 0, 0) */
+    }
+  }
+</style>
+<div class=nested_scope_rule></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.nested_scope_rule');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Nested @scope rules behave like :where(:scope)');
+</script>
+
+
+<style>
+  .nested_scope_rule_trailing {
+    div:where(&) { /* Specificity: (0, 0, 1) */
+      --x: PASS;
+    }
+    @scope (&) {
+      --ignored: 1;
+      .ignored {}
+      --x: FAIL; /* Specificity: (0, 0, 0) */
+    }
+  }
+</style>
+<div class=nested_scope_rule_trailing></div>
+<script>
+  test(() => {
+    let e = document.querySelector('.nested_scope_rule_trailing');
+    assert_equals(getComputedStyle(e).getPropertyValue('--x'), 'PASS');
+  }, 'Nested @scope rules behave like :where(:scope) (trailing)');
+</script>
+
+
+<style id=set_parent_selector_text_style>
+  .set_parent_selector_text {
+    div {
+      color: red;
+    }
+    .a1 {
+      & { color: green };
+    }
+  }
+</style>
+<div class=set_parent_selector_text>
+  <div class=a1>A1</div>
+  <div class=a2>A2</div>
+</div>
+<script>
+  test(() => {
+    let a1 = document.querySelector('.set_parent_selector_text > .a1');
+    let a2 = document.querySelector('.set_parent_selector_text > .a2');
+    assert_equals(getComputedStyle(a1).color, 'rgb(0, 128, 0)');
+    assert_equals(getComputedStyle(a2).color, 'rgb(255, 0, 0)');
+
+    let rules = set_parent_selector_text_style.sheet.cssRules;
+    assert_equals(rules.length, 1);
+    assert_equals(rules[0].cssRules.length, 2);
+
+    let a_rule = rules[0].cssRules[1];
+    assert_equals(a_rule.selectorText, '& .a1');
+    a_rule.selectorText = '.a2';
+
+    assert_equals(getComputedStyle(a1).color, 'rgb(255, 0, 0)');
+    assert_equals(getComputedStyle(a2).color, 'rgb(0, 128, 0)');
+  }, 'Nested declarations rule responds to parent selector text change');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -68,9 +68,9 @@
 
   .test-10 {
     & {
-      background-color: green;
+      background-color: red;
     }
-    background-color: red;
+    background-color: green;
   }
 
   .test-11 {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -10,6 +10,7 @@ PASS .foo { + .bar, .foo, > .baz { color: green; }}
 PASS .foo { .foo { color: green; }}
 PASS .foo { .test > & .bar { color: green; }}
 PASS .foo { .foo, .foo & { color: green; }}
+PASS .foo { .foo, .bar { color: green; }}
 PASS .foo { :is(.bar, .baz) { color: green; }}
 PASS .foo { &:is(.bar, .baz) { color: green; }}
 PASS .foo { :is(.bar, &.baz) { color: green; }}

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
@@ -55,6 +55,7 @@
   testNestedSelector(".foo", {expected:"& .foo"});
   testNestedSelector(".test > & .bar");
   testNestedSelector(".foo, .foo &", {expected:"& .foo, .foo &"});
+  testNestedSelector(".foo, .bar", {expected:"& .foo, & .bar"});
   testNestedSelector(":is(.bar, .baz)", {expected:"& :is(.bar, .baz)"});
   testNestedSelector("&:is(.bar, .baz)");
   testNestedSelector(":is(.bar, &.baz)");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/pseudo-where-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/pseudo-where-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+  .foo {
+    ::before:where(&) {
+      color: red;
+    }
+  }
+</style>
+<div class=foo></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Declarations are serialized on one line, rules on two.
-PASS Mixed declarations/rules are on two lines.
-PASS Implicit rule is serialized
+FAIL Mixed declarations/rules are on two lines. assert_equals: Mixed declarations/rules are on two lines. expected "div {\n  @media screen {\n  color: red; background-color: green;\n}\n}" but got "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}"
+FAIL Implicit rule is serialized assert_equals: Implicit rule is serialized expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n}\n  &:hover { color: navy; }\n}" but got "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n}\n  &:hover { color: navy; }\n}"
 PASS Implicit rule not removed
 PASS Implicit + empty hover rule
 PASS Implicit like rule not in first position
 PASS Two implicit-like rules
-PASS Implicit like rule after decls
-PASS Implicit like rule after decls, missing closing braces
+FAIL Implicit like rule after decls assert_equals: Implicit like rule after decls expected "div {\n  @media screen {\n  color: red;\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\n  & { color: red; }\n  & { color: red; }\n}\n}"
+FAIL Implicit like rule after decls, missing closing braces assert_equals: Implicit like rule after decls, missing closing braces expected "div {\n  @media screen {\n  color: red;\n  & { color: blue; }\n}\n}" but got "div {\n  @media screen {\n  & { color: red; }\n  & { color: blue; }\n}\n}"
 PASS Implicit like rule with other selectors
 PASS Implicit-like rule in style rule
 PASS Empty conditional rule

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.html
@@ -35,12 +35,12 @@
 
   assert_becomes(
     "div { @media screen { color: red; background-color: green; } }",
-    "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}",
+    "div {\n  @media screen {\n  color: red; background-color: green;\n}\n}",
     "Mixed declarations/rules are on two lines."
   );
   assert_becomes(
     "div {\n  @supports selector(&) { color: red; background-color: green; } &:hover { color: navy; } }",
-    "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n}\n  &:hover { color: navy; }\n}",
+    "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n}\n  &:hover { color: navy; }\n}",
     "Implicit rule is serialized",
   );
 
@@ -62,12 +62,12 @@
   );
   assert_becomes(
     "div { @media screen { color: red; & { color: red; }",
-    "div {\n  @media screen {\n  & { color: red; }\n  & { color: red; }\n}\n}",
+    "div {\n  @media screen {\n  color: red;\n  & { color: red; }\n}\n}",
     "Implicit like rule after decls"
   );
   assert_becomes(
     "div { @media screen { color: red; & { color: blue; }",
-    "div {\n  @media screen {\n  & { color: red; }\n  & { color: blue; }\n}\n}",
+    "div {\n  @media screen {\n  color: red;\n  & { color: blue; }\n}\n}",
     "Implicit like rule after decls, missing closing braces"
   );
   assert_becomes(

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log
@@ -50,6 +50,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -58,8 +60,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-type-selector.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/pseudo-part-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/pseudo-where-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-is-consistent-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-is-consistent-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-is-consistent.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope.html


### PR DESCRIPTION
#### c5614f275e72adc642666520ce73837cdd2499ec
<pre>
[WPT] Sync css/css-nesting
<a href="https://bugs.webkit.org/show_bug.cgi?id=278877">https://bugs.webkit.org/show_bug.cgi?id=278877</a>
<a href="https://rdar.apple.com/134959476">rdar://134959476</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c215b3a6ed4c09185d8d60e0e0d16a11463b5f9b">https://github.com/web-platform-tests/wpt/commit/c215b3a6ed4c09185d8d60e0e0d16a11463b5f9b</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/pseudo-where-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/282929@main">https://commits.webkit.org/282929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9d953424237fbf2a9794a3ee2f35f3590d4ab4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15298 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15577 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10552 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14171 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70422 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13175 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56058 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14272 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/802 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->