### PR TITLE
Adopt more smart pointers in the network process

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -204,7 +204,7 @@ public:
 
     void didCreateNetworkProcess();
 
-    const WebResourceLoadStatisticsStore& store() const { return m_store; }
+    const WebResourceLoadStatisticsStore& store() const { return m_store.get(); }
 
     bool domainIDExistsInDatabase(int);
     bool observedDomainNavigationWithLinkDecoration(int);
@@ -215,7 +215,7 @@ public:
     static void interruptAllDatabases();
 
 private:
-    WebResourceLoadStatisticsStore& store() { return m_store; }
+    WebResourceLoadStatisticsStore& store() { return m_store.get(); }
 
     struct Parameters {
         size_t pruneEntriesDownTo { 800 };
@@ -352,7 +352,7 @@ private:
     void deleteTable(StringView);
     void destroyStatements() final;
 
-    WebResourceLoadStatisticsStore& m_store;
+    CheckedRef<WebResourceLoadStatisticsStore> m_store;
     Ref<SuspendableWorkQueue> m_workQueue;
 #if HAVE(CORE_PREDICTION)
     ResourceLoadStatisticsClassifierCocoa m_resourceLoadStatisticsClassifier;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -94,7 +94,9 @@ struct RegistrableDomainsToDeleteOrRestrictWebsiteDataFor {
     bool isEmpty() const { return domainsToDeleteAllCookiesFor.isEmpty() && domainsToDeleteAllButHttpOnlyCookiesFor.isEmpty() && domainsToDeleteAllScriptWrittenStorageFor.isEmpty() && domainsToEnforceSameSiteStrictFor.isEmpty(); }
 };
 
-class WebResourceLoadStatisticsStore final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebResourceLoadStatisticsStore, WTF::DestructionThread::Main> {
+class WebResourceLoadStatisticsStore final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebResourceLoadStatisticsStore, WTF::DestructionThread::Main>, public CanMakeThreadSafeCheckedPtr<WebResourceLoadStatisticsStore> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebResourceLoadStatisticsStore);
 public:
     using ResourceLoadStatistics = WebCore::ResourceLoadStatistics;
     using RegistrableDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -61,7 +61,7 @@ Download::Download(DownloadManager& downloadManager, DownloadID downloadID, Netw
     , m_sessionID(session.sessionID())
     , m_testSpeedMultiplier(session.testSpeedMultiplier())
 {
-    m_downloadManager.didCreateDownload();
+    m_downloadManager->didCreateDownload();
 }
 
 #if PLATFORM(COCOA)
@@ -73,14 +73,14 @@ Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NSUR
     , m_sessionID(session.sessionID())
     , m_testSpeedMultiplier(session.testSpeedMultiplier())
 {
-    m_downloadManager.didCreateDownload();
+    m_downloadManager->didCreateDownload();
 }
 #endif
 
 Download::~Download()
 {
     platformDestroyDownload();
-    m_downloadManager.didDestroyDownload();
+    m_downloadManager->didDestroyDownload();
 }
 
 void Download::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler, IgnoreDidFailCallback ignoreDidFailCallback)
@@ -99,7 +99,7 @@ void Download::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& comple
         DOWNLOAD_RELEASE_LOG("didCancel: (id = %" PRIu64 ")", downloadID().toUInt64());
         if (auto extension = std::exchange(m_sandboxExtension, nullptr))
             extension->revoke();
-        m_downloadManager.downloadFinished(*this);
+        m_downloadManager->downloadFinished(*this);
     };
 
     if (m_download) {
@@ -148,7 +148,7 @@ void Download::didFinish()
         m_sandboxExtension = nullptr;
     }
 
-    m_downloadManager.downloadFinished(*this);
+    m_downloadManager->downloadFinished(*this);
 }
 
 void Download::didFail(const ResourceError& error, std::span<const uint8_t> resumeData)
@@ -165,12 +165,12 @@ void Download::didFail(const ResourceError& error, std::span<const uint8_t> resu
         m_sandboxExtension->revoke();
         m_sandboxExtension = nullptr;
     }
-    m_downloadManager.downloadFinished(*this);
+    m_downloadManager->downloadFinished(*this);
 }
 
 IPC::Connection* Download::messageSenderConnection() const
 {
-    return m_downloadManager.downloadProxyConnection();
+    return m_downloadManager->downloadProxyConnection();
 }
 
 uint64_t Download::messageSenderDestinationID() const

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -70,9 +70,10 @@ class NetworkDataTask;
 class NetworkSession;
 class WebPage;
 
