### PR TITLE
Adopt more smart pointers in the UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -648,6 +648,8 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     [_textFinderClient willDestroyView:self];
 #endif
 
+    [self _setResourceLoadDelegate:nil];
+
 #if PLATFORM(IOS_FAMILY)
     [_contentView _webViewDestroyed];
 

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -176,7 +176,9 @@ private:
 
     void resolveLocation(const WebCore::IntPoint& currentLocation, std::optional<WebCore::IntPoint> location, MouseMoveOrigin, std::optional<String> nodeHandle, Function<void (std::optional<WebCore::IntPoint>, std::optional<AutomationCommandError>)>&&);
 
-    WebPageProxy& m_page;
+    Ref<WebPageProxy> protectedPage() const;
+
+    WeakRef<WebPageProxy> m_page;
     SimulatedInputDispatcher::Client& m_client;
 
     std::optional<WebCore::FrameIdentifier> m_frameID;

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
@@ -28,6 +28,7 @@
 #import "WKFoundation.h"
 
 #import "APIIconLoadingClient.h"
+#import <wtf/CheckedPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
@@ -37,8 +38,9 @@
 
 namespace WebKit {
 
-class IconLoadingDelegate {
+class IconLoadingDelegate : public CanMakeCheckedPtr<IconLoadingDelegate> {
     WTF_MAKE_TZONE_ALLOCATED(IconLoadingDelegate);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IconLoadingDelegate);
 public:
     explicit IconLoadingDelegate(WKWebView *);
     ~IconLoadingDelegate();
@@ -58,7 +60,7 @@ private:
     private:
         void getLoadDecisionForIcon(const WebCore::LinkIcon&, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&&) override;
 
-        IconLoadingDelegate& m_iconLoadingDelegate;
+        CheckedRef<IconLoadingDelegate> m_iconLoadingDelegate;
     };
 
     WKWebView *m_webView;

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
@@ -78,12 +78,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(IconLoadingDelegateIconLoadingClient, IconL
 
 void IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon(const WebCore::LinkIcon& linkIcon, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&& completionHandler)
 {
-    if (!m_iconLoadingDelegate.m_delegateMethods.webViewShouldLoadIconWithParametersCompletionHandler) {
+    if (!m_iconLoadingDelegate->m_delegateMethods.webViewShouldLoadIconWithParametersCompletionHandler) {
         completionHandler(nullptr);
         return;
     }
 
-    auto delegate = m_iconLoadingDelegate.m_delegate.get();
+    auto delegate = m_iconLoadingDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(nullptr);
         return;
@@ -91,7 +91,7 @@ void IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon(const WebCor
 
     RetainPtr<_WKLinkIconParameters> parameters = adoptNS([[_WKLinkIconParameters alloc] _initWithLinkIcon:linkIcon]);
 
-    [delegate webView:m_iconLoadingDelegate.m_webView shouldLoadIconWithParameters:parameters.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (IconLoadCompletionHandler loadCompletionHandler) mutable {
+    [delegate webView:m_iconLoadingDelegate->m_webView shouldLoadIconWithParameters:parameters.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (IconLoadCompletionHandler loadCompletionHandler) mutable {
         ASSERT(RunLoop::isMain());
         if (loadCompletionHandler) {
             completionHandler([loadCompletionHandler = makeBlockPtr(loadCompletionHandler)](API::Data* data) {

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -64,10 +64,10 @@ namespace WebKit {
 
 WKModelView * ModelElementController::modelViewForModelIdentifier(ModelIdentifier modelIdentifier)
 {
-    if (!m_webPageProxy.preferences().modelElementEnabled())
+    if (!m_webPageProxy->preferences().modelElementEnabled())
         return nil;
 
-    auto* proxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(m_webPageProxy.drawingArea());
+    auto* proxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(m_webPageProxy->drawingArea());
     if (!proxy)
         return nil;
 
@@ -88,7 +88,7 @@ void ModelElementController::takeModelElementFullscreen(ModelIdentifier modelIde
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    auto *presentingViewController = m_webPageProxy.uiClient().presentingViewController();
+    auto *presentingViewController = m_webPageProxy->uiClient().presentingViewController();
     if (!presentingViewController)
         return;
 
@@ -153,7 +153,7 @@ void ModelElementController::setInteractionEnabledForModelElement(ModelIdentifie
 
 ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdentifier modelIdentifier)
 {
-    if (!m_webPageProxy.preferences().modelElementEnabled())
+    if (!m_webPageProxy->preferences().modelElementEnabled())
         return nullptr;
 
     return m_inlinePreviews.get(modelIdentifier.uuid).get();
@@ -161,7 +161,7 @@ ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdenti
 
 void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCore::FloatSize size, CompletionHandler<void(Expected<std::pair<String, uint32_t>, WebCore::ResourceError>)>&& completionHandler)
 {
-    if (!m_webPageProxy.preferences().modelElementEnabled()) {
+    if (!m_webPageProxy->preferences().modelElementEnabled()) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Model element disabled"_s }));
         return;
     }
@@ -209,7 +209,7 @@ void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCor
 
 void ModelElementController::modelElementLoadRemotePreview(String uuid, URL fileURL, CompletionHandler<void(std::optional<WebCore::ResourceError>&&)>&& completionHandler)
 {
-    if (!m_webPageProxy.preferences().modelElementEnabled()) {
+    if (!m_webPageProxy->preferences().modelElementEnabled()) {
         completionHandler(WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Model element disabled"_s });
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h
@@ -27,6 +27,7 @@
 
 #import "APIResourceLoadClient.h"
 #import "WKFoundation.h"
+#import <wtf/CheckedPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
@@ -40,8 +41,9 @@ class ResourceLoadClient;
 
 namespace WebKit {
 
-class ResourceLoadDelegate {
+class ResourceLoadDelegate : public CanMakeCheckedPtr<ResourceLoadDelegate> {
     WTF_MAKE_TZONE_ALLOCATED(ResourceLoadDelegate);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ResourceLoadDelegate);
 public:
     explicit ResourceLoadDelegate(WKWebView *);
     ~ResourceLoadDelegate();
@@ -66,7 +68,7 @@ private:
         void didReceiveResponse(ResourceLoadInfo&&, WebCore::ResourceResponse&&) const final;
         void didCompleteWithError(ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceError&&) const final;
 
-        ResourceLoadDelegate& m_resourceLoadDelegate;
+        CheckedRef<ResourceLoadDelegate> m_resourceLoadDelegate;
     };
 
     WeakObjCPtr<WKWebView> m_webView;

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
@@ -81,62 +81,62 @@ ResourceLoadDelegate::ResourceLoadClient::~ResourceLoadClient() = default;
 
 void ResourceLoadDelegate::ResourceLoadClient::didSendRequest(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceRequest&& request) const
 {
-    if (!m_resourceLoadDelegate.m_delegateMethods.didSendRequest)
+    if (!m_resourceLoadDelegate->m_delegateMethods.didSendRequest)
         return;
 
-    auto delegate = m_resourceLoadDelegate.m_delegate.get();
+    auto delegate = m_resourceLoadDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate.m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didSendRequest:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didSendRequest:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceRequest&& request) const
 {
-    if (!m_resourceLoadDelegate.m_delegateMethods.didPerformHTTPRedirection)
+    if (!m_resourceLoadDelegate->m_delegateMethods.didPerformHTTPRedirection)
         return;
 
-    auto delegate = m_resourceLoadDelegate.m_delegate.get();
+    auto delegate = m_resourceLoadDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate.m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didPerformHTTPRedirection:response.nsURLResponse() newRequest:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didPerformHTTPRedirection:response.nsURLResponse() newRequest:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge(WebKit::ResourceLoadInfo&& loadInfo, WebCore::AuthenticationChallenge&& challenge) const
 {
-    if (!m_resourceLoadDelegate.m_delegateMethods.didReceiveChallenge)
+    if (!m_resourceLoadDelegate->m_delegateMethods.didReceiveChallenge)
         return;
 
-    auto delegate = m_resourceLoadDelegate.m_delegate.get();
+    auto delegate = m_resourceLoadDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate.m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didReceiveChallenge:mac(challenge)];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didReceiveChallenge:mac(challenge)];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response) const
 {
-    if (!m_resourceLoadDelegate.m_delegateMethods.didReceiveResponse)
+    if (!m_resourceLoadDelegate->m_delegateMethods.didReceiveResponse)
         return;
 
-    auto delegate = m_resourceLoadDelegate.m_delegate.get();
+    auto delegate = m_resourceLoadDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate.m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didReceiveResponse:response.nsURLResponse()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didReceiveResponse:response.nsURLResponse()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceError&& error) const
 {
-    if (!m_resourceLoadDelegate.m_delegateMethods.didCompleteWithError)
+    if (!m_resourceLoadDelegate->m_delegateMethods.didCompleteWithError)
         return;
 
-    auto delegate = m_resourceLoadDelegate.m_delegate.get();
+    auto delegate = m_resourceLoadDelegate->m_delegate.get();
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate.m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didCompleteWithError:error.nsError() response:response.nsURLResponse()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didCompleteWithError:error.nsError() response:response.nsURLResponse()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.h
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.h
@@ -49,7 +49,7 @@ public:
     void removeAnnotationRelativeToSelection(NSString *annotationName, int64_t selectionOffset, uint64_t length);
 
 private:
-    WebPageProxy& m_page;
+    CheckedRef<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
@@ -46,18 +46,18 @@ TextCheckingController::TextCheckingController(WebPageProxy& webPageProxy)
 
 void TextCheckingController::replaceRelativeToSelection(NSAttributedString *annotatedString, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength)
 {
-    if (!m_page.hasRunningProcess())
+    if (!m_page->hasRunningProcess())
         return;
 
-    m_page.legacyMainFrameProcess().send(Messages::TextCheckingControllerProxy::ReplaceRelativeToSelection(WebCore::AttributedString::fromNSAttributedString(annotatedString), selectionOffset, length, relativeReplacementLocation, relativeReplacementLength), m_page.webPageIDInMainFrameProcess());
+    m_page->legacyMainFrameProcess().send(Messages::TextCheckingControllerProxy::ReplaceRelativeToSelection(WebCore::AttributedString::fromNSAttributedString(annotatedString), selectionOffset, length, relativeReplacementLocation, relativeReplacementLength), m_page.webPageIDInMainFrameProcess());
 }
 
 void TextCheckingController::removeAnnotationRelativeToSelection(NSString *annotationName, int64_t selectionOffset, uint64_t length)
 {
-    if (!m_page.hasRunningProcess())
+    if (!m_page->hasRunningProcess())
         return;
 
-    m_page.legacyMainFrameProcess().send(Messages::TextCheckingControllerProxy::RemoveAnnotationRelativeToSelection(annotationName, selectionOffset, length), m_page.webPageIDInMainFrameProcess());
+    m_page->legacyMainFrameProcess().send(Messages::TextCheckingControllerProxy::RemoveAnnotationRelativeToSelection(annotationName, selectionOffset, length), m_page.webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -52,6 +52,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DrawingAreaProxyCoordinatedGraphics);
+
 DrawingAreaProxyCoordinatedGraphics::DrawingAreaProxyCoordinatedGraphics(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::CoordinatedGraphics, webPageProxy, webProcessProxy)
 #if !PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -52,6 +52,9 @@ class Region;
 namespace WebKit {
 
 class DrawingAreaProxyCoordinatedGraphics final : public DrawingAreaProxy {
+    WTF_MAKE_TZONE_ALLOCATED(DrawingAreaProxyCoordinatedGraphics);
+    WTF_MAKE_NONCOPYABLE(DrawingAreaProxyCoordinatedGraphics);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DrawingAreaProxyCoordinatedGraphics);
 public:
     DrawingAreaProxyCoordinatedGraphics(WebPageProxy&, WebProcessProxy&);
     virtual ~DrawingAreaProxyCoordinatedGraphics();

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -84,7 +84,7 @@ void DownloadProxy::cancel(CompletionHandler<void(API::Data*)>&& completionHandl
         m_dataStore->networkProcess().sendWithAsyncReply(Messages::NetworkProcess::CancelDownload(m_downloadID), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (std::span<const uint8_t> resumeData) mutable {
             m_legacyResumeData = createData(resumeData);
             completionHandler(m_legacyResumeData.get());
-            m_downloadProxyMap.downloadFinished(*this);
+            m_downloadProxyMap->downloadFinished(*this);
         });
     } else
         completionHandler(nullptr);
@@ -209,7 +209,7 @@ void DownloadProxy::didFinish()
     m_client->didFinish(*this);
 
     // This can cause the DownloadProxy object to be deleted.
-    m_downloadProxyMap.downloadFinished(*this);
+    m_downloadProxyMap->downloadFinished(*this);
 }
 
 void DownloadProxy::didFail(const ResourceError& error, std::span<const uint8_t> resumeData)
@@ -219,7 +219,7 @@ void DownloadProxy::didFail(const ResourceError& error, std::span<const uint8_t>
     m_client->didFail(*this, error, m_legacyResumeData.get());
 
     // This can cause the DownloadProxy object to be deleted.
-    m_downloadProxyMap.downloadFinished(*this);
+    m_downloadProxyMap->downloadFinished(*this);
 }
 
 void DownloadProxy::setClient(Ref<API::DownloadClient>&& client)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -125,7 +125,7 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    DownloadProxyMap& m_downloadProxyMap;
+    CheckedRef<DownloadProxyMap> m_downloadProxyMap;
     RefPtr<WebsiteDataStore> m_dataStore;
     Ref<API::DownloadClient> m_client;
     DownloadID m_downloadID;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -62,10 +62,10 @@ class WebPageProxy;
 class WebsiteDataStore;
 struct FrameInfoData;
 
-class DownloadProxyMap : public CanMakeWeakPtr<DownloadProxyMap> {
+class DownloadProxyMap : public CanMakeWeakPtr<DownloadProxyMap>, public CanMakeCheckedPtr<DownloadProxyMap> {
     WTF_MAKE_TZONE_ALLOCATED(DownloadProxyMap);
     WTF_MAKE_NONCOPYABLE(DownloadProxyMap);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DownloadProxyMap);
 public:
     explicit DownloadProxyMap(NetworkProcessProxy&);
     ~DownloadProxyMap();

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -74,10 +74,10 @@ class WebProcessProxy;
 struct UpdateInfo;
 #endif
 
-class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<DrawingAreaIdentifier> {
+class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<DrawingAreaIdentifier>, public CanMakeCheckedPtr<DrawingAreaProxy> {
     WTF_MAKE_TZONE_ALLOCATED(DrawingAreaProxy);
     WTF_MAKE_NONCOPYABLE(DrawingAreaProxy);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DrawingAreaProxy);
 public:
     virtual ~DrawingAreaProxy();
 

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
@@ -56,7 +56,7 @@ Ref<GeolocationPermissionRequestProxy> GeolocationPermissionRequestManagerProxy:
 
 void GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDecision(GeolocationIdentifier geolocationID, bool allowed)
 {
-    if (!m_page.hasRunningProcess())
+    if (!m_page->hasRunningProcess())
         return;
 
     auto it = m_pendingRequests.find(geolocationID);
@@ -68,7 +68,7 @@ void GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDe
     if (!authorizationToken.isNull())
         m_validAuthorizationTokens.add(authorizationToken);
     if (RefPtr process = it->value->process())
-        process->send(Messages::WebPage::DidReceiveGeolocationPermissionDecision(geolocationID, authorizationToken), m_page.webPageIDInProcess(*process));
+        process->send(Messages::WebPage::DidReceiveGeolocationPermissionDecision(geolocationID, authorizationToken), m_page->webPageIDInProcess(*process));
 #else
     UNUSED_PARAM(allowed);
 #endif

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
@@ -55,7 +55,7 @@ public:
 private:
     HashMap<GeolocationIdentifier, RefPtr<GeolocationPermissionRequestProxy>> m_pendingRequests;
     HashSet<String> m_validAuthorizationTokens;
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
@@ -30,6 +30,7 @@
 #import "APIInspectorExtensionClient.h"
 #import "WKFoundation.h"
 #import <WebCore/FrameIdentifier.h>
+#import <wtf/CheckedPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
@@ -38,8 +39,9 @@
 
 namespace WebKit {
 
-class InspectorExtensionDelegate {
+class InspectorExtensionDelegate : public CanMakeCheckedPtr<InspectorExtensionDelegate> {
     WTF_MAKE_TZONE_ALLOCATED(InspectorExtensionDelegate);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorExtensionDelegate);
 public:
     InspectorExtensionDelegate(_WKInspectorExtension *, id <_WKInspectorExtensionDelegate>);
     ~InspectorExtensionDelegate();
@@ -61,7 +63,7 @@ private:
         void didNavigateExtensionTab(const Inspector::ExtensionTabID&, const URL&) override;
         void inspectedPageDidNavigate(const URL&) override;
 
-        InspectorExtensionDelegate& m_inspectorExtensionDelegate;
+        CheckedRef<InspectorExtensionDelegate> m_inspectorExtensionDelegate;
     };
 
     WeakObjCPtr<_WKInspectorExtension> m_inspectorExtension;

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -72,50 +72,50 @@ InspectorExtensionDelegate::InspectorExtensionClient::~InspectorExtensionClient(
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab(const Inspector::ExtensionTabID& extensionTabID, WebCore::FrameIdentifier frameID)
 {
-    if (!m_inspectorExtensionDelegate.m_delegateMethods.inspectorExtensionDidShowTabWithIdentifier)
+    if (!m_inspectorExtensionDelegate->m_delegateMethods.inspectorExtensionDidShowTabWithIdentifier)
         return;
 
-    auto& delegate = m_inspectorExtensionDelegate.m_delegate;
+    auto& delegate = m_inspectorExtensionDelegate->m_delegate;
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate.m_inspectorExtension.get().get() didShowTabWithIdentifier:extensionTabID withFrameHandle:wrapper(API::FrameHandle::create(frameID)).get()];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didShowTabWithIdentifier:extensionTabID withFrameHandle:wrapper(API::FrameHandle::create(frameID)).get()];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didHideExtensionTab(const Inspector::ExtensionTabID& extensionTabID)
 {
-    if (!m_inspectorExtensionDelegate.m_delegateMethods.inspectorExtensionDidHideTabWithIdentifier)
+    if (!m_inspectorExtensionDelegate->m_delegateMethods.inspectorExtensionDidHideTabWithIdentifier)
         return;
 
-    auto& delegate = m_inspectorExtensionDelegate.m_delegate;
+    auto& delegate = m_inspectorExtensionDelegate->m_delegate;
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate.m_inspectorExtension.get().get() didHideTabWithIdentifier:extensionTabID];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didHideTabWithIdentifier:extensionTabID];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionTab(const Inspector::ExtensionTabID& extensionTabID, const WTF::URL& newURL)
 {
-    if (!m_inspectorExtensionDelegate.m_delegateMethods.inspectorExtensionDidNavigateTabWithIdentifier)
+    if (!m_inspectorExtensionDelegate->m_delegateMethods.inspectorExtensionDidNavigateTabWithIdentifier)
         return;
 
-    auto& delegate = m_inspectorExtensionDelegate.m_delegate;
+    auto& delegate = m_inspectorExtensionDelegate->m_delegate;
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate.m_inspectorExtension.get().get() didNavigateTabWithIdentifier:extensionTabID newURL:newURL];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didNavigateTabWithIdentifier:extensionTabID newURL:newURL];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::inspectedPageDidNavigate(const WTF::URL& newURL)
 {
-    if (!m_inspectorExtensionDelegate.m_delegateMethods.inspectorExtensionInspectedPageDidNavigate)
+    if (!m_inspectorExtensionDelegate->m_delegateMethods.inspectorExtensionInspectedPageDidNavigate)
         return;
 
-    auto& delegate = m_inspectorExtensionDelegate.m_delegate;
+    auto& delegate = m_inspectorExtensionDelegate->m_delegate;
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate.m_inspectorExtension.get().get() inspectedPageDidNavigate:newURL];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() inspectedPageDidNavigate:newURL];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -68,8 +68,8 @@ void InspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType co
         return;
     }
 
-    if (m_page.hasRunningProcess())
-        m_page.legacyMainFrameProcess().send(Messages::WebPage::ConnectInspector(identifier(), connectionType), m_page.webPageIDInMainFrameProcess());
+    if (m_page->hasRunningProcess())
+        m_page->legacyMainFrameProcess().send(Messages::WebPage::ConnectInspector(identifier(), connectionType), m_page->webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::disconnect()
@@ -82,8 +82,8 @@ void InspectorTargetProxy::disconnect()
         return;
     }
 
-    if (m_page.hasRunningProcess())
-        m_page.legacyMainFrameProcess().send(Messages::WebPage::DisconnectInspector(identifier()), m_page.webPageIDInMainFrameProcess());
+    if (m_page->hasRunningProcess())
+        m_page->legacyMainFrameProcess().send(Messages::WebPage::DisconnectInspector(identifier()), m_page->webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::sendMessageToTargetBackend(const String& message)
@@ -93,8 +93,8 @@ void InspectorTargetProxy::sendMessageToTargetBackend(const String& message)
         return;
     }
 
-    if (m_page.hasRunningProcess())
-        m_page.legacyMainFrameProcess().send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message), m_page.webPageIDInMainFrameProcess());
+    if (m_page->hasRunningProcess())
+        m_page->legacyMainFrameProcess().send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message), m_page->webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::didCommitProvisionalTarget()

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
@@ -58,7 +58,7 @@ public:
     void sendMessageToTargetBackend(const String&) override;
 
 private:
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
     String m_identifier;
     Inspector::InspectorTargetType m_type;
     WeakPtr<ProvisionalPageProxy> m_provisionalPage;

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -46,47 +46,52 @@ WebPageDebuggable::WebPageDebuggable(WebPageProxy& page)
 
 String WebPageDebuggable::name() const
 {
-    if (!m_page.mainFrame())
+    if (!m_page->mainFrame())
         return String();
 
-    return m_page.mainFrame()->title();
+    return m_page->mainFrame()->title();
 }
 
 String WebPageDebuggable::url() const
 {
-    if (!m_page.mainFrame())
+    if (!m_page->mainFrame())
         return aboutBlankURL().string();
 
-    String url = m_page.mainFrame()->url().string();
+    String url = m_page->mainFrame()->url().string();
     if (url.isEmpty())
         return aboutBlankURL().string();
 
     return url;
 }
 
+Ref<WebPageProxy> WebPageDebuggable::protectedPage() const
+{
+    return m_page.get();
+}
+
 bool WebPageDebuggable::hasLocalDebugger() const
 {
-    return m_page.inspectorController().hasLocalFrontend();
+    return protectedPage()->inspectorController().hasLocalFrontend();
 }
 
 void WebPageDebuggable::connect(FrontendChannel& channel, bool isAutomaticConnection, bool immediatelyPause)
 {
-    m_page.inspectorController().connectFrontend(channel, isAutomaticConnection, immediatelyPause);
+    protectedPage()->inspectorController().connectFrontend(channel, isAutomaticConnection, immediatelyPause);
 }
 
 void WebPageDebuggable::disconnect(FrontendChannel& channel)
 {
-    m_page.inspectorController().disconnectFrontend(channel);
+    protectedPage()->inspectorController().disconnectFrontend(channel);
 }
 
 void WebPageDebuggable::dispatchMessageFromRemote(String&& message)
 {
-    m_page.inspectorController().dispatchMessageFromFrontend(WTFMove(message));
+    protectedPage()->inspectorController().dispatchMessageFromFrontend(WTFMove(message));
 }
 
 void WebPageDebuggable::setIndicating(bool indicating)
 {
-    m_page.inspectorController().setIndicating(indicating);
+    protectedPage()->inspectorController().setIndicating(indicating);
 }
 
 void WebPageDebuggable::setNameOverride(const String& name)

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -57,7 +58,9 @@ public:
     void setNameOverride(const String&);
 
 private:
-    WebPageProxy& m_page;
+    Ref<WebPageProxy> protectedPage() const;
+
+    WeakRef<WebPageProxy> m_page;
     String m_nameOverride;
 };
 

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -66,7 +66,7 @@ public:
         // FIXME <https://webkit.org/b/205537>: this should infer more useful data about the debug target.
         Ref<API::DebuggableInfo> debuggableInfo = API::DebuggableInfo::create(DebuggableInfoData::empty());
         debuggableInfo->setDebuggableType(m_debuggableType);
-        m_proxy->initialize(WTFMove(debuggableInfo), m_inspectorClient.backendCommandsURL());
+        m_proxy->initialize(WTFMove(debuggableInfo), m_inspectorClient->backendCommandsURL());
     }
 
     void show()
@@ -83,12 +83,12 @@ public:
 
     void sendMessageToBackend(const String& message) override
     {
-        m_inspectorClient.sendMessageToBackend(m_connectionID, m_targetID, message);
+        m_inspectorClient->sendMessageToBackend(m_connectionID, m_targetID, message);
     }
 
     void closeFromFrontend() override
     {
-        m_inspectorClient.closeFromFrontend(m_connectionID, m_targetID);
+        m_inspectorClient->closeFromFrontend(m_connectionID, m_targetID);
     }
 
     Ref<API::InspectorConfiguration> configurationForRemoteInspector(RemoteWebInspectorUIProxy&) override
@@ -98,7 +98,7 @@ public:
 
 private:
     Ref<RemoteWebInspectorUIProxy> m_proxy;
-    RemoteInspectorClient& m_inspectorClient;
+    CheckedRef<RemoteInspectorClient> m_inspectorClient;
     ConnectionID m_connectionID;
     TargetID m_targetID;
     Inspector::DebuggableType m_debuggableType;
@@ -154,8 +154,8 @@ void RemoteInspectorClient::connectionClosed()
 {
     m_targets.clear();
     m_inspectorProxyMap.clear();
-    m_observer.connectionClosed(*this);
-    m_observer.targetListChanged(*this);
+    m_observer->connectionClosed(*this);
+    m_observer->targetListChanged(*this);
 }
 
 void RemoteInspectorClient::didClose(Inspector::RemoteInspectorSocketEndpoint&, ConnectionID)
@@ -279,7 +279,7 @@ void RemoteInspectorClient::setTargetList(const Event& event)
         m_inspectorProxyMap.remove(std::make_pair(connectionID, targetID));
 
     m_targets.set(connectionID, WTFMove(targetList));
-    m_observer.targetListChanged(*this);
+    m_observer->targetListChanged(*this);
 }
 
 void RemoteInspectorClient::sendMessageToFrontend(const Event& event)

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/RemoteControllableTarget.h>
 #include <JavaScriptCore/RemoteInspectorConnectionClient.h>
 #include <WebCore/InspectorDebuggableType.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
@@ -41,7 +42,9 @@ namespace WebKit {
 class RemoteInspectorClient;
 class RemoteInspectorProxy;
 
-class RemoteInspectorObserver {
+class RemoteInspectorObserver : public CanMakeCheckedPtr<RemoteInspectorObserver> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorObserver);
 public:
     virtual ~RemoteInspectorObserver() { }
     virtual void targetListChanged(RemoteInspectorClient&) = 0;
@@ -51,8 +54,9 @@ public:
 using ConnectionID = Inspector::ConnectionID;
 using TargetID = Inspector::TargetID;
 
-class RemoteInspectorClient final : public Inspector::RemoteInspectorConnectionClient {
+class RemoteInspectorClient final : public Inspector::RemoteInspectorConnectionClient, public CanMakeCheckedPtr<RemoteInspectorClient> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteInspectorClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorClient);
 public:
     RemoteInspectorClient(URL, RemoteInspectorObserver&);
     ~RemoteInspectorClient();
@@ -89,7 +93,7 @@ private:
     void sendWebInspectorEvent(const String&);
 
     String m_backendCommandsURL;
-    RemoteInspectorObserver& m_observer;
+    CheckedRef<RemoteInspectorObserver> m_observer;
     std::optional<ConnectionID> m_connectionID;
     HashMap<ConnectionID, Vector<Target>> m_targets;
     HashMap<std::pair<ConnectionID, TargetID>, std::unique_ptr<RemoteInspectorProxy>> m_inspectorProxyMap;

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.h
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.h
@@ -39,6 +39,8 @@ namespace WebKit {
 class WebURLSchemeTask;
 
 class RemoteInspectorProtocolHandler final : public RemoteInspectorObserver, public WebURLSchemeHandler {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorProtocolHandler);
 public:
     static Ref<RemoteInspectorProtocolHandler> create(WebPageProxy& page) { return adoptRef(*new RemoteInspectorProtocolHandler(page)); }
 
@@ -59,9 +61,10 @@ private:
     void updateTargetList();
 
     void runScript(const String&);
+    Ref<WebPageProxy> protectedPage() const;
 
     std::unique_ptr<RemoteInspectorClient> m_inspectorClient;
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
     bool m_pageLoaded { false };
     String m_targetListsHtml;
 };

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -59,22 +59,22 @@ RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy(WebPagePr
     : m_webPageProxy(webPageProxy)
     , m_privateCoordinator(WTFMove(privateCoordinator))
 #if !RELEASE_LOG_DISABLED
-    , m_logger(m_webPageProxy.logger())
+    , m_logger(m_webPageProxy->logger())
     , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 #endif
 {
     m_privateCoordinator->setClient(*this);
-    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess(), *this);
+    m_webPageProxy->legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
 }
 
 RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 {
-    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 const SharedPreferencesForWebProcess& RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess() const
 {
-    return m_webPageProxy.legacyMainFrameProcess().sharedPreferencesForWebProcess();
+    return m_webPageProxy->legacyMainFrameProcess().sharedPreferencesForWebProcess();
 }
 
 void RemoteMediaSessionCoordinatorProxy::join(MediaSessionCommandCompletionHandler&& completionHandler)
@@ -165,27 +165,27 @@ void RemoteMediaSessionCoordinatorProxy::trackIdentifierChanged(const String& id
 
 void RemoteMediaSessionCoordinatorProxy::seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::playSession(std::optional<double> atTime, std::optional<MonotonicTime> hostTime, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTFMove(atTime), WTFMove(hostTime) }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTFMove(atTime), WTFMove(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::pauseSession(CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::setSessionTrack(const String& trackId, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged(WebCore::MediaSessionCoordinatorState state)
 {
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -94,7 +94,7 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
     Ref<MediaSessionCoordinatorProxyPrivate> m_privateCoordinator;
 #if !RELEASE_LOG_DISABLED
     Ref<const WTF::Logger> m_logger;

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -61,7 +61,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManagerProxy);
 
 const Logger& MediaKeySystemPermissionRequestManagerProxy::logger() const
 {
-    return m_page.logger();
+    return m_page->logger();
 }
 #endif
 
@@ -88,13 +88,13 @@ void MediaKeySystemPermissionRequestManagerProxy::invalidatePendingRequests()
 
 void MediaKeySystemPermissionRequestManagerProxy::denyRequest(MediaKeySystemPermissionRequestProxy& request, const String& message)
 {
-    if (!m_page.hasRunningProcess())
+    if (!m_page->hasRunningProcess())
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, request.mediaKeySystemID().toUInt64(), ", reason: ", message);
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    m_page.legacyMainFrameProcess().send(Messages::WebPage::MediaKeySystemWasDenied(request.mediaKeySystemID(), message), m_page.webPageIDInMainFrameProcess());
+    m_page->legacyMainFrameProcess().send(Messages::WebPage::MediaKeySystemWasDenied(request.mediaKeySystemID(), message), m_page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(message);
 #endif
@@ -102,13 +102,13 @@ void MediaKeySystemPermissionRequestManagerProxy::denyRequest(MediaKeySystemPerm
 
 void MediaKeySystemPermissionRequestManagerProxy::grantRequest(MediaKeySystemPermissionRequestProxy& request)
 {
-    if (!m_page.hasRunningProcess())
+    if (!m_page->hasRunningProcess())
         return;
 
 #if ENABLE(ENCRYPTED_MEDIA)
     ALWAYS_LOG(LOGIDENTIFIER, request.mediaKeySystemID().toUInt64(), ", keySystem: ", request.keySystem());
 
-    m_page.legacyMainFrameProcess().send(Messages::WebPage::MediaKeySystemWasGranted { request.mediaKeySystemID() }, m_page.webPageIDInMainFrameProcess());
+    m_page->legacyMainFrameProcess().send(Messages::WebPage::MediaKeySystemWasGranted { request.mediaKeySystemID() }, m_page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(request);
 #endif
@@ -117,7 +117,7 @@ void MediaKeySystemPermissionRequestManagerProxy::grantRequest(MediaKeySystemPer
 Ref<MediaKeySystemPermissionRequestProxy> MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame(MediaKeySystemRequestIdentifier mediaKeySystemID, FrameIdentifier frameID, Ref<SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem)
 {
     ALWAYS_LOG(LOGIDENTIFIER, mediaKeySystemID.toUInt64());
-    auto request = MediaKeySystemPermissionRequestProxy::create(*this, mediaKeySystemID, m_page.mainFrame()->frameID(), frameID, WTFMove(topLevelDocumentOrigin), keySystem);
+    auto request = MediaKeySystemPermissionRequestProxy::create(*this, mediaKeySystemID, m_page->mainFrame()->frameID(), frameID, WTFMove(topLevelDocumentOrigin), keySystem);
     m_pendingRequests.add(mediaKeySystemID, request.ptr());
     return request;
 }

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -57,7 +57,7 @@ public:
     explicit MediaKeySystemPermissionRequestManagerProxy(WebPageProxy&);
     ~MediaKeySystemPermissionRequestManagerProxy();
 
-    WebPageProxy& page() const { return m_page; }
+    WebPageProxy& page() const { return m_page.get(); }
 
     void invalidatePendingRequests();
 
@@ -72,7 +72,7 @@ private:
     const void* logIdentifier() const { return m_logIdentifier; }
 #endif
 
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
 
     HashMap<WebCore::MediaKeySystemRequestIdentifier, RefPtr<MediaKeySystemPermissionRequestProxy>> m_pendingRequests;
     HashSet<String> m_validAuthorizationTokens;

--- a/Source/WebKit/UIProcess/ModelElementController.cpp
+++ b/Source/WebKit/UIProcess/ModelElementController.cpp
@@ -40,6 +40,11 @@ ModelElementController::ModelElementController(WebPageProxy& webPageProxy)
 {
 }
 
+WebPageProxy& ModelElementController::page()
+{
+    return m_webPageProxy.get();
+}
+
 }
 
 #endif

--- a/Source/WebKit/UIProcess/ModelElementController.h
+++ b/Source/WebKit/UIProcess/ModelElementController.h
@@ -62,7 +62,7 @@ class ModelElementController : public CanMakeWeakPtr<ModelElementController> {
 public:
     explicit ModelElementController(WebPageProxy&);
 
-    WebPageProxy& page() { return m_webPageProxy; }
+    WebPageProxy& page();
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
     void getCameraForModelElement(ModelIdentifier, CompletionHandler<void(Expected<WebCore::HTMLModelElementCamera, WebCore::ResourceError>)>&&);
@@ -102,7 +102,7 @@ private:
     WKModelView * modelViewForModelIdentifier(ModelIdentifier);
 #endif
 
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
 #if ENABLE(ARKIT_INLINE_PREVIEW_MAC)
     RetainPtr<ASVInlinePreview> previewForUUID(const String&);
     HashMap<String, RetainPtr<ASVInlinePreview>> m_inlinePreviews;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -39,6 +39,11 @@ WebNotificationManagerMessageHandler::WebNotificationManagerMessageHandler(WebPa
 {
 }
 
+Ref<WebPageProxy> WebNotificationManagerMessageHandler::protectedPage() const
+{
+    return m_webPageProxy.get();
+}
+
 void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& connection, const WebCore::NotificationData& data, RefPtr<WebCore::NotificationResources>&& resources, CompletionHandler<void()>&& callback)
 {
     RELEASE_LOG(Push, "WebNotificationManagerMessageHandler showNotification called");
@@ -47,7 +52,7 @@ void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& con
         ServiceWorkerNotificationHandler::singleton().showNotification(connection, data, WTFMove(resources), WTFMove(callback));
         return;
     }
-    m_webPageProxy.showNotification(connection, data, WTFMove(resources));
+    protectedPage()->showNotification(connection, data, WTFMove(resources));
     callback();
 }
 
@@ -58,7 +63,7 @@ void WebNotificationManagerMessageHandler::cancelNotification(WebCore::SecurityO
         serviceWorkerNotificationHandler.cancelNotification(WTFMove(origin), notificationID);
         return;
     }
-    m_webPageProxy.cancelNotification(notificationID);
+    protectedPage()->cancelNotification(notificationID);
 }
 
 void WebNotificationManagerMessageHandler::clearNotifications(const Vector<WTF::UUID>& notificationIDs)
@@ -78,7 +83,7 @@ void WebNotificationManagerMessageHandler::clearNotifications(const Vector<WTF::
     if (!persistentNotifications.isEmpty())
         serviceWorkerNotificationHandler.clearNotifications(persistentNotifications);
     if (!pageNotifications.isEmpty())
-        m_webPageProxy.clearNotifications(pageNotifications);
+        protectedPage()->clearNotifications(pageNotifications);
 }
 
 void WebNotificationManagerMessageHandler::didDestroyNotification(const WTF::UUID& notificationID)
@@ -88,12 +93,12 @@ void WebNotificationManagerMessageHandler::didDestroyNotification(const WTF::UUI
         serviceWorkerNotificationHandler.didDestroyNotification(notificationID);
         return;
     }
-    m_webPageProxy.didDestroyNotification(notificationID);
+    protectedPage()->didDestroyNotification(notificationID);
 }
 
 void WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermission()
 {
-    m_webPageProxy.pageWillLikelyUseNotifications();
+    protectedPage()->pageWillLikelyUseNotifications();
 }
 
 void WebNotificationManagerMessageHandler::requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -46,7 +46,9 @@ private:
     void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
 
-    WebPageProxy& m_webPageProxy;
+    Ref<WebPageProxy> protectedPage() const;
+
+    WeakRef<WebPageProxy> m_webPageProxy;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -251,7 +251,9 @@ private:
     static bool hasOnlySecureContent(const Data&);
     static double estimatedProgress(const Data&);
 
-    WebPageProxy& m_webPageProxy;
+    Ref<WebPageProxy> protectedPage() const;
+
+    WeakRef<WebPageProxy> m_webPageProxy;
 
     Data m_committedState;
     Data m_uncommittedState;

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -96,7 +96,7 @@ void PerActivityStateCPUUsageSampler::loggingTimerFired()
 
 RefPtr<WebPageProxy> PerActivityStateCPUUsageSampler::pageForLogging() const
 {
-    for (Ref webProcess : m_processPool.processes()) {
+    for (Ref webProcess : Ref { m_processPool.get() }->processes()) {
         if (!webProcess->pageCount())
             continue;
         return webProcess->pages()[0].ptr();

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -47,7 +47,7 @@ private:
     void loggingTimerFired();
     RefPtr<WebPageProxy> pageForLogging() const;
 
-    WebProcessPool& m_processPool;
+    WeakRef<WebProcessPool> m_processPool;
     RunLoop::Timer m_loggingTimer;
     typedef HashMap<WebCore::ActivityStateForCPUSampling, Seconds, WTF::IntHash<WebCore::ActivityStateForCPUSampling>, WTF::StrongEnumHashTraits<WebCore::ActivityStateForCPUSampling>> CPUTimeInActivityStateMap;
     CPUTimeInActivityStateMap m_cpuTimeInActivityState;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -53,6 +53,9 @@ class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
 
 class RemoteLayerTreeDrawingAreaProxy : public DrawingAreaProxy {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxy);
+    WTF_MAKE_NONCOPYABLE(RemoteLayerTreeDrawingAreaProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeDrawingAreaProxy);
 public:
     RemoteLayerTreeDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxy();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -51,10 +51,13 @@
 #import <wtf/CallbackAggregator.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/SystemTracing.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxy);
 
 RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::RemoteLayerTree, pageProxy, webProcessProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
@@ -71,7 +71,7 @@ private:
     void appendBlankPixelCount(ScrollingLogEvent::EventType, uint64_t blankPixelCount);
     void appendSynchronousScrollingChange(WTF::MonotonicTime, uint64_t);
 
-    RemoteLayerTreeDrawingAreaProxy& m_drawingArea;
+    CheckedRef<RemoteLayerTreeDrawingAreaProxy> m_drawingArea;
     Vector<ScrollingLogEvent> m_events;
 #if PLATFORM(MAC)
     uint64_t m_lastUnfilledArea;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -124,7 +124,7 @@ static CALayer *findTileGridContainerLayer(CALayer *layer)
 
 unsigned RemoteLayerTreeScrollingPerformanceData::blankPixelCount(const FloatRect& visibleRect) const
 {
-    CALayer *rootLayer = m_drawingArea.remoteLayerTreeHost().rootLayer();
+    CALayer *rootLayer = m_drawingArea->remoteLayerTreeHost().rootLayer();
 
     CALayer *tileGridContainer = findTileGridContainerLayer(rootLayer);
     if (!tileGridContainer) {
@@ -159,15 +159,15 @@ void RemoteLayerTreeScrollingPerformanceData::logData()
     for (auto event : m_events) {
         switch (event.eventType) {
         case ScrollingLogEvent::SwitchedScrollingMode: {
-            m_drawingArea.page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode), event.startTime, event.value);
+            m_drawingArea->page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode), event.startTime, event.value);
             break;
         }
         case ScrollingLogEvent::Exposed: {
-            m_drawingArea.page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::ExposedTilelessArea), event.startTime, event.value);
+            m_drawingArea->page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::ExposedTilelessArea), event.startTime, event.value);
             break;
         }
         case ScrollingLogEvent::Filled: {
-            m_drawingArea.page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), event.startTime, event.value);
+            m_drawingArea->page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), event.startTime, event.value);
             break;
         }
         default:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -63,6 +63,16 @@ RemoteScrollingCoordinatorProxy::~RemoteScrollingCoordinatorProxy()
     m_scrollingTree->invalidate();
 }
 
+WebPageProxy& RemoteScrollingCoordinatorProxy::webPageProxy() const
+{
+    return m_webPageProxy.get();
+}
+
+Ref<WebPageProxy> RemoteScrollingCoordinatorProxy::protectedWebPageProxy() const
+{
+    return m_webPageProxy.get();
+}
+
 ScrollingNodeID RemoteScrollingCoordinatorProxy::rootScrollingNodeID() const
 {
     // FIXME: Locking
@@ -74,7 +84,7 @@ ScrollingNodeID RemoteScrollingCoordinatorProxy::rootScrollingNodeID() const
 
 const RemoteLayerTreeHost* RemoteScrollingCoordinatorProxy::layerTreeHost() const
 {
-    auto* remoteDrawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(m_webPageProxy.drawingArea());
+    auto* remoteDrawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(m_webPageProxy->drawingArea());
     ASSERT(remoteDrawingArea);
     return remoteDrawingArea ? &remoteDrawingArea->remoteLayerTreeHost() : nullptr;
 }
@@ -165,7 +175,7 @@ void RemoteScrollingCoordinatorProxy::applyScrollingTreeLayerPositionsAfterCommi
 
 void RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical)
 {
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 // This comes from the scrolling tree.
@@ -176,10 +186,11 @@ void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll(ScrollingNodeID
     if (!propagatesMainFrameScrolls() && scrolledNodeID == rootScrollingNodeID())
         return;
 
-    if (m_webPageProxy.scrollingUpdatesDisabledForTesting())
+    Ref webPageProxy = m_webPageProxy.get();
+    if (webPageProxy->scrollingUpdatesDisabledForTesting())
         return;
 
-    m_webPageProxy.scrollingNodeScrollViewDidScroll(scrolledNodeID);
+    webPageProxy->scrollingNodeScrollViewDidScroll(scrolledNodeID);
 
     if (m_scrollingTree->isHandlingProgrammaticScroll())
         return;
@@ -189,7 +200,7 @@ void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll(ScrollingNodeID
 
     LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll " << scrolledNodeID << " to " << newScrollPosition << " waitingForDidScrollReply " << m_waitingForDidScrollReply);
 
-    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = m_webPageProxy.scrollingPerformanceData())
+    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = webPageProxy->scrollingPerformanceData())
         scrollPerfData->didScroll(m_scrollingTree->layoutViewport());
 
     if (!m_waitingForDidScrollReply) {
@@ -205,13 +216,14 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll()
         return;
     }
 
+    Ref webPageProxy = m_webPageProxy.get();
     auto scrollUpdates = m_scrollingTree->takePendingScrollUpdates();
     for (unsigned i = 0; i < scrollUpdates.size(); ++i) {
         const auto& update = scrollUpdates[i];
         bool isLastUpdate = i == scrollUpdates.size() - 1;
 
         LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll - node " << update.nodeID << " scroll position " << update.scrollPosition << " isLastUpdate " << isLastUpdate);
-        m_webPageProxy.sendScrollPositionChangedForNode(scrollingTree()->frameIDForScrollingNodeID(update.nodeID), update.nodeID, update.scrollPosition, update.layoutViewportOrigin, update.updateLayerPositionAction == ScrollingLayerPositionAction::Sync, isLastUpdate);
+        webPageProxy->sendScrollPositionChangedForNode(scrollingTree()->frameIDForScrollingNodeID(update.nodeID), update.nodeID, update.scrollPosition, update.layoutViewportOrigin, update.updateLayerPositionAction == ScrollingLayerPositionAction::Sync, isLastUpdate);
         m_waitingForDidScrollReply = true;
     }
 }
@@ -233,7 +245,7 @@ void RemoteScrollingCoordinatorProxy::receivedLastScrollingTreeNodeDidScrollRepl
 
 void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidStopAnimatedScroll(ScrollingNodeID scrolledNodeID)
 {
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::AnimatedScrollDidEndForNode(scrolledNodeID), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::AnimatedScrollDidEndForNode(scrolledNodeID), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 bool RemoteScrollingCoordinatorProxy::scrollingTreeNodeRequestsScroll(ScrollingNodeID scrolledNodeID, const RequestedScrollData& request)
@@ -350,7 +362,7 @@ void RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary()
     if (!m_uiState.changes())
         return;
 
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy->webPageIDInMainFrameProcess());
     m_uiState.clearChanges();
 }
 
@@ -363,7 +375,7 @@ void RemoteScrollingCoordinatorProxy::resetStateAfterProcessExited()
 
 void RemoteScrollingCoordinatorProxy::reportFilledVisibleFreshTile(MonotonicTime timestamp, unsigned unfilledArea)
 {
-    m_webPageProxy.logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), timestamp, unfilledArea);
+    protectedWebPageProxy()->logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), timestamp, unfilledArea);
 }
 
 void RemoteScrollingCoordinatorProxy::reportExposedUnfilledArea(MonotonicTime, unsigned)
@@ -372,25 +384,25 @@ void RemoteScrollingCoordinatorProxy::reportExposedUnfilledArea(MonotonicTime, u
 
 void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(MonotonicTime timestamp, OptionSet<SynchronousScrollingReason> reasons)
 {
-    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = m_webPageProxy.scrollingPerformanceData())
+    if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = m_webPageProxy->scrollingPerformanceData())
         scrollPerfData->didChangeSynchronousScrollingReasons(timestamp, reasons.toRaw());
 }
 
 void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(nodeID, reason), m_webPageProxy.webPageIDInMainFrameProcess());
+        m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason), m_webPageProxy.webPageIDInMainFrameProcess());
+        m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::viewWillStartLiveResize()
@@ -432,12 +444,12 @@ bool RemoteScrollingCoordinatorProxy::scrollingPerformanceTestingEnabled() const
 
 void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
 {
-    m_webPageProxy.sendToProcessContainingFrame(scrollingTree()->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible));
+    protectedWebPageProxy()->sendToProcessContainingFrame(scrollingTree()->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible));
 }
 
 void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
 {
-    m_webPageProxy.sendToProcessContainingFrame(scrollingTree()->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength));
+    protectedWebPageProxy()->sendToProcessContainingFrame(scrollingTree()->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength));
 }
 
 bool RemoteScrollingCoordinatorProxy::isMonitoringWheelEvents()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -116,7 +116,8 @@ public:
     WebCore::ScrollingNodeID rootScrollingNodeID() const;
 
     const RemoteLayerTreeHost* layerTreeHost() const;
-    WebPageProxy& webPageProxy() const { return m_webPageProxy; }
+    WebPageProxy& webPageProxy() const;
+    Ref<WebPageProxy> protectedWebPageProxy() const;
 
     std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(IPC::Connection&, const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 
@@ -200,7 +201,7 @@ protected:
     void sendUIStateChangedIfNecessary();
 
 private:
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
     RefPtr<RemoteScrollingTree> m_scrollingTree;
 
 protected:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -34,6 +34,9 @@ OBJC_CLASS WKDisplayLinkHandler;
 namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxyIOS final : public RemoteLayerTreeDrawingAreaProxy {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxyIOS);
+    WTF_MAKE_NONCOPYABLE(RemoteLayerTreeDrawingAreaProxyIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeDrawingAreaProxyIOS);
 public:
     RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy&, WebProcessProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxyIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -36,6 +36,7 @@
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/ScrollView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 constexpr WebCore::FramesPerSecond DisplayLinkFramesPerSecond = 60;
 
@@ -180,6 +181,8 @@ static void* displayRefreshRateObservationContext = &displayRefreshRateObservati
 namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxyIOS);
 
 RemoteLayerTreeDrawingAreaProxyIOS::RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : RemoteLayerTreeDrawingAreaProxy(pageProxy, webProcessProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -42,6 +42,9 @@ class RemoteScrollingCoordinatorTransaction;
 
 class RemoteLayerTreeDrawingAreaProxyMac final : public RemoteLayerTreeDrawingAreaProxy {
 friend class RemoteScrollingCoordinatorProxyMac;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxyMac);
+    WTF_MAKE_NONCOPYABLE(RemoteLayerTreeDrawingAreaProxyMac);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeDrawingAreaProxyMac);
 public:
     RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy&, WebProcessProxy&);
     ~RemoteLayerTreeDrawingAreaProxyMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -51,6 +51,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxyMac);
+
 static NSString * const transientZoomAnimationKey = @"wkTransientZoomScale";
 static NSString * const transientZoomCommitAnimationKey = @"wkTransientZoomCommit";
 static NSString * const transientZoomScrollPositionOverrideAnimationKey = @"wkScrollPositionOverride";

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -41,6 +41,9 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::TiledCoreAnim
 namespace WebKit {
 
 class TiledCoreAnimationDrawingAreaProxy final : public DrawingAreaProxy {
+    WTF_MAKE_TZONE_ALLOCATED(TiledCoreAnimationDrawingAreaProxy);
+    WTF_MAKE_NONCOPYABLE(TiledCoreAnimationDrawingAreaProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TiledCoreAnimationDrawingAreaProxy);
 public:
     TiledCoreAnimationDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
     virtual ~TiledCoreAnimationDrawingAreaProxy();

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -38,10 +38,13 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/MachSendRight.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TiledCoreAnimationDrawingAreaProxy);
 
 TiledCoreAnimationDrawingAreaProxy::TiledCoreAnimationDrawingAreaProxy(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::TiledCoreAnimation, webPageProxy, webProcessProxy)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -40,6 +40,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DrawingAreaProxyWC);
+
 DrawingAreaProxyWC::DrawingAreaProxyWC(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::WC, webPageProxy, webProcessProxy)
 {

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -29,6 +29,7 @@
 
 #include "BackingStore.h"
 #include "DrawingAreaProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class Region;
@@ -37,6 +38,9 @@ class Region;
 namespace WebKit {
 
 class DrawingAreaProxyWC final : public DrawingAreaProxy {
+    WTF_MAKE_TZONE_ALLOCATED(DrawingAreaProxyWC);
+    WTF_MAKE_NONCOPYABLE(DrawingAreaProxyWC);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DrawingAreaProxyWC);
 public:
     DrawingAreaProxyWC(WebPageProxy&, WebProcessProxy&);
 


### PR DESCRIPTION
#### 6fb6b9002b9ff21cb90a046055d0d46f5f3c0977
<pre>
Adopt more smart pointers in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=278977">https://bugs.webkit.org/show_bug.cgi?id=278977</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::SimulatedInputDispatcher::resolveLocation):
(WebKit::SimulatedInputDispatcher::protectedPage const):
(WebKit::SimulatedInputDispatcher::transitionInputSourceToState):
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm:
(WebKit::IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelViewForModelIdentifier):
(WebKit::ModelElementController::takeModelElementFullscreen):
(WebKit::ModelElementController::previewForModelIdentifier):
(WebKit::ModelElementController::modelElementCreateRemotePreview):
(WebKit::ModelElementController::modelElementLoadRemotePreview):
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h:
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm:
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didSendRequest const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError const):
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.h:
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm:
(WebKit::TextCheckingController::replaceRelativeToSelection):
(WebKit::TextCheckingController::removeAnnotationRelativeToSelection):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::cancel):
(WebKit::DownloadProxy::didFinish):
(WebKit::DownloadProxy::didFail):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp:
(WebKit::GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDecision):
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab):
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didHideExtensionTab):
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionTab):
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::inspectedPageDidNavigate):
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
(WebKit::InspectorTargetProxy::connect):
(WebKit::InspectorTargetProxy::disconnect):
(WebKit::InspectorTargetProxy::sendMessageToTargetBackend):
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:
(WebKit::WebPageDebuggable::name const):
(WebKit::WebPageDebuggable::url const):
(WebKit::WebPageDebuggable::protectedPage const):
(WebKit::WebPageDebuggable::hasLocalDebugger const):
(WebKit::WebPageDebuggable::connect):
(WebKit::WebPageDebuggable::disconnect):
(WebKit::WebPageDebuggable::dispatchMessageFromRemote):
(WebKit::WebPageDebuggable::setIndicating):
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp:
(WebKit::RemoteInspectorClient::connectionClosed):
(WebKit::RemoteInspectorClient::setTargetList):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::protectedPage const):
(WebKit::RemoteInspectorProtocolHandler::runScript):
(WebKit::RemoteInspectorProtocolHandler::platformStartTask):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteMediaSessionCoordinatorProxy::seekSessionToTime):
(WebKit::RemoteMediaSessionCoordinatorProxy::playSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::pauseSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::setSessionTrack):
(WebKit::RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::logger const):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::denyRequest):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::grantRequest):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::page const):
* Source/WebKit/UIProcess/ModelElementController.cpp:
(WebKit::ModelElementController::page):
* Source/WebKit/UIProcess/ModelElementController.h:
(WebKit::ModelElementController::page): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::protectedPage const):
(WebKit::WebNotificationManagerMessageHandler::showNotification):
(WebKit::WebNotificationManagerMessageHandler::cancelNotification):
(WebKit::WebNotificationManagerMessageHandler::clearNotifications):
(WebKit::WebNotificationManagerMessageHandler::didDestroyNotification):
(WebKit::WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermission):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::Transaction::Transaction):
(WebKit::PageLoadState::protectedPage const):
(WebKit::PageLoadState::commitChanges):
(WebKit::PageLoadState::callObserverCallback):
* Source/WebKit/UIProcess/PageLoadState.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
(WebKit::PerActivityStateCPUUsageSampler::pageForLogging const):
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm:
(WebKit::RemoteLayerTreeScrollingPerformanceData::blankPixelCount const):
(WebKit::RemoteLayerTreeScrollingPerformanceData::logData):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::webPageProxy const):
(WebKit::RemoteScrollingCoordinatorProxy::protectedWebPageProxy const):
(WebKit::RemoteScrollingCoordinatorProxy::layerTreeHost const):
(WebKit::RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxy::reportFilledVisibleFreshTile):
(WebKit::RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged):
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::webPageProxy const): Deleted.

Canonical link: <a href="https://commits.webkit.org/283070@main">https://commits.webkit.org/283070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a42ff18b228df926f494f795b03743fb78fefc7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52258 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10811 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37732 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8998 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13544 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-activesourcebuffers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59627 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56358 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59882 "Found 2 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1104 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9873 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->