### PR TITLE
[WebXR] Pass depth buffers to PlatformXRCoordinator to be used for reprojection

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -152,6 +152,7 @@ private:
     MachSendRight m_completionSyncEvent;
     uint64_t m_renderingFrameIndex { ~0u };
     bool m_usingFoveation { false };
+    bool m_blitDepth { false };
 #else
     PlatformGLObject m_colorTexture;
 #endif

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -166,6 +166,7 @@ private:
 
     Vector<PlatformXR::Device::ViewData> m_views;
     PlatformXR::FrameData m_frameData;
+    std::optional<PlatformXR::RequestData> m_requestData;
 
     double m_minimumInlineFOV { 0.0 };
     double m_maximumInlineFOV { piFloat };

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -654,7 +654,7 @@ WebXRSystem::DummyInlineDevice::DummyInlineDevice(ScriptExecutionContext& script
     setSupportedFeatures(XRSessionMode::Inline, { PlatformXR::SessionFeature::ReferenceSpaceTypeViewer });
 }
 
-void WebXRSystem::DummyInlineDevice::requestFrame(PlatformXR::Device::RequestFrameCallback&& callback)
+void WebXRSystem::DummyInlineDevice::requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&& callback)
 {
     if (!scriptExecutionContext())
         return;

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -124,7 +124,7 @@ private:
         void shutDownTrackingAndRendering() final { }
         void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final { }
 
-        void requestFrame(PlatformXR::Device::RequestFrameCallback&&) final;
+        void requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) final;
         Vector<Device::ViewData> views(XRSessionMode) const final;
         std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool) final { return std::nullopt; }
         void deleteLayer(PlatformXR::LayerHandle) final { }

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -432,7 +432,7 @@ public:
     TransformationMatrix to2dTransform() const;
     
     using FloatMatrix4 = std::array<float, 16>;
