### PR TITLE
[tvOS] Add a stub PlaybackSessionInterface and VideoPresentationInterface

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -550,6 +550,7 @@ platform/ios/PlatformPasteboardIOS.mm
 platform/ios/PlatformScreenIOS.mm
 platform/ios/PlaybackSessionInterfaceAVKit.mm @no-unify
 platform/ios/PlaybackSessionInterfaceIOS.mm @no-unify
+platform/ios/PlaybackSessionInterfaceTVOS.cpp
 platform/ios/PreviewConverterIOS.mm
 platform/ios/QuickLook.mm
 platform/ios/ScrollAnimatorIOS.mm
@@ -564,6 +565,7 @@ platform/ios/UIViewControllerUtilities.mm
 platform/ios/UserAgentIOS.mm
 platform/ios/ValidationBubbleIOS.mm
 platform/ios/VideoPresentationInterfaceIOS.mm @no-unify
+platform/ios/VideoPresentationInterfaceTVOS.mm
 platform/ios/WebAVPlayerController.mm
 platform/ios/WebBackgroundTaskController.mm
 platform/ios/WebCoreMotionManager.mm

--- a/Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h
@@ -31,11 +31,14 @@ class NullPlaybackSessionInterface;
 class PlaybackSessionInterfaceAVKit;
 class PlaybackSessionInterfaceIOS;
 class PlaybackSessionInterfaceMac;
+class PlaybackSessionInterfaceTVOS;
 
 #if PLATFORM(WATCHOS)
 using PlatformPlaybackSessionInterface = NullPlaybackSessionInterface;
 #elif ENABLE(LINEAR_MEDIA_PLAYER)
 using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceIOS;
+#elif PLATFORM(APPLETV)
+using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceTVOS;
 #elif PLATFORM(IOS_FAMILY)
 using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceAVKit;
 #elif PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h
@@ -31,11 +31,14 @@ class NullVideoPresentationInterface;
 class VideoPresentationInterfaceAVKit;
 class VideoPresentationInterfaceIOS;
 class VideoPresentationInterfaceMac;
+class VideoPresentationInterfaceTVOS;
 
 #if PLATFORM(WATCHOS)
 using PlatformVideoPresentationInterface = NullVideoPresentationInterface;
 #elif ENABLE(LINEAR_MEDIA_PLAYER)
 using PlatformVideoPresentationInterface = VideoPresentationInterfaceIOS;
