### PR TITLE
[WebGPU] Recycle Textures and TextureViews from the canvas context

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
@@ -35,9 +35,9 @@ Vector<MachSendRight> GPUCompositorIntegration::recreateRenderBuffers(int width,
 }
 #endif
 
-void GPUCompositorIntegration::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
+void GPUCompositorIntegration::prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&& completionHandler)
 {
-    m_backing->prepareForDisplay(WTFMove(completionHandler));
+    m_backing->prepareForDisplay(frameIndex, WTFMove(completionHandler));
 }
 
 void GPUCompositorIntegration::paintCompositedResultsToCanvas(WebCore::ImageBuffer& imageBuffer, uint32_t bufferIndex)

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -53,7 +53,7 @@ public:
     Vector<MachSendRight> recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, WebCore::WebGPU::Device&) const;
 #endif
 
-    void prepareForDisplay(CompletionHandler<void()>&&);
+    void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&);
 
     WebGPU::CompositorIntegration& backing() { return m_backing; }
     const WebGPU::CompositorIntegration& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -62,21 +62,21 @@ void GPUPresentationContext::unconfigure()
     m_backing->unconfigure();
 }
 
-RefPtr<GPUTexture> GPUPresentationContext::getCurrentTexture()
+RefPtr<GPUTexture> GPUPresentationContext::getCurrentTexture(uint32_t index)
 {
     if ((!m_currentTexture || m_currentTexture->isDestroyed()) && m_device.get()) {
-        if (auto currentTexture = m_backing->getCurrentTexture())
+        if (auto currentTexture = m_backing->getCurrentTexture(index))
             m_currentTexture = GPUTexture::create(*currentTexture, m_textureDescriptor, *m_device.get()).ptr();
     }
 
     return m_currentTexture;
 }
 
-void GPUPresentationContext::present(bool presentBacking)
+void GPUPresentationContext::present(uint32_t frameIndex, bool presentBacking)
 {
     m_currentTexture = nullptr;
     if (presentBacking)
-        m_backing->present(presentBacking);
+        m_backing->present(frameIndex, presentBacking);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -52,8 +52,8 @@ public:
     WARN_UNUSED_RETURN bool configure(const GPUCanvasConfiguration&, GPUIntegerCoordinate, GPUIntegerCoordinate, bool);
     void unconfigure();
 
-    RefPtr<GPUTexture> getCurrentTexture();
-    void present(bool presentBacking = false);
+    RefPtr<GPUTexture> getCurrentTexture(uint32_t);
+    void present(uint32_t frameIndex, bool presentBacking = false);
 
     WebGPU::PresentationContext& backing() { return m_backing; }
     const WebGPU::PresentationContext& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -51,10 +51,10 @@ CompositorIntegrationImpl::CompositorIntegrationImpl(ConvertToBackingContext& co
 
 CompositorIntegrationImpl::~CompositorIntegrationImpl() = default;
 
-void CompositorIntegrationImpl::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
+void CompositorIntegrationImpl::prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&& completionHandler)
 {
     if (auto* presentationContext = m_presentationContext.get())
-        presentationContext->present();
+        presentationContext->present(frameIndex);
 
     m_onSubmittedWorkScheduledCallback(WTFMove(completionHandler));
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -89,7 +89,7 @@ private:
     CompositorIntegrationImpl& operator=(const CompositorIntegrationImpl&) = delete;
     CompositorIntegrationImpl& operator=(CompositorIntegrationImpl&&) = delete;
 
-    void prepareForDisplay(CompletionHandler<void()>&&) override;
+    void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) override;
 
 #if PLATFORM(COCOA)
     Vector<MachSendRight> recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, Device&) override;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -127,13 +127,13 @@ void PresentationContextImpl::unconfigure()
     m_currentTexture = nullptr;
 }
 
