### PR TITLE
REGRESSION (253225@main): ASSERT_NOT_REACHED in ImageOverlay updateSubtree()

### DIFF
--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -261,19 +261,19 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
         if (!mediaElement)
             return nullptr;
 
-        Ref shadowRoot = mediaElement->ensureUserAgentShadowRoot();
-        RefPtr controlsHost = mediaElement->mediaControlsHost();
-        if (!controlsHost) {
-            ASSERT_NOT_REACHED();
+        RefPtr shadowRoot = mediaElement->userAgentShadowRoot();
+        if (!shadowRoot)
             return nullptr;
-        }
+
+        RefPtr controlsHost = mediaElement->mediaControlsHost();
+        if (!controlsHost)
+            return nullptr;
 
         auto& containerClass = controlsHost->mediaControlsContainerClassName();
-        for (Ref child : childrenOfType<HTMLDivElement>(shadowRoot.get())) {
+        for (Ref child : childrenOfType<HTMLDivElement>(*shadowRoot)) {
             if (child->hasClassName(containerClass))
                 return &child.get();
         }
-        ASSERT_NOT_REACHED();
         return nullptr;
     })();
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)


### PR DESCRIPTION
#### 416adec17dd115c48a7821dd48392703d12b7625
<pre>
REGRESSION (253225@main): ASSERT_NOT_REACHED in ImageOverlay updateSubtree()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252302">https://bugs.webkit.org/show_bug.cgi?id=252302</a>
<a href="https://rdar.apple.com/105486027">rdar://105486027</a>

Reviewed by Richard Robinson.

After the changes in <a href="https://commits.webkit.org/253225@main">https://commits.webkit.org/253225@main</a>, installing the user agent shadow root
on `HTMLMediaElement` no longer ensures that media controls host elements are also created. As such,
the debug assertions which try to verify that the media controls host and controls container `div`
have been created fail, and we crash when installing Live Text in a `video` with no controls.

The intention behind this logic is to determine whether Live Text should be injected underneath the
user agent shadow root or under the media controls container in the user agent shadow root, so that
Live Text doesn&apos;t overlap the fullscreen/PiP buttons or the slider (and the controls around it).
However, it&apos;s actually not necessary in this case to create and add media controls up front, since
we&apos;ll (correctly) add the media controls _over_ the image overlay anyways, in the case where the
controls haven&apos;t been created yet. If the controls _have_ already been created, then we should get a
non-null `mediaControlsContainer`.

Address this debug assert by checking if the media controls container `div` had already been created
without ensuring the user agent shadow root up front in `updateSubtree`.

This fixes several flaky layout tests in `media/modern-media-controls/tracks-support`.

* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):

Canonical link: <a href="https://commits.webkit.org/283030@main">https://commits.webkit.org/283030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40acdf465975772768c88d0a9ac45e290655bcb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52200 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13607 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70706 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59531 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56296 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59749 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/selections (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14339 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1041 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40156 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->