### PR TITLE
TestWebKitAPI.WebPushDBuiltInTest.ImplicitSilentPushTimerCancelledOnShowingNotification is a constant failure (due to webpushd crash)

### DIFF
--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
@@ -35,6 +35,7 @@
 - (void)removeDeliveredNotificationsWithIdentifiers:(NSArray<NSString *> *) identifiers;
 - (void)getNotificationSettingsWithCompletionHandler:(void(^)(UNNotificationSettings *settings))completionHandler;
 - (void)requestAuthorizationWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError *))completionHandler;
+- (void)setNotificationCategories:(NSSet<UNNotificationCategory *> *) categories;
 - (NSNumber *)getAppBadgeForTesting;
 - (UNNotificationSettings *)notificationSettings;
 @end

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -137,6 +137,11 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
     });
 }
 
+- (void)setNotificationCategories:(NSSet<UNNotificationCategory *> *) categories
+{
+    // No-op. Stubbed out for compatibiltiy with UNUserNotificationCenter.
+}
+
 - (UNNotificationSettings *)notificationSettings
 {
     RetainPtr settings = [UNMutableNotificationSettings emptySettings];


### PR DESCRIPTION
#### 6f82e5b91c8b0bbdcaeccaaec881493739d21839
<pre>
TestWebKitAPI.WebPushDBuiltInTest.ImplicitSilentPushTimerCancelledOnShowingNotification is a constant failure (due to webpushd crash)
<a href="https://bugs.webkit.org/show_bug.cgi?id=278931">https://bugs.webkit.org/show_bug.cgi?id=278931</a>
<a href="https://rdar.apple.com/134969476">rdar://134969476</a>

Reviewed by Sihui Liu.

`webpushd` started using a new UNUserNotifcationCenter API that our _WKMockUserNotificationCenter object didn&apos;t implement.
Therefore it crashed due to a missing selector.
Stub it out to fix up the test.

* Source/WebKit/webpushd/_WKMockUserNotificationCenter.h:
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter setNotificationCategories:]):

Canonical link: <a href="https://commits.webkit.org/282994@main">https://commits.webkit.org/282994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/212e54526d768f8c7087c9a4f20cf6a31fe878e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52112 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10657 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37552 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70563 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59438 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56182 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/919 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40011 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->