### PR TITLE
AX: Various AccessibilityObject and AXObjectCache helper methods take Node* or RenderObject* when they could take a reference

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -391,7 +391,7 @@ public:
     void deferModalChange(Element&);
     void deferMenuListValueChange(Element*);
     void deferNodeAddedOrRemoved(Node*);
-    void handleScrolledToAnchor(const Node* anchorNode);
+    void handleScrolledToAnchor(const Node& anchorNode);
     void onScrollbarUpdate(ScrollView&);
     void onRemoteFrameInitialized(AXRemoteFrame&);
 
@@ -399,7 +399,7 @@ public:
     Node* modalNode();
 
     void deferAttributeChangeIfNeeded(Element&, const QualifiedName&, const AtomString&, const AtomString&);
-    void recomputeIsIgnored(RenderObject*);
+    void recomputeIsIgnored(RenderObject&);
     void recomputeIsIgnored(Node*);
 
     static void enableAccessibility();

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -163,11 +163,11 @@ std::optional<BoundaryPoint> AXTextMarker::boundaryPoint() const
     CharacterOffset characterOffset = *this;
     if (characterOffset.isNull())
         return std::nullopt;
+    // Guaranteed not to be null by checking Character::isNull().
+    RefPtr node = characterOffset.node;
 
     int offset = characterOffset.startIndex + characterOffset.offset;
-    RefPtr node = characterOffset.node;
-    ASSERT(node);
-    if (AccessibilityObject::replacedNodeNeedsCharacter(node.get()) || (node && node->hasTagName(HTMLNames::brTag)))
+    if (AccessibilityObject::replacedNodeNeedsCharacter(*node) || node->hasTagName(HTMLNames::brTag))
         node = nodeAndOffsetForReplacedNode(*node, offset, characterOffset.offset);
     if (!node)
         return std::nullopt;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -61,7 +61,7 @@ class IntPoint;
 class IntSize;
 class ScrollableArea;
 
-bool nodeHasPresentationRole(Node*);
+bool nodeHasPresentationRole(Node&);
 
 class AccessibilityObject : public AXCoreObject, public CanMakeWeakPtr<AccessibilityObject> {
 public:
@@ -309,7 +309,7 @@ public:
 
     // This function checks if the object should be ignored when there's a modal dialog displayed.
     virtual bool ignoredFromModalPresence() const;
-    bool isModalDescendant(Node*) const;
+    bool isModalDescendant(Node&) const;
     bool isModalNode() const override;
 
     bool supportsSetSize() const override;
@@ -557,7 +557,7 @@ public:
     std::optional<SimpleRange> visibleCharacterRange() const override;
     VisiblePositionRange visiblePositionRangeForLine(unsigned) const override { return VisiblePositionRange(); }
 
-    static bool replacedNodeNeedsCharacter(Node* replacedNode);
+    static bool replacedNodeNeedsCharacter(Node& replacedNode);
 
     VisiblePositionRange visiblePositionRangeForUnorderedPositions(const VisiblePosition&, const VisiblePosition&) const override;
     VisiblePositionRange leftLineVisiblePositionRange(const VisiblePosition&) const override;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1074,10 +1074,8 @@ static bool webAreaIsPresentational(RenderObject* renderer)
     if (!renderer || !is<RenderView>(*renderer))
         return false;
     
-    if (auto ownerElement = renderer->document().ownerElement())
-        return nodeHasPresentationRole(ownerElement);
-    
-    return false;
+    auto* ownerElement = renderer->document().ownerElement();
+    return ownerElement && nodeHasPresentationRole(*ownerElement);
 }
 
 bool AccessibilityRenderObject::computeIsIgnored() const

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -274,7 +274,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Node* oldFocusedNode, 
     }
 }
 
-void AXObjectCache::handleScrolledToAnchor(const Node*)
+void AXObjectCache::handleScrolledToAnchor(const Node&)
 {
 }
 

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -164,7 +164,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Node*, Node* newNode)
     postNotification(newNode, AXFocusedUIElementChanged);
 }
 
-void AXObjectCache::handleScrolledToAnchor(const Node*)
+void AXObjectCache::handleScrolledToAnchor(const Node&)
 {
 }
 

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -733,7 +733,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Node*, Node*)
     [rootWebArea->wrapper() accessibilityPostedNotification:@"AXFocusChanged" userInfo:nil];
 }
 
-void AXObjectCache::handleScrolledToAnchor(const Node*)
+void AXObjectCache::handleScrolledToAnchor(const Node&)
 {
 }
 

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -125,12 +125,9 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* o
     client.postAccessibilityFrameLoadingEventNotification(object, loadingEvent);
 }
 
