### PR TITLE
[Writing Tools] Inline animation doesn’t look great in Mail smart reply

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -679,8 +679,6 @@ public:
 
     virtual void removeTextAnimationForAnimationID(const WTF::UUID&) { }
 
-    virtual void removeTransparentMarkersForActiveWritingToolsSession() { }
-
     virtual void removeInitialTextAnimationForActiveWritingToolsSession() { }
 
     virtual void addInitialTextAnimationForActiveWritingToolsSession() { }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5008,9 +5008,9 @@ std::optional<SimpleRange> Page::contextRangeForActiveWritingToolsSession() cons
     return m_writingToolsController->activeSessionRange();
 }
 
-void Page::showSelectionForActiveWritingToolsSession() const
+void Page::intelligenceTextAnimationsDidComplete()
 {
-    return m_writingToolsController->showSelection();
+    m_writingToolsController->intelligenceTextAnimationsDidComplete();
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1190,7 +1190,7 @@ public:
     void respondToReappliedWritingToolsEditing(EditCommandComposition*);
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForActiveWritingToolsSession() const;
-    WEBCORE_EXPORT void showSelectionForActiveWritingToolsSession() const;
+    WEBCORE_EXPORT void intelligenceTextAnimationsDidComplete();
 #endif
 
     bool hasActiveNowPlayingSession() const { return m_hasActiveNowPlayingSession; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2289,8 +2289,8 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
     if (!_partialIntelligenceTextPonderingAnimationCount && _writingToolsTextReplacementsFinished) {
         // If the entire replacement has already been completed, and this is the end of the last animation,
-        // then reveal the selection.
-        _page->showSelectionForActiveWritingToolsSession();
+        // then reveal the selection and end the session if needed.
+        _page->intelligenceTextAnimationsDidComplete();
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1323,12 +1323,12 @@ bool WebPageProxy::writingToolsTextReplacementsFinished()
     return protectedPageClient()->writingToolsTextReplacementsFinished();
 }
 
-void WebPageProxy::showSelectionForActiveWritingToolsSession()
+void WebPageProxy::intelligenceTextAnimationsDidComplete()
 {
     if (!hasRunningProcess())
         return;
 
-    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForActiveWritingToolsSession(), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().send(Messages::WebPage::IntelligenceTextAnimationsDidComplete(), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::removeTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2450,7 +2450,7 @@ public:
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
 
     bool writingToolsTextReplacementsFinished();
-    void showSelectionForActiveWritingToolsSession();
+    void intelligenceTextAnimationsDidComplete();
 
     void didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&);
     void didEndPartialIntelligenceTextPonderingAnimationImpl();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1882,11 +1882,6 @@ void WebChromeClient::removeTextAnimationForAnimationID(const WTF::UUID& animati
     protectedPage()->removeTextAnimationForAnimationID(animationID);
 }
 
-void WebChromeClient::removeTransparentMarkersForActiveWritingToolsSession()
-{
-    protectedPage()->removeTransparentMarkersForActiveWritingToolsSession();
-}
-
 void WebChromeClient::removeInitialTextAnimationForActiveWritingToolsSession()
 {
     protectedPage()->removeInitialTextAnimationForActiveWritingToolsSession();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -524,8 +524,6 @@ private:
 
     void addInitialTextAnimationForActiveWritingToolsSession() final;
 
-    void removeTransparentMarkersForActiveWritingToolsSession() final;
-
     void addSourceTextAnimationForActiveWritingToolsSession(const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&) final;
 
     void addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<WebCore::CharacterRange>&, const String&) final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -71,9 +71,6 @@ class TextAnimationController final {
 public:
     explicit TextAnimationController(WebPage&);
 
-    void removeTransparentMarkersForActiveWritingToolsSession();
-    void removeTransparentMarkersForTextAnimationID(const WTF::UUID&);
-
     void removeInitialTextAnimationForActiveWritingToolsSession();
     void addInitialTextAnimationForActiveWritingToolsSession();
     void addSourceTextAnimationForActiveWritingToolsSession(const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
@@ -93,6 +90,9 @@ private:
     std::optional<WebCore::SimpleRange> contextRangeForTextAnimationID(const WTF::UUID&) const;
     std::optional<WebCore::SimpleRange> contextRangeForActiveWritingToolsSession() const;
     std::optional<WebCore::SimpleRange> unreplacedRangeForActiveWritingToolsSession() const;
+
+    void removeTransparentMarkersForTextAnimationID(const WTF::UUID&);
+    void removeTransparentMarkersForActiveWritingToolsSession();
 
     RefPtr<WebCore::Document> document() const;
     WeakPtr<WebPage> m_webPage;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -981,11 +981,6 @@ void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
     send(Messages::WebPageProxy::RemoveTextAnimationForAnimationID(uuid));
 }
 
-void WebPage::removeTransparentMarkersForActiveWritingToolsSession()
-{
-    m_textAnimationController->removeTransparentMarkersForActiveWritingToolsSession();
-}
-
 void WebPage::removeInitialTextAnimationForActiveWritingToolsSession()
 {
     m_textAnimationController->removeInitialTextAnimationForActiveWritingToolsSession();
@@ -1031,9 +1026,9 @@ void WebPage::enableTextAnimationTypeForElementWithID(const String& elementID)
     m_textAnimationController->enableTextAnimationTypeForElementWithID(elementID);
 }
 
-void WebPage::showSelectionForActiveWritingToolsSession()
+void WebPage::intelligenceTextAnimationsDidComplete()
 {
-    corePage()->showSelectionForActiveWritingToolsSession();
+    corePage()->intelligenceTextAnimationsDidComplete();
 }
 
 void WebPage::didEndPartialIntelligenceTextPonderingAnimation()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1782,7 +1782,6 @@ public:
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&, const WebCore::TextIndicatorData&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& = { });
 
     void removeTextAnimationForAnimationID(const WTF::UUID&);
-    void removeTransparentMarkersForActiveWritingToolsSession();
 
     void removeInitialTextAnimationForActiveWritingToolsSession();
     void addInitialTextAnimationForActiveWritingToolsSession();
@@ -2317,7 +2316,7 @@ private:
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
 
-    void showSelectionForActiveWritingToolsSession();
+    void intelligenceTextAnimationsDidComplete();
 #endif
 
     void remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -796,7 +796,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     EnableSourceTextAnimationAfterElementWithID(String elementID);
     EnableTextAnimationTypeForElementWithID(String elementID);
 
-    ShowSelectionForActiveWritingToolsSession();
+    IntelligenceTextAnimationsDidComplete();
 #endif
 
     TakeSnapshotForTargetedElement(WebCore::ElementIdentifier elementID, WebCore::ScriptExecutionContextIdentifier documentID) -> (std::optional<WebCore::ShareableBitmapHandle> image)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -2171,9 +2171,9 @@ TEST(WritingTools, EphemeralSession)
 
 TEST(WritingTools, TransparencyMarkersForInlineEditing)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Early morning in Cupertino</body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Early morning in Cupertino</body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     auto waitForValue = [webView](NSUInteger expectedValue) {
@@ -2196,6 +2196,14 @@ TEST(WritingTools, TransparencyMarkersForInlineEditing)
 
         waitForValue(1U);
         EXPECT_EQ(1U, [webView transparentContentMarkerCount:@"document.body.childNodes[0]"]);
+
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"Cupertino at the crack of dawn"]);
+
+        [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 26) inContext:contexts.firstObject finished:NO];
+        [webView waitForContentValue:@"Cupertino at the crack of dawn"];
+
+        [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 26) inContext:contexts.firstObject finished:YES];
+        [webView waitForNextPresentationUpdate];
 
         [[webView writingToolsDelegate] didEndWritingToolsSession:session.get() accepted:YES];
 


