### PR TITLE
Improve unexpected DCS ports array logging reliability

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -128,6 +128,10 @@ std::optional<ImageBufferBackendHandle> DynamicContentScalingImageBufferBackend:
                 String objectDescription { adoptCF(CFCopyDescription(port)).get() };
                 auto description = makeString("Unexpected type in DCS ports array: "_s, typeID, " "_s, typeDescription, " "_s, objectDescription);
                 logAndSetCrashLogMessage(description.utf8().data());
+
+                std::array<uint64_t, 6> values { 0, 0, 0, 0, 0, 0 };
+                strncpy(reinterpret_cast<char*>(values.data()), typeDescription.utf8().data(), sizeof(values));
+                CRASH_WITH_INFO(values[0], values[1], values[2], values[3], values[4], values[5]);
             }
             // We `create` instead of `adopt` because CAMachPort has no API to leak its reference.
             return { MachSendRight::create(CAMachPortGetPort(checked_cf_cast<CAMachPortRef>(port))) };


### PR DESCRIPTION
#### 271050047420ff49bcaaac35406c9da2928841bd
<pre>
Improve unexpected DCS ports array logging reliability
<a href="https://bugs.webkit.org/show_bug.cgi?id=278901">https://bugs.webkit.org/show_bug.cgi?id=278901</a>
<a href="https://rdar.apple.com/134994611">rdar://134994611</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::DynamicContentScalingImageBufferBackend::createBackendHandle const):
Adopt CRASH_WITH_INFO to improve the reliability of collection of the offending class name.

Canonical link: <a href="https://commits.webkit.org/282979@main">https://commits.webkit.org/282979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f5d0eeef03c0465b18b85565620a306e6f4d497

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52063 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10604 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32682 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37486 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70494 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59391 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56117 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59593 "Found 121 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.GeolocationBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PageLoadBasic, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/860 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39941 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->