### PR TITLE
[JSC] Upstream partial ARMv7 port of InPlaceInterpreter 1/?

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -158,6 +158,9 @@ const wasmInstance = csr0
 if X86_64 or ARM64 or ARM64E or RISCV64
     const memoryBase = csr3
     const boundsCheckingSize = csr4
+elsif ARMv7
+    const memoryBase = t2
+    const boundsCheckingSize = t3
 else
     const memoryBase = invalidGPR
     const boundsCheckingSize = invalidGPR
@@ -229,39 +232,6 @@ end
 
 macro advanceMCByReg(amount)
     addp amount, MC
-end
-
-# Typed push/pop to make code pretty
-macro pushFloat32FT0()
-    pushFPR()
-end
-
-macro pushFloat32FT1()
-    pushFPR1()
-end
-
-macro popFloat32FT0()
-    popFPR()
-end
-
-macro popFloat32FT1()
-    popFPR1()
-end
-
-macro pushFloat64FT0()
-    pushFPR()
-end
-
-macro pushFloat64FT1()
-    pushFPR1()
-end
-
-macro popFloat64FT0()
-    popFPR()
-end
-
-macro popFloat64FT1()
-    popFPR1()
 end
 
 macro decodeLEBVarUInt32(offset, dst, scratch1, scratch2, scratch3, scratch4)
@@ -568,7 +538,9 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     getIPIntCallee()
 
     # on x86, PL will hold the PC relative offset for argumINT, then IB will take over
-    initPCRelative(ipint_entry, PL)
+    if X86_64
+        initPCRelative(ipint_entry, PL)
+    end
     ipintEntry()
 else
     break

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -7,12 +7,10 @@
 macro saveIPIntRegisters()
     subp IPIntCalleeSaveSpaceStackAligned, sp
     store2ia MC, PC, -8[cfr]
-    storep wasmInstance, -16[cfr]
 end
 
 macro restoreIPIntRegisters()
     load2ia -8[cfr], MC, PC
-    loadp -16[cfr], wasmInstance
     addp IPIntCalleeSaveSpaceStackAligned, sp
 end
 
@@ -39,16 +37,58 @@ end
 # Stack operations
 # Every value on the stack is always 16 bytes! This makes life easy.
 
-macro pushQuad(reg)
-    break
+macro pushQuad(hi, lo)
+    if ARMv7
+        subp 16, sp
+        store2ia lo, hi, [sp]
+    else
+        break
+    end
 end
 
-macro pushQuadPair(reg1, reg2)
-    break
+macro pushDouble(reg)
+    if ARMv7
+        subp 16, sp
+        storei reg, [sp]
+    else
+        break
+    end
 end
 
-macro popQuad(reg, scratch)
-    break
+macro popQuad(hi, lo)
+    if ARMv7
+        load2ia [sp], lo, hi
+        addp 16, sp
+    else
+        break
+    end
+end
+
+macro popDouble(reg)
+    if ARMv7
+        loadi [sp], reg
+        addp 16, sp
+    else
+        break
+    end
+end
+
+macro pushFloat(reg)
+    if ARMv7
+        subp 16, sp
+        stored reg, [sp]
+    else
+        break
+    end
+end
+
+macro popFloat(reg)
+    if ARMv7
+        loadd [sp], reg
+        addp 16, sp
+    else
+        break
+    end
 end
 
 macro pushVectorReg0()
@@ -75,124 +115,205 @@ macro popVectorReg2()
     break
 end
 
-# Pushes ft0 because macros
-macro pushFPR()
-    break
+macro peekDouble(i, reg)
+    if ARMv7
+        loadi (i*16)[sp], reg
+    else
+        break
+    end
 end
 
-macro pushFPR1()
-    break
+macro drop()
+    addp StackValueSize, sp
 end
 
-macro popFPR()
-    break
-end
-
-macro popFPR1()
-    break
-end
-
-# Typed push/pop to make code pretty
+# Typed push/pop/peek to make code pretty
 
 macro pushInt32(reg)
-    break
+    pushDouble(reg)
 end
 
 macro popInt32(reg)
-    break
+    popDouble(reg)
 end
 
-macro pushInt64(reg)
-    break
+macro peekInt32(i, reg)
+    peekDouble(i, reg)
 end
 
-macro popInt64(reg, scratch)
-    break
+macro pushInt64(hi, lo)
+    pushQuad(hi, lo)
 end
 
-# Entry
+macro popInt64(hi, lo)
+    popQuad(hi, lo)
+end
 
-# PM = location in argumINT bytecode
+macro pushFloat32(reg)
+    pushFloat(reg)
+end
+
+macro popFloat32(reg)
+    popFloat(reg)
+end
+
+macro pushFloat64(reg)
+    pushFloat(reg)
+end
+
+macro popFloat64(reg)
+    popFloat(reg)
+end
+
+# Entering IPInt
+
+# MC = location in argumINT bytecode
 # csr1 = tmp
 # t4 = dst
 # t5 = src
 # t6 = end
 # t7 = for dispatch
 
-const argumINTDest = t4
+const argumINTTmp = csr1
+const argumINTDst = t4
 const argumINTSrc = t5
+const argumINTEnd = csr0 # clobbers wasmInstance/WI
+const argumINTDsp = t7
 
 macro ipintEntry()
-    checkStackOverflow(ws0, t6)
+    checkStackOverflow(ws0, argumINTTmp)
 
     # Allocate space for locals and rethrow values
-    load2ia Wasm::IPIntCallee::m_localSizeToAlloc[ws0], t7, t6
-    addp t6, t7
-    mulp LocalSize, t7
-    move sp, t6
-    subp t7, sp
-    move sp, t7
+    loadi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], argumINTTmp
+    loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], argumINTEnd
+    addp argumINTEnd, argumINTTmp
+    mulp LocalSize, argumINTTmp
+    move sp, argumINTEnd
+    subp argumINTTmp, sp
+    move sp, argumINTDsp
     loadp Wasm::IPIntCallee::m_argumINTBytecodePointer[ws0], MC
 
-    push csr1, t4, t5
+    push argumINTTmp, argumINTDst, argumINTSrc, argumINTEnd
 
-    move t7, argumINTDest
+    move argumINTDsp, argumINTDst
     leap FirstArgumentOffset[cfr], argumINTSrc
 
     argumINTDispatch()
 end
 
 macro argumINTDispatch()
-    loadb [MC], csr1
+    loadb [MC], argumINTTmp
     addp 1, MC
-    lshiftp 6, csr1
-    leap (_argumINT_begin + 1), t7
-    addp csr1, t7
-    emit "bx r9"
+    bbgteq argumINTTmp, 0x12, .err
+    lshiftp 6, argumINTTmp
+    leap (_argumINT_begin + 1), argumINTDsp
+    addp argumINTTmp, argumINTDsp
+    emit "bx r9" # argumINTDsp = t7 = r9
+.err:
+    break
 end
 
 macro argumINTInitializeDefaultLocals()
     # zero out remaining locals
-    bpeq argumINTDest, t6, .ipint_entry_finish_zero
-    break
+    bpeq argumINTDst, argumINTEnd, .ipint_entry_finish_zero
+    store2ia 0, 0, [argumINTDst]
+    addp 8, argumINTDst
 end
 
 macro argumINTFinish()
-    pop t5, t4, csr1
+    pop argumINTEnd, argumINTSrc, argumINTDst, argumINTTmp
+end
+
+# FFI Calls
+
+macro functionCall(fn)
+    # Save caller-save registers used by the interpreter
+    push MC, PL
+    fn()
+    pop PL, MC
 end
 
     #############################
     # 0x00 - 0x11: control flow #
     #############################
 
-unimplementedInstruction(_unreachable)
-unimplementedInstruction(_nop)
-unimplementedInstruction(_block)
-unimplementedInstruction(_loop)
-unimplementedInstruction(_if)
-unimplementedInstruction(_else)
+instructionLabel(_unreachable)
+    # unreachable
+    ipintException(Unreachable)
+
+instructionLabel(_nop)
+    # nop
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_block)
+    # block
+    loadi IPInt::BlockMetadata::deltaPC[MC], t0
+    loadi IPInt::BlockMetadata::deltaMC[MC], t1
+    advancePCByReg(t0)
+    advanceMCByReg(t1)
+    nextIPIntInstruction()
+
+instructionLabel(_loop)
+    # loop
+    ipintLoopOSR(1)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_if)
+    # if
+    popInt32(t0)
+    bpneq 0, t0, .ipint_if_taken
+    loadi IPInt::IfMetadata::elseDeltaPC[MC], t0
+    loadi IPInt::IfMetadata::elseDeltaMC[MC], t0
+    advancePCByReg(t0)
+    advanceMCByReg(t1)
+    nextIPIntInstruction()
+.ipint_if_taken:
+    # Skip LEB128
+    loadb IPInt::IfMetadata::instructionLength[MC], t0
+    advanceMC(constexpr (sizeof(IPInt::IfMetadata)))
+    advancePCByReg(t0)
+    nextIPIntInstruction()
+
+instructionLabel(_else)
+    # else
+    # Counterintuitively, we only run this instruction if the if
+    # clause is TAKEN. This is used to branch to the end of the
+    # block.
+    loadi IPInt::BlockMetadata::deltaPC[MC], t0
+    loadi IPInt::BlockMetadata::deltaMC[MC], t1
+    advancePCByReg(t0)
+    advanceMCByReg(t1)
+    nextIPIntInstruction()
+
 unimplementedInstruction(_try)
 unimplementedInstruction(_catch)
 unimplementedInstruction(_throw)
 unimplementedInstruction(_rethrow)
 unimplementedInstruction(_throw_ref)
 
