### PR TITLE
[TextureMapper] acquireTextureFromPool should return a reference

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -49,7 +49,7 @@ BitmapTexturePool::BitmapTexturePool()
 {
 }
 
-RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
+Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
 {
     Entry* selectedEntry = std::find_if(m_textures.begin(), m_textures.end(),
         [&](Entry& entry) {
@@ -70,7 +70,7 @@ RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Opt
     scheduleReleaseUnusedTextures();
 
     selectedEntry->markIsInUse();
-    return selectedEntry->m_texture.copyRef();
+    return selectedEntry->m_texture;
 }
 
 void BitmapTexturePool::scheduleReleaseUnusedTextures()

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -40,19 +40,19 @@ class BitmapTexturePool {
 public:
     BitmapTexturePool();
 
-    RefPtr<BitmapTexture> acquireTexture(const IntSize&, OptionSet<BitmapTexture::Flags>);
+    Ref<BitmapTexture> acquireTexture(const IntSize&, OptionSet<BitmapTexture::Flags>);
     void releaseUnusedTexturesTimerFired();
 
 private:
     struct Entry {
-        explicit Entry(RefPtr<BitmapTexture>&& texture)
+        explicit Entry(Ref<BitmapTexture>&& texture)
             : m_texture(WTFMove(texture))
         { }
 
         void markIsInUse() { m_lastUsedTime = MonotonicTime::now(); }
         bool canBeReleased (MonotonicTime minUsedTime) const { return m_lastUsedTime < minUsedTime && m_texture->refCount() == 1; }
 
-        RefPtr<BitmapTexture> m_texture;
+        Ref<BitmapTexture> m_texture;
         MonotonicTime m_lastUsedTime;
     };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -184,7 +184,7 @@ TextureMapper::TextureMapper()
 {
 }
 
-RefPtr<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
+Ref<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
 {
     return m_texturePool.acquireTexture(size, flags);
 }
@@ -288,11 +288,11 @@ void TextureMapper::drawNumber(int number, const Color& color, const FloatPoint&
     IntRect sourceRect(IntPoint::zero(), size);
     IntRect targetRect(roundedIntPoint(targetPoint), size);
 
-    RefPtr<BitmapTexture> texture = m_texturePool.acquireTexture(size, { BitmapTexture::Flags::SupportsAlpha });
+    auto texture = m_texturePool.acquireTexture(size, { BitmapTexture::Flags::SupportsAlpha });
     const unsigned char* bits = cairo_image_surface_get_data(surface);
     int stride = cairo_image_surface_get_stride(surface);
     texture->updateContents(bits, sourceRect, IntPoint::zero(), stride);
-    drawTexture(*texture, targetRect, modelViewMatrix, 1.0f, AllEdgesExposed::Yes);
+    drawTexture(texture.get(), targetRect, modelViewMatrix, 1.0f, AllEdgesExposed::Yes);
 
     cairo_surface_destroy(surface);
     cairo_destroy(cr);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -89,7 +89,7 @@ public:
 
     RefPtr<BitmapTexture> applyFilters(RefPtr<BitmapTexture>&, const FilterOperations&, bool defersLastPass);
 
-    WEBCORE_EXPORT RefPtr<BitmapTexture> acquireTextureFromPool(const IntSize&, OptionSet<BitmapTexture::Flags>);
+    WEBCORE_EXPORT Ref<BitmapTexture> acquireTextureFromPool(const IntSize&, OptionSet<BitmapTexture::Flags>);
 
 #if USE(GRAPHICS_LAYER_WC)
     WEBCORE_EXPORT void releaseUnusedTexturesNow();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -749,7 +749,7 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
 {
     auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
-        SetForScope scopedSurface(options.surface, surface);
+        SetForScope scopedSurface(options.surface, surface.ptr());
         SetForScope scopedOffset(options.offset, -toIntSize(rect.location()));
         SetForScope scopedOpacity(options.opacity, 1);
 
@@ -757,22 +757,22 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
         paintSelfChildrenReplicaFilterAndMask(options);
     }
 
-    commitSurface(options, *surface, rect, options.opacity);
+    commitSurface(options, surface.get(), rect, options.opacity);
 }
 
 void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
 {
     auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
-        SetForScope scopedSurface(options.surface, surface);
+        SetForScope scopedSurface(options.surface, surface.ptr());
         SetForScope scopedOffset(options.offset, -toIntSize(rect.location()));
         SetForScope scopedOpacity(options.opacity, 1);
 
         paintIntoSurface(options);
-        surface = options.surface;
+        surface = Ref { *options.surface };
     }
 
-    commitSurface(options, *surface, rect, options.opacity);
+    commitSurface(options, surface.get(), rect, options.opacity);
 }
 
 void TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions& options)
@@ -848,7 +848,7 @@ void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& 
                 tileRect.intersect(rect);
                 auto surface = options.textureMapper.acquireTextureFromPool(tileRect.size(), { BitmapTexture::Flags::SupportsAlpha, BitmapTexture::Flags::DepthBuffer });
                 {
-                    SetForScope scopedSurface(options.surface, surface);
+                    SetForScope scopedSurface(options.surface, surface.ptr());
                     SetForScope scopedOffset(options.offset, -toIntSize(tileRect.location()));
                     SetForScope scopedOpacity(options.opacity, 1);
 
@@ -868,7 +868,7 @@ void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& 
                 options.holePunchRects.clear();
 
                 // And finally, blend the intermediate surface.
-                options.textureMapper.drawTexture(*surface, tileRect, { }, options.opacity);
+                options.textureMapper.drawTexture(surface.get(), tileRect, { }, options.opacity);
             }
         }
     }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -224,10 +224,6 @@ private:
 
     bool filtersCanBeComposited(const FilterOperations&) const;
 
-#if USE(SKIA)
-    RefPtr<BitmapTexture> acquireTextureForAcceleratedBuffer(const IntSize&);
-#endif
-
     Nicosia::PlatformLayer::LayerID m_id;
     GraphicsLayerTransform m_layerTransform;
     TransformationMatrix m_cachedInverseTransform;


### PR DESCRIPTION
#### 93fe71d1865c34ec840ccc10906ef2542b2e5aa1
<pre>
[TextureMapper] acquireTextureFromPool should return a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=278902">https://bugs.webkit.org/show_bug.cgi?id=278902</a>

Reviewed by Fujii Hironori.

It never returns nullptr.

* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
(WebCore::BitmapTexturePool::Entry::Entry):
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::acquireTextureFromPool):
(WebCore::TextureMapper::drawNumber):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintWithIntermediateSurface):
(WebCore::TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface):
(WebCore::TextureMapperLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:

Canonical link: <a href="https://commits.webkit.org/282955@main">https://commits.webkit.org/282955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a418f3ebda0eeffe383d621c3cab34065818c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68801 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/15384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/15384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67844 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14260 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8723 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8757 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/7198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9819 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39955 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->