### PR TITLE
[WebGPU] id<MTLSamplerState> is retained unnecessarily

### DIFF
--- a/Source/WebGPU/WebGPU/Sampler.h
+++ b/Source/WebGPU/WebGPU/Sampler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import <wtf/FastMalloc.h>
+#import <wtf/Lock.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/TZoneMalloc.h>
@@ -81,6 +82,7 @@ private:
 
     const Ref<Device> m_device;
     // static is intentional here as the limit is per process
+    static Lock samplerStateLock;
     static NSMutableDictionary<SamplerIdentifier*, id<MTLSamplerState>> *cachedSamplerStates;
     static NSMutableOrderedSet<SamplerIdentifier*> *lastAccessedKeys;
 


### PR DESCRIPTION
#### 3845740eb3e24283fc43ea8786240c453c24e4be
<pre>
[WebGPU] id&lt;MTLSamplerState&gt; is retained unnecessarily
<a href="https://bugs.webkit.org/show_bug.cgi?id=278972">https://bugs.webkit.org/show_bug.cgi?id=278972</a>
&lt;radar://135086198&gt;

Reviewed by Dan Glastonbury.

The sampler cache was holding on to the sampler when it did not need to.

Also fix race which could occur when two WebGPU work queues tried to
create a sampler at the same time.

* Source/WebGPU/WebGPU/Sampler.h:
* Source/WebGPU/WebGPU/Sampler.mm:
(WebGPU::Sampler::~Sampler):
(WebGPU::Sampler::samplerState const):

Canonical link: <a href="https://commits.webkit.org/283095@main">https://commits.webkit.org/283095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d7665559afb79e9811e380b8aee47f84a9ba50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52194 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37669 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70698 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59525 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56290 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59743 "Found 121 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.GeolocationBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PageLoadBasic, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1035 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40148 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->