+#elif PLATFORM(APPLETV)
+using PlatformVideoPresentationInterface = VideoPresentationInterfaceTVOS;
 #elif PLATFORM(IOS_FAMILY)
 using PlatformVideoPresentationInterface = VideoPresentationInterfaceAVKit;
 #elif PLATFORM(MAC)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.cpp
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlaybackSessionInterfaceTVOS.h"
+
+#if PLATFORM(APPLETV)
+
+namespace WebCore {
+
+Ref<PlaybackSessionInterfaceTVOS> PlaybackSessionInterfaceTVOS::create(PlaybackSessionModel& model)
+{
+    Ref interface = adoptRef(*new PlaybackSessionInterfaceTVOS(model));
+    interface->initialize();
+    return interface;
+}
+
+PlaybackSessionInterfaceTVOS::PlaybackSessionInterfaceTVOS(PlaybackSessionModel& model)
+    : PlaybackSessionInterfaceIOS { model }
+{
+    ASSERT(isUIThread());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(APPLETV)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(APPLETV)
+
+#include "PlaybackSessionInterfaceIOS.h"
+
+namespace WebCore {
+
+class PlaybackSessionInterfaceTVOS final : public PlaybackSessionInterfaceIOS {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceTVOS);
+public:
+    WEBCORE_EXPORT static Ref<PlaybackSessionInterfaceTVOS> create(PlaybackSessionModel&);
+
+    // PlaybackSessionInterfaceIOS
+    WebAVPlayerController *playerController() const final { return { }; }
+    WKSLinearMediaPlayer *linearMediaPlayer() const final { return { }; }
+    void durationChanged(double) final { }
+    void currentTimeChanged(double, double) final { }
+    void bufferedTimeChanged(double) final { }
+    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
+    void seekableRangesChanged(const TimeRanges&, double, double) final { }
+    void canPlayFastReverseChanged(bool) final { }
+    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
+    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
+    void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
+    void wirelessVideoPlaybackDisabledChanged(bool) final { }
+    void mutedChanged(bool) final { }
+    void volumeChanged(double) final { }
+#if !RELEASE_LOG_DISABLED
+    ASCIILiteral logClassName() const final { return "PlaybackSessionInterfaceTVOS"_s; }
+#endif
+
+private:
+    PlaybackSessionInterfaceTVOS(PlaybackSessionModel&);
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(APPLETV)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -256,25 +256,25 @@ void VideoPresentationInterfaceIOS::doSetup()
 
     setupPlayerViewController();
 
-    UIViewController *playerViewController = this->playerViewController();
+    if (UIViewController *playerViewController = this->playerViewController()) {
+        if (m_viewController) {
+            [m_viewController addChildViewController:playerViewController];
+            [[m_viewController view] addSubview:playerViewController.view];
+            [playerViewController didMoveToParentViewController:m_viewController.get()];
+        } else
+            [m_parentView addSubview:playerViewController.view];
 
-    if (m_viewController) {
-        [m_viewController addChildViewController:playerViewController];
-        [[m_viewController view] addSubview:playerViewController.view];
-        [playerViewController didMoveToParentViewController:m_viewController.get()];
-    } else
-        [m_parentView addSubview:playerViewController.view];
+        playerViewController.view.frame = [m_parentView convertRect:m_inlineRect toView:playerViewController.view.superview];
+        playerViewController.view.backgroundColor = clearUIColor();
+        playerViewController.view.autoresizingMask = (UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin);
 
-    playerViewController.view.frame = [m_parentView convertRect:m_inlineRect toView:playerViewController.view.superview];
-    playerViewController.view.backgroundColor = clearUIColor();
-    playerViewController.view.autoresizingMask = (UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin);
+        [playerViewController.view setNeedsLayout];
+        [playerViewController.view layoutIfNeeded];
 
-    [playerViewController.view setNeedsLayout];
-    [playerViewController.view layoutIfNeeded];
-
-    if (m_targetStandby && !m_currentMode.hasVideo() && !m_returningToStandby) {
-        [m_window setHidden:YES];
-        [playerViewController.view setHidden:YES];
+        if (m_targetStandby && !m_currentMode.hasVideo() && !m_returningToStandby) {
+            [m_window setHidden:YES];
+            [playerViewController.view setHidden:YES];
+        }
     }
 
     [CATransaction commit];

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(APPLETV)
+
+#include "VideoPresentationInterfaceIOS.h"
+
+namespace WebCore {
+
+class VideoPresentationInterfaceTVOS final : public VideoPresentationInterfaceIOS {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceTVOS);
+public:
+    WEBCORE_EXPORT static Ref<VideoPresentationInterfaceTVOS> create(PlaybackSessionInterfaceIOS&);
+
+    // VideoPresentationInterfaceIOS
+    void hasVideoChanged(bool) final { }
+    AVPlayerViewController *avPlayerViewController() const final { return { }; }
+    bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
+    bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
+    bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
+    
+private:
+    VideoPresentationInterfaceTVOS(PlaybackSessionInterfaceIOS&);
+
+    // VideoPresentationInterfaceIOS
+    void updateRouteSharingPolicy() final { }
+    void setupPlayerViewController() final { }
+    void invalidatePlayerViewController() final { }
+    UIViewController *playerViewController() const final { return { }; }
+    void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
+    void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
+    void tryToStartPictureInPicture() final { }
+    void stopPictureInPicture() final { }
+    void setShowsPlaybackControls(bool) final { }
+    void setContentDimensions(const FloatSize&) final { }
+    void setAllowsPictureInPicturePlayback(bool) final { }
+    bool isExternalPlaybackActive() const final { return false; }
+    bool willRenderToLayer() const final { return true; }
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(APPLETV)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.mm
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "VideoPresentationInterfaceTVOS.h"
+
+#if PLATFORM(APPLETV)
+
+namespace WebCore {
+
+Ref<VideoPresentationInterfaceTVOS> VideoPresentationInterfaceTVOS::create(PlaybackSessionInterfaceIOS& playbackSessionInterface)
+{
+    return adoptRef(*new VideoPresentationInterfaceTVOS(playbackSessionInterface));
+}
+
+VideoPresentationInterfaceTVOS::VideoPresentationInterfaceTVOS(PlaybackSessionInterfaceIOS& playbackSessionInterface)
+    : VideoPresentationInterfaceIOS { playbackSessionInterface }
+{
+}
+
+void VideoPresentationInterfaceTVOS::presentFullscreen(bool, Function<void(BOOL, NSError *)>&& completionHandler)
+{
+    completionHandler(NO, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
+}
+
+void VideoPresentationInterfaceTVOS::dismissFullscreen(bool, Function<void(BOOL, NSError *)>&& completionHandler)
+{
+    completionHandler(NO, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(APPLETV)

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -38,6 +38,7 @@
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_COMMA_BEGIN
 
+#include <webrtc/api/environment/environment_factory.h>
 #include <webrtc/modules/video_coding/codecs/av1/libaom_av1_encoder.h>
 #include <webrtc/modules/video_coding/codecs/vp8/include/vp8.h>
 #include <webrtc/modules/video_coding/codecs/vp9/include/vp9.h>

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -40,6 +40,7 @@
 #import <WebCore/NullPlaybackSessionInterface.h>
 #import <WebCore/PlaybackSessionInterfaceAVKit.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
+#import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -50,9 +50,11 @@
 #import <WebCore/NullVideoPresentationInterface.h>
 #import <WebCore/PlaybackSessionInterfaceAVKit.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
+#import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <WebCore/TimeRanges.h>
 #import <WebCore/VideoPresentationInterfaceAVKit.h>
 #import <WebCore/VideoPresentationInterfaceMac.h>
+#import <WebCore/VideoPresentationInterfaceTVOS.h>
 #import <WebCore/WebAVPlayerLayer.h>
 #import <WebCore/WebAVPlayerLayerView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -78,6 +78,7 @@
 #import <WebCore/PlatformPlaybackSessionInterface.h>
 #import <WebCore/PlaybackSessionInterfaceAVKit.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
+#import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <WebCore/RunLoopObserver.h>
 #import <WebCore/SearchPopupMenuCocoa.h>
 #import <WebCore/SleepDisabler.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -292,6 +292,7 @@
 #include <WebCore/NullPlaybackSessionInterface.h>
 #include <WebCore/PlaybackSessionInterfaceAVKit.h>
 #include <WebCore/PlaybackSessionInterfaceMac.h>
+#include <WebCore/PlaybackSessionInterfaceTVOS.h>
 #include <WebCore/RunLoopObserver.h>
 #include <WebCore/SystemBattery.h>
 #include <objc/runtime.h>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -41,7 +41,9 @@
 #import "WebPreferences.h"
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceTVOS.h>
 #import <WebCore/VideoPresentationInterfaceAVKit.h>
+#import <WebCore/VideoPresentationInterfaceTVOS.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/CheckedRef.h>
 #import <wtf/FastMalloc.h>


### PR DESCRIPTION
#### 3fa1d20da60e00014b0539014ca6c6eb878ba836
<pre>
[tvOS] Add a stub PlaybackSessionInterface and VideoPresentationInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=278882">https://bugs.webkit.org/show_bug.cgi?id=278882</a>
<a href="https://rdar.apple.com/134965640">rdar://134965640</a>

Reviewed by Jer Noble.

Added PlaybackSessionInterfaceTVOS and VideoPresentationInterfaceTVOS, which are subclasses of
PlaybackSessionInterfaceIOS and VideoPresentationInterfaceIOS respectively. Taught
VideoPresentationInterfaceIOS to tolerate a nil playerViewController.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.cpp: Added.
(WebCore::PlaybackSessionInterfaceTVOS::create):
(WebCore::PlaybackSessionInterfaceTVOS::PlaybackSessionInterfaceTVOS):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h: Added.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::doSetup):
* Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.h: Added.
* Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.mm: Added.
(WebCore::VideoPresentationInterfaceTVOS::create):
(WebCore::VideoPresentationInterfaceTVOS::VideoPresentationInterfaceTVOS):
(WebCore::VideoPresentationInterfaceTVOS::presentFullscreen):
(WebCore::VideoPresentationInterfaceTVOS::dismissFullscreen):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:

Canonical link: <a href="https://commits.webkit.org/282939@main">https://commits.webkit.org/282939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26fa2e6e77ae9797b9de12d3da628f2e12761169

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64697 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15582 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13354 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13181 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56064 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/808 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39874 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->