+# MC = location in uINT bytecode
+# csr1 = tmp # clobbers PC
+# t7 = for dispatch
 
 macro uintDispatch()
-    loadb [MC], t6
+    loadb [MC], csr1
     addp 1, MC
-    bilt t6, 5, .safe
+    bilt csr1, 0x12, .safe
     break
 .safe:
-    lshiftp 6, t6
+    lshiftp 6, csr1
     leap (_uint_begin + 1), t7
-    addp t6, t7
+    addp csr1, t7
     # t7 = r9
     emit "bx r9"
 end
 
 instructionLabel(_end)
-    #loadp UnboxedWasmCalleeStackSlot[cfr], ws0
+    loadp UnboxedWasmCalleeStackSlot[cfr], ws0
     loadi Wasm::IPIntCallee::m_bytecodeEnd[ws0], t0
     bpeq PC, t0, .ipint_end_ret
     advancePC(1)
@@ -200,14 +321,139 @@ instructionLabel(_end)
 .ipint_end_ret:
     loadp Wasm::IPIntCallee::m_uINTBytecodePointer[ws0], MC
     ipintEpilogueOSR(10)
+    loadp Wasm::IPIntCallee::m_highestReturnStackOffset[ws0], sc0
+    addp cfr, sc0
     uintDispatch()
 
-unimplementedInstruction(_br)
-unimplementedInstruction(_br_if)
-unimplementedInstruction(_br_table)
-unimplementedInstruction(_return)
-unimplementedInstruction(_call)
-unimplementedInstruction(_call_indirect)
+instructionLabel(_br)
+    # br
+    # number to pop
+    loadh IPInt::BranchTargetMetadata::toPop[MC], t0
+    # number to keep
+    loadh IPInt::BranchTargetMetadata::toKeep[MC], t5
+
+    # ex. pop 3 and keep 2
+    #
+    # +4 +3 +2 +1 sp
+    # a  b  c  d  e
+    # d  e
+    #
+    # [sp + k + numToPop] = [sp + k] for k in numToKeep-1 -> 0
+    move t0, t2
+    lshiftp 4, t2
+    leap [sp, t2], t2
+
+.ipint_br_poploop:
+    bpeq t5, 0, .ipint_br_popend
+    subp 1, t5
+    move t5, t3
+    lshiftp 4, t3
+    load2ia [sp, t3], t0, t1
+    store2ia t0, t1, [t2, t3]
+    load2ia 8[sp, t3], t0, t1
+    store2ia t0, t1, 8[t2, t3]
+    jmp .ipint_br_poploop
+.ipint_br_popend:
+    loadh IPInt::BranchTargetMetadata::toPop[MC], t0
+    lshiftp 4, t0
+    leap [sp, t0], sp
+    loadi IPInt::BlockMetadata::deltaPC[MC], t0
+    loadi IPInt::BlockMetadata::deltaMC[MC], t1
+    advancePCByReg(t0)
+    advanceMCByReg(t1)
+    nextIPIntInstruction()
+
+instructionLabel(_br_if)
+    # pop i32
+    popInt32(t0)
+    bineq t0, 0, _ipint_br
+    loadb IPInt::BranchMetadata::instructionLength[MC], t0
+    advanceMC(constexpr (sizeof(IPInt::BranchMetadata)))
+    advancePCByReg(t0)
+    nextIPIntInstruction()
+
+instructionLabel(_br_table)
+    # br_table
+    popInt32(t0)
+    loadi IPInt::SwitchMetadata::size[MC], t1
+    advanceMC(constexpr (sizeof(IPInt::SwitchMetadata)))
+    bib t0, t1, .ipint_br_table_clamped
+    subp t1, 1, t0
+.ipint_br_table_clamped:
+    move t0, t1
+    lshiftp 3, t0
+    lshiftp 2, t1
+    addp t1, t0
+    addp t0, MC
+    jmp _ipint_br
+
+instructionLabel(_return)
+    loadp UnboxedWasmCalleeStackSlot[cfr], ws0
+    # ret
+    loadi Wasm::IPIntCallee::m_bytecodeEnd[ws0], PC
+    loadp Wasm::IPIntCallee::m_uINTBytecode[ws0], MC
+    # This is guaranteed going to an end instruction, so skip
+    # dispatch and end of program check for speed
+    jmp .ipint_end_ret
+
+const IPIntCallCallee = sc1
+const IPIntCallFunctionSlot = sc0
+
+instructionLabel(_call)
+    loadp Wasm::IPIntCallee::m_bytecode[ws0], t0
+    move PC, t1
+    subp t0, t1
+    storei t1, CallSiteIndex[cfr]
+
+    loadb IPInt::CallMetadata::length[MC], t0
+    advancePCByReg(t0)
+
+    # get function index
+    loadb IPInt::CallMetadata::functionIndex[MC], a1
+    advanceMC(IPInt::CallMetadata::signature)
+
+    subp 16, sp
+    move sp, a2
+
+    # operation returns the entrypoint in r0 and the target instance in r1
+    # operation stores the target callee to sp[0] and target function info to sp[1]
+    operationCall(macro() cCall3(_ipint_extern_prepare_call) end)
+    loadp [sp], IPIntCallCallee
+    loadp 8[sp], IPIntCallFunctionSlot
+    addp 16, sp
+
+    # call
+    jmp .ipint_call_common
+
+instructionLabel(_call_indirect)
+    loadp Wasm::IPIntCallee::m_bytecode[ws0], t0
+    move PC, t1
+    subp t0, t1
+    storei t1, CallSiteIndex[cfr]
+
+    loadb IPInt::CallIndirectMetadata::length[MC], t2
+    advancePCByReg(t2)
+
+    # Get function index by pointer, use it as a return for callee
+    move sp, a2
+
+    # Get callIndirectMetadata
+    move cfr, a1
+    move MC, a3
+    advanceMC(IPInt::CallIndirectMetadata::signature)
+
+    operationCall(macro() cCall4(_ipint_extern_prepare_call_indirect) end)
+    btpz r1, .ipint_call_indirect_throw
+
+    loadp [sp], IPIntCallCallee
+    loadp 8[sp], IPIntCallFunctionSlot
+    addp 16, sp
+
+    jmp .ipint_call_common
+
+.ipint_call_indirect_throw:
+    jmp _wasm_throw_from_slow_path_trampoline
+
 unimplementedInstruction(_return_call)
 unimplementedInstruction(_return_call_indirect)
 unimplementedInstruction(_call_ref)
@@ -216,8 +462,27 @@ reservedOpcode(0x16)
 reservedOpcode(0x17)
 unimplementedInstruction(_delegate)
 unimplementedInstruction(_catch_all)
-unimplementedInstruction(_drop)
-unimplementedInstruction(_select)
+
+instructionLabel(_drop)
+    drop()
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_select)
+    popInt32(t0)
+    bieq t0, 0, .ipint_select_val2
+    drop()
+    advancePC(1)
+    advanceMC(8)
+    nextIPIntInstruction()
+.ipint_select_val2:
+    popQuad(t1, t0)
+    drop()
+    pushQuad(t1, t0)
+    advancePC(1)
+    advanceMC(8)
+    nextIPIntInstruction()
+
 unimplementedInstruction(_select_t)
 reservedOpcode(0x1d)
 reservedOpcode(0x1e)
@@ -227,186 +492,1874 @@ unimplementedInstruction(_try_table)
     # 0x20 - 0x26: get and set values #
     ###################################
 
