### PR TITLE
Use NativePromise for WebCodecs encode/decode/flush methods

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -113,30 +113,27 @@ static ExceptionOr<VideoEncoder::Config> createVideoEncoderConfig(const WebCodec
     return VideoEncoder::Config { config.width, config.height, useAnnexB, config.bitrate.value_or(0), config.framerate.value_or(0), config.latencyMode == LatencyMode::Realtime, scalabilityMode };
 }
 
-bool WebCodecsVideoEncoder::updateRates(const WebCodecsVideoEncoderConfig& config)
+void WebCodecsVideoEncoder::updateRates(const WebCodecsVideoEncoderConfig& config)
 {
     auto bitrate = config.bitrate.value_or(0);
     auto framerate = config.framerate.value_or(0);
 
     m_isMessageQueueBlocked = true;
-    bool isChangingRatesSupported = m_internalEncoder->setRates(bitrate, framerate, [this, weakThis = WeakPtr { *this }, bitrate, framerate]() mutable {
+    protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_internalEncoder->setRates(bitrate, framerate), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, bitrate, framerate] (auto&&) mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
+        if (protectedThis->m_state == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
             return;
 
         if (bitrate)
-            m_baseConfiguration.bitrate = bitrate;
+            protectedThis->m_baseConfiguration.bitrate = bitrate;
         if (framerate)
-            m_baseConfiguration.framerate = framerate;
-        m_isMessageQueueBlocked = false;
-        processControlMessageQueue();
+            protectedThis->m_baseConfiguration.framerate = framerate;
+        protectedThis->m_isMessageQueueBlocked = false;
+        protectedThis->processControlMessageQueue();
     });
-    if (!isChangingRatesSupported)
-        m_isMessageQueueBlocked = false;
-    return isChangingRatesSupported;
 }
 
 ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& context, WebCodecsVideoEncoderConfig&& config)
