### PR TITLE
Minor MotionPath code cleanup

### DIFF
--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -64,7 +64,6 @@ static FloatPoint normalPositionForOffsetPath(PathOperation* operation, const Fl
 
 std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const RenderElement& renderer)
 {
-    MotionPathData data;
     auto pathOperation = renderer.style().offsetPath();
     if (!is<RenderLayerModelObject>(renderer) || !pathOperation)
         return std::nullopt;
@@ -83,22 +82,24 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
         return floatPointForLengthPoint(offsetPosition, referenceRect.size());
     };
 
-    if (auto* container = renderer.containingBlock()) {
-        data.containingBlockBoundingRect = containingBlockRectForRenderer(renderer, *container, *pathOperation);
-        data.offsetFromContainingBlock = offsetFromContainer(renderer, *container, data.containingBlockBoundingRect.rect());
+    auto* container = renderer.containingBlock();
+    if (!container)
+        return std::nullopt;
 
-        auto offsetPosition = renderer.style().offsetPosition();
+    MotionPathData data;
+    data.containingBlockBoundingRect = containingBlockRectForRenderer(renderer, *container, *pathOperation);
+    data.offsetFromContainingBlock = offsetFromContainer(renderer, *container, data.containingBlockBoundingRect.rect());
 
-        if (is<ShapePathOperation>(pathOperation))
-            data.usedStartingPosition = startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container);
-        if (auto* rayPathOperation = dynamicDowncast<RayPathOperation>(pathOperation)) {
-            auto startingPosition = rayPathOperation->position();
-            data.usedStartingPosition = startingPosition.x().isAuto() ? startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container) : floatPointForLengthPoint(startingPosition, data.containingBlockBoundingRect.rect().size());
-        }
-        return data;
+    auto offsetPosition = renderer.style().offsetPosition();
+    if (is<ShapePathOperation>(pathOperation))
+        data.usedStartingPosition = startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container);
+
+    if (auto* rayPathOperation = dynamicDowncast<RayPathOperation>(pathOperation)) {
+        auto startingPosition = rayPathOperation->position();
+        data.usedStartingPosition = startingPosition.x().isAuto() ? startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container) : floatPointForLengthPoint(startingPosition, data.containingBlockBoundingRect.rect().size());
     }
 
-    return std::nullopt;
+    return data;
 }
 
 static PathTraversalState traversalStateAtDistance(const Path& path, const Length& distance)
@@ -122,7 +123,7 @@ static PathTraversalState traversalStateAtDistance(const Path& path, const Lengt
 
 void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const TransformOperationData& transformData, const FloatPoint& transformOrigin, const PathOperation& offsetPath, const LengthPoint& offsetAnchor, const Length& offsetDistance, const OffsetRotation& offsetRotate, TransformBox transformBox)
 {
-    auto& boundingBox = transformData.boundingBox;
+    auto boundingBox = transformData.boundingBox;
     auto anchor = transformOrigin;
     if (!offsetAnchor.x().isAuto())
         anchor = floatPointForLengthPoint(offsetAnchor, boundingBox.size()) + boundingBox.location();
@@ -131,6 +132,7 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
     auto path = offsetPath.getPath(transformData);
     if (!path)
         return;
+
     auto traversalState = traversalStateAtDistance(*path, offsetDistance);
     matrix.translate(traversalState.current().x(), traversalState.current().y());
 
@@ -200,10 +202,10 @@ static FloatPoint currentOffsetForData(const MotionPathData& data)
     return FloatPoint(data.usedStartingPosition - data.offsetFromContainingBlock);
 }
 
-std::optional<Path> MotionPath::computePathForRay(const RayPathOperation& rayPathOperation, const TransformOperationData& data)
+std::optional<Path> MotionPath::computePathForRay(const RayPathOperation& rayPathOperation, const TransformOperationData& transformData)
 {
-    auto motionPathData = data.motionPathData;
-    auto elementBoundingBox = data.boundingBox;
+    auto motionPathData = transformData.motionPathData;
+    auto elementBoundingBox = transformData.boundingBox;
     if (!motionPathData || motionPathData->containingBlockBoundingRect.rect().isZero())
         return std::nullopt;
 
@@ -229,9 +231,9 @@ static FloatRoundedRect offsetRectForData(const MotionPathData& data)
     return rect;
 }
 