-unimplementedInstruction(_local_get)
-unimplementedInstruction(_local_set)
-unimplementedInstruction(_local_tee)
-unimplementedInstruction(_global_get)
-unimplementedInstruction(_global_set)
+instructionLabel(_local_get)
+    # local.get
+    loadb 1[PC], t0
+    advancePC(2)
+    bbaeq t0, 128, _ipint_local_get_slow_path
+.ipint_local_get_post_decode:
+    # Index into locals
+    mulp LocalSize, t0
+    load2ia [PL, t0], t0, t1
+    # Push to stack
+    pushQuad(t1, t0)
+    nextIPIntInstruction()
+
+instructionLabel(_local_set)
+    # local.set
+    loadb 1[PC], t0
+    advancePC(2)
+    bbaeq t0, 128, _ipint_local_set_slow_path
+.ipint_local_set_post_decode:
+    # Pop from stack
+    popQuad(t3, t2)
+    # Store to locals
+    mulp LocalSize, t0
+    store2ia t2, t3, [PL, t0]
+    nextIPIntInstruction()
+
+instructionLabel(_local_tee)
+    # local.tee
+    loadb 1[PC], t0
+    advancePC(2)
+    bbaeq t0, 128, _ipint_local_tee_slow_path
+.ipint_local_tee_post_decode:
+    # Load from stack
+    load2ia [sp], t3, t2
+    # Store to locals
+    mulp LocalSize, t0
+    store2ia t2, t3, [PL, t0]
+    nextIPIntInstruction()
+
+instructionLabel(_global_get)
+    # Load pre-computed index from metadata
+    loadb IPInt::GlobalMetadata::bindingMode[MC], t2
+    loadi IPInt::GlobalMetadata::index[MC], t1
+    loadp CodeBlock[cfr], t0
+    loadp JSWebAssemblyInstance::m_globals[t0], t0
+    lshiftp 1, t1
+    load2ia [t0, t1, 8], t0, t1
+    bieq t2, 0, .ipint_global_get_embedded
+    load2ia [t0], t0, t1
+.ipint_global_get_embedded:
+    pushQuad(t1, t0)
+
+    loadb IPInt::GlobalMetadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::GlobalMetadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_global_set)
+    # isRef = 1 => ref, use slowpath
+    loadb IPInt::GlobalMetadata::isRef[MC], t0
+    bineq t0, 0, .ipint_global_set_refpath
+    # bindingMode = 1 => portable
+    loadb IPInt::GlobalMetadata::bindingMode[MC], t5
+    # get global addr
+    loadp CodeBlock[cfr], t0
+    loadp JSWebAssemblyInstance::m_globals[t0], t0
+    # get value to store
+    popQuad(t3, t2)
+    # get index
+    loadi IPInt::GlobalMetadata::index[MC], t1
+    lshiftp 1, t1
+    bieq t5, 0, .ipint_global_set_embedded
+    # portable: dereference then set
+    loadp [t0, t1, 8], t0
+    store2ia t2, t3, [t0]
+    loadb IPInt::GlobalMetadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::GlobalMetadata)))
+    nextIPIntInstruction()
+.ipint_global_set_embedded:
+    # embedded: set directly
+    store2ia t2, t3, [t0, t1, 8]
+    loadb IPInt::GlobalMetadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::GlobalMetadata)))
+    nextIPIntInstruction()
+
+.ipint_global_set_refpath:
+    loadi IPInt::GlobalMetadata::index[MC], a1
+    # Pop from stack
+    popQuad(a2, a3)
+    operationCall(macro() cCall4(_ipint_extern_set_global_ref) end)
+
+    loadb IPInt::GlobalMetadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::GlobalMetadata)))
+    nextIPIntInstruction()
+
 unimplementedInstruction(_table_get)
 unimplementedInstruction(_table_set)
 reservedOpcode(0x27)
-unimplementedInstruction(_i32_load_mem)
-unimplementedInstruction(_i64_load_mem)
-unimplementedInstruction(_f32_load_mem)
-unimplementedInstruction(_f64_load_mem)
-unimplementedInstruction(_i32_load8s_mem)
-unimplementedInstruction(_i32_load8u_mem)
-unimplementedInstruction(_i32_load16s_mem)
-unimplementedInstruction(_i32_load16u_mem)
-unimplementedInstruction(_i64_load8s_mem)
-unimplementedInstruction(_i64_load8u_mem)
-unimplementedInstruction(_i64_load16s_mem)
-unimplementedInstruction(_i64_load16u_mem)
-unimplementedInstruction(_i64_load32s_mem)
-unimplementedInstruction(_i64_load32u_mem)
-unimplementedInstruction(_i32_store_mem)
-unimplementedInstruction(_i64_store_mem)
-unimplementedInstruction(_f32_store_mem)
-unimplementedInstruction(_f64_store_mem)
-unimplementedInstruction(_i32_store8_mem)
-unimplementedInstruction(_i32_store16_mem)
-unimplementedInstruction(_i64_store8_mem)
-unimplementedInstruction(_i64_store16_mem)
-unimplementedInstruction(_i64_store32_mem)
+
+macro ipintWithMemory()
+    loadp CodeBlock[cfr], t3
+    load2ia JSWebAssemblyInstance::m_cachedMemory[t3], memoryBase, boundsCheckingSize
+end
+
+# NB: mutates mem to be mem + offset, clobbers offset
+macro ipintMaterializePtrAndCheckMemoryBound(mem, offset, size)
+    addps offset, mem
+    bcs .outOfBounds
+    addps size - 1, mem, offset
+    bcs .outOfBounds
+    bpb offset, boundsCheckingSize, .continuation
+.outOfBounds:
+    ipintException(OutOfBoundsMemoryAccess)
+.continuation:
+end
+
+instructionLabel(_i32_load_mem)
+    # i32.load
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 4)
+    # load memory location
+    loadi [memoryBase, t0], t1
+    pushInt32(t1)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load_mem)
+    # i32.load
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 8)
+    # load memory location
+    load2ia [memoryBase, t0], t0, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_f32_load_mem)
+    # f32.load
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 4)
+    # load memory location
+    loadi [memoryBase, t0], t0 # NB: can be unaligned, hence loadi, fi2f instead of loadf (VLDR)
+    fi2f t0, ft0
+    pushFloat32(ft0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_f64_load_mem)
+    # f64.load
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 8)
+    # load memory location
+    load2ia [memoryBase, t0], t0, t1 # NB: can be unaligned, hence loadi, fii2d instead of loadd
+    fii2d t0, t1, ft0
+    pushFloat64(ft0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_load8s_mem)
+    # i32.load8_s
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadb [memoryBase, t0], t1
+    sxb2i t1, t1
+    pushInt32(t1)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_load8u_mem)
+    # i32.load8_u
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadb [memoryBase, t0], t1
+    pushInt32(t1)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_load16s_mem)
+    # i32.load16_s
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 2)
+    # load memory location
+    loadh [memoryBase, t0], t1
+    sxh2i t1, t1
+    pushInt32(t1)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_load16u_mem)
+    # i32.load16_u
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 2)
+    # load memory location
+    loadh [memoryBase, t0], t1
+    pushInt32(t1)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load8s_mem)
+    # i64.load8_s
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadb [memoryBase, t0], t0
+    sxb2i t0, t0
+    rshifti t0, 31, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load8u_mem)
+    # i64.load8_u
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadb [memoryBase, t0], t0
+    move 0, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load16s_mem)
+    # i64.load16_s
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadh [memoryBase, t0], t0
+    sxh2i t0, t0
+    rshifti t0, 31, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load16u_mem)
+    # i64.load16_u
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadh [memoryBase, t0], t0
+    move 0, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load32s_mem)
+    # i64.load32_s
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadi [memoryBase, t0], t0
+    rshifti t0, 31, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_load32u_mem)
+    # i64.load8_s
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 1)
+    # load memory location
+    loadi [memoryBase, t0], t0
+    move 0, t1
+    pushInt64(t1, t0)
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_store_mem)
+    # i32.store
+    # pop data
+    popInt32(t0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 4)
+    # store at memory location
+    storei t0, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_store_mem)
+    # i64.store
+    # peek index
+    peekInt32(1, t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 8)
+    # pop data
+    popInt64(t1, t0)
+    # drop index
+    drop()
+    # store at memory location
+    store2ia t0, t1, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_f32_store_mem)
+    # f32.store
+    # pop data
+    popFloat32(ft0)
+    # pop index
+    popInt32(t0)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t0, t1, 4)
+    # store at memory location
+    ff2i ft0, t1 # NB: can be unaligned, hence ff2i, storei instead of storef (VSTR)
+    storei t1, [memoryBase, t0]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_f64_store_mem)
+    # f64.store
+    # pop data
+    popFloat64(ft0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 8)
+    # store at memory location
+    fd2ii ft0, t0, t1 # NB: can be unaligned, hence fd2ii, store2ia instead of stored
+    store2ia t0, t1, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_store8_mem)
+    # i32.store8
+    # pop data
+    popInt32(t0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 1)
+    # store at memory location
+    storeb t0, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i32_store16_mem)
+    # i32.store16
+    # pop data
+    popInt32(t0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 2)
+    # store at memory location
+    storeh t0, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_store8_mem)
+    # i64.store8
+    # pop data
+    popInt32(t0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 1)
+    # store at memory location
+    storeb t0, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_store16_mem)
+    # i64.store16
+    # pop data
+    popInt32(t0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 2)
+    # store at memory location
+    storeh t0, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_store32_mem)
+    # i64.store32
+    # pop data
+    popInt32(t0)
+    # pop index
+    popInt32(t5)
+    loadi IPInt::Const32Metadata::value[MC], t1
+    ipintWithMemory()
+    ipintMaterializePtrAndCheckMemoryBound(t5, t1, 4)
+    # store at memory location
+    storei t0, [memoryBase, t5]
+
+    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
 unimplementedInstruction(_memory_size)
-unimplementedInstruction(_memory_grow)
+
+instructionLabel(_memory_grow)
+    popInt32(a1)
+    operationCall(macro() cCall2(_ipint_extern_memory_grow) end)
+    pushInt32(r0)
+    ipintReloadMemory()
+    advancePC(2)
+    nextIPIntInstruction()
 
     ################################
     # 0x41 - 0x44: constant values #
     ################################
 
