### PR TITLE
[Part 2] All numeric CSSPrimitiveValue resolvers need to take CSSToLengthConversionData: -webkit-line-clamp

### DIFF
--- a/LayoutTests/fast/css/webkit-line-clamp-calculated-value-expected.txt
+++ b/LayoutTests/fast/css/webkit-line-clamp-calculated-value-expected.txt
@@ -10,6 +10,18 @@ PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is 
 testDiv.style['-webkit-line-clamp'] = 'calc(2 * 3)'
 PASS testDiv.style['-webkit-line-clamp'] is "calc(6)"
 PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "6"
+testDiv.style['-webkit-line-clamp'] = 'calc(-2%)'
+PASS testDiv.style['-webkit-line-clamp'] is "calc(-2%)"
+PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "0%"
+testDiv.style['-webkit-line-clamp'] = 'calc(-2)'
+PASS testDiv.style['-webkit-line-clamp'] is "calc(-2)"
+PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "1"
+testDiv.style['-webkit-line-clamp'] = 'calc(10 + (sign(2cqw - 10px) * 5))'
+PASS testDiv.style['-webkit-line-clamp'] is "calc(10 + (5 * sign(2cqw - 10px)))"
+PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "5"
+testDiv.style['-webkit-line-clamp'] = 'calc(10% + (sign(2cqw - 10px) * 5%))'
+PASS testDiv.style['-webkit-line-clamp'] is "calc(10% + (5% * sign(2cqw - 10px)))"
+PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "5%"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/webkit-line-clamp-calculated-value.html
+++ b/LayoutTests/fast/css/webkit-line-clamp-calculated-value.html
@@ -1,19 +1,45 @@
 <!DOCTYPE html>
 <body>
 <script src="../../resources/js-test-pre.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 100px;
+  }
+</style>
+<div id="container">
 <div id="testDiv"></div>
+</div>
 <script>
 description("Tests assigning a calculated value to -webkit-line-clamp CSS property.");
 
 var testDiv = document.getElementById("testDiv");
 
 shouldBeEmptyString("testDiv.style['-webkit-line-clamp']");
+
 evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(10% * 2)'");
 shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(20%)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "20%");
+
 evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(2 * 3)'");
 shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(6)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "6");
+
+evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(-2%)'");
+shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(-2%)");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "0%");
+
+evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(-2)'");
+shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(-2)");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "1");
+
+evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(10 + (sign(2cqw - 10px) * 5))'");
+shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(10 + (5 * sign(2cqw - 10px)))");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "5");
+
+evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(10% + (sign(2cqw - 10px) * 5%))'");
+shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(10% + (5% * sign(2cqw - 10px)))");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "5%");
 
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -38,7 +38,6 @@
 #include "FontSizeAdjust.h"
 #include "GraphicsTypes.h"
 #include "Length.h"
-#include "LineClampValue.h"
 #include "ListStyleType.h"
 #include "RenderStyleConstants.h"
 #include "SVGRenderStyleDefs.h"
@@ -143,20 +142,6 @@ template<> constexpr TYPE fromCSSValueID(CSSValueID value) { \
     } \
     ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT(); \
     return { }; \
-}
-
-template<> inline LineClampValue fromCSSValue(const CSSValue& value)
-{
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-
-    if (primitiveValue.primitiveType() == CSSUnitType::CSS_INTEGER)
-        return LineClampValue(primitiveValue.resolveAsIntegerDeprecated<int>(), LineClamp::LineCount);
-
-    if (primitiveValue.primitiveType() == CSSUnitType::CSS_PERCENTAGE)
-        return LineClampValue(primitiveValue.resolveAsPercentageDeprecated<int>(), LineClamp::Percentage);
-
-    ASSERT(primitiveValue.valueID() == CSSValueNone);
-    return LineClampValue();
 }
 
 #define TYPE ReflectionDirection

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7980,6 +7980,7 @@
         },
         "-webkit-line-clamp": {
             "codegen-properties": {
+                "converter": "LineClamp",
                 "parser-grammar": "none | <percentage [0,inf]> | <integer [1,inf]>"
             },
             "status": "non-standard"

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -59,6 +59,7 @@
 #include "FontSizeAdjust.h"
 #include "FrameDestructionObserverInlines.h"
 #include "GridPositionsResolver.h"
+#include "LineClampValue.h"
 #include "LocalFrame.h"
 #include "QuotesData.h"
 #include "RenderStyleInlines.h"
@@ -229,6 +230,8 @@ public:
 
     static BlockEllipsis convertBlockEllipsis(BuilderState&, const CSSValue&);
     static size_t convertMaxLines(BuilderState&, const CSSValue&);
+
+    static LineClampValue convertLineClamp(BuilderState&, const CSSValue&);
 
 private:
     friend class BuilderCustom;
@@ -2252,6 +2255,20 @@ inline size_t BuilderConverter::convertMaxLines(BuilderState& builderState, cons
     if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone)
         return 0;
     return convertNumber<size_t>(builderState, value);
+}
+
+inline LineClampValue BuilderConverter::convertLineClamp(BuilderState& builderState, const CSSValue& value)
+{
+    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+
+    if (primitiveValue.primitiveType() == CSSUnitType::CSS_INTEGER)
+        return LineClampValue(std::max(primitiveValue.resolveAsInteger<int>(builderState.cssToLengthConversionData()), 1), LineClamp::LineCount);
+
+    if (primitiveValue.primitiveType() == CSSUnitType::CSS_PERCENTAGE)
+        return LineClampValue(std::max(primitiveValue.resolveAsPercentage<int>(builderState.cssToLengthConversionData()), 0), LineClamp::Percentage);
+
+    ASSERT(primitiveValue.valueID() == CSSValueNone);
+    return LineClampValue();
 }
 
 } // namespace Style


### PR DESCRIPTION
#### 14660ece4d0b91a618e17883e2c95358c9258e6b
<pre>
[Part 2] All numeric CSSPrimitiveValue resolvers need to take CSSToLengthConversionData: -webkit-line-clamp
<a href="https://bugs.webkit.org/show_bug.cgi?id=278937">https://bugs.webkit.org/show_bug.cgi?id=278937</a>

Reviewed by Darin Adler.

Removes use of &quot;Deprecated&quot; primitive value resolvers for -webkit-line-clamp.

* LayoutTests/fast/css/webkit-line-clamp-calculated-value-expected.txt:
* LayoutTests/fast/css/webkit-line-clamp-calculated-value.html:
    - Adds tests that require conversion data to get the right result.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleBuilderConverter.h:
    - Move -webkit-line-clamp to use an explicit converter so it
      can access conversion data.

Canonical link: <a href="https://commits.webkit.org/283024@main">https://commits.webkit.org/283024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10c5ca461da83a2d326f57d713cb5831fd61fa42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59565 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70683 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13404 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56276 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14337 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7348 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40133 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->