-std::optional<Path> MotionPath::computePathForBox(const BoxPathOperation&, const TransformOperationData& data)
+std::optional<Path> MotionPath::computePathForBox(const BoxPathOperation&, const TransformOperationData& transformData)
 {
-    if (auto motionPathData = data.motionPathData) {
+    if (auto motionPathData = transformData.motionPathData) {
         Path path;
         path.addRoundedRect(offsetRectForData(*motionPathData), PathRoundedRect::Strategy::PreferBezier);
         return path;
@@ -239,9 +241,9 @@ std::optional<Path> MotionPath::computePathForBox(const BoxPathOperation&, const
     return std::nullopt;
 }
 
-std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pathOperation, const TransformOperationData& data)
+std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pathOperation, const TransformOperationData& transformData)
 {
-    if (auto motionPathData = data.motionPathData) {
+    if (auto motionPathData = transformData.motionPathData) {
         auto& shape = pathOperation.basicShape();
         auto containingBlockRect = offsetRectForData(*motionPathData).rect();
         if (auto* centerCoordShape = dynamicDowncast<BasicShapeCircleOrEllipse>(shape)) {
@@ -250,7 +252,7 @@ std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pa
         }
         return pathOperation.pathForReferenceRect(containingBlockRect);
     }
-    return pathOperation.pathForReferenceRect(data.boundingBox);
+    return pathOperation.pathForReferenceRect(transformData.boundingBox);
 
 }
 

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -48,13 +48,16 @@ class MotionPath {
 public:
     static std::optional<MotionPathData> motionPathDataForRenderer(const RenderElement&);
     static bool needsUpdateAfterContainingBlockLayout(const PathOperation&);
+
     static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, const FloatPoint& transformOrigin, const PathOperation&, const LengthPoint& offsetAnchor, const Length& offsetDistance, const OffsetRotation&, TransformBox);
     static void applyMotionPathTransform(const RenderStyle&, const TransformOperationData&, TransformationMatrix&);
+
     WEBCORE_EXPORT static std::optional<Path> computePathForBox(const BoxPathOperation&, const TransformOperationData&);
+    WEBCORE_EXPORT static std::optional<Path> computePathForShape(const ShapePathOperation&, const TransformOperationData&);
     static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&);
+
     static double lengthForRayPath(const RayPathOperation&, const MotionPathData&);
     static double lengthForRayContainPath(const FloatRect& elementRect, double computedPathLength);
-    WEBCORE_EXPORT static std::optional<Path> computePathForShape(const ShapePathOperation&, const TransformOperationData&);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### b6936fdb0a53e2d299b2956ce9ecb70991bf680f
<pre>
Minor MotionPath code cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=278968">https://bugs.webkit.org/show_bug.cgi?id=278968</a>
<a href="https://rdar.apple.com/135079984">rdar://135079984</a>

Reviewed by Tim Nguyen.

Various unctions in MotionPath take a `data` argument, but sometimes this is a
TransformOperationData and sometimes a MotionPathData. Fix by calling it a
`transformData` for the former case.

Also early return in `MotionPath::motionPathDataForRenderer()` in the no
containing block case.

* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::motionPathDataForRenderer):
(WebCore::MotionPath::applyMotionPathTransform):
(WebCore::MotionPath::computePathForRay):
(WebCore::MotionPath::computePathForBox):
(WebCore::MotionPath::computePathForShape):
* Source/WebCore/rendering/MotionPath.h:

Canonical link: <a href="https://commits.webkit.org/283032@main">https://commits.webkit.org/283032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/621343593371757cd8f646dfaabcb2d8ea4843c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52188 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68028 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40991 "Found 1 new test failure: accessibility/out-of-bounds-rowspan.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13594 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59518 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56283 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59732 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/attributes (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14341 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1028 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->