### PR TITLE
Give WKWebExtensionCommand a userVisibleShortcut SPI

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -30,6 +30,7 @@
 #define CGCOLORTAGGEDPOINTER_H_
 
 #import <AppKit/NSInspectorBar.h>
+#import <AppKit/NSMenu_Private.h>
 #import <AppKit/NSTextInputClient_Private.h>
 #import <AppKit/NSWindow_Private.h>
 
@@ -41,6 +42,11 @@
 
 @interface NSInspectorBar : NSObject
 @property (getter=isVisible) BOOL visible;
+@end
+
+@interface NSKeyboardShortcut
++ (id)shortcutWithKeyEquivalent:(NSString *)keyEquivalent modifierMask:(NSUInteger)modifierMask;
+@property (readonly) NSString *localizedDisplayName;
 @end
 
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -134,6 +134,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
     return _webExtensionCommand->shortcutString();
 }
 
+- (NSString *)_userVisibleShortcut
+{
+    return _webExtensionCommand->userVisibleShortcut();
+}
+
 #if USE(APPKIT)
 - (BOOL)_matchesEvent:(NSEvent *)event
 {
@@ -203,6 +208,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 #endif
 
 - (NSString *)_shortcut
+{
+    return nil;
+}
+
+- (NSString *)_userVisibleShortcut
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandPrivate.h
@@ -34,6 +34,13 @@
  */
 @property (nonatomic, readonly, copy) NSString *_shortcut;
 
+/*!
+ @abstract Represents the user visible shortcut for the web extension, formatted according to the system.
+ @discussion Provides a string representation of the shortcut, incorporating any customizations made to the ``activationKey``
+ and ``modifierFlags`` properties. It will be empty if no shortcut is defined for the command.
+ */
+@property (nonatomic, readonly, copy) NSString *_userVisibleShortcut;
+
 #if TARGET_OS_OSX
 /*!
  @abstract Determines whether an event matches the command's activation key and modifier flags.

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -94,6 +94,7 @@ public:
     void setModifierFlags(OptionSet<ModifierFlags> modifierFlags) { dispatchChangedEventSoonIfNeeded(); m_modifierFlags = modifierFlags; }
 
     String shortcutString() const;
+    String userVisibleShortcut() const;
 
     CocoaMenuItem *platformMenuItem() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -28,7 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "WebExtensionUtilities.h"
-#import <WebKit/WKWebExtensionCommand.h>
+#import <WebKit/WKWebExtensionCommandPrivate.h>
 
 #if USE(APPKIT)
 #import <Carbon/Carbon.h>
@@ -135,6 +135,7 @@ TEST(WKWebExtensionAPICommands, CommandForEvent)
 
     EXPECT_NOT_NULL(command);
     EXPECT_NS_EQUAL(command.identifier, @"test-command");
+    EXPECT_NS_EQUAL(command._userVisibleShortcut, @"⌥⌘Z");
 
     keyCommandEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSZeroPoint modifierFlags:(NSEventModifierFlagControl | NSEventModifierFlagShift)
         timestamp:0 windowNumber:0 context:nil characters:@"Á" charactersIgnoringModifiers:@"y" isARepeat:NO keyCode:kVK_ANSI_A];
@@ -142,6 +143,7 @@ TEST(WKWebExtensionAPICommands, CommandForEvent)
 
     EXPECT_NOT_NULL(command);
     EXPECT_NS_EQUAL(command.identifier, @"_execute_action");
+    EXPECT_NS_EQUAL(command._userVisibleShortcut, @"⌃⇧Y");
 
     keyCommandEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSZeroPoint modifierFlags:(NSEventModifierFlagCommand | NSEventModifierFlagOption)
         timestamp:0 windowNumber:0 context:nil characters:@"å" charactersIgnoringModifiers:@"a" isARepeat:NO keyCode:kVK_ANSI_A];


### PR DESCRIPTION
#### 6abfe5152e1420ffbcccdd1e4385223d47367a42
<pre>
Give WKWebExtensionCommand a userVisibleShortcut SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=278948">https://bugs.webkit.org/show_bug.cgi?id=278948</a>
&lt;<a href="https://rdar.apple.com/problem/135039103">rdar://problem/135039103</a>&gt;

Reviewed by Timothy Hatcher.

This method uses AppKit SPI for generating this string for macOS, and builds up a string representing the keyboard
shortcut on iOS.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand _userVisibleShortcut]): Call into WebExtensionCommand::userVisibleShortcut.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::userVisibleShortcut const): Use SPI on macOS and build a string on iOS.
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICommands, CommandForEvent)): Test the _userVisibleShortcut of the
commands given as part of this test.

Canonical link: <a href="https://commits.webkit.org/283001@main">https://commits.webkit.org/283001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4367ec02a7b1fde8f87a5dbcab956fae4b0201d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15781 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67962 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32759 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14378 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70625 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8841 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8875 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14321 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/961 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->