-void AXObjectCache::handleScrolledToAnchor(const Node* scrolledToNode)
+void AXObjectCache::handleScrolledToAnchor(const Node& scrolledToNode)
 {
-    if (!scrolledToNode)
-        return;
-
-    if (RefPtr object = AccessibilityObject::firstAccessibleObjectFromNode(scrolledToNode))
+    if (RefPtr object = AccessibilityObject::firstAccessibleObjectFromNode(&scrolledToNode))
         postPlatformNotification(*object, AXScrolledToAnchor);
 }
 

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -56,11 +56,11 @@ void AXObjectCache::attachWrapper(AccessibilityObject&)
     // software requests them via get_accChild.
 }
 
-void AXObjectCache::handleScrolledToAnchor(const Node* anchorNode)
+void AXObjectCache::handleScrolledToAnchor(const Node& anchorNode)
 {
     // The anchor node may not be accessible. Post the notification for the
     // first accessible object.
-    if (RefPtr object = AccessibilityObject::firstAccessibleObjectFromNode(anchorNode))
+    if (RefPtr object = AccessibilityObject::firstAccessibleObjectFromNode(&anchorNode))
         postPlatformNotification(*object, AXScrolledToAnchor);
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3676,7 +3676,7 @@ void LocalFrameView::scrollToAnchor()
         scrollRectToVisible(rect, *anchorNode->renderer(), insideFixed, { SelectionRevealMode::Reveal, ScrollAlignment::alignLeftAlways, ScrollAlignment::alignToEdgeIfNeeded, ShouldAllowCrossOriginScrolling::No });
 
     if (AXObjectCache* cache = m_frame->document()->existingAXObjectCache())
-        cache->handleScrolledToAnchor(anchorNode.get());
+        cache->handleScrolledToAnchor(*anchorNode);
 
     // scrollRectToVisible can call into setScrollPosition(), which resets m_maintainScrollPositionAnchor.
     LOG_WITH_STREAM(Scrolling, stream << " restoring anchor node to " << anchorNode.get());


### PR DESCRIPTION
#### 030cac1847daa66c0b4e1404deeee8f15c61d6ac
<pre>
AX: Various AccessibilityObject and AXObjectCache helper methods take Node* or RenderObject* when they could take a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=278956">https://bugs.webkit.org/show_bug.cgi?id=278956</a>
<a href="https://rdar.apple.com/135063206">rdar://135063206</a>

Reviewed by Chris Fleizach.

In all callsites of these functions that take Node* or RenderObject*, we know from the context that the passed pointer
cannot be null (e.g. because we already checked), meaning we&apos;re performing unnecessary null-checks:

  - recomputeIsIgnored(RenderObject*)
  - replacedNodeNeedsCharacter(Node*)
  - isReplacedNodeOrBR(Node* node)
  - handleScrolledToAnchor(const Node*)
  - nodeHasPresentationRole(Node*)
  - isModalDescendant(Node*)

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::recomputeIsIgnored):
(WebCore::AXObjectCache::traverseToOffsetInRange):
(WebCore::AXObjectCache::lengthForRange):
(WebCore::AXObjectCache::rangeForNodeContents):
(WebCore::isReplacedNodeOrBR):
(WebCore::characterOffsetsInOrder):
(WebCore::boundaryPoint):
(WebCore::AXObjectCache::nextCharacterOffset):
(WebCore::AXObjectCache::previousBoundary):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::deferRecomputeIsIgnoredIfNeeded):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::boundaryPoint const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::replacedNodeNeedsCharacter):
(WebCore::AccessibilityObject::stringForRange const):
(WebCore::AccessibilityObject::stringForVisiblePositionRange):
(WebCore::AccessibilityObject::isModalDescendant const):
(WebCore::AccessibilityObject::ignoredFromModalPresence const):
(WebCore::nodeHasPresentationRole):
(WebCore::AccessibilityObject::supportsPressAction const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::webAreaIsPresentational):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::handleScrolledToAnchor):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::handleScrolledToAnchor):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::handleScrolledToAnchor):
* Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp:
(WebCore::AXObjectCache::handleScrolledToAnchor):
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::handleScrolledToAnchor):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToAnchor):

Canonical link: <a href="https://commits.webkit.org/283031@main">https://commits.webkit.org/283031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab6bc54912ec048b7fe78637e000350222c2f657

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52199 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13605 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70704 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13422 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59529 "Found 1 new test failure: inspector/dom/getMediaStats.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56294 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59752 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/selections (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14340 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1039 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->