-unimplementedInstruction(_i32_const)
-unimplementedInstruction(_i64_const)
-unimplementedInstruction(_f32_const)
-unimplementedInstruction(_f64_const)
+instructionLabel(_i32_const)
+    # i32.const
+    loadb IPInt::InstructionLengthMetadata::length[MC], t1
+    bigteq t1, 2, .ipint_i32_const_slowpath
+    loadb 1[PC], t0
+    lshifti 7, t1
+    ori t1, t0
+    sxb2i t0, t0
+    pushInt32(t0)
+    advancePC(2)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    nextIPIntInstruction()
+.ipint_i32_const_slowpath:
+    # Load pre-computed value from metadata
+    loadi IPInt::Const32Metadata::value[MC], t0
+    # Push to stack
+    pushInt32(t0)
+
+    advancePCByReg(t1)
+    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_i64_const)
+    # i64.const
+    # Load pre-computed value from metadata
+    load2ia IPInt::Const64Metadata::value[MC], t0, t1
+    # Push to stack
+    pushInt64(t1, t0)
+    loadb IPInt::Const64Metadata::instructionLength[MC], t0
+
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::Const64Metadata)))
+    nextIPIntInstruction()
+
+instructionLabel(_f32_const)
+    # f32.const
+    # Load pre-computed value from metadata
+    loadi 1[PC], t0 # NB: can be unaligned, hence loadi, fi2f instead of loadf (VLDR)
+    fi2f t0, ft0
+    pushFloat32(ft0)
+
+    advancePC(5)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_const)
+    # f64.const
+    # Load pre-computed value from metadata
+    load2ia 1[PC], t0, t1 # NB: can be unaligned, hence loadi, fii2d instead of loadd
+    fii2d t0, t1, ft0
+    pushFloat64(ft0)
+
+    advancePC(9)
+    nextIPIntInstruction()
 
     ###############################
     # 0x45 - 0x4f: i32 comparison #
     ###############################
 
-unimplementedInstruction(_i32_eqz)
-unimplementedInstruction(_i32_eq)
-unimplementedInstruction(_i32_ne)
-unimplementedInstruction(_i32_lt_s)
-unimplementedInstruction(_i32_lt_u)
-unimplementedInstruction(_i32_gt_s)
-unimplementedInstruction(_i32_gt_u)
-unimplementedInstruction(_i32_le_s)
-unimplementedInstruction(_i32_le_u)
-unimplementedInstruction(_i32_ge_s)
-unimplementedInstruction(_i32_ge_u)
+instructionLabel(_i32_eqz)
+    # i32.eqz
+    popInt32(t0)
+    cieq t0, 0, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_eq)
+    # i32.eq
+    popInt32(t1)
+    popInt32(t0)
+    cieq t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_ne)
+    # i32.ne
+    popInt32(t1)
+    popInt32(t0)
+    cineq t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_lt_s)
+    # i32.lt_s
+    popInt32(t1)
+    popInt32(t0)
+    cilt t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_lt_u)
+    # i32.lt_u
+    popInt32(t1)
+    popInt32(t0)
+    cib t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_gt_s)
+    # i32.gt_s
+    popInt32(t1)
+    popInt32(t0)
+    cigt t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_gt_u)
+    # i32.gt_u
+    popInt32(t1)
+    popInt32(t0)
+    cia t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_le_s)
+    # i32.le_s
+    popInt32(t1)
+    popInt32(t0)
+    cilteq t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_le_u)
+    # i32.le_u
+    popInt32(t1)
+    popInt32(t0)
+    cibeq t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_ge_s)
+    # i32.ge_s
+    popInt32(t1)
+    popInt32(t0)
+    cigteq t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_ge_u)
+    # i32.ge_u
+    popInt32(t1)
+    popInt32(t0)
+    ciaeq t0, t1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x50 - 0x5a: i64 comparison #
     ###############################
 
-unimplementedInstruction(_i64_eqz)
-unimplementedInstruction(_i64_eq)
-unimplementedInstruction(_i64_ne)
-unimplementedInstruction(_i64_lt_s)
-unimplementedInstruction(_i64_lt_u)
-unimplementedInstruction(_i64_gt_s)
-unimplementedInstruction(_i64_gt_u)
-unimplementedInstruction(_i64_le_s)
-unimplementedInstruction(_i64_le_u)
-unimplementedInstruction(_i64_ge_s)
-unimplementedInstruction(_i64_ge_u)
+instructionLabel(_i64_eqz)
+    # i64.eqz
+    popInt64(t1, t0)
+    move 0, t2
+    btinz t1, .ipint_i64_eqz_return
+    cieq t0, 0, t2
+.ipint_i64_eqz_return:
+    pushInt32(t2)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_eq)
+    # i64.eq
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 0, t5
+    bineq t1, t3, .ipint_i64_eq_return
+    cieq t0, t2, t5
+.ipint_i64_eq_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_ne)
+    # i64.ne
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bineq t1, t3, .ipint_i64_ne_return
+    cineq t0, t2, t5
+.ipint_i64_ne_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_lt_s)
+    # i64.lt_s
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bilt t1, t3, .ipint_i64_lt_s_return
+    move 0, t5
+    bigt t1, t3, .ipint_i64_lt_s_return
+    cib t0, t2, t5
+.ipint_i64_lt_s_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_lt_u)
+    # i64.lt_u
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bib t1, t3, .ipint_i64_lt_u_return
+    move 0, t5
+    bia t1, t3, .ipint_i64_lt_u_return
+    cib t0, t2, t5
+.ipint_i64_lt_u_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_gt_s)
+    # i64.gt_s
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bigt t1, t3, .ipint_i64_gt_s_return
+    move 0, t5
+    bilt t1, t3, .ipint_i64_gt_s_return
+    cia t0, t2, t5
+.ipint_i64_gt_s_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_gt_u)
+    # i64.gt_u
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bia t1, t3, .ipint_i64_gt_u_return
+    move 0, t5
+    bib t1, t3, .ipint_i64_gt_u_return
+    cia t0, t2, t5
+.ipint_i64_gt_u_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_le_s)
+    # i64.le_s
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bilt t1, t3, .ipint_i64_le_s_return
+    move 0, t5
+    bigt t1, t3, .ipint_i64_le_s_return
+    cibeq t0, t2, t5
+.ipint_i64_le_s_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_le_u)
+    # i64.le_u
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bib t1, t3, .ipint_i64_le_u_return
+    move 0, t5
+    bia t1, t3, .ipint_i64_le_u_return
+    cibeq t0, t2, t5
+.ipint_i64_le_u_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_ge_s)
+    # i64.ge_s
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 1, t5
+    bigt t1, t3, .ipint_i64_ge_s_return
+    move 0, t5
+    bilt t1, t3, .ipint_i64_ge_s_return
+    ciaeq t0, t2, t5
+.ipint_i64_ge_s_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_ge_u)
+    # i64.ge_u
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    move 0, t5
+    bib t1, t3, .ipint_i64_ge_u_return
+    move 1, t5
+    bia t1, t3, .ipint_i64_ge_u_return
+    ciaeq t0, t2, t5
+.ipint_i64_ge_u_return:
+    pushInt32(t5)
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x5b - 0x60: f32 comparison #
     ###############################
 
-unimplementedInstruction(_f32_eq)
-unimplementedInstruction(_f32_ne)
-unimplementedInstruction(_f32_lt)
-unimplementedInstruction(_f32_gt)
-unimplementedInstruction(_f32_le)
-unimplementedInstruction(_f32_ge)
+instructionLabel(_f32_eq)
+    # f32.eq
+    popFloat32(ft1)
+    popFloat32(ft0)
+    cfeq ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_ne)
+    # f32.ne
+    popFloat32(ft1)
+    popFloat32(ft0)
+    cfnequn ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_lt)
+    # f32.lt
+    popFloat32(ft1)
+    popFloat32(ft0)
+    cflt ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_gt)
+    # f32.gt
+    popFloat32(ft1)
+    popFloat32(ft0)
+    cfgt ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_le)
+    # f32.le
+    popFloat32(ft1)
+    popFloat32(ft0)
+    cflteq ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_ge)
+    # f32.ge
+    popFloat32(ft1)
+    popFloat32(ft0)
+    cfgteq ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x61 - 0x66: f64 comparison #
     ###############################
 
-unimplementedInstruction(_f64_eq)
-unimplementedInstruction(_f64_ne)
-unimplementedInstruction(_f64_lt)
-unimplementedInstruction(_f64_gt)
-unimplementedInstruction(_f64_le)
-unimplementedInstruction(_f64_ge)
+instructionLabel(_f64_eq)
+    # f64.eq
+    popFloat64(ft1)
+    popFloat64(ft0)
+    cdeq ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_ne)
+    # f64.ne
+    popFloat64(ft1)
+    popFloat64(ft0)
+    cdnequn ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_lt)
+    # f64.lt
+    popFloat64(ft1)
+    popFloat64(ft0)
+    cdlt ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_gt)
+    # f64.gt
+    popFloat64(ft1)
+    popFloat64(ft0)
+    cdgt ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_le)
+    # f64.le
+    popFloat64(ft1)
+    popFloat64(ft0)
+    cdlteq ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_ge)
+    # f64.ge
+    popFloat64(ft1)
+    popFloat64(ft0)
+    cdgteq ft0, ft1, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x67 - 0x78: i32 operations #
     ###############################
 
