### PR TITLE
Don't eagerly evaluate calc() of <integer> values

### DIFF
--- a/LayoutTests/fast/css/order-calculated-value-expected.txt
+++ b/LayoutTests/fast/css/order-calculated-value-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS testDiv.style['order'] is ""
 testDiv.style['order'] = 'calc(2 * 3)'
-PASS testDiv.style['order'] is "6"
+PASS testDiv.style['order'] is "calc(6)"
 PASS window.getComputedStyle(testDiv).getPropertyValue('order') is "6"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/order-calculated-value.html
+++ b/LayoutTests/fast/css/order-calculated-value.html
@@ -9,7 +9,7 @@ var testDiv = document.getElementById("testDiv");
 
 shouldBeEmptyString("testDiv.style['order']");
 evalAndLog("testDiv.style['order'] = 'calc(2 * 3)'");
-shouldBeEqualToString("testDiv.style['order']", "6");
+shouldBeEqualToString("testDiv.style['order']", "calc(6)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('order')", "6");
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/css/webkit-line-clamp-calculated-value-expected.txt
+++ b/LayoutTests/fast/css/webkit-line-clamp-calculated-value-expected.txt
@@ -8,7 +8,7 @@ testDiv.style['-webkit-line-clamp'] = 'calc(10% * 2)'
 PASS testDiv.style['-webkit-line-clamp'] is "calc(20%)"
 PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "20%"
 testDiv.style['-webkit-line-clamp'] = 'calc(2 * 3)'
-PASS testDiv.style['-webkit-line-clamp'] is "6"
+PASS testDiv.style['-webkit-line-clamp'] is "calc(6)"
 PASS window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp') is "6"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/webkit-line-clamp-calculated-value.html
+++ b/LayoutTests/fast/css/webkit-line-clamp-calculated-value.html
@@ -12,7 +12,7 @@ evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(10% * 2)'");
 shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(20%)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "20%");
 evalAndLog("testDiv.style['-webkit-line-clamp'] = 'calc(2 * 3)'");
-shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "6");
+shouldBeEqualToString("testDiv.style['-webkit-line-clamp']", "calc(6)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('-webkit-line-clamp')", "6");
 
 </script>

--- a/LayoutTests/fast/css/z-index-calculated-value-expected.txt
+++ b/LayoutTests/fast/css/z-index-calculated-value-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS testDiv.style['z-index'] is ""
 testDiv.style['z-index'] = 'calc(-2 * 3)'
-PASS testDiv.style['z-index'] is "-6"
+PASS testDiv.style['z-index'] is "calc(-6)"
 PASS window.getComputedStyle(testDiv).getPropertyValue('z-index') is "-6"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/z-index-calculated-value.html
+++ b/LayoutTests/fast/css/z-index-calculated-value.html
@@ -9,7 +9,7 @@ var testDiv = document.getElementById("testDiv");
 
 shouldBeEmptyString("testDiv.style['z-index']");
 evalAndLog("testDiv.style['z-index'] = 'calc(-2 * 3)'");
-shouldBeEqualToString("testDiv.style['z-index']", "-6");
+shouldBeEqualToString("testDiv.style['z-index']", "calc(-6)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('z-index')", "-6");
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/signs-abs-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/signs-abs-computed-expected.txt
@@ -202,7 +202,7 @@ PASS abs(-1deg) should be used-value-equivalent to 1deg
 PASS abs(-1grad) should be used-value-equivalent to 1grad
 PASS abs(-1rad) should be used-value-equivalent to 1rad
 PASS abs(-1turn) should be used-value-equivalent to 1turn
