### PR TITLE
fast/forms/textfield-onchange-without-focus.html is flaky

### DIFF
--- a/LayoutTests/fast/forms/textfield-onchange-without-focus-expected.html
+++ b/LayoutTests/fast/forms/textfield-onchange-without-focus-expected.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <script>
-function test() {
+onload = async () => {
   const select = document.querySelector('select');
   select.setCustomValidity('validity');
   select.reportValidity();
@@ -9,14 +10,19 @@ function test() {
   textarea.setRangeText('lol');
   select.autofocus = true;
 
-  setTimeout(() => {
-    select.reportValidity();
-    textarea.blur();
-  }, 0);
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  select.reportValidity();
+  textarea.blur();
+
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>
-<body onload='test()'>
+<body>
   <p>The onchange should not be triggered by textarea when it got something changed without being focused. Pass if not crashed, and the focused select box is displayed.</p>
   <select></select>
   <textarea></textarea>
 </body>
+</html>

--- a/LayoutTests/fast/forms/textfield-onchange-without-focus.html
+++ b/LayoutTests/fast/forms/textfield-onchange-without-focus.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <script>
-function test() {
+onload = async () => {
   const select = document.querySelector('select');
   select.setCustomValidity('validity');
   select.reportValidity();
@@ -9,14 +10,19 @@ function test() {
   textarea.setRangeText('lol');
   select.autofocus = true;
 
-  setTimeout(() => {
-    select.reportValidity();
-    textarea.blur();
-  }, 0);
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  select.reportValidity();
+  textarea.blur();
+
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>
-<body onload='test()'>
+<body>
   <p>The onchange should not be triggered by textarea when it got something changed without being focused. Pass if not crashed, and the focused select box is displayed.</p>
   <select></select>
   <textarea onchange="document.all[2].appendChild(document.querySelector('select'));"></textarea>
 </body>
+</html>


### PR DESCRIPTION
#### 0d5917793679f4a7913286f34ad2eab3dbbfc093
<pre>
fast/forms/textfield-onchange-without-focus.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=278900">https://bugs.webkit.org/show_bug.cgi?id=278900</a>

Reviewed by Tim Nguyen.

This test was flaky for Windows port due to two reasons. This test was
using setTimeout without waitUntilDone or reftest-wait class of the
root element.

Because non-cocoa ports are using shadow DOM for the validity bubble,
we have to wait for the layout after reportValidity. Use
requestAnimationFrame to wait.

* LayoutTests/fast/forms/textfield-onchange-without-focus-expected.html:
* LayoutTests/fast/forms/textfield-onchange-without-focus.html:

Canonical link: <a href="https://commits.webkit.org/282952@main">https://commits.webkit.org/282952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/091f3f0e05c7725b88374d1ec0818f6996c0422a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56034 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14248 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70495 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13235 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56118 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/861 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39942 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->