-unimplementedInstruction(_i32_clz)
-unimplementedInstruction(_i32_ctz)
-unimplementedInstruction(_i32_popcnt)
-unimplementedInstruction(_i32_add)
-unimplementedInstruction(_i32_sub)
-unimplementedInstruction(_i32_mul)
-unimplementedInstruction(_i32_div_s)
-unimplementedInstruction(_i32_div_u)
-unimplementedInstruction(_i32_rem_s)
-unimplementedInstruction(_i32_rem_u)
-unimplementedInstruction(_i32_and)
-unimplementedInstruction(_i32_or)
-unimplementedInstruction(_i32_xor)
-unimplementedInstruction(_i32_shl)
-unimplementedInstruction(_i32_shr_s)
-unimplementedInstruction(_i32_shr_u)
-unimplementedInstruction(_i32_rotl)
-unimplementedInstruction(_i32_rotr)
+instructionLabel(_i32_clz)
+    # i32.clz
+    popInt32(t0)
+    lzcnti t0, t1
+    pushInt32(t1)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_ctz)
+    # i32.ctz
+    popInt32(t0)
+    tzcnti t0, t1
+    pushInt32(t1)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_popcnt)
+    # i32.popcnt
+    popInt32(t1)
+    operationCall(macro() cCall2(_slow_path_wasm_popcount) end)
+    pushInt32(r1)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_add)
+    # i32.add
+    popInt32(t1)
+    popInt32(t0)
+    addi t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_sub)
+    # i32.sub
+    popInt32(t1)
+    popInt32(t0)
+    subi t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_mul)
+    # i32.mul
+    popInt32(t1)
+    popInt32(t0)
+    muli t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_div_s)
+    # i32.div_s
+    popInt32(t1)
+    popInt32(t0)
+    btiz t1, .ipint_i32_div_s_throwDivisionByZero
+
+    bineq t1, -1, .ipint_i32_div_s_safe
+    bieq t0, constexpr INT32_MIN, .ipint_i32_div_s_throwIntegerOverflow
+
+.ipint_i32_div_s_safe:
+    functionCall(macro () cCall2(_i32_div_s) end)
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i32_div_s_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+.ipint_i32_div_s_throwIntegerOverflow:
+    ipintException(IntegerOverflow)
+
+instructionLabel(_i32_div_u)
+    # i32.div_u
+    popInt32(t1)
+    popInt32(t0)
+    btiz t1, .ipint_i32_div_u_throwDivisionByZero
+
+    functionCall(macro () cCall2(_i32_div_u) end)
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i32_div_u_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+instructionLabel(_i32_rem_s)
+    # i32.rem_s
+    popInt32(t1)
+    popInt32(t0)
+
+    btiz t1, .ipint_i32_rem_s_throwDivisionByZero
+
+    bineq t1, -1, .ipint_i32_rem_s_safe
+    bineq t0, constexpr INT32_MIN, .ipint_i32_rem_s_safe
+
+    move 0, t0
+    jmp .ipint_i32_rem_s_return
+
+.ipint_i32_rem_s_safe:
+    functionCall(macro () cCall2(_i32_rem_s) end)
+
+.ipint_i32_rem_s_return:
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i32_rem_s_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+instructionLabel(_i32_rem_u)
+    # i32.rem_u
+    popInt32(t1)
+    popInt32(t0)
+    btiz t1, .ipint_i32_rem_u_throwDivisionByZero
+
+    functionCall(macro () cCall2(_i32_rem_u) end)
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i32_rem_u_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+instructionLabel(_i32_and)
+    # i32.and
+    popInt32(t1)
+    popInt32(t0)
+    andi t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_or)
+    # i32.or
+    popInt32(t1)
+    popInt32(t0)
+    ori t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_xor)
+    # i32.xor
+    popInt32(t1)
+    popInt32(t0)
+    xori t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_shl)
+    # i32.shl
+    popInt32(t1)
+    popInt32(t0)
+    lshifti t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_shr_s)
+    # i32.shr_s
+    popInt32(t1)
+    popInt32(t0)
+    rshifti t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_shr_u)
+    # i32.shr_u
+    popInt32(t1)
+    popInt32(t0)
+    urshifti t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_rotl)
+    # i32.rotl
+    popInt32(t1)
+    popInt32(t0)
+    lrotatei t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_rotr)
+    # i32.rotr
+    popInt32(t1)
+    popInt32(t0)
+    rrotatei t1, t0
+    pushInt32(t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x79 - 0x8a: i64 operations #
     ###############################
 
-unimplementedInstruction(_i64_clz)
-unimplementedInstruction(_i64_ctz)
-unimplementedInstruction(_i64_popcnt)
-unimplementedInstruction(_i64_add)
-unimplementedInstruction(_i64_sub)
-unimplementedInstruction(_i64_mul)
-unimplementedInstruction(_i64_div_s)
-unimplementedInstruction(_i64_div_u)
-unimplementedInstruction(_i64_rem_s)
-unimplementedInstruction(_i64_rem_u)
-unimplementedInstruction(_i64_and)
-unimplementedInstruction(_i64_or)
-unimplementedInstruction(_i64_xor)
-unimplementedInstruction(_i64_shl)
-unimplementedInstruction(_i64_shr_s)
-unimplementedInstruction(_i64_shr_u)
-unimplementedInstruction(_i64_rotl)
-unimplementedInstruction(_i64_rotr)
+instructionLabel(_i64_clz)
+    # i64.clz
+    popInt64(t1, t0)
+    btiz t1, .ipint_i64_clz_bottom
+
+    lzcnti t1, t0
+    jmp .ipint_i64_clz_return
+
+.ipint_i64_clz_bottom:
+    lzcnti t0, t0
+    addi 32, t0
+
+.ipint_i64_clz_return:
+    move 0, t1
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_ctz)
+    # i64.ctz
+    popInt64(t1, t0)
+    btiz t0, .ipint_i64_ctz_top
+
+    tzcnti t0, t0
+    jmp .ipint_i64_ctz_return
+
+.ipint_i64_ctz_top:
+    tzcnti t1, t0
+    addi 32, t0
+
+.ipint_i64_ctz_return:
+    move 0, t1
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_popcnt)
+    # i64.popcnt
+    popInt64(t3, t2)
+    operationCall(macro() cCall2(_slow_path_wasm_popcountll) end)
+    move 0, t0
+    pushInt64(t0, r1)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_add)
+    # i64.add
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    addis t2, t0
+    adci  t3, t1
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_sub)
+    # i64.sub
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    subis t2, t0
+    sbci  t3, t1
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_mul)
+    # i64.mul
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    muli t2, t1
+    muli t0, t3
+    umulli t0, t2, t0, t2
+    addi t1, t2
+    addi t3, t2
+    pushInt64(t2, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_div_s)
+    # i64.div_s
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    btinz t3, .ipint_i64_div_s_nonZero
+    btiz t2, .ipint_i64_div_s_throwDivisionByZero
+
+.ipint_i64_div_s_nonZero:
+    bineq t3, -1, .ipint_i64_div_s_safe
+    bineq t2, -1, .ipint_i64_div_s_safe
+    bineq t1, constexpr INT32_MIN, .ipint_i64_div_s_safe
+    btiz t0, .ipint_i64_div_s_throwIntegerOverflow
+
+.ipint_i64_div_s_safe:
+    functionCall(macro () cCall4(_i64_div_s) end)
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i64_div_s_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+.ipint_i64_div_s_throwIntegerOverflow:
+    ipintException(IntegerOverflow)
+
+instructionLabel(_i64_div_u)
+    # i64.div_u
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    btinz t3, .ipint_i64_div_u_nonZero
+    btiz t2, .ipint_i64_div_u_throwDivisionByZero
+
+.ipint_i64_div_u_nonZero:
+    functionCall(macro () cCall4(_i64_div_u) end)
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i64_div_u_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+instructionLabel(_i64_rem_s)
+    # i64.rem_s
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    btinz t3, .ipint_i64_rem_s_nonZero
+    btiz t2, .ipint_i64_rem_s_throwDivisionByZero
+
+.ipint_i64_rem_s_nonZero:
+    bineq t3, -1, .ipint_i64_rem_s_safe
+    bineq t2, -1, .ipint_i64_rem_s_safe
+    bineq t1, constexpr INT32_MIN, .ipint_i64_rem_s_safe
+
+    move 0, t1
+    move 0, t0
+    jmp .ipint_i64_rem_s_return
+
+.ipint_i64_rem_s_safe:
+    functionCall(macro () cCall4(_i64_rem_s) end)
+
+.ipint_i64_rem_s_return:
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i64_rem_s_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+instructionLabel(_i64_rem_u)
+    # i64.rem_u
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    btinz t3, .ipint_i64_rem_u_nonZero
+    btiz t2, .ipint_i64_rem_u_throwDivisionByZero
+
+.ipint_i64_rem_u_nonZero:
+    functionCall(macro () cCall4(_i64_rem_u) end)
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_i64_rem_u_throwDivisionByZero:
+    ipintException(DivisionByZero)
+
+instructionLabel(_i64_and)
+    # i64.and
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    andi t3, t1
+    andi t2, t0
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_or)
+    # i64.or
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    ori t3, t1
+    ori t2, t0
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_xor)
+    # i64.xor
+    popInt64(t3, t2)
+    popInt64(t1, t0)
+    xori t3, t1
+    xori t2, t0
+    pushInt64(t1, t0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_shl)
+    # i64.shl
+    popInt32(t2)
+    popInt64(t1, t0)
+    andi 0x3f, t2
+    btiz t2, .ipint_i64_shl_return
+    bib t2, 32, .ipint_i64_lessThan32
+
+    subi 32, t2
+    lshifti t0, t2, t1
+    move 0, t0
+    jmp .ipint_i64_shl_return
+
+.ipint_i64_lessThan32:
+    lshifti t2, t1
+    move 32, t3
+    subi t2, t3
+    urshifti t0, t3, t3
+    ori t3, t1
+    lshifti t2, t0
+
+.ipint_i64_shl_return:
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_shr_s)
+    # i64.shr_s
+    popInt32(t2)
+    popInt64(t1, t0)
+    andi 0x3f, t2
+    btiz t2, .ipint_i64_shr_s_return
+    bib t2, 32, .ipint_i64_shr_s_lessThan32
+
+    subi 32, t2
+    rshifti t1, t2, t0
+    rshifti 31, t1
+    jmp .ipint_i64_shr_s_return
+
+.ipint_i64_shr_s_lessThan32:
+    urshifti t2, t0
+    move 32, t3
+    subi t2, t3
+    lshifti t1, t3, t3
+    ori t3, t0
+    rshifti t2, t1
+
+.ipint_i64_shr_s_return:
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_shr_u)
+    # i64.shr_u
+    popInt32(t2)
+    popInt64(t1, t0)
+    andi 0x3f, t2
+    btiz t2, .ipint_i64_shr_u_return
+    bib t2, 32, .ipint_i64_shr_u_lessThan32
+
+    subi 32, t2
+    urshifti t1, t2, t0
+    move 0, t1
+    jmp .ipint_i64_shr_u_return
+
+.ipint_i64_shr_u_lessThan32:
+    urshifti t2, t0
+    move 32, t3
+    subi t2, t3
+    lshifti t1, t3, t3
+    ori t3, t0
+    urshifti t2, t1
+
+.ipint_i64_shr_u_return:
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_rotl)
+    # i64.rotl
+    popInt32(t2)
+    popInt64(t1, t0)
+    andi t2, 0x20, t3
+    btiz t3, .ipint_i64_rotl_noSwap
+
+    move t0, t3
+    move t1, t0
+    move t3, t1
+
+.ipint_i64_rotl_noSwap:
+    andi 0x1f, t2
+    btiz t2, .ipint_i64_rotl_return
+
+    move 32, t5
+    subi t2, t5
+    urshifti t0, t5, t3
+    urshifti t1, t5, t5
+    lshifti t2, t0
+    lshifti t2, t1
+    ori t5, t0
+    ori t3, t1
+
+.ipint_i64_rotl_return:
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_rotr)
+    # i64.rotr
+    popInt32(t2)
+    popInt64(t1, t0)
+    andi t2, 0x20, t3
+    btiz t3, .ipint_i64_rotr_noSwap
+
+    move t0, t3
+    move t1, t0
+    move t3, t1
+
+.ipint_i64_rotr_noSwap:
+    andi 0x1f, t2
+    btiz t2, .ipint_i64_rotr_return
+
+    move 32, t5
+    subi t2, t5
+    lshifti t0, t5, t3
+    lshifti t1, t5, t5
+    urshifti t2, t0
+    urshifti t2, t1
+    ori t5, t0
+    ori t3, t1
+
+.ipint_i64_rotr_return:
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x8b - 0x98: f32 operations #
     ###############################
 