-RefPtr<Texture> PresentationContextImpl::getCurrentTexture()
+RefPtr<Texture> PresentationContextImpl::getCurrentTexture(uint32_t frameIndex)
 {
     if (!m_swapChain)
         return nullptr; // FIXME: This should return an invalid texture instead.
 
     if (!m_currentTexture) {
-        auto texturePtr = wgpuSwapChainGetCurrentTexture(m_swapChain.get());
+        auto texturePtr = wgpuSwapChainGetCurrentTexture(m_swapChain.get(), frameIndex);
         if (!texturePtr)
             return nullptr;
 
@@ -142,10 +142,10 @@ RefPtr<Texture> PresentationContextImpl::getCurrentTexture()
     return m_currentTexture;
 }
 
-void PresentationContextImpl::present(bool)
+void PresentationContextImpl::present(uint32_t frameIndex, bool)
 {
     if (auto* surface = m_swapChain.get())
-        wgpuSwapChainPresent(surface);
+        wgpuSwapChainPresent(surface, frameIndex);
     m_currentTexture = nullptr;
 }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
@@ -52,7 +52,7 @@ public:
 
     void setSize(uint32_t width, uint32_t height);
 
-    void present(bool = false);
+    void present(uint32_t frameIndex, bool = false);
 
     WGPUSurface backing() const { return m_backing.get(); }
     RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) final;
@@ -70,7 +70,7 @@ private:
     bool configure(const CanvasConfiguration&) final;
     void unconfigure() final;
 
-    RefPtr<Texture> getCurrentTexture() final;
+    RefPtr<Texture> getCurrentTexture(uint32_t) final;
 
     TextureFormat m_format { TextureFormat::Bgra8unorm };
     uint32_t m_width { 0 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -75,6 +75,11 @@ void TextureImpl::destroy()
     wgpuTextureDestroy(m_backing.get());
 }
 
+void TextureImpl::undestroy()
+{
+    wgpuTextureUndestroy(m_backing.get());
+}
+
 void TextureImpl::setLabelInternal(const String& label)
 {
     wgpuTextureSetLabel(m_backing.get(), label.utf8().data());

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
@@ -64,6 +64,7 @@ private:
     RefPtr<TextureView> createView(const std::optional<TextureViewDescriptor>&) final;
 
     void destroy() final;
+    void undestroy() final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
@@ -60,7 +60,7 @@ public:
     virtual Vector<MachSendRight> recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, Device&) = 0;
 #endif
 
-    virtual void prepareForDisplay(CompletionHandler<void()>&&) = 0;
+    virtual void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) = 0;
     virtual void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage*)>) = 0;
     virtual void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t bufferIndex) = 0;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
@@ -50,9 +50,9 @@ public:
 
     WARN_UNUSED_RETURN virtual bool configure(const CanvasConfiguration&) = 0;
     virtual void unconfigure() = 0;
-    virtual void present(bool = false) = 0;
+    virtual void present(uint32_t frameIndex, bool = false) = 0;
 
-    virtual RefPtr<Texture> getCurrentTexture() = 0;
+    virtual RefPtr<Texture> getCurrentTexture(uint32_t) = 0;
     virtual RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) = 0;
 
 protected:

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
@@ -51,6 +51,7 @@ public:
     virtual RefPtr<TextureView> createView(const std::optional<TextureViewDescriptor>&) = 0;
 
     virtual void destroy() = 0;
+    virtual void undestroy() = 0;
 
 protected:
     Texture() = default;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -87,7 +87,7 @@ private:
 
     CanvasType htmlOrOffscreenCanvas() const;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&, bool);
