### PR TITLE
Use notification center delegate events to drive close and click events

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -362,17 +362,24 @@ private:
 
 #if PLATFORM(IOS)
 
-@interface _WKWebsiteDataStoreBSActionHandler : NSObject <_UIApplicationBSActionHandler>
+@interface _WKWebsiteDataStoreBSActionHandler : NSObject <_UIApplicationBSActionHandler> {
+    BlockPtr<WKWebsiteDataStore *(_WKWebPushAction *)> _webPushActionHandler;
+}
 + (_WKWebsiteDataStoreBSActionHandler *)shared;
 - (void)setWebPushActionHandler:(WKWebsiteDataStore *(^)(_WKWebPushAction *action))handler;
+- (BOOL)handleNotificationResponse:(UNNotificationResponse *)response;
 @end
 
 @interface _WKWebsiteDataStoreNotificationCenterDelegate : NSObject <UNUserNotificationCenterDelegate>
 @end
 
 @implementation _WKWebsiteDataStoreNotificationCenterDelegate
+
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler
 {
+#if PLATFORM(IOS)
+    [WKWebsiteDataStore handleNotificationResponse:response];
+#endif
     completionHandler();
 }
 
@@ -1343,7 +1350,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 #if PLATFORM(IOS)
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        [UIApplication.sharedApplication _registerInternalBSActionHandler:_WKWebsiteDataStoreBSActionHandler.shared];
+        [UIApplication.sharedApplication _registerBSActionHandler:_WKWebsiteDataStoreBSActionHandler.shared];
 
         if (!UNUserNotificationCenter.currentNotificationCenter.delegate) {
             static NeverDestroyed<RetainPtr<_WKWebsiteDataStoreNotificationCenterDelegate>> notificationDelegate = adoptNS([[_WKWebsiteDataStoreNotificationCenterDelegate alloc] init]);
@@ -1354,6 +1361,15 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 #else
     // FIXME: Implement for macOS
     UNUSED_PARAM(handler);
+#endif
+}
+
++ (BOOL)handleNotificationResponse:(UNNotificationResponse *)response
+{
+#if PLATFORM(IOS)
+    return [_WKWebsiteDataStoreBSActionHandler.shared handleNotificationResponse:response];
+#else
+    return NO;
 #endif
 }
 
@@ -1387,9 +1403,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 
 #if PLATFORM(IOS)
 
-@implementation _WKWebsiteDataStoreBSActionHandler {
-    BlockPtr<WKWebsiteDataStore *(_WKWebPushAction *)> _webPushActionHandler;
-}
+@implementation _WKWebsiteDataStoreBSActionHandler
 
 + (_WKWebsiteDataStoreBSActionHandler *)shared
 {
@@ -1403,38 +1417,25 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     _webPushActionHandler = handler;
 }
 
+- (BOOL)handleNotificationResponse:(UNNotificationResponse *)response
+{
+    RetainPtr<_WKWebPushAction> webPushAction = [_WKWebPushAction _webPushActionWithNotificationResponse:response];
+    if (!webPushAction)
+        return NO;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        WKWebsiteDataStore *dataStore = _WKWebsiteDataStoreBSActionHandler.shared->_webPushActionHandler.get()(webPushAction.get());
+        [dataStore _handleWebPushAction:webPushAction.get()];
+    });
+
+    return YES;
+}
+
 - (NSSet<BSAction *> *)_respondToApplicationActions:(NSSet<BSAction *> *)applicationActions fromTransitionContext:(FBSSceneTransitionContext *)transitionContext
 {
     RetainPtr unhandled = adoptNS([[NSMutableSet alloc] init]);
 
     for (BSAction *action in applicationActions) {
-        if (action.UIActionType == UIActionTypeNotificationResponse) {
-            // Try to pull out a notification response from the action
-            UNNotificationResponse *response = nil;
-            if ([action respondsToSelector:@selector(response)])
-                response = [action response];
-            if (!response || ![response isKindOfClass:[UNNotificationResponse class]]) {
-                [unhandled addObject:action];
-                continue;
-            }
-
-            RetainPtr<_WKWebPushAction> webPushAction = [_WKWebPushAction _webPushActionWithNotificationResponse:response];
-            if (!webPushAction) {
-                [unhandled addObject:action];
-                continue;
-            }
-
-            WKWebsiteDataStore *dataStore = _webPushActionHandler.get()(webPushAction.get());
-            [dataStore _handleWebPushAction:webPushAction.get()];
-
-            // Whether or not the data store truly handled the _WKWebPushAction, the BSAction definitely represents
-            // a web push notification activation, so we consume it.
-            if ([action canSendResponse])
-                [action sendResponse:nil];
-
-            continue;
-        }
-
         NSDictionary *object = [action.info objectForSetting:WebKit::WebPushD::pushActionSetting];
         _WKWebPushAction *pushAction = [_WKWebPushAction webPushActionWithDictionary:object];
         if (!pushAction) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -28,6 +28,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class UNNotificationResponse;
 @class WKSecurityOrigin;
 @class WKWebView;
 @class _WKResourceLoadStatisticsThirdParty;
@@ -150,6 +151,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 @property (nonatomic, readonly) NSString *_webPushPartition;
 
 + (void)_setWebPushActionHandler:(WKWebsiteDataStore *(^)(_WKWebPushAction *))handler WK_API_AVAILABLE(ios(WK_IOS_TBA));
++ (BOOL)handleNotificationResponse:(UNNotificationResponse *)response WK_API_AVAILABLE(ios(WK_IOS_TBA));
 
 @end
 


### PR DESCRIPTION
#### c22b64a0bc64c82042e780557fde3f38bbefb04e
<pre>
Use notification center delegate events to drive close and click events
<a href="https://rdar.apple.com/134990333">rdar://134990333</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278897">https://bugs.webkit.org/show_bug.cgi?id=278897</a>

Reviewed by Ben Nham.

Relying on the other mechanism for this required more work than is possible at this time.

This patch adds:
- SPI for clients to pass in UNNotificationResponse objects to be handled
- Changes the default notification center delegate to use that SPI for automatic handling
  in cases where the client doesn&apos;t have their own notification center delegate

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[_WKWebsiteDataStoreNotificationCenterDelegate userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:]):
(+[WKWebsiteDataStore handleNotificationResponse:]):
(-[_WKWebsiteDataStoreBSActionHandler handleNotificationResponse:]):
(-[_WKWebsiteDataStoreBSActionHandler _respondToApplicationActions:fromTransitionContext:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:

Canonical link: <a href="https://commits.webkit.org/283013@main">https://commits.webkit.org/283013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98ad0751aeed6f88370923092625ca0717df0b3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15531 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15813 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10715 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37626 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13373 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56243 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14332 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7318 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->