-unimplementedInstruction(_f32_abs)
-unimplementedInstruction(_f32_neg)
-unimplementedInstruction(_f32_ceil)
-unimplementedInstruction(_f32_floor)
-unimplementedInstruction(_f32_trunc)
-unimplementedInstruction(_f32_nearest)
-unimplementedInstruction(_f32_sqrt)
-unimplementedInstruction(_f32_add)
-unimplementedInstruction(_f32_sub)
-unimplementedInstruction(_f32_mul)
-unimplementedInstruction(_f32_div)
-unimplementedInstruction(_f32_min)
-unimplementedInstruction(_f32_max)
-unimplementedInstruction(_f32_copysign)
+instructionLabel(_f32_abs)
+    # f32.abs
+    popFloat32(ft0)
+    absf ft0, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_neg)
+    # f32.neg
+    popFloat32(ft0)
+    negf ft0, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_ceil)
+    # f32.ceil
+    popFloat32(ft0)
+    functionCall(macro () cCall2(_ceilFloat) end)
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_floor)
+    # f32.floor
+    popFloat32(ft0)
+    functionCall(macro () cCall2(_floorFloat) end)
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_trunc)
+    # f32.trunc
+    popFloat32(ft0)
+    functionCall(macro () cCall2(_truncFloat) end)
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_nearest)
+    # f32.nearest
+    popFloat32(ft0)
+    functionCall(macro () cCall2(_f32_nearest) end)
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_sqrt)
+    # f32.sqrt
+    popFloat32(ft0)
+    sqrtf ft0, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_add)
+    # f32.add
+    popFloat32(ft1)
+    popFloat32(ft0)
+    addf ft1, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_sub)
+    # f32.sub
+    popFloat32(ft1)
+    popFloat32(ft0)
+    subf ft1, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_mul)
+    # f32.mul
+    popFloat32(ft1)
+    popFloat32(ft0)
+    mulf ft1, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_div)
+    # f32.div
+    popFloat32(ft1)
+    popFloat32(ft0)
+    divf ft1, ft0
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_min)
+    # f32.min
+    popFloat32(ft1)
+    popFloat32(ft0)
+    bfeq ft0, ft1, .ipint_f32_min_equal
+    bflt ft0, ft1, .ipint_f32_min_lt
+    bfgt ft0, ft1, .ipint_f32_min_return
+
+.ipint_f32_min_NaN:
+    addf ft0, ft1
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_f32_min_equal:
+    orf ft0, ft1
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_f32_min_lt:
+    moved ft0, ft1
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_f32_min_return:
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_max)
+    # f32.max
+    popFloat32(ft1)
+    popFloat32(ft0)
+
+    bfeq ft1, ft0, .ipint_f32_max_equal
+    bflt ft1, ft0, .ipint_f32_max_lt
+    bfgt ft1, ft0, .ipint_f32_max_return
+
+.ipint_f32_max_NaN:
+    addf ft0, ft1
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_f32_max_equal:
+    andf ft0, ft1
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_f32_max_lt:
+    moved ft0, ft1
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+.ipint_f32_max_return:
+    pushFloat32(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f32_copysign)
+    # f32.copysign
+    popFloat32(ft1)
+    popFloat32(ft0)
+
+    ff2i ft1, t1
+    move 0x80000000, t2
+    andi t2, t1
+
+    ff2i ft0, t0
+    move 0x7fffffff, t2
+    andi t2, t0
+
+    ori t1, t0
+    fi2f t0, ft0
+
+    pushFloat32(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
 
     ###############################
     # 0x99 - 0xa6: f64 operations #
     ###############################
 
-unimplementedInstruction(_f64_abs)
-unimplementedInstruction(_f64_neg)
-unimplementedInstruction(_f64_ceil)
-unimplementedInstruction(_f64_floor)
-unimplementedInstruction(_f64_trunc)
-unimplementedInstruction(_f64_nearest)
-unimplementedInstruction(_f64_sqrt)
-unimplementedInstruction(_f64_add)
-unimplementedInstruction(_f64_sub)
-unimplementedInstruction(_f64_mul)
-unimplementedInstruction(_f64_div)
-unimplementedInstruction(_f64_min)
-unimplementedInstruction(_f64_max)
-unimplementedInstruction(_f64_copysign)
+instructionLabel(_f64_abs)
+    # f64.abs
+    popFloat64(ft0)
+    absd ft0, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_neg)
+    # f64.neg
+    popFloat64(ft0)
+    negd ft0, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_ceil)
+    # f64.ceil
+    popFloat64(ft0)
+    functionCall(macro () cCall2(_ceilDouble) end)
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_floor)
+    # f64.floor
+    popFloat64(ft0)
+    functionCall(macro () cCall2(_floorDouble) end)
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_trunc)
+    # f64.trunc
+    popFloat64(ft0)
+    functionCall(macro () cCall2(_truncDouble) end)
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_nearest)
+    # f64.nearest
+    popFloat64(ft0)
+    functionCall(macro () cCall2(_f64_nearest) end)
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_sqrt)
+    # f64.sqrt
+    popFloat64(ft0)
+    sqrtd ft0, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_add)
+    # f64.add
+    popFloat64(ft1)
+    popFloat64(ft0)
+    addd ft1, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_sub)
+    # f64.sub
+    popFloat64(ft1)
+    popFloat64(ft0)
+    subd ft1, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_mul)
+    # f64.mul
+    popFloat64(ft1)
+    popFloat64(ft0)
+    muld ft1, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_div)
+    # f64.div
+    popFloat64(ft1)
+    popFloat64(ft0)
+    divd ft1, ft0
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_min)
+    # f64.min
+    popFloat64(ft1)
+    popFloat64(ft0)
+    bdeq ft0, ft1, .ipint_f64_min_equal
+    bdlt ft0, ft1, .ipint_f64_min_lt
+    bdgt ft0, ft1, .ipint_f64_min_return
+
+.ipint_f64_min_NaN:
+    addd ft0, ft1
+    jmp .ipint_f64_min_return
+
+.ipint_f64_min_equal:
+    ord ft0, ft1
+    jmp .ipint_f64_min_return
+
+.ipint_f64_min_lt:
+    moved ft0, ft1
+    # continue with .ipint_f64_min_return
+
+.ipint_f64_min_return:
+    pushFloat64(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_max)
+    # f64.max
+    popFloat64(ft1)
+    popFloat64(ft0)
+
+    bdeq ft1, ft0, .ipint_f64_max_equal
+    bdlt ft1, ft0, .ipint_f64_max_lt
+    bdgt ft1, ft0, .ipint_f64_max_return
+
+.ipint_f64_max_NaN:
+    addd ft0, ft1
+    jmp .ipint_f64_max_return
+
+.ipint_f64_max_equal:
+    andd ft0, ft1
+    jmp .ipint_f64_max_return
+
+.ipint_f64_max_lt:
+    moved ft0, ft1
+    # continue with .ipint_f64_max_return
+
+.ipint_f64_max_return:
+    pushFloat64(ft1)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_f64_copysign)
+    # f64.copysign
+    popFloat64(ft1)
+    popFloat64(ft0)
+
+    fd2ii ft1, t2, t3
+    fd2ii ft0, t0, t1
+    andi 0x7fffffff, t1
+    andi 0x80000000, t3
+    ori t3, t1
+
+    pushFloat64(ft0)
+
+    advancePC(1)
+    nextIPIntInstruction()
 
     ############################
     # 0xa7 - 0xc4: conversions #