-    void present();
+    void present(uint32_t frameIndex);
 
     struct Configuration {
         Ref<GPUDevice> device;

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -107,7 +107,6 @@ Ref<CommandEncoder> Device::createCommandEncoder(const WGPUCommandEncoderDescrip
     // https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder
 
     auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];
-    commandBufferDescriptor.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
     auto commandBuffer = protectedQueue()->commandBufferWithDescriptor(commandBufferDescriptor);
     if (!commandBuffer)
         return CommandEncoder::createInvalid(*this);

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -62,8 +62,8 @@ public:
     virtual void configure(Device&, const WGPUSwapChainDescriptor&);
     virtual void unconfigure();
 
-    virtual void present();
-    virtual Texture* getCurrentTexture();
+    virtual void present(uint32_t);
+    virtual Texture* getCurrentTexture(uint32_t);
     virtual TextureView* getCurrentTextureView(); // FIXME: This should return a TextureView&.
 
     virtual bool isPresentationContextIOSurface() const { return false; }

--- a/Source/WebGPU/WebGPU/PresentationContext.mm
+++ b/Source/WebGPU/WebGPU/PresentationContext.mm
@@ -74,11 +74,11 @@ void PresentationContext::unconfigure()
 {
 }
 
-void PresentationContext::present()
+void PresentationContext::present(uint32_t)
 {
 }
 
-Texture* PresentationContext::getCurrentTexture()
+Texture* PresentationContext::getCurrentTexture(uint32_t)
 {
     return nullptr;
 }
@@ -117,9 +117,9 @@ WGPUTextureFormat wgpuSurfaceGetPreferredFormat(WGPUSurface surface, WGPUAdapter
     return WebGPU::protectedFromAPI(surface)->getPreferredFormat(WebGPU::protectedFromAPI(adapter));
 }
 
-WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain)
+WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain, uint32_t index)
 {
-    return WebGPU::protectedFromAPI(swapChain)->getCurrentTexture();
+    return WebGPU::protectedFromAPI(swapChain)->getCurrentTexture(index);
 }
 
 WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain)
@@ -127,9 +127,9 @@ WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain)
     return WebGPU::protectedFromAPI(swapChain)->getCurrentTextureView();
 }
 
-void wgpuSwapChainPresent(WGPUSwapChain swapChain)
+void wgpuSwapChainPresent(WGPUSwapChain swapChain, uint32_t index)
 {
-    WebGPU::protectedFromAPI(swapChain)->present();
+    WebGPU::protectedFromAPI(swapChain)->present(index);
 }
 
 RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat)

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
@@ -47,9 +47,9 @@ public:
     void configure(Device&, const WGPUSwapChainDescriptor&) override;
     void unconfigure() override;
 
-    void present() override;
-    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
-    TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
+    void present(uint32_t) override;
+    Texture* getCurrentTexture(uint32_t) override;
+    TextureView* getCurrentTextureView() override;
 
     bool isPresentationContextCoreAnimation() const override { return true; }
 

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
@@ -126,7 +126,7 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
     return { currentDrawable, texture.ptr(), textureView.ptr() };
 }
 
-void PresentationContextCoreAnimation::present()
+void PresentationContextCoreAnimation::present(uint32_t)
 {
     if (!m_configuration)
         return;
@@ -139,7 +139,7 @@ void PresentationContextCoreAnimation::present()
     m_configuration->currentFrameState = std::nullopt;
 }
 