-FAIL sign(10px - 1em) should be used-value-equivalent to 0; fontSize=10px assert_equals: sign(10px - 1em) and 0 serialize to the same thing in used values. expected "0" but got "1"
-FAIL sign(10px - 2em) should be used-value-equivalent to -1; fontSize=10px assert_equals: sign(10px - 2em) and -1 serialize to the same thing in used values. expected "-1" but got "1"
+PASS sign(10px - 1em) should be used-value-equivalent to 0; fontSize=10px
+PASS sign(10px - 2em) should be used-value-equivalent to -1; fontSize=10px
 PASS calc(sign(10%) * 100px) should be used-value-equivalent to 100px
 

--- a/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
@@ -84,6 +84,7 @@ static CanonicalDimension::Dimension determineCanonicalDimension(Calculation::Ca
     case Calculation::Category::PercentLength:
         return CanonicalDimension::Dimension::Length;
 
+    case Calculation::Category::Integer:
     case Calculation::Category::Number:
     case Calculation::Category::Percent:
     case Calculation::Category::Length:

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -50,6 +50,7 @@ template<typename Op, typename... Args> static double executeMathOperation(Args&
 static bool percentageResolveToDimension(const SimplificationOptions& options)
 {
     switch (options.category) {
+    case Calculation::Category::Integer:
     case Calculation::Category::Number:
     case Calculation::Category::Length:
     case Calculation::Category::Percent:
@@ -841,6 +842,7 @@ std::optional<Child> simplify(Product& root, const SimplificationOptions& option
     if (success) {
         if (auto category = productResult.type.calculationCategory()) {
             switch (*category) {
+            case Calculation::Category::Integer:
             case Calculation::Category::Number:
                 return makeChild(Number { .value = productResult.value });
             case Calculation::Category::Percent:

--- a/Source/WebCore/css/calc/CSSCalcType.cpp
+++ b/Source/WebCore/css/calc/CSSCalcType.cpp
@@ -320,6 +320,7 @@ Type Type::determineType(CSSUnitType unitType)
 Type::PercentHintValue Type::determinePercentHint(Calculation::Category category)
 {
     switch (category) {
+    case Calculation::Category::Integer:
     case Calculation::Category::Number:
     case Calculation::Category::Percent:
     case Calculation::Category::Length:
@@ -341,6 +342,7 @@ Type::PercentHintValue Type::determinePercentHint(Calculation::Category category
 bool Type::matches(Calculation::Category category) const
 {
     switch (category) {
+    case Calculation::Category::Integer:
     case Calculation::Category::Number:
         return matchesAny<Match::Number>();
     case Calculation::Category::Percent:

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -127,6 +127,8 @@ CSSUnitType CSSCalcValue::primitiveType() const
     // This returns the CSSUnitType associated with the value returned by doubleValue, or, if CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH, that a call to createCalculationValue() is needed.
 
     switch (m_tree.category) {
+    case Calculation::Category::Integer:
+        return CSSUnitType::CSS_INTEGER;
     case Calculation::Category::Number:
         return CSSUnitType::CSS_NUMBER;
     case Calculation::Category::Percent:
@@ -185,6 +187,9 @@ inline double CSSCalcValue::clampToPermittedRange(double value) const
     // it must be clamped to the nearest supported multiple of 360deg.
     if (m_tree.category == Calculation::Category::Angle && std::isinf(value))
         return 0;
+
+    if (m_tree.category == Calculation::Category::Integer)
+        value = std::floor(value + 0.5);
 
     return m_tree.range == ValueRange::NonNegative && value < 0 ? 0 : value;
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -60,17 +60,9 @@ struct CSSPrimitiveValueResolverBase {
     }
 
     template<typename IntType, IntegerValueRange integerRange>
-    static RefPtr<CSSPrimitiveValue> resolve(UnevaluatedCalc<IntegerRaw<IntType, integerRange>> calc, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions)
+    static RefPtr<CSSPrimitiveValue> resolve(UnevaluatedCalc<IntegerRaw<IntType, integerRange>> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
     {
-        // FIXME: This should not be eagerly resolving the calc. Instead, callers
-        // should resolve and round at style resolution. This will be incorrect calc
-        // expressions that contain relative lengths (which can appear in any calc
-        // expression, not just length expressions).
-
-        // https://drafts.csswg.org/css-values-4/#integers
-        // Rounding to the nearest integer requires rounding in the direction of +∞ when the fractional portion is exactly 0.5.
-        auto value = clampTo<IntType>(std::floor(std::max(calc.calc->doubleValueDeprecated(symbolTable), computeMinimumValue(integerRange)) + 0.5));
-        return CSSPrimitiveValue::createInteger(value);
+        return CSSPrimitiveValue::create(value.calc);
     }
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -59,7 +59,7 @@ struct IntegerKnownTokenTypeFunctionConsumer {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, Calculation::Category::Number, WTFMove(symbolsAllowed), options)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, Calculation::Category::Integer, WTFMove(symbolsAllowed), options)) {
             range = rangeCopy;
             return {{ value.releaseNonNull() }};
         }

--- a/Source/WebCore/platform/calc/CalculationCategory.cpp
+++ b/Source/WebCore/platform/calc/CalculationCategory.cpp
@@ -34,6 +34,7 @@ namespace Calculation {
 TextStream& operator<<(TextStream& ts, Category category)
 {
     switch (category) {
+    case Category::Integer: ts << "integer"; break;
     case Category::Number: ts << "number"; break;
     case Category::Percent: ts << "percent"; break;
     case Category::Length: ts << "length"; break;

--- a/Source/WebCore/platform/calc/CalculationCategory.h
+++ b/Source/WebCore/platform/calc/CalculationCategory.h
@@ -31,6 +31,7 @@ namespace WebCore {
 namespace Calculation {
 
 enum class Category : uint8_t {
+    Integer,
     Number,
     Percent,
     Length,


### PR DESCRIPTION
#### 76d664198b75324545784c30904dc1cd2e7d244d
<pre>
Don&apos;t eagerly evaluate calc() of &lt;integer&gt; values
<a href="https://bugs.webkit.org/show_bug.cgi?id=278950">https://bugs.webkit.org/show_bug.cgi?id=278950</a>

Reviewed by Darin Adler.

Makes processing of &lt;integer&gt; primitive values match other
primitive values by deferring calc() evaluation until style
building. With it no longer being eagerly evaluated, we also
now need to handle it as a potential calc() value to allow
proper clamping to integral bounds.

* LayoutTests/fast/css/order-calculated-value-expected.txt:
* LayoutTests/fast/css/order-calculated-value.html:
* LayoutTests/fast/css/webkit-line-clamp-calculated-value-expected.txt:
* LayoutTests/fast/css/webkit-line-clamp-calculated-value.html:
* LayoutTests/fast/css/z-index-calculated-value-expected.txt:
* LayoutTests/fast/css/z-index-calculated-value.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/signs-abs-computed-expected.txt:
* Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp:
(WebCore::CSSCalc::determineCanonicalDimension):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::percentageResolveToDimension):
(WebCore::CSSCalc::simplify):
* Source/WebCore/css/calc/CSSCalcType.cpp:
(WebCore::CSSCalc::Type::determinePercentHint):
(WebCore::CSSCalc::Type::matches const):
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::primitiveType const):
(WebCore::CSSCalcValue::clampToPermittedRange const):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
(WebCore::CSSPropertyParserHelpers::CSSPrimitiveValueResolverBase::resolve):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h:
(WebCore::CSSPropertyParserHelpers::IntegerKnownTokenTypeFunctionConsumer::consume):
* Source/WebCore/platform/calc/CalculationCategory.cpp:
(WebCore::Calculation::operator&lt;&lt;):
* Source/WebCore/platform/calc/CalculationCategory.h:

Canonical link: <a href="https://commits.webkit.org/283008@main">https://commits.webkit.org/283008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6809971945bc8d06e3f87077181d64b0773a78e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10696 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37598 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13344 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56225 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/969 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40077 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->