-    FloatMatrix4 toColumnMajorFloatArray() const;
+    WEBCORE_EXPORT FloatMatrix4 toColumnMajorFloatArray() const;
 
     // A local-space layer is implicitly defined at the z = 0 plane, with its front side
     // facing the positive z-axis (i.e. a camera looking along the negative z-axis sees

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -223,6 +223,15 @@ enum class HandJoint : unsigned {
 
 class TrackingAndRenderingClient;
 
+struct DepthRange {
+    float near { 0.1f };
+    float far { 1000.0f };
+};
+
+struct RequestData {
+    DepthRange depthRange;
+};
+
 struct FrameData {
     struct FloatQuaternion {
         float x { 0.0f };
@@ -294,6 +303,8 @@ struct FrameData {
         std::optional<LayerSetupData> layerSetup = { std::nullopt };
         uint64_t renderingFrameIndex { 0 };
         std::optional<ExternalTextureData> textureData;
+        // FIXME: <rdar://134998122> Remove when new CC lands.
+        bool requestDepth { false };
 #else
         WebCore::IntSize framebufferSize;
         PlatformGLObject opaqueTexture { 0 };
@@ -411,7 +422,7 @@ public:
     virtual Vector<ViewData> views(SessionMode) const = 0;
 
     using RequestFrameCallback = Function<void(FrameData&&)>;
-    virtual void requestFrame(RequestFrameCallback&&) = 0;
+    virtual void requestFrame(std::optional<RequestData>&&, RequestFrameCallback&&) = 0;
     virtual void submitFrame(Vector<Layer>&&) { };
 protected:
     Device() = default;

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -168,7 +168,7 @@ void OpenXRDevice::initializeReferenceSpace(PlatformXR::ReferenceSpaceType space
         updateStageParameters();
 }
 
-void OpenXRDevice::requestFrame(RequestFrameCallback&& callback)
+void OpenXRDevice::requestFrame(std::optional<RequestData>&&, RequestFrameCallback&& callback)
 {
     m_queue.dispatch([this, protectedThis = Ref { *this }, callback = WTFMove(callback)]() mutable {
         pollEvents();

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h
@@ -65,7 +65,7 @@ private:
     void shutDownTrackingAndRendering() final;
     void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final;
     bool supportsSessionShutdownNotification() const final { return true; }
-    void requestFrame(RequestFrameCallback&&) final;
+    void requestFrame(std::optional<RequestData>&&, RequestFrameCallback&&) final;
     void submitFrame(Vector<Device::Layer>&&) final;
     Vector<ViewData> views(SessionMode) const final;
     std::optional<LayerHandle> createLayerProjection(uint32_t width, uint32_t height, bool alpha) final;

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -193,7 +193,7 @@ void SimulatedXRDevice::frameTimerFired()
         m_FrameCallback(WTFMove(data));
 }
 
-void SimulatedXRDevice::requestFrame(RequestFrameCallback&& callback)
+void SimulatedXRDevice::requestFrame(std::optional<PlatformXR::RequestData>&&, RequestFrameCallback&& callback)
 {
     m_FrameCallback = WTFMove(callback);
     if (!m_frameTimer.isActive())

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -94,7 +94,7 @@ private:
     bool supportsSessionShutdownNotification() const final { return m_supportsShutdownNotification; }
     void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final { }
     Vector<PlatformXR::Device::ViewData> views(PlatformXR::SessionMode) const final;
-    void requestFrame(RequestFrameCallback&&) final;
+    void requestFrame(std::optional<PlatformXR::RequestData>&&, RequestFrameCallback&&) final;
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t width, uint32_t height, bool alpha) final;
     void deleteLayer(PlatformXR::LayerHandle) final;
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -819,6 +819,7 @@ def headers_for_type(type):
         'PlatformXR::FrameData': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::Layout': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::ReferenceSpaceType': ['<WebCore/PlatformXR.h>'],
+        'PlatformXR::RequestData': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::SessionFeature': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::SessionMode': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::VisibilityState': ['<WebCore/PlatformXR.h>'],

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -71,6 +71,16 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
     TransientPointer,
 };
 
+[Nested] struct PlatformXR::DepthRange {
+    float near;
+    float far;
+};
+
+header: <WebCore/PlatformXR.h>
+[CustomHeader] struct PlatformXR::RequestData {
+    PlatformXR::DepthRange depthRange;
+};
+
 [Nested] struct PlatformXR::FrameData::FloatQuaternion {
     float x;
     float y;
@@ -132,6 +142,7 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
     std::optional<PlatformXR::FrameData::LayerSetupData> layerSetup;
     uint64_t renderingFrameIndex;
     std::optional<PlatformXR::FrameData::ExternalTextureData> textureData;
+    bool requestDepth;
 #else
     WebCore::IntSize framebufferSize;
     PlatformGLObject opaqueTexture;

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -112,10 +112,10 @@ Vector<PlatformXR::Device::ViewData> XRDeviceProxy::views(SessionMode mode) cons
     return views;
 }
 
-void XRDeviceProxy::requestFrame(PlatformXR::Device::RequestFrameCallback&& callback)
+void XRDeviceProxy::requestFrame(std::optional<PlatformXR::RequestData>&& requestData, PlatformXR::Device::RequestFrameCallback&& callback)
 {
     if (m_xrSystem)
-        m_xrSystem->requestFrame(WTFMove(callback));
+        m_xrSystem->requestFrame(WTFMove(requestData), WTFMove(callback));
     else
         callback({ });
 }

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.h
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.h
@@ -61,7 +61,7 @@ private:
     bool supportsSessionShutdownNotification() const final { return true; }
     void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final { }
     Vector<PlatformXR::Device::ViewData> views(PlatformXR::SessionMode) const final;
-    void requestFrame(PlatformXR::Device::RequestFrameCallback&&) final;
+    void requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) final;
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool) final;
     void deleteLayer(PlatformXR::LayerHandle) override { };
     void submitFrame(Vector<PlatformXR::Device::Layer>&&) final;

--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -75,7 +75,7 @@ public:
     virtual void endSessionIfExists(WebPageProxy&) = 0;
 
     // Session display loop.
-    virtual void scheduleAnimationFrame(WebPageProxy&, PlatformXR::Device::RequestFrameCallback&&) = 0;
+    virtual void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) = 0;
     virtual void submitFrame(WebPageProxy&) { }
 };
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -183,7 +183,7 @@ void PlatformXRSystem::shutDownTrackingAndRendering()
     setImmersiveSessionState(ImmersiveSessionState::SessionEndingFromWebContent, [](bool) mutable { });
 }
 