-Texture* PresentationContextCoreAnimation::getCurrentTexture()
+Texture* PresentationContextCoreAnimation::getCurrentTexture(uint32_t)
 {
     if (!m_configuration)
         return nullptr;

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -46,9 +46,9 @@ public:
     void configure(Device&, const WGPUSwapChainDescriptor&) override;
     void unconfigure() override;
 
-    void present() override;
-    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
-    TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
+    void present(uint32_t) override;
+    Texture* getCurrentTexture(uint32_t) override;
+    TextureView* getCurrentTextureView() override;
 
     bool isPresentationContextIOSurface() const override { return true; }
 
@@ -68,7 +68,6 @@ private:
     Vector<RenderBuffer> m_renderBuffers;
     RefPtr<Device> m_device;
     RefPtr<Texture> m_invalidTexture;
-    size_t m_currentIndex { 0 };
     id<MTLFunction> m_luminanceClampFunction;
     id<MTLComputePipelineState> m_computePipelineState;
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3219,9 +3219,11 @@ void Texture::destroy()
     if (!m_canvasBacking)
         m_texture = Ref { m_device }->placeholderTexture(format());
     m_destroyed = true;
-    for (auto& view : m_textureViews) {
-        if (view.get())
-            view->destroy();
+    if (!m_canvasBacking) {
+        for (auto& view : m_textureViews) {
+            if (view.get())
+                view->destroy();
+        }
     }
     if (!m_canvasBacking) {
         for (Ref commandEncoder : m_commandEncoders)
@@ -3752,6 +3754,11 @@ WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, const WGPUTextureView
 void wgpuTextureDestroy(WGPUTexture texture)
 {
     WebGPU::protectedFromAPI(texture)->destroy();
+}
+
+void wgpuTextureUndestroy(WGPUTexture texture)
+{
+    WebGPU::fromAPI(texture).recreateIfNeeded();
 }
 
 void wgpuTextureSetLabel(WGPUTexture texture, const char* label)

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1584,7 +1584,7 @@ typedef void (*WGPUProcSurfaceRelease)(WGPUSurface surface) WGPU_FUNCTION_ATTRIB
 
 // Procs of SwapChain
 typedef WGPUTextureView (*WGPUProcSwapChainGetCurrentTextureView)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUProcSwapChainPresent)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcSwapChainPresent)(WGPUSwapChain swapChain, uint32_t frameIndex) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcSwapChainReference)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcSwapChainRelease)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 