-class Download : public IPC::MessageSender, public CanMakeWeakPtr<Download> {
+class Download : public IPC::MessageSender, public CanMakeWeakPtr<Download>, public CanMakeCheckedPtr<Download> {
     WTF_MAKE_TZONE_ALLOCATED(Download);
     WTF_MAKE_NONCOPYABLE(Download);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Download);
 public:
     Download(DownloadManager&, DownloadID, NetworkDataTask&, NetworkSession&, const String& suggestedFilename = { });
 #if PLATFORM(COCOA)
@@ -104,7 +105,7 @@ public:
 
     void applicationDidEnterBackground() { m_monitor.applicationDidEnterBackground(); }
     void applicationWillEnterForeground() { m_monitor.applicationWillEnterForeground(); }
-    DownloadManager& manager() const { return m_downloadManager; }
+    DownloadManager& manager() const { return m_downloadManager.get(); }
 
     unsigned testSpeedMultiplier() const { return m_testSpeedMultiplier; }
 
@@ -116,7 +117,7 @@ private:
     void platformCancelNetworkLoad(CompletionHandler<void(std::span<const uint8_t>)>&&);
     void platformDestroyDownload();
 
-    DownloadManager& m_downloadManager;
+    CheckedRef<DownloadManager> m_downloadManager;
     DownloadID m_downloadID;
     Ref<DownloadManager::Client> m_client;
 

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
@@ -45,6 +45,8 @@ DownloadManager::DownloadManager(Client& client)
 {
 }
 
+DownloadManager::~DownloadManager() = default;
+
 void DownloadManager::startDownload(PAL::SessionID sessionID, DownloadID downloadID, const ResourceRequest& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, const String& suggestedName)
 {
     auto* networkSession = client().networkSession(sessionID);

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -61,9 +61,10 @@ class PendingDownload;
 
 enum class CallDownloadDidStart : bool { No, Yes };
 
-class DownloadManager {
+class DownloadManager : public CanMakeCheckedPtr<DownloadManager> {
     WTF_MAKE_NONCOPYABLE(DownloadManager);
-
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DownloadManager);
 public:
     class Client {
     public:
@@ -88,6 +89,7 @@ public:
     };
 
     explicit DownloadManager(Client&);
+    ~DownloadManager();
 
     void startDownload(PAL::SessionID, DownloadID, const WebCore::ResourceRequest&, const std::optional<WebCore::SecurityOriginData>& topOrigin, std::optional<NavigatingToAppBoundDomain>, const String& suggestedName = { });
     void dataTaskBecameDownloadTask(DownloadID, std::unique_ptr<Download>&&);

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMap.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMap.cpp
@@ -33,6 +33,9 @@
 
 namespace WebKit {
 
+DownloadMap::DownloadMap() = default;
+
+DownloadMap::~DownloadMap() = default;
 
 Download* DownloadMap::get(DownloadID downloadID) const
 {

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMap.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMap.h
@@ -40,6 +40,8 @@ typedef HashMap<DownloadID, std::unique_ptr<Download>> DownloadMap;
 class DownloadMap {
 public:
     typedef HashMap<DownloadID, std::unique_ptr<Download>> DownloadMapType;
+    DownloadMap();
+    ~DownloadMap();
 
     Download* get(DownloadID) const;
     bool isEmpty() const;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -95,14 +95,14 @@ void DownloadMonitor::downloadReceivedBytes(uint64_t bytesReceived)
 
 void DownloadMonitor::applicationWillEnterForeground()
 {
-    DOWNLOAD_MONITOR_RELEASE_LOG("applicationWillEnterForeground (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
+    DOWNLOAD_MONITOR_RELEASE_LOG("applicationWillEnterForeground (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
     m_timer.stop();
     m_interval = 0;
 }
 
 void DownloadMonitor::applicationDidEnterBackground()
 {
-    DOWNLOAD_MONITOR_RELEASE_LOG("applicationDidEnterBackground (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
+    DOWNLOAD_MONITOR_RELEASE_LOG("applicationDidEnterBackground (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
     ASSERT(!m_timer.isActive());
     ASSERT(!m_interval);
     m_timer.startOneShot(throughputIntervals[0].time / testSpeedMultiplier());
@@ -110,7 +110,7 @@ void DownloadMonitor::applicationDidEnterBackground()
 
 uint32_t DownloadMonitor::testSpeedMultiplier() const
 {
-    return m_download.testSpeedMultiplier();
+    return m_download->testSpeedMultiplier();
 }
 
 void DownloadMonitor::timerFired()
@@ -119,13 +119,13 @@ void DownloadMonitor::timerFired()
 
     RELEASE_ASSERT(m_interval < std::size(throughputIntervals));
     if (measuredThroughputRate() < throughputIntervals[m_interval].bytesPerSecond) {
-        DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: cancelling download (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
-        m_download.cancel([](auto) { }, Download::IgnoreDidFailCallback::No);
+        DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: cancelling download (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
+        m_download->cancel([](auto) { }, Download::IgnoreDidFailCallback::No);
     } else if (m_interval + 1 < std::size(throughputIntervals)) {
-        DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: sufficient throughput rate (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
+        DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: sufficient throughput rate (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
         m_timer.startOneShot(timeUntilNextInterval(m_interval++) / testSpeedMultiplier());
     } else
-        DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: Download reached threshold to not be terminated (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
+        DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: Download reached threshold to not be terminated (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -45,7 +45,7 @@ public:
     void timerFired();
 
 private:
-    Download& m_download;
+    CheckedRef<Download> m_download;
 
     double measuredThroughputRate() const;
     uint32_t testSpeedMultiplier() const;

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -42,7 +42,7 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
     if (m_sandboxExtension)
         m_sandboxExtension->consume();
 
-    auto* networkSession = m_downloadManager.client().networkSession(m_sessionID);
+    auto* networkSession = m_downloadManager->client().networkSession(m_sessionID);
     if (!networkSession) {
         WTFLogAlways("Could not find network session with given session ID");
         return;

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -58,8 +58,9 @@ class NetworkConnectionToWebProcess;
 class NetworkProcess;
 class NetworkSession;
 
-class NetworkSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver {
+class NetworkSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver, public CanMakeCheckedPtr<NetworkSocketChannel> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkSocketChannel);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSocketChannel);
 public:
     static std::unique_ptr<NetworkSocketChannel> create(NetworkConnectionToWebProcess&, PAL::SessionID, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -175,7 +175,7 @@ std::optional<WebCore::ProcessIdentifier> WebSharedWorker::firstSharedWorkerObje
 
 WebSharedWorkerServerToContextConnection* WebSharedWorker::contextConnection() const
 {
-    return m_server.contextConnectionForRegistrableDomain(topRegistrableDomain());
+    return m_server->contextConnectionForRegistrableDomain(topRegistrableDomain());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -112,7 +112,7 @@ private:
     void suspendIfNeeded();
     void resumeIfNeeded();
 
-    WebSharedWorkerServer& m_server;
+    CheckedRef<WebSharedWorkerServer> m_server;
     WebCore::SharedWorkerKey m_key;
     WebCore::WorkerOptions m_workerOptions;
     ListHashSet<Object> m_sharedWorkerObjects;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -53,7 +53,7 @@ WebSharedWorkerServer::~WebSharedWorkerServer() = default;
 
 PAL::SessionID WebSharedWorkerServer::sessionID()
 {
-    return m_session.sessionID();
+    return m_session->sessionID();
 }
 
 void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&& port, WebCore::WorkerOptions&& workerOptions)
@@ -152,7 +152,7 @@ void WebSharedWorkerServer::createContextConnection(const WebCore::RegistrableDo
     RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::createContextConnection will create a connection");
 
     m_pendingContextConnectionDomains.add(registrableDomain);
-    m_session.networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::SharedWorker, registrableDomain, requestingProcessIdentifier, std::nullopt, m_session.sessionID() }, [this, weakThis = WeakPtr { *this }, registrableDomain] (auto remoteProcessIdentifier) {
+    m_session->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::SharedWorker, registrableDomain, requestingProcessIdentifier, std::nullopt, m_session->sessionID() }, [this, weakThis = WeakPtr { *this }, registrableDomain] (auto remoteProcessIdentifier) {
         if (!weakThis)
             return;
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -64,8 +64,9 @@ class WebSharedWorker;
 class WebSharedWorkerServerConnection;
 class WebSharedWorkerServerToContextConnection;
 
-class WebSharedWorkerServer : public CanMakeWeakPtr<WebSharedWorkerServer> {
+class WebSharedWorkerServer : public CanMakeWeakPtr<WebSharedWorkerServer>, public CanMakeCheckedPtr<WebSharedWorkerServer> {
     WTF_MAKE_TZONE_ALLOCATED(WebSharedWorkerServer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSharedWorkerServer);
 public:
     explicit WebSharedWorkerServer(NetworkSession&);
     ~WebSharedWorkerServer();
@@ -93,7 +94,7 @@ private:
     void didFinishFetchingSharedWorkerScript(WebSharedWorker&, WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&);
     void shutDownSharedWorker(const WebCore::SharedWorkerKey&);
 
-    NetworkSession& m_session;
+    CheckedRef<NetworkSession> m_session;
     HashMap<WebCore::ProcessIdentifier, std::unique_ptr<WebSharedWorkerServerConnection>> m_connections;
     HashMap<WebCore::RegistrableDomain, WeakRef<WebSharedWorkerServerToContextConnection>> m_contextConnections;
     HashSet<WebCore::RegistrableDomain> m_pendingContextConnectionDomains;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -62,6 +62,16 @@ WebSharedWorkerServerConnection::~WebSharedWorkerServerConnection()
     CONNECTION_RELEASE_LOG("~WebSharedWorkerServerConnection:");
 }
 
+WebSharedWorkerServer& WebSharedWorkerServerConnection::server()
+{
+    return m_server.get();
+}
+
+const WebSharedWorkerServer& WebSharedWorkerServerConnection::server() const
+{
+    return m_server.get();
+}
+
 IPC::Connection* WebSharedWorkerServerConnection::messageSenderConnection() const
 {
     return m_contentConnection.ptr();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -65,8 +65,8 @@ public:
     WebSharedWorkerServerConnection(NetworkProcess&, WebSharedWorkerServer&, IPC::Connection&, WebCore::ProcessIdentifier);
     ~WebSharedWorkerServerConnection();
 
-    WebSharedWorkerServer& server() { return m_server; }
-    const WebSharedWorkerServer& server() const { return m_server; }
+    WebSharedWorkerServer& server();
+    const WebSharedWorkerServer& server() const;
 
     PAL::SessionID sessionID();
     NetworkSession* session();
@@ -91,7 +91,7 @@ private:
 
     Ref<IPC::Connection> m_contentConnection;
     Ref<NetworkProcess> m_networkProcess;
-    WebSharedWorkerServer& m_server;
+    CheckedRef<WebSharedWorkerServer> m_server;
     WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -65,18 +65,18 @@ WebSharedWorkerServerToContextConnection::WebSharedWorkerServerToContextConnecti
 WebSharedWorkerServerToContextConnection::~WebSharedWorkerServerToContextConnection()
 {
     CONTEXT_CONNECTION_RELEASE_LOG("~WebSharedWorkerServerToContextConnection:");
-    if (m_server && m_server->contextConnectionForRegistrableDomain(registrableDomain()) == this)
-        m_server->removeContextConnection(*this);
+    if (CheckedPtr server = m_server.get(); server && server->contextConnectionForRegistrableDomain(registrableDomain()) == this)
+        server->removeContextConnection(*this);
 }
 
 WebCore::ProcessIdentifier WebSharedWorkerServerToContextConnection::webProcessIdentifier() const
 {
-    return m_connection.webProcessIdentifier();
+    return m_connection->webProcessIdentifier();
 }
 
 IPC::Connection& WebSharedWorkerServerToContextConnection::ipcConnection() const
 {
-    return m_connection.connection();
+    return m_connection->connection();
 }
 
 IPC::Connection* WebSharedWorkerServerToContextConnection::messageSenderConnection() const
@@ -89,40 +89,46 @@ uint64_t WebSharedWorkerServerToContextConnection::messageSenderDestinationID() 
     return 0;
 }
 
+Ref<NetworkConnectionToWebProcess> WebSharedWorkerServerToContextConnection::protectedConnection() const
+{
+    return m_connection.get();
+}
+
 void WebSharedWorkerServerToContextConnection::connectionIsNoLongerNeeded()
 {
     CONTEXT_CONNECTION_RELEASE_LOG("connectionIsNoLongerNeeded:");
-    m_connection.sharedWorkerServerToContextConnectionIsNoLongerNeeded();
+    protectedConnection()->sharedWorkerServerToContextConnectionIsNoLongerNeeded();
 }
 
 void WebSharedWorkerServerToContextConnection::postErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("postErrorToWorkerObject: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
-    if (m_server)
-        m_server->postErrorToWorkerObject(sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent);
+    if (CheckedPtr server = m_server.get())
+        server->postErrorToWorkerObject(sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent);
 }
 
 void WebSharedWorkerServerToContextConnection::sharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("sharedWorkerTerminated: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
-    if (m_server)
-        m_server->sharedWorkerTerminated(sharedWorkerIdentifier);
+    if (CheckedPtr server = m_server.get())
+        server->sharedWorkerTerminated(sharedWorkerIdentifier);
 }
 
 void WebSharedWorkerServerToContextConnection::launchSharedWorker(WebSharedWorker& sharedWorker)
 {
-    m_connection.networkProcess().addAllowedFirstPartyForCookies(m_connection.webProcessIdentifier(), WebCore::RegistrableDomain::uncheckedCreateFromHost(sharedWorker.origin().topOrigin.host()), LoadedWebArchive::No, [] { });
+    Ref connection = m_connection.get();
+    connection->protectedNetworkProcess()->addAllowedFirstPartyForCookies(connection->webProcessIdentifier(), WebCore::RegistrableDomain::uncheckedCreateFromHost(sharedWorker.origin().topOrigin.host()), LoadedWebArchive::No, [] { });
 
     CONTEXT_CONNECTION_RELEASE_LOG("launchSharedWorker: sharedWorkerIdentifier=%" PRIu64, sharedWorker.identifier().toUInt64());
     sharedWorker.markAsRunning();
     auto initializationData = sharedWorker.initializationData();
     if (auto contextIdentifier = initializationData.clientIdentifier) {
         initializationData.clientIdentifier = WebCore::ScriptExecutionContextIdentifier { contextIdentifier->object(), webProcessIdentifier() };
-        if (auto* serviceWorkerOldConnection = m_connection.networkProcess().webProcessConnection(contextIdentifier->processIdentifier())) {
-            if (auto* swOldConnection = serviceWorkerOldConnection->swConnection()) {
+        if (RefPtr serviceWorkerOldConnection = connection->protectedNetworkProcess()->webProcessConnection(contextIdentifier->processIdentifier())) {
+            if (CheckedPtr swOldConnection = serviceWorkerOldConnection->swConnection()) {
                 if (auto clientData = swOldConnection->gatherClientData(*contextIdentifier)) {
                     swOldConnection->unregisterServiceWorkerClient(*contextIdentifier);
-                    if (auto* swNewConnection = m_connection.swConnection()) {
+                    if (CheckedPtr swNewConnection = connection->swConnection()) {
                         clientData->serviceWorkerClientData.identifier = *initializationData.clientIdentifier;
                         swNewConnection->registerServiceWorkerClient(WTFMove(clientData->clientOrigin), WTFMove(clientData->serviceWorkerClientData), clientData->controllingServiceWorkerRegistrationIdentifier, WTFMove(clientData->userAgent));
                     }
@@ -166,7 +172,7 @@ void WebSharedWorkerServerToContextConnection::addSharedWorkerObject(WebCore::Sh
     sharedWorkerObjects.add(sharedWorkerObjectIdentifier);
 
     if (webProcessIdentifier() != sharedWorkerObjectIdentifier.processIdentifier() && sharedWorkerObjects.size() == 1)
-        m_connection.networkProcess().send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::SharedWorker, sharedWorkerObjectIdentifier.processIdentifier(), webProcessIdentifier() }, 0);
+        m_connection->protectedNetworkProcess()->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::SharedWorker, sharedWorkerObjectIdentifier.processIdentifier(), webProcessIdentifier() }, 0);
 
     m_idleTerminationTimer.stop();
 }
@@ -184,7 +190,7 @@ void WebSharedWorkerServerToContextConnection::removeSharedWorkerObject(WebCore:
 
     m_sharedWorkerObjects.remove(it);
     if (webProcessIdentifier() != sharedWorkerObjectIdentifier.processIdentifier())
-        m_connection.networkProcess().send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::SharedWorker, sharedWorkerObjectIdentifier.processIdentifier(), webProcessIdentifier() }, 0);
+        m_connection->protectedNetworkProcess()->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::SharedWorker, sharedWorkerObjectIdentifier.processIdentifier(), webProcessIdentifier() }, 0);
 
     if (m_sharedWorkerObjects.isEmpty()) {
         CONTEXT_CONNECTION_RELEASE_LOG("removeSharedWorkerObject: connection is now idle, starting a timer to terminate it");

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -89,6 +89,8 @@ private:
     void idleTerminationTimerFired();
     void connectionIsNoLongerNeeded();
 
+    Ref<NetworkConnectionToWebProcess> protectedConnection() const;
+
     // IPC messages.
     void postErrorToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
     void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier);
@@ -97,7 +99,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    NetworkConnectionToWebProcess& m_connection;
+    WeakRef<NetworkConnectionToWebProcess> m_connection;
     WeakPtr<WebSharedWorkerServer> m_server;
     WebCore::RegistrableDomain m_registrableDomain;
     HashMap<WebCore::ProcessIdentifier, HashSet<WebCore::SharedWorkerObjectIdentifier>> m_sharedWorkerObjects;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -380,6 +380,11 @@ void Cache::browsingContextRemoved(WebPageProxyIdentifier webPageProxyID, WebCor
 #endif
 }
 
+Ref<NetworkProcess> Cache::protectedNetworkProcess()
+{
+    return m_networkProcess;
+}
+
 void Cache::retrieve(const WebCore::ResourceRequest& request, std::optional<GlobalFrameID> frameID, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, RetrieveCompletionHandler&& completionHandler)
 {
     ASSERT(request.url().protocolIsInHTTPFamily());

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -151,7 +151,7 @@ enum class CacheOption : uint8_t {
 #endif
 };
 
-class Cache : public RefCounted<Cache> {
+class Cache : public RefCounted<Cache>, public CanMakeWeakPtr<Cache> {
 public:
     ~Cache();
     static RefPtr<Cache> open(NetworkProcess&, const String& cachePath, OptionSet<CacheOption>, PAL::SessionID);
@@ -206,6 +206,7 @@ public:
     void browsingContextRemoved(WebPageProxyIdentifier, WebCore::PageIdentifier, WebCore::FrameIdentifier);
 
     NetworkProcess& networkProcess() { return m_networkProcess.get(); }
+    Ref<NetworkProcess> protectedNetworkProcess();
     PAL::SessionID sessionID() const { return m_sessionID; }
     const String& storageDirectory() const { return m_storageDirectory; }
     void fetchData(bool shouldComputeSize, CompletionHandler<void(Vector<WebsiteData::Entry>&&)>&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -245,16 +245,17 @@ private:
             LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) * Subresource: '%s'.", subresourceLoad->key.identifier().utf8().data());
 #endif
 
+        Ref storage = m_storage.get();
         if (m_existingEntry) {
             m_existingEntry->updateSubresourceLoads(m_subresourceLoads);
-            m_storage.store(m_existingEntry->encodeAsStorageRecord(), [](const Data&) { });
+            storage->store(m_existingEntry->encodeAsStorageRecord(), [](const Data&) { });
         } else {
-            SubresourcesEntry entry(makeSubresourcesKey(m_mainResourceKey, m_storage.salt()), m_subresourceLoads);
-            m_storage.store(entry.encodeAsStorageRecord(), [](const Data&) { });
+            SubresourcesEntry entry(makeSubresourcesKey(m_mainResourceKey, storage->salt()), m_subresourceLoads);
+            storage->store(entry.encodeAsStorageRecord(), [](const Data&) { });
         }
     }
 
-    Storage& m_storage;
+    CheckedRef<Storage> m_storage;
     Key m_mainResourceKey;
     Vector<std::unique_ptr<SubresourceLoad>> m_subresourceLoads;
     WTF::Function<void()> m_loadCompletionHandler;
@@ -278,6 +279,11 @@ SpeculativeLoadManager::~SpeculativeLoadManager()
 {
 }
 
+Ref<Storage> SpeculativeLoadManager::protectedStorage() const
+{
+    return m_storage.get();
+}
+
 bool SpeculativeLoadManager::canUsePreloadedEntry(const PreloadedEntry& entry, const ResourceRequest& actualRequest)
 {
     if (!entry.wasRevalidated())
@@ -298,12 +304,12 @@ bool SpeculativeLoadManager::canRetrieve(const Key& storageKey, const WebCore::R
     if (auto preloadedEntry = m_preloadedEntries.get(storageKey)) {
         if (!canUsePreloadedEntry(*preloadedEntry, request)) {
             LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) Retrieval: Could not use preloaded entry to satisfy request for '%s' due to HTTP headers mismatch:", storageKey.identifier().utf8().data());
-            logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, preloadedEntry->wasRevalidated() ? DiagnosticLoggingKeys::wastedSpeculativeWarmupWithRevalidationKey() : DiagnosticLoggingKeys::wastedSpeculativeWarmupWithoutRevalidationKey());
+            logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, preloadedEntry->wasRevalidated() ? DiagnosticLoggingKeys::wastedSpeculativeWarmupWithRevalidationKey() : DiagnosticLoggingKeys::wastedSpeculativeWarmupWithoutRevalidationKey());
             return false;
         }
 
         LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) Retrieval: Using preloaded entry to satisfy request for '%s':", storageKey.identifier().utf8().data());
-        logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, preloadedEntry->wasRevalidated() ? DiagnosticLoggingKeys::successfulSpeculativeWarmupWithRevalidationKey() : DiagnosticLoggingKeys::successfulSpeculativeWarmupWithoutRevalidationKey());
+        logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, preloadedEntry->wasRevalidated() ? DiagnosticLoggingKeys::successfulSpeculativeWarmupWithRevalidationKey() : DiagnosticLoggingKeys::successfulSpeculativeWarmupWithoutRevalidationKey());
         return true;
     }
 
@@ -311,16 +317,16 @@ bool SpeculativeLoadManager::canRetrieve(const Key& storageKey, const WebCore::R
     auto* pendingPreload = m_pendingPreloads.get(storageKey);
     if (!pendingPreload) {
         if (m_notPreloadedEntries.get(storageKey))
-            logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::entryWronglyNotWarmedUpKey());
+            logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::entryWronglyNotWarmedUpKey());
         else
-            logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::unknownEntryRequestKey());
+            logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::unknownEntryRequestKey());
 
         return false;
     }
 
     if (!canUsePendingPreload(*pendingPreload, request)) {
         LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) Retrieval: revalidation already in progress for '%s' but unusable due to HTTP headers mismatch:", storageKey.identifier().utf8().data());
-        logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::wastedSpeculativeWarmupWithRevalidationKey());
+        logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::wastedSpeculativeWarmupWithRevalidationKey());
         return false;
     }
 
@@ -371,7 +377,7 @@ void SpeculativeLoadManager::registerLoad(GlobalFrameID frameID, const ResourceR
         ASSERT(!m_pendingFrameLoads.contains(frameID));
 
         // Start tracking loads in this frame.
-        auto pendingFrameLoad = PendingFrameLoad::create(Ref { m_storage }, resourceKey, [this, frameID] {
+        auto pendingFrameLoad = PendingFrameLoad::create(protectedStorage(), resourceKey, [this, frameID] {
             bool wasRemoved = m_pendingFrameLoads.remove(frameID);
             ASSERT_UNUSED(wasRemoved, wasRemoved);
         });
@@ -415,15 +421,15 @@ void SpeculativeLoadManager::addPreloadedEntry(std::unique_ptr<Entry> entry, con
         auto preloadedEntry = m_preloadedEntries.take(key);
         ASSERT(preloadedEntry);
         if (preloadedEntry->wasRevalidated())
-            logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::wastedSpeculativeWarmupWithRevalidationKey());
+            logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::wastedSpeculativeWarmupWithRevalidationKey());
         else
-            logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::wastedSpeculativeWarmupWithoutRevalidationKey());
+            logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::wastedSpeculativeWarmupWithoutRevalidationKey());
     }));
 }
 
 void SpeculativeLoadManager::retrieveEntryFromStorage(const SubresourceInfo& info, RetrieveCompletionHandler&& completionHandler)
 {
-    m_storage.retrieve(info.key(), static_cast<unsigned>(info.priority()), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
+    protectedStorage()->retrieve(info.key(), static_cast<unsigned>(info.priority()), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
         if (!record) {
             completionHandler(nullptr);
             return false;
@@ -464,7 +470,7 @@ bool SpeculativeLoadManager::satisfyPendingRequests(const Key& key, Entry* entry
 void SpeculativeLoadManager::preconnectForSubresource(const SubresourceInfo& subresourceInfo, Entry* entry, const GlobalFrameID& frameID, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain)
 {
 #if ENABLE(SERVER_PRECONNECT)
-    auto* networkSession = m_cache.networkProcess().networkSession(m_cache.sessionID());
+    auto* networkSession = m_cache->protectedNetworkProcess()->networkSession(m_cache->sessionID());
     if (!networkSession)
         return;
 
@@ -515,7 +521,7 @@ void SpeculativeLoadManager::revalidateSubresource(const SubresourceInfo& subres
 
     LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) Speculatively revalidating '%s':", key.identifier().utf8().data());
 
-    auto revalidator = makeUnique<SpeculativeLoad>(m_cache, frameID, revalidationRequest, WTFMove(entry), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, [this, key, revalidationRequest, frameID](std::unique_ptr<Entry> revalidatedEntry) {
+    auto revalidator = makeUnique<SpeculativeLoad>(Ref { m_cache.get() }, frameID, revalidationRequest, WTFMove(entry), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, [this, key, revalidationRequest, frameID](std::unique_ptr<Entry> revalidatedEntry) {
         ASSERT(!revalidatedEntry || !revalidatedEntry->needsValidation());
         ASSERT(!revalidatedEntry || revalidatedEntry->key() == key);
 
@@ -524,7 +530,7 @@ void SpeculativeLoadManager::revalidateSubresource(const SubresourceInfo& subres
 
         if (satisfyPendingRequests(key, revalidatedEntry.get())) {
             if (revalidatedEntry)
-                logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::successfulSpeculativeWarmupWithRevalidationKey());
+                logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::successfulSpeculativeWarmupWithRevalidationKey());
             return;
         }
 
@@ -587,7 +593,7 @@ void SpeculativeLoadManager::preloadEntry(const Key& key, const SubresourceInfo&
 
         if (satisfyPendingRequests(key, entry.get())) {
             if (entry)
-                logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::successfulSpeculativeWarmupWithoutRevalidationKey());
+                logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::successfulSpeculativeWarmupWithoutRevalidationKey());
             return;
         }
         
@@ -611,7 +617,7 @@ void SpeculativeLoadManager::startSpeculativeRevalidation(const GlobalFrameID& f
         else {
             LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) Not preloading '%s' because it is marked as transient", key.identifier().utf8().data());
             m_notPreloadedEntries.add(key, makeUnique<ExpiringEntry>([this, key, frameID] {
-                logSpeculativeLoadingDiagnosticMessage(Ref { m_cache.networkProcess() }, frameID, DiagnosticLoggingKeys::entryRightlyNotWarmedUpKey());
+                logSpeculativeLoadingDiagnosticMessage(m_cache->protectedNetworkProcess(), frameID, DiagnosticLoggingKeys::entryRightlyNotWarmedUpKey());
                 m_notPreloadedEntries.remove(key);
             }));
         }
@@ -621,8 +627,9 @@ void SpeculativeLoadManager::startSpeculativeRevalidation(const GlobalFrameID& f
 void SpeculativeLoadManager::retrieveSubresourcesEntry(const Key& storageKey, WTF::Function<void (std::unique_ptr<SubresourcesEntry>)>&& completionHandler)
 {
     ASSERT(storageKey.type() == "Resource"_s);
-    auto subresourcesStorageKey = makeSubresourcesKey(storageKey, m_storage.salt());
-    m_storage.retrieve(subresourcesStorageKey, static_cast<unsigned>(ResourceLoadPriority::Medium), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
+    Ref storage = m_storage.get();
+    auto subresourcesStorageKey = makeSubresourcesKey(storageKey, storage->salt());
+    storage->retrieve(subresourcesStorageKey, static_cast<unsigned>(ResourceLoadPriority::Medium), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
         if (!record) {
             completionHandler(nullptr);
             return false;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
@@ -90,8 +90,10 @@ private:
     static bool canUsePreloadedEntry(const PreloadedEntry&, const WebCore::ResourceRequest& actualRequest);
     static bool canUsePendingPreload(const SpeculativeLoad&, const WebCore::ResourceRequest& actualRequest);
 
-    Cache& m_cache;
-    Storage& m_storage;
+    Ref<Storage> protectedStorage() const;
+
+    WeakRef<Cache> m_cache;
+    CheckedRef<Storage> m_storage;
 
     class PendingFrameLoad;
     HashMap<GlobalFrameID, RefPtr<PendingFrameLoad>> m_pendingFrameLoads;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -46,7 +46,9 @@ namespace NetworkCache {
 
 class IOChannel;
 
-class Storage : public ThreadSafeRefCounted<Storage, WTF::DestructionThread::Main> {
+class Storage : public ThreadSafeRefCounted<Storage, WTF::DestructionThread::Main>, public CanMakeThreadSafeCheckedPtr<Storage> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Storage);
 public:
     enum class Mode { Normal, AvoidRandomness };
     static RefPtr<Storage> open(const String& cachePath, Mode, size_t capacity);

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
@@ -61,7 +61,7 @@ class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public NetworkTaskCo
     WTF_MAKE_TZONE_ALLOCATED(WebSocketTask);
 public:
     WebSocketTask(NetworkSocketChannel&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WeakPtr<SessionSet>&&, const WebCore::ResourceRequest&, const WebCore::ClientOrigin&, RetainPtr<NSURLSessionWebSocketTask>&&, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
-    ~WebSocketTask() = default;
+    ~WebSocketTask();
 
     void sendString(std::span<const uint8_t>, CompletionHandler<void()>&&);
     void sendData(std::span<const uint8_t>, CompletionHandler<void()>&&);
@@ -91,7 +91,7 @@ private:
     NSURLSessionTask* task() const final;
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const final { return m_storedCredentialsPolicy; }
 
-    NetworkSocketChannel& m_channel;
+    CheckedPtr<NetworkSocketChannel> m_channel;
     RetainPtr<NSURLSessionWebSocketTask> m_task;
     bool m_receivedDidClose { false };
     bool m_receivedDidConnect { false };

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -68,8 +68,10 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
         blockCookies();
 
     readNextMessage();
-    m_channel.didSendHandshakeRequest(ResourceRequest { [m_task currentRequest] });
+    m_channel->didSendHandshakeRequest(ResourceRequest { [m_task currentRequest] });
 }
+
+WebSocketTask::~WebSocketTask() = default;
 
 void WebSocketTask::readNextMessage()
 {
@@ -85,17 +87,17 @@ void WebSocketTask::readNextMessage()
             if (!m_receivedDidConnect) {
                 ResourceResponse response { [m_task response] };
                 if (!response.isNull())
-                    m_channel.didReceiveHandshakeResponse(WTFMove(response));
+                    m_channel->didReceiveHandshakeResponse(WTFMove(response));
             }
 
-            m_channel.didReceiveMessageError([error localizedDescription]);
+            m_channel->didReceiveMessageError([error localizedDescription]);
             didClose(WebCore::ThreadableWebSocketChannel::CloseEventCodeAbnormalClosure, emptyString());
             return;
         }
         if (message.type == NSURLSessionWebSocketMessageTypeString)
-            m_channel.didReceiveText(message.string);
+            m_channel->didReceiveText(message.string);
         else
-            m_channel.didReceiveBinaryData(span(message.data));
+            m_channel->didReceiveBinaryData(span(message.data));
 
         readNextMessage();
     }).get()];
@@ -119,8 +121,8 @@ void WebSocketTask::didConnect(const String& protocol)
         extensionsValue = [(NSHTTPURLResponse *)response valueForHTTPHeaderField:@"Sec-WebSocket-Extensions"];
 
     m_receivedDidConnect = true;
-    m_channel.didConnect(protocol, extensionsValue);
-    m_channel.didReceiveHandshakeResponse(ResourceResponse { [m_task response] });
+    m_channel->didConnect(protocol, extensionsValue);
+    m_channel->didReceiveHandshakeResponse(ResourceResponse { [m_task response] });
 }
 
 void WebSocketTask::didClose(unsigned short code, const String& reason)
@@ -129,7 +131,7 @@ void WebSocketTask::didClose(unsigned short code, const String& reason)
         return;
 
     m_receivedDidClose = true;
-    m_channel.didClose(code, reason);
+    m_channel->didClose(code, reason);
 }
 
 void WebSocketTask::sendString(std::span<const uint8_t> utf8String, CompletionHandler<void()>&& callback)
@@ -174,7 +176,7 @@ WebSocketTask::TaskIdentifier WebSocketTask::identifier() const
 
 NetworkSessionCocoa* WebSocketTask::networkSession()
 {
-    return static_cast<NetworkSessionCocoa*>(m_channel.session());
+    return static_cast<NetworkSessionCocoa*>(m_channel->session());
 }
 
 NSURLSessionTask* WebSocketTask::task() const

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -56,7 +56,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
         localhostAlias = WebCore::CurlStream::LocalhostAlias::Enable;
 
     m_streamID = m_scheduler.createStream(request.url(), *this, WebCore::CurlStream::ServerTrustEvaluation::Enable, localhostAlias);
-    m_channel.didSendHandshakeRequest(WebCore::ResourceRequest(m_request));
+    m_channel->didSendHandshakeRequest(WebCore::ResourceRequest(m_request));
 }
 
 WebSocketTask::~WebSocketTask()
@@ -107,7 +107,7 @@ void WebSocketTask::resume()
 
 NetworkSessionCurl* WebSocketTask::networkSession()
 {
-    return static_cast<NetworkSessionCurl*>(m_channel.session());
+    return static_cast<NetworkSessionCurl*>(m_channel->session());
 }
 
 void WebSocketTask::didOpen(WebCore::CurlStreamID)
@@ -180,14 +180,14 @@ void WebSocketTask::didReceiveData(WebCore::CurlStreamID, const WebCore::SharedB
             {
                 String message = data.size() ? String::fromUTF8(data) : emptyString();
                 if (!message.isNull())
-                    m_channel.didReceiveText(message);
+                    m_channel->didReceiveText(message);
                 else
                     didFail("Could not decode a text frame as UTF-8."_s);
             }
             break;
 
         case WebCore::WebSocketFrame::OpCodeBinary:
-            m_channel.didReceiveBinaryData(data);
+            m_channel->didReceiveBinaryData(data);
             break;
 
         case WebCore::WebSocketFrame::OpCodeClose:
@@ -313,8 +313,8 @@ Expected<bool, String> WebSocketTask::validateOpeningHandshake()
     m_state = State::Opened;
     m_didCompleteOpeningHandshake = true;
 
-    m_channel.didConnect(m_handshake->serverWebSocketProtocol(), m_handshake->acceptedExtensions());
-    m_channel.didReceiveHandshakeResponse(WebCore::ResourceResponse(m_handshake->serverHandshakeResponse()));
+    m_channel->didConnect(m_handshake->serverWebSocketProtocol(), m_handshake->acceptedExtensions());
+    m_channel->didReceiveHandshakeResponse(WebCore::ResourceResponse(m_handshake->serverHandshakeResponse()));
 
     m_handshake = nullptr;
     return true;
@@ -457,7 +457,7 @@ void WebSocketTask::didFail(String&& reason)
     m_hasContinuousFrame = false;
     m_continuousFrameData.clear();
 
-    m_channel.didReceiveMessageError(WTFMove(reason));
+    m_channel->didReceiveMessageError(WTFMove(reason));
     didClose(WebCore::ThreadableWebSocketChannel::CloseEventCode::CloseEventCodeAbnormalClosure, { });
 }
 
@@ -474,7 +474,7 @@ void WebSocketTask::didClose(int32_t code, const String& reason)
         if (!weakThis)
             return;
 
-        m_channel.didClose(code, reason);
+        m_channel->didClose(code, reason);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
@@ -108,7 +108,7 @@ private:
     bool isStreamInvalidated() { return m_streamID == WebCore::invalidCurlStreamID; }
     void destructStream();
 
-    NetworkSocketChannel& m_channel;
+    CheckedRef<NetworkSocketChannel> m_channel;
     WebPageProxyIdentifier m_webProxyPageID;
     WebCore::ResourceRequest m_request;
     String m_protocol;

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -83,13 +83,13 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
     {
         // No need to subscribe to the "request-certificate" signal, just set the client certificate upfront.
         auto protectionSpace = WebCore::AuthenticationChallenge::protectionSpaceForClientCertificate(WebCore::soupURIToURL(soup_message_get_uri(msg)));
-        auto certificate = m_channel.session()->networkStorageSession()->credentialStorage().get(m_request.cachePartition(), protectionSpace).certificate();
+        auto certificate = m_channel->session()->networkStorageSession()->credentialStorage().get(m_request.cachePartition(), protectionSpace).certificate();
         soup_message_set_tls_client_certificate(msg, certificate);
     }
 
     g_signal_connect(msg, "request-certificate-password", G_CALLBACK(+[](SoupMessage* msg, GTlsPassword* tlsPassword, WebSocketTask* task) -> gboolean {
         auto protectionSpace = WebCore::AuthenticationChallenge::protectionSpaceForClientCertificatePassword(WebCore::soupURIToURL(soup_message_get_uri(msg)), tlsPassword);
-        auto password = task->m_channel.session()->networkStorageSession()->credentialStorage().get(task->m_request.cachePartition(), protectionSpace).password().utf8();
+        auto password = task->m_channel->session()->networkStorageSession()->credentialStorage().get(task->m_request.cachePartition(), protectionSpace).password().utf8();
         g_tls_password_set_value(tlsPassword, reinterpret_cast<const unsigned char*>(password.data()), password.length());
         soup_message_tls_client_certificate_password_request_complete(msg);
         return TRUE;
@@ -116,7 +116,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
 
     g_signal_connect(msg, "starting", G_CALLBACK(+[](SoupMessage* msg, WebSocketTask* task) {
         task->m_request.updateFromSoupMessageHeaders(soup_message_get_request_headers(msg));
-        task->m_channel.didSendHandshakeRequest(WTFMove(task->m_request));
+        task->m_channel->didSendHandshakeRequest(WTFMove(task->m_request));
     }), this);
 }
 
@@ -164,9 +164,9 @@ void WebSocketTask::didConnect(GRefPtr<SoupWebsocketConnection>&& connection)
     g_signal_connect_swapped(m_connection.get(), "error", reinterpret_cast<GCallback>(didReceiveErrorCallback), this);
     g_signal_connect_swapped(m_connection.get(), "closed", reinterpret_cast<GCallback>(didCloseCallback), this);
 
-    m_channel.didConnect(String::fromLatin1(soup_websocket_connection_get_protocol(m_connection.get())), acceptedExtensions());
+    m_channel->didConnect(String::fromLatin1(soup_websocket_connection_get_protocol(m_connection.get())), acceptedExtensions());
 
-    m_channel.didReceiveHandshakeResponse(m_handshakeMessage.get());
+    m_channel->didReceiveHandshakeResponse(m_handshakeMessage.get());
     g_signal_handlers_disconnect_by_data(m_handshakeMessage.get(), this);
     m_handshakeMessage = nullptr;
 }
@@ -182,10 +182,10 @@ void WebSocketTask::didReceiveMessageCallback(WebSocketTask* task, SoupWebsocket
 
     switch (dataType) {
     case SOUP_WEBSOCKET_DATA_TEXT:
-        task->m_channel.didReceiveText(String::fromUTF8(dataSpan));
+        task->m_channel->didReceiveText(String::fromUTF8(dataSpan));
         break;
     case SOUP_WEBSOCKET_DATA_BINARY:
-        task->m_channel.didReceiveBinaryData(dataSpan);
+        task->m_channel->didReceiveBinaryData(dataSpan);
         break;
     }
 }
@@ -205,11 +205,11 @@ void WebSocketTask::didFail(String&& errorMessage)
 
     m_receivedDidFail = true;
     if (m_handshakeMessage) {
-        m_channel.didReceiveHandshakeResponse(m_handshakeMessage.get());
+        m_channel->didReceiveHandshakeResponse(m_handshakeMessage.get());
         g_signal_handlers_disconnect_by_data(m_handshakeMessage.get(), this);
         m_handshakeMessage = nullptr;
     }
-    m_channel.didReceiveMessageError(WTFMove(errorMessage));
+    m_channel->didReceiveMessageError(WTFMove(errorMessage));
     if (!m_connection) {
         didClose(SOUP_WEBSOCKET_CLOSE_ABNORMAL, { });
         return;
@@ -235,7 +235,7 @@ void WebSocketTask::didClose(unsigned short code, const String& reason)
         return;
 
     m_receivedDidClose = true;
-    m_channel.didClose(code, reason);
+    m_channel->didClose(code, reason);
 }
 
 void WebSocketTask::sendString(std::span<const uint8_t> utf8, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
@@ -62,7 +62,7 @@ private:
     static void didReceiveErrorCallback(WebSocketTask*, GError*);
     static void didCloseCallback(WebSocketTask*);
 
-    NetworkSocketChannel& m_channel;
+    CheckedRef<NetworkSocketChannel> m_channel;
     WebCore::ResourceRequest m_request;
     GRefPtr<SoupMessage> m_handshakeMessage;
     GRefPtr<SoupWebsocketConnection> m_connection;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -269,11 +269,11 @@ void CacheStorageManager::reset()
     }
 
     for (auto& cache : m_caches)
-        m_registry.unregisterCache(cache->identifier());
+        m_registry->unregisterCache(cache->identifier());
     m_caches.clear();
 
     for (auto& identifier : m_removedCaches.keys())
-        m_registry.unregisterCache(identifier);
+        m_registry->unregisterCache(identifier);
     m_removedCaches.clear();
 
     m_cacheRefConnections.clear();
@@ -295,7 +295,7 @@ bool CacheStorageManager::initializeCaches()
     m_isInitialized = true;
     for (auto& [name, uniqueName] : *cachesList) {
         auto cache = makeUnique<CacheStorageCache>(*this, name, uniqueName, m_path, m_queue.copyRef());
-        m_registry.registerCache(cache->identifier(), *cache.get());
+        m_registry->registerCache(cache->identifier(), *cache.get());
         m_caches.append(WTFMove(cache));
     }
 
@@ -322,7 +322,7 @@ void CacheStorageManager::openCache(const String& name, WebCore::DOMCacheEngine:
 
     makeDirty();
     auto& cache = m_caches.last();
-    m_registry.registerCache(cache->identifier(), *cache);
+    m_registry->registerCache(cache->identifier(), *cache);
     cache->open(WTFMove(callback));
 }
 
@@ -493,7 +493,7 @@ void CacheStorageManager::removeUnusedCache(WebCore::DOMCacheIdentifier cacheIde
 {
     if (auto cache = m_removedCaches.take(cacheIdentifier)) {
         cache->removeAllRecords();
-        m_registry.unregisterCache(cacheIdentifier);
+        m_registry->unregisterCache(cacheIdentifier);
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -95,7 +95,7 @@ private:
     std::pair<uint64_t, HashSet<WebCore::DOMCacheIdentifier>> m_pendingSize;
     String m_path;
     FileSystem::Salt m_salt;
-    CacheStorageRegistry& m_registry;
+    CheckedRef<CacheStorageRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;
     Vector<std::unique_ptr<CacheStorageCache>> m_caches;
     HashMap<WebCore::DOMCacheIdentifier, std::unique_ptr<CacheStorageCache>> m_removedCaches;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DOMCacheIdentifier.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -33,8 +34,9 @@ namespace WebKit {
 
 class CacheStorageCache;
 
-class CacheStorageRegistry {
+class CacheStorageRegistry : public CanMakeThreadSafeCheckedPtr<CacheStorageRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(CacheStorageRegistry);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CacheStorageRegistry);
 public:
     CacheStorageRegistry();
     void registerCache(WebCore::DOMCacheIdentifier, CacheStorageCache&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -34,8 +35,9 @@ namespace WebKit {
 
 class FileSystemStorageHandle;
 
-class FileSystemStorageHandleRegistry {
+class FileSystemStorageHandleRegistry : public CanMakeThreadSafeCheckedPtr<FileSystemStorageHandleRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(FileSystemStorageHandleRegistry);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileSystemStorageHandleRegistry);
 public:
     FileSystemStorageHandleRegistry();
     void registerHandle(WebCore::FileSystemHandleIdentifier, FileSystemStorageHandle&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -100,7 +100,7 @@ Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystem
     m_handlesByConnection.ensure(connection, [&] {
         return HashSet<WebCore::FileSystemHandleIdentifier> { };
     }).iterator->value.add(newHandleIdentifier);
-    m_registry.registerHandle(newHandleIdentifier, *newHandle);
+    m_registry->registerHandle(newHandleIdentifier, *newHandle);
     m_handles.add(newHandleIdentifier, WTFMove(newHandle));
     return newHandleIdentifier;
 }
@@ -126,7 +126,7 @@ void FileSystemStorageManager::closeHandle(FileSystemStorageHandle& handle)
         if (handles.remove(identifier))
             break;
     }
-    m_registry.unregisterHandle(identifier);
+    m_registry->unregisterHandle(identifier);
 }
 
 void FileSystemStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
@@ -140,7 +140,7 @@ void FileSystemStorageManager::connectionClosed(IPC::Connection::UniqueID connec
     auto identifiers = connectionHandles->value;
     for (auto identifier : identifiers) {
         m_handles.remove(identifier);
-        m_registry.unregisterHandle(identifier);
+        m_registry->unregisterHandle(identifier);
     }
 
     m_lockMap.removeIf([&identifiers](auto& entry) {
@@ -183,7 +183,7 @@ void FileSystemStorageManager::close()
     for (auto& [connectionID, identifiers] : m_handlesByConnection) {
         for (auto identifier : identifiers) {
             auto takenHandle = m_handles.take(identifier);
-            m_registry.unregisterHandle(identifier);
+            m_registry->unregisterHandle(identifier);
 
             // Send message to web process to invalidate active sync access handle.
             if (auto accessHandleIdentifier = takenHandle->activeSyncAccessHandle())

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -66,7 +66,7 @@ private:
     void close();
 
     String m_path;
-    FileSystemStorageHandleRegistry& m_registry;
+    CheckedRef<FileSystemStorageHandleRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;
     HashMap<IPC::Connection::UniqueID, HashSet<WebCore::FileSystemHandleIdentifier>> m_handlesByConnection;
     HashMap<WebCore::FileSystemHandleIdentifier, std::unique_ptr<FileSystemStorageHandle>> m_handles;

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -297,22 +297,22 @@ void IDBStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequestData
 
 void IDBStorageManager::registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection& connection)
 {
-    m_registry.registerConnection(connection);
+    m_registry->registerConnection(connection);
 }
 
 void IDBStorageManager::unregisterConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection& connection)
 {
-    m_registry.unregisterConnection(connection);
+    m_registry->unregisterConnection(connection);
 }
 
 void IDBStorageManager::registerTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction& transaction)
 {
-    m_registry.registerTransaction(transaction);
+    m_registry->registerTransaction(transaction);
 }
 
 void IDBStorageManager::unregisterTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction& transaction)
 {
-    m_registry.unregisterTransaction(transaction);
+    m_registry->unregisterTransaction(transaction);
 }
 
 std::unique_ptr<WebCore::IDBServer::IDBBackingStore> IDBStorageManager::createBackingStore(const WebCore::IDBDatabaseIdentifier& identifier)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -78,7 +78,7 @@ private:
     void requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) final;
 
     String m_path;
-    IDBStorageRegistry& m_registry;
+    CheckedRef<IDBStorageRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;
     HashMap<WebCore::IDBDatabaseIdentifier, std::unique_ptr<WebCore::IDBServer::UniqueIDBDatabase>> m_databases;
 };

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -35,6 +35,8 @@ namespace WebKit {
 
 IDBStorageRegistry::IDBStorageRegistry() = default;
 
+IDBStorageRegistry::~IDBStorageRegistry() = default;
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageRegistry);
 
 WebCore::IDBServer::IDBConnectionToClient& IDBStorageRegistry::ensureConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include <WebCore/IDBDatabaseConnectionIdentifier.h>
 #include <WebCore/IDBResourceIdentifier.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,10 +43,12 @@ namespace WebKit {
 
 class IDBStorageConnectionToClient;
 
-class IDBStorageRegistry {
+class IDBStorageRegistry : public CanMakeThreadSafeCheckedPtr<IDBStorageRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageRegistry);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBStorageRegistry);
 public:
     IDBStorageRegistry();
+    ~IDBStorageRegistry();
     WebCore::IDBServer::IDBConnectionToClient& ensureConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
     void removeConnectionToClient(IPC::Connection::UniqueID);
     void registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
@@ -162,7 +162,7 @@ void LocalStorageManager::connectionClosedForLocalStorageArea(IPC::Connection::U
     if (is<MemoryStorageArea>(*m_localStorageArea) && !m_localStorageArea->isEmpty())
         return;
 
-    m_registry.unregisterStorageArea(m_localStorageArea->identifier());
+    m_registry->unregisterStorageArea(m_localStorageArea->identifier());
     m_localStorageArea = nullptr;
 }
 
@@ -175,7 +175,7 @@ void LocalStorageManager::connectionClosedForTransientStorageArea(IPC::Connectio
     if (m_transientStorageArea->hasListeners() || !m_transientStorageArea->isEmpty())
         return;
 
-    m_registry.unregisterStorageArea(m_transientStorageArea->identifier());
+    m_registry->unregisterStorageArea(m_transientStorageArea->identifier());
     m_transientStorageArea = nullptr;
 }
 
@@ -187,7 +187,7 @@ StorageAreaIdentifier LocalStorageManager::connectToLocalStorageArea(IPC::Connec
         else
             m_localStorageArea = makeUnique<MemoryStorageArea>(origin, StorageAreaBase::StorageType::Local);
 
-        m_registry.registerStorageArea(m_localStorageArea->identifier(), *m_localStorageArea);
+        m_registry->registerStorageArea(m_localStorageArea->identifier(), *m_localStorageArea);
     }
 
     ASSERT(m_path.isEmpty() || is<SQLiteStorageArea>(*m_localStorageArea));
@@ -199,7 +199,7 @@ StorageAreaIdentifier LocalStorageManager::connectToTransientLocalStorageArea(IP
 {
     if (!m_transientStorageArea) {
         m_transientStorageArea = makeUnique<MemoryStorageArea>(origin, StorageAreaBase::StorageType::Local);
-        m_registry.registerStorageArea(m_transientStorageArea->identifier(), *m_transientStorageArea);
+        m_registry->registerStorageArea(m_transientStorageArea->identifier(), *m_transientStorageArea);
     }
 
     ASSERT(is<MemoryStorageArea>(*m_transientStorageArea));

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -70,7 +70,7 @@ private:
     void connectionClosedForTransientStorageArea(IPC::Connection::UniqueID);
 
     String m_path;
-    StorageAreaRegistry& m_registry;
+    CheckedRef<StorageAreaRegistry> m_registry;
     std::unique_ptr<MemoryStorageArea> m_transientStorageArea;
     std::unique_ptr<StorageAreaBase> m_localStorageArea;
 };

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
@@ -72,13 +72,13 @@ void SessionStorageManager::removeNamespace(StorageNamespaceIdentifier namespace
         return;
 
     m_storageAreas.remove(identifier);
-    m_registry.unregisterStorageArea(identifier);
+    m_registry->unregisterStorageArea(identifier);
 }
 
 StorageAreaIdentifier SessionStorageManager::addStorageArea(std::unique_ptr<MemoryStorageArea> storageArea, StorageNamespaceIdentifier namespaceIdentifier)
 {
     auto identifier = storageArea->identifier();
-    m_registry.registerStorageArea(identifier, *storageArea);
+    m_registry->registerStorageArea(identifier, *storageArea);
     m_storageAreasByNamespace.add(namespaceIdentifier, identifier);
     m_storageAreas.add(identifier, WTFMove(storageArea));
 

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
@@ -58,7 +58,7 @@ public:
 private:
     StorageAreaIdentifier addStorageArea(std::unique_ptr<MemoryStorageArea>, StorageNamespaceIdentifier);
 
-    StorageAreaRegistry& m_registry;
+    CheckedRef<StorageAreaRegistry> m_registry;
     HashMap<StorageAreaIdentifier, std::unique_ptr<MemoryStorageArea>> m_storageAreas;
     HashMap<StorageNamespaceIdentifier, StorageAreaIdentifier> m_storageAreasByNamespace;
 };

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "StorageAreaIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -33,8 +34,9 @@ namespace WebKit {
 
 class StorageAreaBase;
 
-class StorageAreaRegistry {
+class StorageAreaRegistry : public CanMakeThreadSafeCheckedPtr<StorageAreaRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(StorageAreaRegistry);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StorageAreaRegistry);
 public:
     StorageAreaRegistry();
     void registerStorageArea(StorageAreaIdentifier, StorageAreaBase&);

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -89,7 +89,7 @@ void LibWebRTCSocketClient::close()
     RELEASE_LOG_ERROR_IF(result, Network, "LibWebRTCSocketClient::close (ID=%" PRIu64 ") failed with error %d", m_identifier.toUInt64(), m_socket->GetError());
 
     m_socket->DeregisterReceivedPacketCallback();
-    m_rtcProvider.takeSocket(m_identifier);
+    Ref { m_rtcProvider.get() }->takeSocket(m_identifier);
 }
 
 void LibWebRTCSocketClient::setOption(int option, int value)
@@ -137,7 +137,8 @@ void LibWebRTCSocketClient::signalClose(rtc::AsyncPacketSocket* socket, int erro
 
     // We want to remove 'this' from the socket map now but we will destroy it asynchronously
     // so that the socket parameter of signalClose remains alive as the caller of signalClose may actually being using it afterwards.
-    m_rtcProvider.callOnRTCNetworkThread([socket = m_rtcProvider.takeSocket(m_identifier)] { });
+    Ref rtcProvider = m_rtcProvider.get();
+    rtcProvider.callOnRTCNetworkThread([socket = rtcProvider.takeSocket(m_identifier)] { });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
@@ -72,7 +72,7 @@ private:
 
     WebCore::LibWebRTCSocketIdentifier m_identifier;
     Type m_type;
-    NetworkRTCProvider& m_rtcProvider;
+    CheckedRef<NetworkRTCProvider> m_rtcProvider;
     std::unique_ptr<rtc::AsyncPacketSocket> m_socket;
     Ref<IPC::Connection> m_connection;
     int m_sendError { 0 };

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -415,8 +415,18 @@ void NetworkManager::onGatheredNetworks(RTCNetwork::IPAddress&& ipv4, RTCNetwork
     });
 }
 
+NetworkRTCMonitor::NetworkRTCMonitor(NetworkRTCProvider& rtcProvider)
+    : m_rtcProvider(rtcProvider)
+{
+}
+
 NetworkRTCMonitor::~NetworkRTCMonitor()
 {
+}
+
+NetworkRTCProvider& NetworkRTCMonitor::rtcProvider()
+{
+    return m_rtcProvider.get();
 }
 
 const RTCNetwork::IPAddress& NetworkRTCMonitor::ipv4() const
@@ -444,18 +454,18 @@ void NetworkRTCMonitor::stopUpdating()
 void NetworkRTCMonitor::onNetworksChanged(const Vector<RTCNetwork>& networkList, const RTCNetwork::IPAddress& ipv4, const RTCNetwork::IPAddress& ipv6)
 {
     RTC_RELEASE_LOG("onNetworksChanged sent");
-    m_rtcProvider.connection().send(Messages::WebRTCMonitor::NetworksChanged(networkList, ipv4, ipv6), 0);
+    m_rtcProvider->protectedConnection()->send(Messages::WebRTCMonitor::NetworksChanged(networkList, ipv4, ipv6), 0);
 }
 
 
 void NetworkRTCMonitor::ref()
 {
-    m_rtcProvider.ref();
+    m_rtcProvider->ref();
 }
 
 void NetworkRTCMonitor::deref()
 {
-    m_rtcProvider.deref();
+    m_rtcProvider->deref();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 
 #include "RTCNetwork.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -45,13 +46,13 @@ class NetworkRTCProvider;
 
 class NetworkRTCMonitor final : public CanMakeWeakPtr<NetworkRTCMonitor> {
 public:
-    explicit NetworkRTCMonitor(NetworkRTCProvider& rtcProvider) : m_rtcProvider(rtcProvider) { }
+    explicit NetworkRTCMonitor(NetworkRTCProvider&);
     ~NetworkRTCMonitor();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
     void stopUpdating();
     bool isStarted() const { return m_isStarted; }
-    NetworkRTCProvider& rtcProvider() { return m_rtcProvider; }
+    NetworkRTCProvider& rtcProvider();
 
     void onNetworksChanged(const Vector<RTCNetwork>&, const RTCNetwork::IPAddress&, const RTCNetwork::IPAddress&);
 
@@ -64,7 +65,7 @@ public:
 private:
     void startUpdatingIfNeeded();
 
-    NetworkRTCProvider& m_rtcProvider;
+    CheckedRef<NetworkRTCProvider> m_rtcProvider;
     bool m_isStarted { false };
 };
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -81,7 +81,9 @@ struct SocketComparator {
     }
 };
 
-class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public ThreadSafeRefCounted<NetworkRTCProvider, WTF::DestructionThread::MainRunLoop> {
+class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public ThreadSafeRefCounted<NetworkRTCProvider, WTF::DestructionThread::MainRunLoop>, public CanMakeThreadSafeCheckedPtr<NetworkRTCProvider> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkRTCProvider);
 public:
     static Ref<NetworkRTCProvider> create(NetworkConnectionToWebProcess& connection)
     {
@@ -114,6 +116,7 @@ public:
     void callOnRTCNetworkThread(Function<void()>&&);
 
     IPC::Connection& connection() { return m_ipcConnection.get(); }
+    Ref<IPC::Connection> protectedConnection() { return m_ipcConnection.get(); }
 
     void closeSocket(WebCore::LibWebRTCSocketIdentifier);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
@@ -68,7 +68,7 @@ private:
     Vector<uint8_t> createMessageBuffer(std::span<const uint8_t>);
 
     WebCore::LibWebRTCSocketIdentifier m_identifier;
-    NetworkRTCProvider& m_rtcProvider;
+    CheckedRef<NetworkRTCProvider> m_rtcProvider;
     Ref<IPC::Connection> m_connection;
     RetainPtr<nw_connection_t> m_nwConnection;
     bool m_isSTUN { false };

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -164,7 +164,7 @@ void NetworkRTCTCPSocketCocoa::close()
 #endif
     if (m_nwConnection)
         nw_connection_cancel(m_nwConnection.get());
-    m_rtcProvider.takeSocket(m_identifier);
+    Ref { m_rtcProvider.get() }->takeSocket(m_identifier);
 }
 
 void NetworkRTCTCPSocketCocoa::setOption(int option, int value)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
@@ -74,7 +74,7 @@ private:
     void setOption(int option, int value) final;
     void sendTo(std::span<const uint8_t>, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
 
-    NetworkRTCProvider& m_rtcProvider;
+    CheckedRef<NetworkRTCProvider> m_rtcProvider;
     WebCore::LibWebRTCSocketIdentifier m_identifier;
     Ref<NetworkRTCUDPSocketCocoaConnections> m_connections;
 };

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -116,7 +116,7 @@ NetworkRTCUDPSocketCocoa::~NetworkRTCUDPSocketCocoa()
 void NetworkRTCUDPSocketCocoa::close()
 {
     m_connections->close();
-    m_rtcProvider.takeSocket(m_identifier);
+    Ref { m_rtcProvider.get() }->takeSocket(m_identifier);
 }
 
 void NetworkRTCUDPSocketCocoa::setOption(int option, int value)


### PR DESCRIPTION
#### da72e62564fb6cd84c716a04605ac5f11c26bb45
<pre>
Adopt more smart pointers in the network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=278973">https://bugs.webkit.org/show_bug.cgi?id=278973</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::removeDataRecords):
(WebKit::ResourceLoadStatisticsStore::grandfatherExistingWebsiteData):
(WebKit::ResourceLoadStatisticsStore::updateCacheMaxAgeCap):
(WebKit::ResourceLoadStatisticsStore::updateClientSideCookiesAgeCap):
(WebKit::ResourceLoadStatisticsStore::updateCookieBlockingForDomains):
(WebKit::ResourceLoadStatisticsStore::logTestingEvent):
(WebKit::ResourceLoadStatisticsStore::removeAllStorageAccess):
(WebKit::ResourceLoadStatisticsStore::debugBroadcastConsoleMessage):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
(WebKit::Download::Download):
(WebKit::Download::~Download):
(WebKit::Download::cancel):
(WebKit::Download::didFinish):
(WebKit::Download::didFail):
(WebKit::Download::messageSenderConnection const):
* Source/WebKit/NetworkProcess/Downloads/Download.h:
(WebKit::Download::manager const):
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMap.cpp:
* Source/WebKit/NetworkProcess/Downloads/DownloadMap.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
(WebKit::DownloadMonitor::applicationWillEnterForeground):
(WebKit::DownloadMonitor::applicationDidEnterBackground):
(WebKit::DownloadMonitor::testSpeedMultiplier const):
(WebKit::DownloadMonitor::timerFired):
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::resume):
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::WebSharedWorker::contextConnection const):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::sessionID):
(WebKit::WebSharedWorkerServer::createContextConnection):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::server):
(WebKit::WebSharedWorkerServerConnection::server const):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
(WebKit::WebSharedWorkerServerConnection::server): Deleted.
(WebKit::WebSharedWorkerServerConnection::server const): Deleted.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::~WebSharedWorkerServerToContextConnection):
(WebKit::WebSharedWorkerServerToContextConnection::webProcessIdentifier const):
(WebKit::WebSharedWorkerServerToContextConnection::ipcConnection const):
(WebKit::WebSharedWorkerServerToContextConnection::protectedConnection const):
(WebKit::WebSharedWorkerServerToContextConnection::connectionIsNoLongerNeeded):
(WebKit::WebSharedWorkerServerToContextConnection::postErrorToWorkerObject):
(WebKit::WebSharedWorkerServerToContextConnection::sharedWorkerTerminated):
(WebKit::WebSharedWorkerServerToContextConnection::launchSharedWorker):
(WebKit::WebSharedWorkerServerToContextConnection::addSharedWorkerObject):
(WebKit::WebSharedWorkerServerToContextConnection::removeSharedWorkerObject):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::protectedNetworkProcess):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::PendingFrameLoad::saveToDiskIfReady):
(WebKit::NetworkCache::SpeculativeLoadManager::protectedStorage const):
(WebKit::NetworkCache::SpeculativeLoadManager::canRetrieve const):
(WebKit::NetworkCache::SpeculativeLoadManager::registerLoad):
(WebKit::NetworkCache::SpeculativeLoadManager::addPreloadedEntry):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveEntryFromStorage):
(WebKit::NetworkCache::SpeculativeLoadManager::preconnectForSubresource):
(WebKit::NetworkCache::SpeculativeLoadManager::revalidateSubresource):
(WebKit::NetworkCache::SpeculativeLoadManager::preloadEntry):
(WebKit::NetworkCache::SpeculativeLoadManager::startSpeculativeRevalidation):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveSubresourcesEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::readNextMessage):
(WebKit::WebSocketTask::didConnect):
(WebKit::WebSocketTask::didClose):
(WebKit::WebSocketTask::networkSession):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::networkSession):
(WebKit::WebSocketTask::didReceiveData):
(WebKit::WebSocketTask::validateOpeningHandshake):
(WebKit::WebSocketTask::didFail):
(WebKit::WebSocketTask::didClose):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h:
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::didConnect):
(WebKit::WebSocketTask::didReceiveMessageCallback):
(WebKit::WebSocketTask::didFail):
(WebKit::WebSocketTask::didClose):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::reset):
(WebKit::CacheStorageManager::initializeCaches):
(WebKit::CacheStorageManager::openCache):
(WebKit::CacheStorageManager::removeUnusedCache):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::createHandle):
(WebKit::FileSystemStorageManager::closeHandle):
(WebKit::FileSystemStorageManager::connectionClosed):
(WebKit::FileSystemStorageManager::close):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::registerConnection):
(WebKit::IDBStorageManager::unregisterConnection):
(WebKit::IDBStorageManager::registerTransaction):
(WebKit::IDBStorageManager::unregisterTransaction):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
(WebKit::LocalStorageManager::connectionClosedForLocalStorageArea):
(WebKit::LocalStorageManager::connectionClosedForTransientStorageArea):
(WebKit::LocalStorageManager::connectToLocalStorageArea):
(WebKit::LocalStorageManager::connectToTransientLocalStorageArea):
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp:
(WebKit::SessionStorageManager::removeNamespace):
(WebKit::SessionStorageManager::addStorageArea):
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h:
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:
(WebKit::LibWebRTCSocketClient::close):
(WebKit::LibWebRTCSocketClient::signalClose):
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkRTCMonitor::NetworkRTCMonitor):
(WebKit::NetworkRTCMonitor::rtcProvider):
(WebKit::NetworkRTCMonitor::onNetworksChanged):
(WebKit::NetworkRTCMonitor::ref):
(WebKit::NetworkRTCMonitor::deref):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
(WebKit::NetworkRTCProvider::protectedConnection):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::NetworkRTCTCPSocketCocoa::close):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoa::close):

Canonical link: <a href="https://commits.webkit.org/283042@main">https://commits.webkit.org/283042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa9fc884486aaf77c433548b91edf34e16e4e0be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68997 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52198 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10755 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37671 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14455 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70702 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56291 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59744 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7364 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1036 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9856 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40152 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->