@@ -152,11 +149,13 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
 
     if (m_internalEncoder) {
         queueControlMessageAndProcess({ *this, [this, config]() mutable {
-            if (isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config) && updateRates(config))
+            if (isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
+                updateRates(config);
                 return;
+            }
 
             m_isMessageQueueBlocked = true;
-            m_internalEncoder->flush([weakThis = ThreadSafeWeakPtr { *this }, config = WTFMove(config).isolatedCopy(), pendingActivity = takePendingWebCodecActivity()]() mutable {
+            protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_internalEncoder->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, config = WTFMove(config), pendingActivity = takePendingWebCodecActivity()] (auto&&) mutable {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
@@ -172,8 +171,10 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
 
     bool isSupportedCodec = isSupportedEncoderCodec(config.codec, context.settingsValues());
     queueControlMessageAndProcess({ *this, [this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
-        if (isSupportedCodec && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config) && updateRates(config))
+        if (isSupportedCodec && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
+            updateRates(config);
             return;
+        }
 
         m_isMessageQueueBlocked = true;
         VideoEncoder::PostTaskCallback postTaskCallback = [weakThis = ThreadSafeWeakPtr { *this }, identifier](auto&& task) {
@@ -283,18 +284,15 @@ ExceptionOr<void> WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&& frame
     queueControlMessageAndProcess({ *this, [this, internalFrame = internalFrame.releaseNonNull(), timestamp = frame->timestamp(), duration = frame->duration(), options = WTFMove(options)]() mutable {
         --m_encodeQueueSize;
         scheduleDequeueEvent();
-        m_internalEncoder->encode({ WTFMove(internalFrame), timestamp, duration }, options.keyFrame, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = takePendingWebCodecActivity()](String&& result) {
+
+        protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_internalEncoder->encode({ WTFMove(internalFrame), timestamp, duration }, options.keyFrame), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = takePendingWebCodecActivity()] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
-            ASSERT(protectedThis);
-            if (!protectedThis)
+            if (!protectedThis || !!result)
                 return;
 
-            if (!result.isNull()) {
-                if (RefPtr context = protectedThis->scriptExecutionContext())
-                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: "_s, result));
-                protectedThis->closeEncoder(Exception { ExceptionCode::EncodingError, WTFMove(result) });
-                return;
-            }
+            if (RefPtr context = protectedThis->scriptExecutionContext())
+                context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: "_s, result.error()));
+            protectedThis->closeEncoder(Exception { ExceptionCode::EncodingError, WTFMove(result.error()) });
         });
     } });
     return { };
@@ -309,7 +307,7 @@ void WebCodecsVideoEncoder::flush(Ref<DeferredPromise>&& promise)
 
     m_pendingFlushPromises.append(WTFMove(promise));
     queueControlMessageAndProcess({ *this, [this, clearFlushPromiseCount = m_clearFlushPromiseCount]() mutable {
-        m_internalEncoder->flush([weakThis = ThreadSafeWeakPtr { *this }, clearFlushPromiseCount, pendingActivity = takePendingWebCodecActivity()] {
+        protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_internalEncoder->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, clearFlushPromiseCount, pendingActivity = takePendingWebCodecActivity()] (auto&&) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || clearFlushPromiseCount != protectedThis->m_clearFlushPromiseCount)
                 return;
@@ -435,12 +433,14 @@ void WebCodecsVideoEncoder::processControlMessageQueue()
 
 void WebCore::WebCodecsVideoEncoder::suspend(ReasonForSuspension)
 {
-    // FIXME: Implement.
 }
 
 void WebCodecsVideoEncoder::stop()
 {
-    // FIXME: Implement.
+    m_state = WebCodecsCodecState::Closed;
+    m_internalEncoder = nullptr;
+    m_controlMessageQueue.clear();
+    m_pendingFlushPromises.clear();
 }
 
 bool WebCodecsVideoEncoder::virtualHasPendingActivity() const

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -102,7 +102,7 @@ private:
     void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoEncoder>&&);
     void processControlMessageQueue();
     WebCodecsEncodedVideoChunkMetadata createEncodedChunkMetadata(std::optional<unsigned>);
-    bool updateRates(const WebCodecsVideoEncoderConfig&);
+    void updateRates(const WebCodecsVideoEncoderConfig&);
 
     WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_encodeQueueSize { 0 };

--- a/Source/WebCore/platform/AudioDecoder.h
+++ b/Source/WebCore/platform/AudioDecoder.h
@@ -30,8 +30,7 @@
 
 #include <span>
 #include <wtf/CompletionHandler.h>
-#include <wtf/Expected.h>
-#include <wtf/Ref.h>
+#include <wtf/NativePromise.h>
 
 namespace WebCore {
 
@@ -70,10 +69,10 @@ public:
 
     static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    using DecodeCallback = Function<void(String&&)>;
-    virtual void decode(EncodedData&&, DecodeCallback&&) = 0;
+    using DecodePromise = NativePromise<void, String>;
+    virtual Ref<DecodePromise> decode(EncodedData&&) = 0;
 
-    virtual void flush(Function<void()>&&) = 0;
+    virtual Ref<GenericPromise> flush() = 0;
     virtual void reset() = 0;
     virtual void close() = 0;
 };

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -34,7 +34,7 @@
 #include "WebCodecsAudioInternalData.h"
 #include <span>
 #include <wtf/CompletionHandler.h>
-#include <wtf/Expected.h>
+#include <wtf/NativePromise.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -86,10 +86,10 @@ public:
 
     static void create(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    using EncodeCallback = Function<void(String&&)>;
-    virtual void encode(RawFrame&&, EncodeCallback&&) = 0;
+    using EncodePromise = NativePromise<void, String>;
+    virtual Ref<EncodePromise> encode(RawFrame&&) = 0;
 
-    virtual void flush(Function<void()>&&) = 0;
+    virtual Ref<GenericPromise> flush() = 0;
     virtual void reset() = 0;
     virtual void close() = 0;
 };

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -28,8 +28,7 @@
 #include "ProcessIdentity.h"
 #include <span>
 #include <wtf/CompletionHandler.h>
-#include <wtf/Expected.h>
-#include <wtf/Ref.h>
+#include <wtf/NativePromise.h>
 
 namespace WebCore {
 
@@ -74,10 +73,10 @@ public:
     static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
     WEBCORE_EXPORT static void createLocalDecoder(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    using DecodeCallback = Function<void(String&&)>;
-    virtual void decode(EncodedFrame&&, DecodeCallback&&) = 0;
+    using DecodePromise = NativePromise<void, String>;
+    virtual Ref<DecodePromise> decode(EncodedFrame&&) = 0;
 
-    virtual void flush(Function<void()>&&) = 0;
+    virtual Ref<GenericPromise> flush() = 0;
     virtual void reset() = 0;
     virtual void close() = 0;
 

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -32,7 +32,7 @@
 #include "VideoFrame.h"
 #include <span>
 #include <wtf/CompletionHandler.h>
-#include <wtf/Expected.h>
+#include <wtf/NativePromise.h>
 
 namespace WebCore {
 
@@ -77,12 +77,11 @@ public:
     static void create(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
     WEBCORE_EXPORT static void createLocalEncoder(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    using EncodeCallback = Function<void(String&&)>;
-    virtual void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) = 0;
+    using EncodePromise = NativePromise<void, String>;
+    virtual Ref<EncodePromise> encode(RawFrame&&, bool shouldGenerateKeyFrame) = 0;
 
-    // FIXME: Evaluate whether we can make it virtual pure and not return a boolean.
-    virtual bool setRates(uint64_t /* bitRate */, double /* frameRate */, Function<void()>&&) { return false; }
-    virtual void flush(Function<void()>&&) = 0;
+    virtual Ref<GenericPromise> setRates(uint64_t /* bitRate */, double /* frameRate */) = 0;
+    virtual Ref<GenericPromise> flush() = 0;
     virtual void reset() = 0;
     virtual void close() = 0;
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
@@ -40,8 +40,8 @@ public:
     ~GStreamerAudioDecoder();
 
 private:
-    void decode(EncodedData&&, DecodeCallback&&) final;
-    void flush(Function<void()>&&) final;
+    Ref<DecodePromise> decode(EncodedData&&) final;
+    Ref<GenericPromise> flush() final;
     void reset() final;
     void close() final;
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
@@ -40,8 +40,8 @@ public:
     ~GStreamerAudioEncoder();
 
 private:
-    void encode(RawFrame&&, EncodeCallback&&) final;
-    void flush(Function<void()>&&) final;
+    Ref<EncodePromise> encode(RawFrame&&) final;
+    Ref<GenericPromise> flush() final;
     void reset() final;
     void close() final;
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -379,7 +379,7 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
             auto durationInUs = duration.toTimeScale(1000000);
             DecodingPromise::Producer producer;
             auto promise = producer.promise();
-            m_videoDecoder->decode({ { byteCast<uint8_t>(data), size }, true, presentationTimeInUs.timeValue(), durationInUs.timeValue() }, [weakThis = ThreadSafeWeakPtr { *this }, this, duration = PAL::toCMTime(duration), producer = WTFMove(producer)](String&&) {
+            m_videoDecoder->decode({ { byteCast<uint8_t>(data), size }, true, presentationTimeInUs.timeValue(), durationInUs.timeValue() })->whenSettled(m_decompressionQueue.get(), [weakThis = ThreadSafeWeakPtr { *this }, this, duration = PAL::toCMTime(duration), producer = WTFMove(producer)] (auto&&) {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis || isInvalidated()) {
                     producer.reject(0);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
@@ -41,8 +41,8 @@ public:
     ~GStreamerVideoDecoder();
 
 private:
-    void decode(EncodedFrame&&, DecodeCallback&&) final;
-    void flush(Function<void()>&&) final;
+    Ref<DecodePromise> decode(EncodedFrame&&) final;
+    Ref<GenericPromise> flush() final;
     void reset() final;
     void close() final;
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
@@ -35,14 +35,15 @@ class GStreamerVideoEncoder : public VideoEncoder {
 public:
     static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    GStreamerVideoEncoder(DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    GStreamerVideoEncoder(const Config&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
     ~GStreamerVideoEncoder();
 
 private:
-    void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) final;
-    void flush(Function<void()>&&) final;
+    Ref<EncodePromise> encode(RawFrame&&, bool shouldGenerateKeyFrame) final;
+    Ref<GenericPromise> flush() final;
     void reset() final;
     void close() final;
+    Ref<GenericPromise> setRates(uint64_t bitRate, double frameRate) final;
 
     Ref<GStreamerInternalVideoEncoder> m_internalEncoder;
 };

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -52,8 +52,8 @@ public:
     ~LibWebRTCVPXVideoDecoder();
 
 private:
-    void decode(EncodedFrame&&, DecodeCallback&&) final;
-    void flush(Function<void()>&&) final;
+    Ref<DecodePromise> decode(EncodedFrame&&) final;
+    Ref<GenericPromise> flush() final;
     void reset() final;
     void close() final;
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -53,11 +53,11 @@ public:
 
 private:
     int initialize(LibWebRTCVPXVideoEncoder::Type, const VideoEncoder::Config&);
-    void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) final;
-    void flush(Function<void()>&&) final;
+    Ref<EncodePromise> encode(RawFrame&&, bool shouldGenerateKeyFrame) final;
+    Ref<GenericPromise> flush() final;
     void reset() final;
     void close() final;
-    bool setRates(uint64_t bitRate, double frameRate, Function<void()>&&) final;
+    Ref<GenericPromise> setRates(uint64_t bitRate, double frameRate) final;
 
     Ref<LibWebRTCVPXInternalVideoEncoder> m_internalEncoder;
 };

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -85,7 +85,7 @@ private:
 
     void createDecoder(VideoDecoderIdentifier, WebCore::VideoCodecType, const String& codecString, bool useRemoteFrames, bool enableAdditionalLogging, CompletionHandler<void(bool)>&&);
     void releaseDecoder(VideoDecoderIdentifier);
-    void flushDecoder(VideoDecoderIdentifier);
+    void flushDecoder(VideoDecoderIdentifier, CompletionHandler<void()>&&);
     void setDecoderFormatDescription(VideoDecoderIdentifier, std::span<const uint8_t>, uint16_t width, uint16_t height);
     void decodeFrame(VideoDecoderIdentifier, int64_t timeStamp, std::span<const uint8_t>, CompletionHandler<void(bool)>&&);
     void setFrameSize(VideoDecoderIdentifier, uint16_t width, uint16_t height);
@@ -95,7 +95,7 @@ private:
     void initializeEncoder(VideoEncoderIdentifier, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     void encodeFrame(VideoEncoderIdentifier, SharedVideoFrame&&, int64_t timeStamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame, CompletionHandler<void(bool)>&&);
     void flushEncoder(VideoEncoderIdentifier, CompletionHandler<void()>&&);
-    void setEncodeRates(VideoEncoderIdentifier, uint32_t bitRate, uint32_t frameRate);
+    void setEncodeRates(VideoEncoderIdentifier, uint32_t bitRate, uint32_t frameRate, CompletionHandler<void()>&&);
     void setSharedVideoFrameSemaphore(VideoEncoderIdentifier, IPC::Semaphore&&);
     void setSharedVideoFrameMemory(VideoEncoderIdentifier, WebCore::SharedMemory::Handle&&);
     void setRTCLoggingLevel(WTFLogLevel);

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -26,7 +26,7 @@
 messages -> LibWebRTCCodecsProxy NotRefCounted {
     CreateDecoder(WebKit::VideoDecoderIdentifier id, enum:uint8_t WebCore::VideoCodecType codecType, String codecString, bool useRemoteFrames, bool enableAdditionalLogging) -> (bool success);
     ReleaseDecoder(WebKit::VideoDecoderIdentifier id)
-    FlushDecoder(WebKit::VideoDecoderIdentifier id)
+    FlushDecoder(WebKit::VideoDecoderIdentifier id) -> ()
     SetDecoderFormatDescription(WebKit::VideoDecoderIdentifier id, std::span<const uint8_t> description, uint16_t width, uint16_t height)
     DecodeFrame(WebKit::VideoDecoderIdentifier id, int64_t timeStamp, std::span<const uint8_t> data) -> (bool success)
     SetFrameSize(WebKit::VideoDecoderIdentifier id, uint16_t width, uint16_t height)
@@ -36,7 +36,7 @@ messages -> LibWebRTCCodecsProxy NotRefCounted {
     InitializeEncoder(WebKit::VideoEncoderIdentifier id, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate)
     EncodeFrame(WebKit::VideoEncoderIdentifier id, struct WebKit::SharedVideoFrame buffer, int64_t timeStamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame) -> (bool success)
     FlushEncoder(WebKit::VideoEncoderIdentifier id) -> ()
-    SetEncodeRates(WebKit::VideoEncoderIdentifier id, uint32_t bitRate, uint32_t frameRate)
+    SetEncodeRates(WebKit::VideoEncoderIdentifier id, uint32_t bitRate, uint32_t frameRate) -> ()
     SetSharedVideoFrameSemaphore(WebKit::VideoEncoderIdentifier id, IPC::Semaphore semaphore)
     SetSharedVideoFrameMemory(WebKit::VideoEncoderIdentifier id, WebCore::SharedMemory::Handle storageHandle)
     SetRTCLoggingLevel(WTFLogLevel level)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
@@ -24,7 +24,6 @@
 
 messages -> LibWebRTCCodecs NotRefCounted {
     FailedDecoding(WebKit::VideoDecoderIdentifier identifier)
-    FlushDecoderCompleted(WebKit::VideoDecoderIdentifier identifier)
     CompletedDecoding(WebKit::VideoDecoderIdentifier identifier, int64_t timeStamp, int64_t timeStampNs, struct WebKit::RemoteVideoFrameProxyProperties frame)
     CompletedDecodingCV(WebKit::VideoDecoderIdentifier identifier, int64_t timeStamp, int64_t timeStampNs, RetainPtr<CVPixelBufferRef> pixelBuffer)
     CompletedEncoding(WebKit::VideoEncoderIdentifier identifier, std::span<const uint8_t> data, struct webrtc::WebKitEncodedFrameInfo info);


### PR DESCRIPTION
#### 39a1102365fe8338a6ee5082b47000ae8a1560e9
<pre>
Use NativePromise for WebCodecs encode/decode/flush methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=278909">https://bugs.webkit.org/show_bug.cgi?id=278909</a>
<a href="https://rdar.apple.com/135005637">rdar://135005637</a>

Reviewed by Philippe Normand and Jean-Yves Avenard.

We move all these methods to NativePromise as it is easier to read and is easier for maintenance.
For instance, the NativePromises are wrapped via ScriptExecutionContext::enqueueTaskWhenSettled so that
it is guaranteed for the callback to be executed and destroyed in the context thread.
This will allow us to use ActiveDOMObject pending activities as part of these callbacks in a follow-up.
Another step will be to migrate the create encoder/decoder methods to NativePromise as well.

* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::decode):
(WebCore::WebCodecsAudioDecoder::flush):
(WebCore::WebCore::WebCodecsAudioDecoder::suspend):
(WebCore::WebCodecsAudioDecoder::stop):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
(WebCore::WebCodecsAudioEncoder::encode):
(WebCore::WebCodecsAudioEncoder::flush):
(WebCore::WebCore::WebCodecsAudioEncoder::suspend):
(WebCore::WebCodecsAudioEncoder::stop):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
(WebCore::WebCore::WebCodecsVideoDecoder::suspend):
(WebCore::WebCodecsVideoDecoder::stop):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::updateRates):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCodecsVideoEncoder::flush):
(WebCore::WebCore::WebCodecsVideoEncoder::suspend):
(WebCore::WebCodecsVideoEncoder::stop):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/platform/AudioDecoder.h:
* Source/WebCore/platform/AudioEncoder.h:
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/VideoEncoder.h:
(WebCore::VideoEncoder::setRates): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerAudioDecoder::decode):
(WebCore::GStreamerAudioDecoder::flush):
(WebCore::GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder):
(WebCore::GStreamerInternalAudioDecoder::decode):
(WebCore::GStreamerInternalAudioDecoder::flush):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::encode):
(WebCore::GStreamerAudioEncoder::flush):
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
(WebCore::GStreamerInternalAudioEncoder::flush):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSample):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerVideoDecoder::decode):
(WebCore::GStreamerVideoDecoder::flush):
(WebCore::GStreamerInternalVideoDecoder::decode):
(WebCore::GStreamerInternalVideoDecoder::flush):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::GStreamerVideoEncoder):
(WebCore::GStreamerVideoEncoder::encode):
(WebCore::GStreamerVideoEncoder::flush):
(WebCore::GStreamerVideoEncoder::setRates):
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::initialize):
(WebCore::GStreamerInternalVideoEncoder::setRates):
(WebCore::GStreamerInternalVideoEncoder::applyRates):
(WebCore::GStreamerInternalVideoEncoder::flush):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXVideoDecoder::decode):
(WebCore::LibWebRTCVPXVideoDecoder::flush):
(WebCore::LibWebRTCVPXInternalVideoDecoder::decode):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::encode):
(WebCore::LibWebRTCVPXVideoEncoder::flush):
(WebCore::LibWebRTCVPXVideoEncoder::setRates):
(WebCore::LibWebRTCVPXInternalVideoEncoder::encode):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::flushDecoder):
(WebKit::LibWebRTCCodecsProxy::setEncodeRates):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoder::decode):
(WebKit::RemoteVideoDecoder::flush):
(WebKit::RemoteVideoEncoder::encode):
(WebKit::RemoteVideoEncoder::setRates):
(WebKit::RemoteVideoEncoder::flush):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::decodeVideoFrame):
(WebKit::LibWebRTCCodecs::flushDecoder):
(WebKit::LibWebRTCCodecs::sendFrameToDecode):
(WebKit::LibWebRTCCodecs::decodeWebRTCFrame):
(WebKit::LibWebRTCCodecs::decodeFrame):
(WebKit::LibWebRTCCodecs::decodeFrameInternal):
(WebKit::LibWebRTCCodecs::encodeFrameInternal):
(WebKit::LibWebRTCCodecs::encodeFrame):
(WebKit::LibWebRTCCodecs::flushEncoder):
(WebKit::LibWebRTCCodecs::setEncodeRates):
(WebKit::LibWebRTCCodecs::gpuProcessConnectionDidClose):
(WebKit::LibWebRTCCodecs::setDecoderConnection):
(WebKit::LibWebRTCCodecs::flushDecoderCompleted): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in:

Canonical link: <a href="https://commits.webkit.org/283145@main">https://commits.webkit.org/283145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f14058e7073d8c51cfc7ed05852a284a552f65fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52405 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70956 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59728 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60003 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1260 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->