@@ -1822,13 +1822,14 @@ WGPU_EXPORT void wgpuSurfaceRelease(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE
 
 // Methods of SwapChain
 WGPU_EXPORT WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuSwapChainPresent(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuSwapChainPresent(WGPUSwapChain swapChain, uint32_t frameIndex) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSwapChainReference(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSwapChainRelease(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 
 // Methods of Texture
 WGPU_EXPORT WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, WGPU_NULLABLE WGPUTextureViewDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureDestroy(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuTextureUndestroy(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint32_t wgpuTextureGetDepthOrArrayLayers(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUTextureDimension wgpuTextureGetDimension(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUTextureFormat wgpuTextureGetFormat(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -125,7 +125,7 @@ typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChai
 WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label);
 
 // FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
-WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);
+WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain, uint32_t frameIndex);
 
 WGPU_EXPORT WGPUExternalTexture wgpuDeviceImportExternalTexture(WGPUDevice device, const WGPUExternalTextureDescriptor* descriptor);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -92,9 +92,9 @@ void RemoteCompositorIntegration::recreateRenderBuffers(int width, int height, W
 }
 #endif
 
-void RemoteCompositorIntegration::prepareForDisplay(CompletionHandler<void(bool)>&& completionHandler)
+void RemoteCompositorIntegration::prepareForDisplay(uint32_t frameIndex, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedBacking()->prepareForDisplay([completionHandler = WTFMove(completionHandler)]() mutable {
+    protectedBacking()->prepareForDisplay(frameIndex, [completionHandler = WTFMove(completionHandler)]() mutable {
         completionHandler(true);
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -108,7 +108,7 @@ private:
     void recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, WebKit::WebGPUIdentifier deviceIdentifier, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
 #endif
 
-    void prepareForDisplay(CompletionHandler<void(bool)>&&);
+    void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void(bool)>&&);
 
     Ref<WebCore::WebGPU::CompositorIntegration> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -28,7 +28,7 @@ messages -> RemoteCompositorIntegration NotRefCounted Stream {
 #if PLATFORM(COCOA)
     void RecreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace destinationColorSpace, enum:uint8_t WebCore::AlphaPremultiplication alphaMode, WebCore::WebGPU::TextureFormat textureFormat, WebKit::WebGPUIdentifier deviceIdentifier) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
 #endif
-    void PrepareForDisplay() -> (bool dummy) Synchronous NotStreamEncodableReply // Because CanvasRenderingContext::prepareForDisplay() requires the layer contents synchronously, this needs to be Synchronous.
+    void PrepareForDisplay(uint32_t frameIndex) -> (bool dummy) Synchronous NotStreamEncodableReply // Because CanvasRenderingContext::prepareForDisplay() requires the layer contents synchronously, this needs to be Synchronous.
     void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer, uint32_t bufferIndex) -> () Synchronous
     void Destruct()
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -76,14 +76,14 @@ void RemotePresentationContext::unconfigure()
     protectedBacking()->unconfigure();
 }
 
-void RemotePresentationContext::present()
+void RemotePresentationContext::present(uint32_t frameIndex)
 {
-    protectedBacking()->present();
+    protectedBacking()->present(frameIndex);
 }
 
-void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
+void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier, uint32_t frameIndex)
 {
-    auto texture = protectedBacking()->getCurrentTexture();
+    auto texture = protectedBacking()->getCurrentTexture(frameIndex);
     ASSERT(texture);
     auto connection = m_gpuConnectionToWebProcess.get();
     if (!texture || !connection)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -87,9 +87,9 @@ private:
 
     void configure(const WebGPU::CanvasConfiguration&);
     void unconfigure();
-    void present();
+    void present(uint32_t frameIndex);
 
-    void getCurrentTexture(WebGPUIdentifier);
+    void getCurrentTexture(WebGPUIdentifier, uint32_t frameIndex);
 
     Ref<WebCore::WebGPU::PresentationContext> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
@@ -27,8 +27,8 @@
 messages -> RemotePresentationContext NotRefCounted Stream {
     void Configure(WebKit::WebGPU::CanvasConfiguration configuration)
     void Unconfigure()
-    void GetCurrentTexture(WebKit::WebGPUIdentifier identifier)
-    void Present()
+    void GetCurrentTexture(WebKit::WebGPUIdentifier identifier, uint32_t frameIndex)
+    void Present(uint32_t frameIndex)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -93,6 +93,11 @@ void RemoteTexture::destroy()
     protectedBacking()->destroy();
 }
 
+void RemoteTexture::undestroy()
+{
+    protectedBacking()->undestroy();
+}
+
 void RemoteTexture::destruct()
 {
     Ref { m_objectHeap.get() }->removeObject(m_identifier);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -88,6 +88,7 @@ private:
     void createView(const std::optional<WebGPU::TextureViewDescriptor>&, WebGPUIdentifier);
 
     void destroy();
+    void undestroy();
     void destruct();
 
     void setLabel(String&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
@@ -27,6 +27,7 @@
 messages -> RemoteTexture NotRefCounted Stream {
     void CreateView(std::optional<WebKit::WebGPU::TextureViewDescriptor> descriptor, WebKit::WebGPUIdentifier identifier)
     void Destroy()
+    void Undestroy()
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -65,12 +65,11 @@ Vector<MachSendRight> RemoteCompositorIntegrationProxy::recreateRenderBuffers(in
 }
 #endif
 
-void RemoteCompositorIntegrationProxy::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
+void RemoteCompositorIntegrationProxy::prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&& completionHandler)
 {
-    auto sendResult = sendSync(Messages::RemoteCompositorIntegration::PrepareForDisplay());
+    auto sendResult = sendSync(Messages::RemoteCompositorIntegration::PrepareForDisplay(frameIndex));
     UNUSED_VARIABLE(sendResult);
-
-    RefPtr { m_presentationContext }->present();
+    RefPtr { m_presentationContext }->present(frameIndex);
 
     completionHandler();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -94,7 +94,7 @@ private:
     Vector<MachSendRight> recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, WebCore::WebGPU::Device&) override;
 #endif
 
-    void prepareForDisplay(CompletionHandler<void()>&&) override;
+    void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) override;
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoderProxy);
 RemoteComputePassEncoderProxy::RemoteComputePassEncoderProxy(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(parent.root())
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -46,8 +46,7 @@ public:
 
     virtual ~RemoteComputePassEncoderProxy();
 
-    RemoteCommandEncoderProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -89,7 +88,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteCommandEncoderProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <WebCore/WebGPUPresentationContext.h>
+#include <array>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -56,7 +57,7 @@ public:
     RemoteGPUProxy& root() { return m_parent->root(); }
     Ref<RemoteGPUProxy> protectedRoot() { return m_parent->root(); }
 
-    void present(bool = false) final;
+    void present(uint32_t frameIndex, bool = false) final;
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -82,12 +83,13 @@ private:
     bool configure(const WebCore::WebGPU::CanvasConfiguration&) final;
     void unconfigure() final;
 
-    RefPtr<WebCore::WebGPU::Texture> getCurrentTexture() final;
+    RefPtr<WebCore::WebGPU::Texture> getCurrentTexture(uint32_t) final;
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteGPUProxy> m_parent;
-    RefPtr<RemoteTextureProxy> m_currentTexture;
+    static constexpr size_t textureCount = 3;
+    std::array<RefPtr<RemoteTextureProxy>, textureCount> m_currentTexture;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoderProxy);
 RemoteRenderPassEncoderProxy::RemoteRenderPassEncoderProxy(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(parent.root())
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -46,8 +46,7 @@ public:
 
     virtual ~RemoteRenderPassEncoderProxy();
 
-    RemoteCommandEncoderProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -115,7 +114,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteCommandEncoderProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -38,10 +38,11 @@ namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextureProxy);
 
-RemoteTextureProxy::RemoteTextureProxy(Ref<RemoteGPUProxy>&& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteTextureProxy::RemoteTextureProxy(Ref<RemoteGPUProxy>&& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, bool isCanvasBacking)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
     , m_root(WTFMove(root))
+    , m_isCanvasBacking(isCanvasBacking)
 {
 }
 
@@ -51,8 +52,28 @@ RemoteTextureProxy::~RemoteTextureProxy()
     UNUSED_VARIABLE(sendResult);
 }
 
+static bool equalDescriptors(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& a, const std::optional<WebCore::WebGPU::TextureViewDescriptor>& b)
+{
+    if (!a && !b)
+        return true;
+
+    if (!a || !b)
+        return false;
+
+    return a->format == b->format
+        && a->dimension == b->dimension
+        && a->aspect == b->aspect
+        && a->baseMipLevel == b->baseMipLevel
+        && a->mipLevelCount == b->mipLevelCount
+        && a->baseArrayLayer == b->baseArrayLayer
+        && a->arrayLayerCount == b->arrayLayerCount;
+}
+
 RefPtr<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& descriptor)
 {
+    if (m_isCanvasBacking && m_lastCreatedView && equalDescriptors(descriptor, m_lastCreatedViewDescriptor))
+        return m_lastCreatedView;
+
     std::optional<TextureViewDescriptor> convertedDescriptor;
     Ref convertToBackingContext = m_convertToBackingContext;
 
@@ -69,12 +90,23 @@ RefPtr<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::o
 
     auto result = RemoteTextureViewProxy::create(*this, convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
-    return result;
+    if (!m_isCanvasBacking)
+        return result;
+
+    m_lastCreatedView = WTFMove(result);
+    m_lastCreatedViewDescriptor = descriptor;
+    return m_lastCreatedView;
 }
 
 void RemoteTextureProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteTexture::Destroy());
+    UNUSED_VARIABLE(sendResult);
+}
+
+void RemoteTextureProxy::undestroy()
+{
+    auto sendResult = send(Messages::RemoteTexture::Undestroy());
     UNUSED_VARIABLE(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -43,19 +43,20 @@ class ConvertToBackingContext;
 class RemoteTextureProxy final : public WebCore::WebGPU::Texture {
     WTF_MAKE_TZONE_ALLOCATED(RemoteTextureProxy);
 public:
-    static Ref<RemoteTextureProxy> create(Ref<RemoteGPUProxy>&& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteTextureProxy> create(Ref<RemoteGPUProxy>&& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, bool isCanvasBacking = false)
     {
-        return adoptRef(*new RemoteTextureProxy(WTFMove(root), convertToBackingContext, identifier));
+        return adoptRef(*new RemoteTextureProxy(WTFMove(root), convertToBackingContext, identifier, isCanvasBacking));
     }
 
     virtual ~RemoteTextureProxy();
 
     RemoteGPUProxy& root() { return m_root; }
+    void undestroy() final;
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteTextureProxy(Ref<RemoteGPUProxy>&&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteTextureProxy(Ref<RemoteGPUProxy>&&, ConvertToBackingContext&, WebGPUIdentifier, bool isCanvasBacking);
 
     RemoteTextureProxy(const RemoteTextureProxy&) = delete;
     RemoteTextureProxy(RemoteTextureProxy&&) = delete;
@@ -73,12 +74,15 @@ private:
     RefPtr<WebCore::WebGPU::TextureView> createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>&) final;
 
     void destroy() final;
-
     void setLabelInternal(const String&) final;
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteGPUProxy> m_root;
+
+    RefPtr<WebCore::WebGPU::TextureView> m_lastCreatedView;
+    std::optional<WebCore::WebGPU::TextureViewDescriptor> m_lastCreatedViewDescriptor;
+    bool m_isCanvasBacking { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextureViewProxy);
 RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(parent.root())
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -46,8 +46,7 @@ public:
 
     virtual ~RemoteTextureViewProxy();
 
-    RemoteTextureProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -71,7 +70,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteTextureProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### c82e8887fedd66de190d8bc9f75f16710f856673
<pre>
[WebGPU] Recycle Textures and TextureViews from the canvas context
<a href="https://bugs.webkit.org/show_bug.cgi?id=278936">https://bugs.webkit.org/show_bug.cgi?id=278936</a>
<a href="https://rdar.apple.com/135030724">rdar://135030724</a>

Reviewed by Tadeu Zagallo.

WebGPU requires getCurrentTexture() to be called every frame, which resulted
in a new IPC received and sender being created every frame, which results
in too many objects accumulated in iOS leading to eventual jetsams.

This is not needed, we can just recycle the textures.

* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp:
(WebCore::GPUCompositorIntegration::prepareForDisplay):
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h:
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp:
(WebCore::GPUPresentationContext::getCurrentTexture):
(WebCore::GPUPresentationContext::present):
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::prepareForDisplay):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::PresentationContextImpl::getCurrentTexture):
(WebCore::WebGPU::PresentationContextImpl::present):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::undestroy):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
(WebCore::GPUCanvasContextCocoa::present):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
* Source/WebGPU/WebGPU/PresentationContext.h:
* Source/WebGPU/WebGPU/PresentationContext.mm:
(WebGPU::PresentationContext::present):
(WebGPU::PresentationContext::getCurrentTexture):
(wgpuSwapChainGetCurrentTexture):
(wgpuSwapChainPresent):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h:
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm:
(WebGPU::PresentationContextCoreAnimation::present):
(WebGPU::PresentationContextCoreAnimation::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
(WebGPU::RenderPassEncoder::endPass):
* Source/WebGPU/WebGPU/Texture.mm:
(wgpuTextureUndestroy):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::prepareForDisplay):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::present):
(WebKit::RemotePresentationContext::getCurrentTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::undestroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteComputePassEncoderProxy::RemoteComputePassEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
(WebKit::WebGPU::RemotePresentationContextProxy::unconfigure):
(WebKit::WebGPU::RemotePresentationContextProxy::getCurrentTexture):
(WebKit::WebGPU::RemotePresentationContextProxy::present):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::RemoteRenderPassEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::RemoteTextureProxy):
(WebKit::WebGPU::equalDescriptors):
(WebKit::WebGPU::RemoteTextureProxy::createView):
(WebKit::WebGPU::RemoteTextureProxy::undestroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
(WebKit::WebGPU::RemoteTextureViewProxy::RemoteTextureViewProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:

Canonical link: <a href="https://commits.webkit.org/285860@main">https://commits.webkit.org/285860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfdf6f39a550516593949d52b2b1fc08bd0a1db6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58075 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/16557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20993 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23370 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79688 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66393 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65672 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7725 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3830 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1109 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->