### PR TITLE
[css-logical] split logical shorthand relative prioritization animation test off from css/css-logical/animation-001.html as a dedicated tentative test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001-expected.txt
@@ -7,7 +7,6 @@ PASS Logical properties in animations respect the direction
 PASS Physical properties win over logical properties in object notation
 PASS Physical properties win over logical properties in array notation
 PASS Physical properties with variables win over logical properties
-FAIL Logical shorthands follow the usual prioritization based on number of component longhands assert_equals: expected "300px" but got "0px"
 PASS Physical longhands win over logical shorthands
 PASS Logical longhands win over physical shorthands
 PASS Physical shorthands win over logical shorthands

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001.html
@@ -105,23 +105,6 @@ test(t => {
   const div = addDiv(t);
   const anim = div.animate(
     {
-      marginInlineStart: '100px',
-      marginInline: '200px',
-      margin: 'logical 300px',
-    },
-    { duration: 1, easing: 'step-start' }
-  );
-  assert_equals(getComputedStyle(div).marginLeft, '100px');
-  assert_equals(getComputedStyle(div).marginRight, '200px');
-  assert_equals(getComputedStyle(div).marginTop, '300px');
-  assert_equals(getComputedStyle(div).marginBottom, '300px');
-}, 'Logical shorthands follow the usual prioritization based on number of'
-   + ' component longhands');
-
-test(t => {
-  const div = addDiv(t);
-  const anim = div.animate(
-    {
       marginInline: '100px',
       marginLeft: '200px',
     },

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Logical shorthands follow the usual prioritization based on number of component longhands assert_equals: expected "300px" but got "0px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Logical shorthands follow the usual prioritization based on number of component longhands</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/#calculating-computed-keyframes">
+<meta name="assert" content="Shorthand properties with fewer longhand components override those with more longhand components (e.g. border-top overrides border-color).">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../css-animations/support/testcommon.js"></script>
+
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  const div = addDiv(t);
+  const anim = div.animate(
+    {
+      marginInlineStart: '100px',
+      marginInline: '200px',
+      margin: 'logical 300px',
+    },
+    { duration: 1, easing: 'step-start' }
+  );
+  assert_equals(getComputedStyle(div).marginLeft, '100px');
+  assert_equals(getComputedStyle(div).marginRight, '200px');
+  assert_equals(getComputedStyle(div).marginTop, '300px');
+  assert_equals(getComputedStyle(div).marginBottom, '300px');
+}, 'Logical shorthands follow the usual prioritization based on number of'
+   + ' component longhands');
+
+</script>


### PR DESCRIPTION
#### f87a80026fb4424c96649d7ae0fc73f18fe74480
<pre>
[css-logical] split logical shorthand relative prioritization animation test off from css/css-logical/animation-001.html as a dedicated tentative test
<a href="https://bugs.webkit.org/show_bug.cgi?id=278910">https://bugs.webkit.org/show_bug.cgi?id=278910</a>
<a href="https://rdar.apple.com/135006627">rdar://135006627</a>

Reviewed by Anne van Kesteren.

Given the `logical` keyword for the `margin` shorthand, and other relative shorthands, is not stable yet,
as discussed in <a href="https://github.com/w3c/csswg-drafts/issues/1282">https://github.com/w3c/csswg-drafts/issues/1282</a>, we split off the test in
`css/css-logical/animation-001.html` that relies on this feature and make a new test file marked `.tentative`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animation-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/282961@main">https://commits.webkit.org/282961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd293f9456699948dc2db9f712958b8143d8ebff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15385 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10617 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13422 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14261 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13255 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56131 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/878 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9821 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39956 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->