### PR DESCRIPTION
#### b0f15e3387325335db99c91364f034df46d86005
<pre>
[Writing Tools] Inline animation doesn’t look great in Mail smart reply
<a href="https://bugs.webkit.org/show_bug.cgi?id=278884">https://bugs.webkit.org/show_bug.cgi?id=278884</a>
<a href="https://rdar.apple.com/134458783">rdar://134458783</a>

Reviewed by Aditya Keerthi.

Ensure that the writing tools controller and intelligence text animation controller only have their
states reset after all animations have completed, or after the Writing Tools session is ended,
whichever is last.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::removeTransparentMarkersForActiveWritingToolsSession): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::intelligenceTextAnimationsDidComplete):
(WebCore::Page::showSelectionForActiveWritingToolsSession const): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::intelligenceTextAnimationsDidComplete):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession):
(WebCore::WritingToolsController::showSelection const): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _didEndPartialIntelligenceTextPonderingAnimation]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::intelligenceTextAnimationsDidComplete):
(WebKit::WebPageProxy::showSelectionForActiveWritingToolsSession): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager updateIsTextVisible:forChunk:completion:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::removeTransparentMarkersForActiveWritingToolsSession): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::intelligenceTextAnimationsDidComplete):
(WebKit::WebPage::showSelectionForActiveWritingToolsSession): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/283109@main">https://commits.webkit.org/283109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8108025391886382c2a02c5ffe9196baed1af2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69139 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52311 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14597 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9067 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13555 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56422 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59911 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1166 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9895 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40294 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41371 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->