### PR TITLE
New-test(282375@main): [ iOS ] http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html is a constant text failure

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix-expected.txt
@@ -1,1 +1,1 @@
-:~:text=This,-is%20a%20very
+:~:text=Th,-is%20is%20a

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html
@@ -9,7 +9,7 @@ if (window.testRunner)
 window.addEventListener('load', () => {
     const range = document.createRange();
     range.setStart(document.body.childNodes[0], 0);
-    range.setEnd(document.body.childNodes[0], 4);
+    range.setEnd(document.body.childNodes[0], 2);
     document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
 });
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7530,9 +7530,6 @@ imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss [ Pass
 # webkit.org/b/278333 [ iOS ] media/remove-video-best-media-element-in-main-frame-crash.html is a flaky timeout
 media/remove-video-best-media-element-in-main-frame-crash.html [ Pass Timeout ]
 
-# webkit.org/b/278325 New-test(282375@main): [ iOS ] http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html is a constant text failure
-http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html [ Failure ]
-
 # webkit.org/b/278340 [ iOS ] compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html is a flaky image failure
 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ Pass ImageOnlyFailure ]
 


### PR DESCRIPTION
#### 0eb5838f4c376aecb9f6f42c6518fa5fbb3d2947
<pre>
New-test(282375@main): [ iOS ] http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=278325">https://bugs.webkit.org/show_bug.cgi?id=278325</a>
<a href="https://rdar.apple.com/134272513">rdar://134272513</a>

Reviewed by Richard Robinson.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix-expected.txt:
* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html:
* LayoutTests/platform/ios/TestExpectations:
Adjust this test a tiny bit to work around (very strange) platform differences in
word iteration behavior. (See also bug 278056 which ran into similar).

It doesn&apos;t affect what this test is testing; move the end of the highlight
into the middle of a word so that word iteration is stable between iOS and macOS.

Canonical link: <a href="https://commits.webkit.org/282938@main">https://commits.webkit.org/282938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bb106e9dab4e3d540e4d91e01c9390d20dfee36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15604 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55999 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14198 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8664 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56084 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7150 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->