### PR TITLE
Enable YouTube plugin replacement for all of WebKit

### DIFF
--- a/LayoutTests/security/contentSecurityPolicy/object-src-none-blocks-youtube-plugin-replacement.html
+++ b/LayoutTests/security/contentSecurityPolicy/object-src-none-blocks-youtube-plugin-replacement.html
@@ -8,9 +8,6 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-if (window.internals)
-    window.internals.settings.setYouTubeFlashPluginReplacementEnabled(true);
-
 function done()
 {
     if (window.testRunner)

--- a/LayoutTests/security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html
+++ b/LayoutTests/security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html
@@ -8,9 +8,6 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-if (window.internals)
-    window.internals.settings.setYouTubeFlashPluginReplacementEnabled(true);
-
 // Waiting at least 100ms seems to ensure that YouTube plugin replacement has loaded.
 window.setTimeout(function () {
     if (window.testRunner)

--- a/LayoutTests/security/contentSecurityPolicy/plugins-types-blocks-youtube-plugin-replacement-without-mime-type.html
+++ b/LayoutTests/security/contentSecurityPolicy/plugins-types-blocks-youtube-plugin-replacement-without-mime-type.html
@@ -8,9 +8,6 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-if (window.internals)
-    window.internals.settings.setYouTubeFlashPluginReplacementEnabled(true);
-
 function done()
 {
     if (window.testRunner)

--- a/LayoutTests/security/contentSecurityPolicy/plugins-types-blocks-youtube-plugin-replacement.html
+++ b/LayoutTests/security/contentSecurityPolicy/plugins-types-blocks-youtube-plugin-replacement.html
@@ -8,9 +8,6 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-if (window.internals)
-    window.internals.settings.setYouTubeFlashPluginReplacementEnabled(true);
-
 function done()
 {
     if (window.testRunner)

--- a/Source/WebCore/Modules/plugins/PluginReplacement.h
+++ b/Source/WebCore/Modules/plugins/PluginReplacement.h
@@ -34,7 +34,6 @@ class HTMLPlugInElement;
 class RenderElement;
 class RenderStyle;
 class RenderTreePosition;
-class Settings;
 class ShadowRoot;
 
 class PluginReplacement : public RefCounted<PluginReplacement> {
@@ -51,16 +50,14 @@ typedef Ref<PluginReplacement> (*CreatePluginReplacement)(HTMLPlugInElement&, co
 typedef bool (*PluginReplacementSupportsType)(const String&);
 typedef bool (*PluginReplacementSupportsFileExtension)(StringView);
 typedef bool (*PluginReplacementSupportsURL)(const URL&);
-typedef bool (*PluginReplacementEnabledForSettings)(const Settings&);
 
 class ReplacementPlugin {
 public:
-    ReplacementPlugin(CreatePluginReplacement constructor, PluginReplacementSupportsType supportsType, PluginReplacementSupportsFileExtension supportsFileExtension, PluginReplacementSupportsURL supportsURL, PluginReplacementEnabledForSettings isEnabledBySettings)
+    ReplacementPlugin(CreatePluginReplacement constructor, PluginReplacementSupportsType supportsType, PluginReplacementSupportsFileExtension supportsFileExtension, PluginReplacementSupportsURL supportsURL)
         : m_constructor(constructor)
         , m_supportsType(supportsType)
         , m_supportsFileExtension(supportsFileExtension)
         , m_supportsURL(supportsURL)
-        , m_isEnabledBySettings(isEnabledBySettings)
     {
     }
 
@@ -69,7 +66,6 @@ public:
         , m_supportsType(other.m_supportsType)
         , m_supportsFileExtension(other.m_supportsFileExtension)
         , m_supportsURL(other.m_supportsURL)
-        , m_isEnabledBySettings(other.m_isEnabledBySettings)
     {
     }
 
@@ -77,14 +73,12 @@ public:
     bool supportsType(const String& mimeType) const { return m_supportsType(mimeType); }
     bool supportsFileExtension(StringView extension) const { return m_supportsFileExtension(extension); }
     bool supportsURL(const URL& url) const { return m_supportsURL(url); }
-    bool isEnabledBySettings(const Settings& settings) const { return m_isEnabledBySettings(settings); };
 
 private:
     CreatePluginReplacement m_constructor;
     PluginReplacementSupportsType m_supportsType;
     PluginReplacementSupportsFileExtension m_supportsFileExtension;
     PluginReplacementSupportsURL m_supportsURL;
-    PluginReplacementEnabledForSettings m_isEnabledBySettings;
 };
 
 typedef void (*PluginReplacementRegistrar)(const ReplacementPlugin&);

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 void YouTubePluginReplacement::registerPluginReplacement(PluginReplacementRegistrar registrar)
 {
-    registrar(ReplacementPlugin(create, supportsMIMEType, supportsFileExtension, supportsURL, isEnabledBySettings));
+    registrar(ReplacementPlugin(create, supportsMIMEType, supportsFileExtension, supportsURL));
 }
 
 Ref<PluginReplacement> YouTubePluginReplacement::create(HTMLPlugInElement& plugin, const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues)
@@ -337,9 +337,4 @@ bool YouTubePluginReplacement::supportsURL(const URL& url)
     return isYouTubeURL(url);
 }
 
-bool YouTubePluginReplacement::isEnabledBySettings(const Settings& settings)
-{
-    return settings.youTubeFlashPluginReplacementEnabled();
-}
-    
 }

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
@@ -50,7 +50,6 @@ private:
     static bool supportsMIMEType(const String&);
     static bool supportsFileExtension(StringView);
     static bool supportsURL(const URL&);
-    static bool isEnabledBySettings(const Settings&);
 
     void installReplacement(ShadowRoot&) final;
 

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -358,7 +358,7 @@ bool HTMLPlugInElement::requestObject(const String& relativeURL, const String& m
         completedURL = document().completeURL(relativeURL);
 
     ReplacementPlugin* replacement = pluginReplacementForType(completedURL, mimeType);
-    if (!replacement || !replacement->isEnabledBySettings(document().settings()))
+    if (!replacement)
         return false;
 
     LOG(Plugins, "%p - Found plug-in replacement for %s.", this, completedURL.string().utf8().data());

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -506,10 +506,3 @@ WebkitImageReadyEventEnabled:
   defaultValue:
     WebCore:
       default: false
-
-YouTubeFlashPluginReplacementEnabled:
-  type: bool
-  defaultValue:
-    WebCore:
-      PLATFORM(COCOA): true
-      default: false


### PR DESCRIPTION
#### a07ed2d34cca0026f33d49481f21b93fc929af09
<pre>
Enable YouTube plugin replacement for all of WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=278957">https://bugs.webkit.org/show_bug.cgi?id=278957</a>

Reviewed by Michael Catanzaro and Sam Weinig.

It&apos;s about to be standardized and therefore this should work for all
WebKit ports.

* LayoutTests/security/contentSecurityPolicy/object-src-none-blocks-youtube-plugin-replacement.html:
* LayoutTests/security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html:
* LayoutTests/security/contentSecurityPolicy/plugins-types-blocks-youtube-plugin-replacement-without-mime-type.html:
* LayoutTests/security/contentSecurityPolicy/plugins-types-blocks-youtube-plugin-replacement.html:
* Source/WebCore/Modules/plugins/PluginReplacement.h:
(WebCore::ReplacementPlugin::ReplacementPlugin):
(WebCore::ReplacementPlugin::supportsURL const):
(WebCore::ReplacementPlugin::isEnabledBySettings const): Deleted.
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
(WebCore::YouTubePluginReplacement::registerPluginReplacement):
(WebCore::YouTubePluginReplacement::isEnabledBySettings): Deleted.
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.h:
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::requestObject):
* Source/WebCore/page/Settings.yaml:

Canonical link: <a href="https://commits.webkit.org/283191@main">https://commits.webkit.org/283191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58131ebe53cc0ac1e42f67c8f3a47bd1379ef570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52169 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70661 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59499 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56253 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59705 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/attributes (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/998 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40111 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->