@@ -433,15 +2386,66 @@ unimplementedInstruction(_f64_convert_i32_u)
 unimplementedInstruction(_f64_convert_i64_s)
 unimplementedInstruction(_f64_convert_i64_u)
 unimplementedInstruction(_f64_promote_f32)
-unimplementedInstruction(_i32_reinterpret_f32)
-unimplementedInstruction(_i64_reinterpret_f64)
+
+instructionLabel(_i32_reinterpret_f32)
+    popFloat32(ft0)
+    ff2i ft0, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_reinterpret_f64)
+    popFloat64(ft0)
+    fd2ii ft0, t0, t1
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
 unimplementedInstruction(_f32_reinterpret_i32)
 unimplementedInstruction(_f64_reinterpret_i64)
-unimplementedInstruction(_i32_extend8_s)
-unimplementedInstruction(_i32_extend16_s)
-unimplementedInstruction(_i64_extend8_s)
-unimplementedInstruction(_i64_extend16_s)
-unimplementedInstruction(_i64_extend32_s)
+
+instructionLabel(_i32_extend8_s)
+    # i32.extend8_s
+    popInt32(t0)
+    sxb2i t0, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i32_extend16_s)
+    # i32.extend8_s
+    popInt32(t0)
+    sxh2i t0, t0
+    pushInt32(t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_extend8_s)
+    # i64.extend8_s
+    popInt32(t0)
+    sxb2i t0, t0
+    rshifti t0, 31, t1
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_extend16_s)
+    # i64.extend8_s
+    popInt32(t0)
+    sxh2i t0, t0
+    rshifti t0, 31, t1
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
+instructionLabel(_i64_extend32_s)
+    # i64.extend8_s
+    popInt32(t0)
+    rshifti t0, 31, t1
+    pushInt64(t1, t0)
+    advancePC(1)
+    nextIPIntInstruction()
+
 reservedOpcode(0xc5)
 reservedOpcode(0xc6)
 reservedOpcode(0xc7)
@@ -990,17 +2994,149 @@ slowPathLabel(_local_set)
 slowPathLabel(_local_tee)
     break
 
+##################################
+## "Out of line" logic for call ##
+##################################
+
+# time to use the safe for call registers!
+# sc0 = mINT shadow stack pointer (tracks the Wasm stack)
+
+const mintSS = sc1
+
+macro mintPop(hi, lo)
+    load2ia [mintSS], lo, hi
+    addp 16, mintSS
+end
+
+macro mintPopF(reg)
+    loadd [mintSS], reg
+    addp 16, mintSS
+end
+
+macro mintArgDispatch()
+    loadb [MC], sc0
+    addp 1, MC
+    bilt sc0, (constexpr IPInt::CallArgumentBytecode::NumOpcodes), .safe
     break
+.safe:
+    lshiftp 6, sc0
+    leap (_mint_begin + 1), t7
+    addp sc0, t7
+    # t7 = r9
+    emit "bx r9"
+end
+
+macro mintRetDispatch()
+    loadb [MC], sc0
+    addp 1, MC
+    bilt sc0, (constexpr IPInt::CallResultBytecode::NumOpcodes), .safe
+    break
+.safe:
+    lshiftp 6, sc0
+    leap (_mint_begin_return + 1), t7
+    addp sc0, t7
+    # t7 = r9
+    emit "bx r9"
+end
+
+.ipint_call_common:
+    # we need to do some planning ahead to not step on our own values later
+    # step 1: save all the stuff we had earlier
+    # step 2: calling
+    # - if we have more results than arguments, we need to move our stack pointer up in advance, or else
+    #   pushing 16B values to the stack will overtake cleaning up 8B return values. we get this value from
+    #   CallSignatureMetadata::numExtraResults
+    # - set up the stack frame (with size CallSignatureMetadata::stackFrameSize)
+    # step 2.5: saving registers:
+    # - push our important data onto the stack here, after the saved space
+    # step 3: jump to called function
+    # - swap out instances, reload memory, and call
+    # step 4: returning
+    # - pop the registers from step 2.5
+    # - we've left enough space for us to push our new values starting at the original stack pointer now! yay!
+
+    const targetEntrypoint = r0
+    const targetInstance = r1
+
+    const argSP = t3
+    const shadowSP = t4
+
+    # calculate the SP after popping all arguments
+    move sp, argSP
+    loadh IPInt::CallSignatureMetadata::numArguments[MC], t2
+    lshiftp StackValueShift, t2
+    addp t2, argSP
+
+    # (down = decreasing address)
+    # <first non-arg> <- argSP = SP after all arguments
+    # arg
+    # ...
+    # arg
+    # arg             <- initial SP
+
+    # store sp as our shadow stack for arguments later
+    # make extra space if necessary
+    move sp, shadowSP
+    loadh IPInt::CallSignatureMetadata::numExtraResults[MC], t2
+    lshiftp StackValueShift, t2
+    subp t2, sp
+
+    # <first non-arg> <- argSP
+    # arg
+    # ...
+    # arg
+    # arg             <- shadowSP = initial sp
+    # reserved
+    # reserved        <- sp
+
+    push argSP, PC
+    push PL, wasmInstance
+
+    # set up the call frame
+    move sp, t3
+    loadi IPInt::CallSignatureMetadata::stackFrameSize[MC], t2
+    subp t2, sp
+
+    advanceMC(constexpr (sizeof(IPInt::CallSignatureMetadata)))
+
+    # <first non-arg> <- argSP
+    # arg
+    # ...
+    # arg
+    # arg             <- shadowSP = initial sp
+    # reserved
+    # reserved
+    # argSP, PC
+    # PL, wasmInstance
+    # call frame
+    # call frame
+    # call frame
+    # call frame
+    # call frame
+    # call frame      <- sp
+
+    # set up the Callee slot
+    storep IPIntCallCallee, Callee - CallerFrameAndPCSize[sp]
+    storep IPIntCallFunctionSlot, CodeBlock - CallerFrameAndPCSize[sp]
+
+    push targetEntrypoint, targetInstance
+    move t3, csr0
+
+    move t4, mintSS
+
+    mintArgDispatch()
 
 mintAlign(_a0)
 _mint_begin:
-    break
+    mintPop(a1, a0)
+    mintArgDispatch()
 
 mintAlign(_a1)
     break
 
 mintAlign(_a2)
-    break
+    mintPop(a3, a2)
+    mintArgDispatch()
 
 mintAlign(_a3)
     break
@@ -1018,10 +3154,12 @@ mintAlign(_a7)
     break
 
 mintAlign(_fa0)
-    break
+    mintPopF(ft0)
+    mintArgDispatch()
 
 mintAlign(_fa1)
-    break
+    mintPopF(ft1)
+    mintArgDispatch()
 
 mintAlign(_fa2)
     break
@@ -1063,11 +3201,54 @@ mintAlign(_tail_call)
     break
 
 mintAlign(_call)
