### PR TITLE
Do some more smart pointer adoption in XMLErrors and XMLTreeViewer

### DIFF
--- a/Source/WebCore/xml/XMLErrors.h
+++ b/Source/WebCore/xml/XMLErrors.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <libxml/parser.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextPosition.h>
@@ -51,7 +52,7 @@ public:
 private:
     void appendErrorMessage(ASCIILiteral typeString, TextPosition, const char* message);
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
     int m_errorCount { 0 };
     std::optional<TextPosition> m_lastErrorPosition;
     StringBuilder m_errorMessages;

--- a/Source/WebCore/xml/XMLTreeViewer.cpp
+++ b/Source/WebCore/xml/XMLTreeViewer.cpp
@@ -56,12 +56,14 @@ XMLTreeViewer::XMLTreeViewer(Document& document)
 void XMLTreeViewer::transformDocumentToTreeView()
 {
     String scriptString = StringImpl::createWithoutCopying(XMLViewer_js);
-    m_document.frame()->script().evaluateIgnoringException(ScriptSourceCode(scriptString, JSC::SourceTaintedOrigin::Untainted));
-    m_document.frame()->script().evaluateIgnoringException(ScriptSourceCode(AtomString("prepareWebKitXMLViewer('This XML file does not appear to have any style information associated with it. The document tree is shown below.');"_s), JSC::SourceTaintedOrigin::Untainted));
+    Ref document = m_document.get();
+    RefPtr frame = document->frame();
+    frame->checkedScript()->evaluateIgnoringException(ScriptSourceCode(scriptString, JSC::SourceTaintedOrigin::Untainted));
+    frame->checkedScript()->evaluateIgnoringException(ScriptSourceCode(AtomString("prepareWebKitXMLViewer('This XML file does not appear to have any style information associated with it. The document tree is shown below.');"_s), JSC::SourceTaintedOrigin::Untainted));
 
     String cssString = StringImpl::createWithoutCopying(XMLViewer_css);
-    auto text = m_document.createTextNode(WTFMove(cssString));
-    m_document.getElementById(String("xml-viewer-style"_s))->appendChild(text);
+    Ref text = document->createTextNode(WTFMove(cssString));
+    document->getElementById(String("xml-viewer-style"_s))->appendChild(WTFMove(text));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLTreeViewer.h
+++ b/Source/WebCore/xml/XMLTreeViewer.h
@@ -31,6 +31,8 @@
 
 #if ENABLE(XSLT)
 
+#include <wtf/CheckedRef.h>
+
 namespace WebCore {
 
 class Document;
@@ -42,7 +44,7 @@ public:
     void transformDocumentToTreeView();
 
 private:
-    Document& m_document;
+    CheckedRef<Document> m_document;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ca1c93338d55155858afe46350e47c6dc5b320b4
<pre>
Do some more smart pointer adoption in XMLErrors and XMLTreeViewer
<a href="https://bugs.webkit.org/show_bug.cgi?id=278953">https://bugs.webkit.org/show_bug.cgi?id=278953</a>

Reviewed by Darin Adler.

* Source/WebCore/xml/XMLErrors.cpp:
(WebCore::createXHTMLParserErrorHeader):
(WebCore::XMLErrors::insertErrorMessageBlock):
* Source/WebCore/xml/XMLErrors.h:
* Source/WebCore/xml/XMLTreeViewer.cpp:
(WebCore::XMLTreeViewer::transformDocumentToTreeView):
* Source/WebCore/xml/XMLTreeViewer.h:

Canonical link: <a href="https://commits.webkit.org/283010@main">https://commits.webkit.org/283010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0103891031baebdb88e6b3adb480a08e75e4d530

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52147 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10705 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67973 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/40937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14389 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70636 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56229 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/973 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9844 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40084 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->