### PR TITLE
text-spacing: text-autospace: Fix computeInlineBoxBoundaryTextSpacingsIfNeeded to operate on InlineItemList before cached

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 namespace Layout {
 
-using InlineBoxBoundaryTextSpacings = WTF::HashMap<unsigned, float>;
+using InlineBoxBoundaryTextSpacings = WTF::HashMap<size_t, float, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
 // InlineContentCache is used to cache content for subsequent layouts.
 class InlineContentCache {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_INLINE(InlineContentCache);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -98,7 +98,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
         // FIXME: Add support for partial, yet paragraph level bidi content handling.
         breakAndComputeBidiLevels(inlineItemList);
     }
-    computeInlineBoxBoundaryTextSpacingsIfNeeded();
+    computeInlineBoxBoundaryTextSpacingsIfNeeded(inlineItemList);
     computeInlineTextItemWidths(inlineItemList);
 
     auto adjustInlineContentCacheWithNewInlineItems = [&] {
@@ -135,7 +135,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
 #endif
 }
 
-void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded()
+void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded(const InlineItemList& inlineItemList)
 {
     if (!m_hasTextAutospace)
         return;
@@ -146,7 +146,6 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded()
     InlineBoxBoundaryTextSpacings spacings;
     Vector<unsigned> inlineBoxStartIndexesOnInlineItemsList;
     bool processInlineBoxBoundary = false;
-    auto& inlineItemList = inlineContentCache().inlineItems().content();
     for (unsigned inlineItemIndex = 0; inlineItemIndex < inlineItemList.size(); ++inlineItemIndex) {
         auto& inlineItem = inlineItemList[inlineItemIndex];
         if (inlineItem.isInlineBoxStart()) {
@@ -753,7 +752,7 @@ void InlineItemsBuilder::computeInlineTextItemWidths(InlineItemList& inlineItemL
         auto needsMeasuring = length && !inlineTextItem->isZeroWidthSpaceSeparator();
         if (!needsMeasuring || !canCacheMeasuredWidthOnInlineTextItem(inlineTextBox, inlineTextItem->isWhitespace()))
             continue;
-        if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(inlineItemIndex); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
+        if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(inlineItemIndex - 1); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
             extraInlineTextSpacing = inlineBoxBoundaryTextSpacing->value;
 
         inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + length, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState) + extraInlineTextSpacing);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
@@ -61,7 +61,7 @@ private:
     
     bool contentRequiresVisualReordering() const { return m_contentRequiresVisualReordering; }
 
-    void computeInlineBoxBoundaryTextSpacingsIfNeeded();
+    void computeInlineBoxBoundaryTextSpacingsIfNeeded(const InlineItemList&);
 
     const ElementBox& root() const { return m_root; }
     InlineContentCache& inlineContentCache() { return m_inlineContentCache; }


### PR DESCRIPTION
#### a10f5772f6a2343c601e3a7982b193ec58641c5f
<pre>
text-spacing: text-autospace: Fix computeInlineBoxBoundaryTextSpacingsIfNeeded to operate on InlineItemList before cached
<a href="https://bugs.webkit.org/show_bug.cgi?id=278917">https://bugs.webkit.org/show_bug.cgi?id=278917</a>
<a href="https://rdar.apple.com/problem/135012026">rdar://problem/135012026</a>

Reviewed by Alan Baradlay.

This is yet another preparation patch for text-autospace implementation across element
boundaries.

At [1] we have implemented the Layout part of it, which we need to fix here:

InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded computes text spacing based on InlineItemList.
It currently uses the list cached as InlineContentCache, however, at that point in InlineItemsBuilder::build
we haven&apos;t yet cached such list. We need to use the list being prepared by ::build.

Our current HashMap for tracking such spacings (InlineBoxBoundaryTextSpacings) maps from Index to spacings.
Index can be 0 and in such cases HashMap needs traits for being able to differentiate between a empty key
and a 0-value key.

InlineBoxBoundaryTextSpacings maps using indexes of InlineStartBox on InlineItemList. This will be used
on future for moving the display box correspondent to the InlineStartBox to the &quot;logical right&quot;. However,
during Layout we don&apos;t have a notion of placement yet, so we make this spacing contribute to the
InlineTextItem&apos;s width instead, since the InlineStartBox&apos;s width is currently not taken into consideration
during layout.

* Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::build):
(WebCore::Layout::InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h:

Canonical link: <a href="https://commits.webkit.org/282999@main">https://commits.webkit.org/282999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffafaa823e7b70e29ec47bc742e230428904da52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52105 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67877 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32722 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14293 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59427 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56161 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14320 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7224 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39988 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->