### PR TITLE
Ensure network cache files and directories created by WebKit are excluded from backup

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -214,9 +214,21 @@ RefPtr<Storage> Storage::open(const String& baseCachePath, Mode mode, size_t cap
     ASSERT(!baseCachePath.isNull());
 
     auto cachePath = makeCachePath(baseCachePath);
+    bool hasMarkedExcludedFromBackup = false;
+    if (cachePath != baseCachePath) {
+        if (!FileSystem::makeAllDirectories(cachePath))
+            return nullptr;
 
-    if (!FileSystem::makeAllDirectories(makeVersionedDirectoryPath(cachePath)))
+        FileSystem::setExcludedFromBackup(cachePath, true);
+        hasMarkedExcludedFromBackup = true;
+    }
+
+    auto versionedDirectoryPath = makeVersionedDirectoryPath(cachePath);
+    if (!FileSystem::makeAllDirectories(versionedDirectoryPath))
         return nullptr;
+
+    if (!hasMarkedExcludedFromBackup)
+        FileSystem::setExcludedFromBackup(versionedDirectoryPath, true);
 
     auto salt = FileSystem::readOrMakeSalt(makeSaltFilePath(cachePath));
     if (!salt)


### PR DESCRIPTION
#### 1e4bf82ac6e8e375828cb4176c78dbf2d3c08d30
<pre>
Ensure network cache files and directories created by WebKit are excluded from backup
<a href="https://bugs.webkit.org/show_bug.cgi?id=278944">https://bugs.webkit.org/show_bug.cgi?id=278944</a>
<a href="https://rdar.apple.com/121547438">rdar://121547438</a>

Reviewed by Chris Dumez.

When client sets custom path for network cache storage, the path may not be excluded from backup as the default WebKit
network cache directory. WebKit cannot mark the custom path as excluded from backup as client may store some other
data in the directory, but WebKit can mark the files created by WebKit as excluded because those files are not expected
to be backed up.

API test: WebKit.NetworkCacheExcludedFromBackup

* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::open):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST(WebKit, NetworkCacheExcludedFromBackup)):

Canonical link: <a href="https://commits.webkit.org/283002@main">https://commits.webkit.org/283002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecd600d71ff48daa8220726e47a20f038832713b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52130 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67940 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40909 "Found 1 new test failure: accessibility/out-of-bounds-rowspan-orphan-rows.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13503 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14356 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13327 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8853 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/947 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40051 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41129 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->