-void PlatformXRSystem::requestFrame(CompletionHandler<void(PlatformXR::FrameData&&)>&& completionHandler)
+void PlatformXRSystem::requestFrame(std::optional<PlatformXR::RequestData>&& requestData, CompletionHandler<void(PlatformXR::FrameData&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
     MESSAGE_CHECK_COMPLETION(m_immersiveSessionState == ImmersiveSessionState::SessionRunning || m_immersiveSessionState == ImmersiveSessionState::SessionEndingFromSystem, completionHandler({ }));
@@ -193,7 +193,7 @@ void PlatformXRSystem::requestFrame(CompletionHandler<void(PlatformXR::FrameData
     }
 
     if (auto* xrCoordinator = PlatformXRSystem::xrCoordinator())
-        xrCoordinator->scheduleAnimationFrame(m_page, WTFMove(completionHandler));
+        xrCoordinator->scheduleAnimationFrame(m_page, WTFMove(requestData), WTFMove(completionHandler));
     else
         completionHandler({ });
 }

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -86,7 +86,7 @@ private:
     void requestPermissionOnSessionFeatures(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
     void initializeTrackingAndRendering();
     void shutDownTrackingAndRendering();
-    void requestFrame(CompletionHandler<void(PlatformXR::FrameData&&)>&&);
+    void requestFrame(std::optional<PlatformXR::RequestData>&&, CompletionHandler<void(PlatformXR::FrameData&&)>&&);
     void submitFrame();
     void didCompleteShutdownTriggeredBySystem();
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -31,7 +31,7 @@ messages -> PlatformXRSystem NotRefCounted {
     RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
     InitializeTrackingAndRendering()
     ShutDownTrackingAndRendering()
-    RequestFrame() -> (struct PlatformXR::FrameData frameData)
+    RequestFrame(std::optional<PlatformXR::RequestData> requestData) -> (struct PlatformXR::FrameData frameData)
     SubmitFrame()
     DidCompleteShutdownTriggeredBySystem()
 }

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -53,7 +53,7 @@ public:
     void startSession(WebPageProxy&, WeakPtr<SessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) override;
     void endSessionIfExists(WebPageProxy&) override;
 
-    void scheduleAnimationFrame(WebPageProxy&, PlatformXR::Device::RequestFrameCallback&&) override;
+    void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) override;
     void submitFrame(WebPageProxy&) override;
 
 protected:

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -189,7 +189,7 @@ void ARKitCoordinator::endSessionIfExists(WebPageProxy& page)
     endSessionIfExists(page.webPageIDInMainFrameProcess());
 }
 
-void ARKitCoordinator::scheduleAnimationFrame(WebPageProxy& page, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback)
+void ARKitCoordinator::scheduleAnimationFrame(WebPageProxy& page, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback)
 {
     RELEASE_LOG(XR, "ARKitCoordinator::scheduleAnimationFrame");
     WTF::switchOn(m_state,

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -91,9 +91,9 @@ void PlatformXRSystemProxy::didCompleteShutdownTriggeredBySystem()
     m_page.send(Messages::PlatformXRSystem::DidCompleteShutdownTriggeredBySystem());
 }
 
-void PlatformXRSystemProxy::requestFrame(PlatformXR::Device::RequestFrameCallback&& callback)
+void PlatformXRSystemProxy::requestFrame(std::optional<PlatformXR::RequestData>&& requestData, PlatformXR::Device::RequestFrameCallback&& callback)
 {
-    m_page.sendWithAsyncReply(Messages::PlatformXRSystem::RequestFrame(), WTFMove(callback));
+    m_page.sendWithAsyncReply(Messages::PlatformXRSystem::RequestFrame(WTFMove(requestData)), WTFMove(callback));
 }
 
 std::optional<PlatformXR::LayerHandle> PlatformXRSystemProxy::createLayerProjection(uint32_t, uint32_t, bool)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -59,7 +59,7 @@ public:
     void initializeTrackingAndRendering();
     void shutDownTrackingAndRendering();
     void didCompleteShutdownTriggeredBySystem();
-    void requestFrame(PlatformXR::Device::RequestFrameCallback&&);
+    void requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&);
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool);
     void submitFrame();
 


### PR DESCRIPTION
#### 901e3d24e8892975a8c746b2f899326325c4b5db
<pre>
[WebXR] Pass depth buffers to PlatformXRCoordinator to be used for reprojection
<a href="https://bugs.webkit.org/show_bug.cgi?id=278903">https://bugs.webkit.org/show_bug.cgi?id=278903</a>
<a href="https://rdar.apple.com/134998453">rdar://134998453</a>

Reviewed by Mike Wyrzykowski.

For the PlatformXRCoordinator to make use of the contents of the depth buffer
from WebGL rendering to perform re-projection of frames when the page misses the
presentation epoch, the coordinator needs to know the current depth range, which
representations the mapping from the near/far planes to the range supported by
the depth buffer.

The depth range can be changed via the WebXR API and needs to be passes via
XRDevice to the coordinator. This information is passes along with the
requestFrame API when ever new XRRenderState is applied.

Additionally, the hack to clear the depth buffers to FLT_MIN has been removed
from WebXROpaqueFramebuffer. |requestDepth| member of
|PlatformXR::FrameData::LayerData| represents a request from the coordinator for
scene depth to be presented via the passed depth textures.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::applyPendingRenderState):
(WebCore::WebXRSession::requestFrameIfNeeded):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::DummyInlineDevice::requestFrame):
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::requestFrame):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::requestFrame):
* Source/WebKit/Shared/XR/XRDeviceProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::requestFrame):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::requestFrame):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/283077@main">https://commits.webkit.org/283077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7d27ec260e121be18ecf5b3b070b48844ba907c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16033 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68211 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56392 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/64656 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37823 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14627 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9097 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56452 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1194 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9877 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40324 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->