### PR TITLE
Large Autorelease Pool faults in com.apple.WebKit.Networking

### DIFF
--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -54,13 +54,15 @@ bool PublicSuffixStore::platformIsPublicSuffix(StringView domain) const
 
 String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView host) const
 {
-    size_t separatorPosition;
-    for (unsigned labelStart = 0; (separatorPosition = host.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {
-        if (isPublicSuffix(host.substring(separatorPosition + 1)))
-            return host.substring(labelStart).toString();
-    }
+    @autoreleasepool {
+        size_t separatorPosition;
+        for (unsigned labelStart = 0; (separatorPosition = host.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {
+            if (isPublicSuffix(host.substring(separatorPosition + 1)))
+                return host.substring(labelStart).toString();
+        }
 
-    return { };
+        return { };
+    }
 }
 
 void PublicSuffixStore::enablePublicSuffixCache()

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -100,8 +100,10 @@ static Vector<Cookie> nsCookiesToCookieVector(NSArray<NSHTTPCookie *> *nsCookies
     Vector<Cookie> cookies;
     cookies.reserveInitialCapacity(nsCookies.count);
     for (NSHTTPCookie *nsCookie in nsCookies) {
-        if (!filter || filter(nsCookie))
-            cookies.append(nsCookie);
+        @autoreleasepool {
+            if (!filter || filter(nsCookie))
+                cookies.append(nsCookie);
+        }
     }
     if (filter)
         cookies.shrinkToFit();
@@ -603,8 +605,10 @@ void NetworkStorageSession::deleteCookiesMatching(const Function<bool(NSHTTPCook
         return;
 
     for (NSHTTPCookie *cookie in cookies.get()) {
-        if (matches(cookie))
-            deleteHTTPCookie(cookieStorage.get(), cookie, [aggregator] { });
+        @autoreleasepool {
+            if (matches(cookie))
+                deleteHTTPCookie(cookieStorage.get(), cookie, [aggregator] { });
+        }
     }
 
     END_BLOCK_OBJC_EXCEPTIONS


### PR DESCRIPTION
#### 1179d8237d6f5b46dc9c1498a306bebbfd0b6cc2
<pre>
Large Autorelease Pool faults in com.apple.WebKit.Networking
<a href="https://bugs.webkit.org/show_bug.cgi?id=278970">https://bugs.webkit.org/show_bug.cgi?id=278970</a>
<a href="https://rdar.apple.com/122475484">rdar://122475484</a> (StabilityTracer: Large Autorelease Pool)

Reviewed by Chris Dumez.

Drain @autoreleasepool in loops with potentially a large number of iterations.

* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::deleteCookiesMatching):

Canonical link: <a href="https://commits.webkit.org/283444@main">https://commits.webkit.org/283444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d05c81f639e07aa0edd88bbd7e63cd8c3d73cfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52191 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10751 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70694 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59521 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56286 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59736 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/selections (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1031 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40144 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->