-    break
+    pop wasmInstance, sc3 # sc3 = targetEntrypoint
+
+    # Save stack pointer, if we tail call someone who changes the frame above's stack argument size
+    move sp, sc1
+    storep sc1, ThisArgumentOffset[cfr]
+
+    # Make the call
+    call sc3, WasmEntryPtrTag
+
+    # Restore the stack pointer
+    loadp ThisArgumentOffset[cfr], sc0
+    move sc0, sp
+
+    # <first non-arg>   <- argSP
+    # arg
+    # ...
+    # arg
+    # arg
+    # reserved
+    # reserved
+    # argSP, PC
+    # PL, wasmInstance  <- csr0
+    # call frame return
+    # call frame return
+    # call frame
+    # call frame
+    # call frame
+    # call frame        <- sp
+
+    loadi IPInt::CallReturnMetadata::stackFrameSize[MC], csr0
+    leap [sp, csr0], csr0
+
+    const mintRetSrc = t2
+    const mintRetDst = t3
+
+    loadi IPInt::CallReturnMetadata::firstStackArgumentSPOffset[MC], t2
+    advanceMC(IPInt::CallReturnMetadata::resultBytecode)
+    leap [sp, t2], mintRetSrc
+
+    loadp 3*MachineRegisterSize[csr0], mintRetDst # load argSP
+
+    mintRetDispatch()
 
 mintAlign(_r0)
 _mint_begin_return:
-    break
+    subp StackValueSize, mintRetDst
+    store2ia r0, r1, [mintRetDst]
+    mintRetDispatch()
 
 mintAlign(_r1)
     break
@@ -1091,7 +3272,9 @@ mintAlign(_r7)
     break
 
 mintAlign(_fr0)
-    break
+    subp StackValueSize, mintRetDst
+    stored ft0, [mintRetDst]
+    mintRetDispatch()
 
 mintAlign(_fr1)
     break
@@ -1121,11 +3304,42 @@ mintAlign(_stack_gap)
     break
 
 mintAlign(_end)
-    break
+
+    # <first non-arg>   <- argSP
+    # return result
+    # ...
+    # return result
+    # return result
+    # return result
+    # return result     <- mintRetDst => new SP
+    # argSP, PC
+    # PL, wasmInstance  <- csr0
+    # call frame return <- sp
+    # call frame return
+    # call frame
+    # call frame
+    # call frame
+    # call frame
+
+    # note: we don't care about argSP anymore
+    load2ia [csr0], wasmInstance, PL
+    move mintRetDst, sp
+
+    # Restore PC / MC
+    push MC
+    getIPIntCallee()
+    pop MC
+
+    # Restore IB
+    IfIPIntUsesIB(macro()
+        pcrtoaddr _ipint_unreachable, IB
+    end)
+    nextIPIntInstruction()
 
 uintAlign(_r0)
 _uint_begin:
-    break
+    popQuad(r1, r0)
+    uintDispatch()
 
 uintAlign(_r1)
     break
@@ -1149,7 +3363,8 @@ uintAlign(_r7)
     break
 
 uintAlign(_fr0)
-    break
+    popFloat(ft0)
+    uintDispatch()
 
 uintAlign(_fr1)
     break
@@ -1172,31 +3387,36 @@ uintAlign(_fr6)
 uintAlign(_fr7)
     break
 
+# destination on stack is sc0
+
 uintAlign(_stack)
     break
 
 uintAlign(_ret)
     jmp .ipint_exit
 
-# PM = location in argumINT bytecode
-# t5 = tmp
-# t6 = dst
-# t7 = src
-# cfr
-# r12 = for dispatch
-
-# const argumINTDest = t6
-# const argumINTSrc = t7
+# MC = location in argumINT bytecode
+# csr1 = tmp
+# t4 = dst
+# t5 = src
+# t6
+# t7 = for dispatch
 
 argumINTAlign(_a0)
 _argumINT_begin:
-    break
+    storei a0, [argumINTDst]
+    storei a1, 4[argumINTDst]
+    addp LocalSize, argumINTDst
+    argumINTDispatch()
 
 argumINTAlign(_a1)
     break
 
 argumINTAlign(_a2)
-    break
+    storei a2, [argumINTDst]
+    storei a3, 4[argumINTDst]
+    addp LocalSize, argumINTDst
+    argumINTDispatch()
 
 argumINTAlign(_a3)
     break
@@ -1214,10 +3434,14 @@ argumINTAlign(_a7)
     break
 
 argumINTAlign(_fa0)
-    break
+    stored fa0, [argumINTDst]
+    addp LocalSize, argumINTDst
+    argumINTDispatch()
 
 argumINTAlign(_fa1)
-    break
+    stored fa1, [argumINTDst]
+    addp LocalSize, argumINTDst
+    argumINTDispatch()
 
 argumINTAlign(_fa2)
     break

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -185,7 +185,7 @@ end
 
 # Entering IPInt
 
-# PM = location in argumINT bytecode
+# MC = location in argumINT bytecode
 # csr0 = tmp
 # csr1 = dst
 # csr2 = src
@@ -6072,15 +6072,14 @@ _wasm_ipint_call_return_location_wide32:
     # call frame
     # call frame        <- sp
 
-    loadi [MC], sc3
-    advanceMC(IPInt::CallReturnMetadata::resultBytecode)
+    loadi IPInt::CallReturnMetadata::stackFrameSize[MC], sc3
     leap [sp, sc3], sc3
 
     const mintRetSrc = sc1
     const mintRetDst = sc2
 
-    loadi [MC], sc1
-    advanceMC(4)
+    loadi IPInt::CallReturnMetadata::firstStackArgumentSPOffset[MC], mintRetSrc
+    advanceMC(IPInt::CallReturnMetadata::resultBytecode)
     leap [sp, mintRetSrc], mintRetSrc
 
 if ARM64 or ARM64E

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -41,7 +41,11 @@
 namespace JSC { namespace Wasm {
 
 constexpr unsigned numberOfLLIntCalleeSaveRegisters = 2;
+#if CPU(ARM)
+constexpr unsigned numberOfIPIntCalleeSaveRegisters = 2;
+#else
 constexpr unsigned numberOfIPIntCalleeSaveRegisters = 3;
+#endif
 constexpr unsigned numberOfLLIntInternalRegisters = 2;
 constexpr unsigned numberOfIPIntInternalRegisters = 2;
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -97,8 +97,8 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
     } else if (type.isI64()) {
         size_t size = m_metadata.size();
         IPInt::Const64Metadata mdConst {
-            .instructionLength = { .length = safeCast<uint8_t>(length) },
-            .value = static_cast<uint64_t>(value)
+            .value = static_cast<uint64_t>(value),
+            .instructionLength = { .length = safeCast<uint8_t>(length) }
         };
         m_metadata.grow(size + sizeof(mdConst));
         WRITE_TO_METADATA(m_metadata.data() + size, mdConst, IPInt::Const64Metadata);
@@ -117,8 +117,8 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
 void FunctionIPIntMetadataGenerator::addLEB128V128Constant(v128_t value, size_t length)
 {
     IPInt::Const128Metadata mdConst {
-        .instructionLength = { .length = safeCast<uint8_t>(length) },
-        .value = value
+        .value = value,
+        .instructionLength = { .length = safeCast<uint8_t>(length) }
     };
     size_t size = m_metadata.size();
     m_metadata.grow(size + sizeof(mdConst));
@@ -169,6 +169,7 @@ void FunctionIPIntMetadataGenerator::addReturnData(const FunctionSignature& sig,
     m_uINTBytecode.reverse();
     m_uINTBytecode.append(static_cast<uint8_t>(IPInt::UIntBytecode::End));
 }
+
 
 } }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -129,18 +129,20 @@ struct GlobalMetadata {
 // Constant metadata structures
 
 struct Const32Metadata {
+    // instructionLength needs to go first because we encode small
+    // i32 as just instructionLength with the value embedded in bytecode.
     InstructionLengthMetadata instructionLength;
     uint32_t value;
 };
 
 struct Const64Metadata {
-    InstructionLengthMetadata instructionLength;
     uint64_t value;
+    InstructionLengthMetadata instructionLength;
 };
 
 struct Const128Metadata {
-    InstructionLengthMetadata instructionLength;
     v128_t value;
+    InstructionLengthMetadata instructionLength;
 };
 
 struct TableInitMetadata {
@@ -246,6 +248,7 @@ enum class CallResultBytecode : uint8_t { // (mINT)
 
 struct CallReturnMetadata {
     uint32_t stackFrameSize; // 4B for stack frame size
+    uint32_t firstStackArgumentSPOffset; // 4B for stack argument offset
     CallResultBytecode resultBytecode[0];
 };
 


### PR DESCRIPTION
#### 85a8ccef08a7a28c16e7719ade5f8f409eebbfb3
<pre>
[JSC] Upstream partial ARMv7 port of InPlaceInterpreter 1/?
<a href="https://bugs.webkit.org/show_bug.cgi?id=278921">https://bugs.webkit.org/show_bug.cgi?id=278921</a>

Reviewed by Keith Miller and Justin Michaud.

This adds current porting efforts of the InPlaceInterpreter to ARMv7.

Changes affecting 64 bit:

 - change Const64Metadata and Const128Metadata field order
   to avoid unaligned loads

 - explicitly define firstStackArgumentSPOffset in CallReturnMetadata
   (improve readability)

 - update an outdated comment

 - remove some macros for pushing/popping floats (no longer used by 64 bit!)

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128V128Constant):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addCallCommonData):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:

Canonical link: <a href="https://commits.webkit.org/293368@main">https://commits.webkit.org/293368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b97803601f22dedcfef8256e5edc747bd8362a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49293 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26789 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/32297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48675 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91392 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106201 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97334 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18806 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19506 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30935 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120952 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25571 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->