### PR TITLE
[JSC] Make shared wasm entrypoint succinct

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -561,7 +561,7 @@ macro boxInt32(r, rTag)
     end
 end
 
-// This is the interpreted analogue to createJSToWasmJITInterpreterCrashForSIMDParameters
+// This is the interpreted analogue to createJSToWasmJITSharedCrashForSIMDParameters
 op(js_to_wasm_wrapper_entry_crash_for_simd_parameters, macro()
     if not WEBASSEMBLY or C_LOOP
         error
@@ -578,7 +578,7 @@ op(js_to_wasm_wrapper_entry_crash_for_simd_parameters, macro()
 end)
 
 // This is the interpreted analogue to createJSToWasmWrapper
-// If you change this, make sure to modify JSToWasm.cpp:createJSToWasmJITInterpreter
+// If you change this, make sure to modify JSToWasm.cpp:createJSToWasmJITShared
 op(js_to_wasm_wrapper_entry, macro ()
     if not WEBASSEMBLY or C_LOOP
         error
@@ -648,7 +648,7 @@ if ASSERT_ENABLED
     clobberVolatileRegisters()
 end
 
-    macro saveJSEntrypointInterpreterRegisters()
+    macro saveJSEntrypointRegisters()
         subp constexpr Wasm::JITLessJSEntrypointCallee::SpillStackSpaceAligned, sp
         if ARM64 or ARM64E
             storepairq memoryBase, boundsCheckingSize, -2 * SlotSize[cfr]
@@ -663,7 +663,7 @@ end
         end
     end
 
-    macro restoreJSEntrypointInterpreterRegisters()
+    macro restoreJSEntrypointRegisters()
         if ARM64 or ARM64E
             loadpairq -2 * SlotSize[cfr], memoryBase, boundsCheckingSize
             loadp -3 * SlotSize[cfr], wasmInstance
@@ -679,7 +679,7 @@ end
 
     tagReturnAddress sp
     preserveCallerPCAndCFR()
-    saveJSEntrypointInterpreterRegisters()
+    saveJSEntrypointRegisters()
 
     # Load data from the entry callee
     # This was written by doVMEntry
@@ -878,7 +878,7 @@ else
 end
 
     # Clean up and return
-    restoreJSEntrypointInterpreterRegisters()
+    restoreJSEntrypointRegisters()
     clobberVolatileRegisters()
     restoreCallerPCAndCFR()
     ret

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -446,14 +446,14 @@ CodePtr<WasmEntryPtrTag> JITLessJSEntrypointCallee::entrypointImpl() const
     if (Options::useWasmSIMD() && (wasmCallingConvention().callInformationFor(typeDefinition).argumentsOrResultsIncludeV128)) {
 #if ENABLE(JIT)
         if (Options::useJIT())
-            return createJSToWasmJITInterpreterCrashForSIMDParameters()->entrypoint.compilation->code().retagged<WasmEntryPtrTag>();
+            return createJSToWasmJITSharedCrashForSIMDParameters()->entrypoint.compilation->code().retagged<WasmEntryPtrTag>();
 #endif
         return LLInt::getCodeFunctionPtr<CFunctionPtrTag>(js_to_wasm_wrapper_entry_crash_for_simd_parameters);
     }
 
 #if ENABLE(JIT)
     if (Options::useJIT())
-        return createJSToWasmJITInterpreter()->entrypoint.compilation->code().retagged<WasmEntryPtrTag>();
+        return createJSToWasmJITShared()->entrypoint.compilation->code().retagged<WasmEntryPtrTag>();
 #endif
     return LLInt::getCodeFunctionPtr<CFunctionPtrTag>(js_to_wasm_wrapper_entry);
 }

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -197,7 +197,7 @@ public:
     }
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const;
-    JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
+    static JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
 
     static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, ident); }

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.h
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.h
@@ -45,8 +45,8 @@ struct CallInformation;
 class JSEntrypointCallee;
 
 void marshallJSResult(CCallHelpers& jit, const TypeDefinition&, const CallInformation& wasmFrameConvention, const RegisterAtOffsetList& savedResultRegisters, CCallHelpers::JumpList& exceptionChecks);
-std::shared_ptr<InternalFunction> createJSToWasmJITInterpreterCrashForSIMDParameters();
-std::shared_ptr<InternalFunction> createJSToWasmJITInterpreter();
+std::shared_ptr<InternalFunction> createJSToWasmJITSharedCrashForSIMDParameters();
+std::shared_ptr<InternalFunction> createJSToWasmJITShared();
 std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers&, JSEntrypointCallee&, Callee*, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>*, const ModuleInformation&, MemoryMode, uint32_t functionIndex);
 
 } } // namespace JSC::Wasm


### PR DESCRIPTION
#### 73cf9deb7e468ec10eb51fc94663f2683d0e3ebd
<pre>
[JSC] Make shared wasm entrypoint succinct
<a href="https://bugs.webkit.org/show_bug.cgi?id=278978">https://bugs.webkit.org/show_bug.cgi?id=278978</a>
<a href="https://rdar.apple.com/135095645">rdar://135095645</a>

Reviewed by Justin Michaud.

1. Do not use CCallHelper::Address { }, which is not consistent to the rest of the all JIT code.
2. Use CCallHelper::addressFor instead of directly pointing at sizeof(CPURegister) * n.
3. Use emitSaveCalleeSaveFor and emitRestoreCalleeSavesFor instead of doing them manually
4. Use cageConditionally.
5. Use lowestAccessibleAddress() directly. When emitting JIT code, it is already constant value.
6. Rename and drop &quot;Interpreter&quot; since it is no longer interpreter.

* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::unboxNativeCallee):
(JSC::AssemblyHelpers::boxNativeCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmJITInterpreter):

Canonical link: <a href="https://commits.webkit.org/283046@main">https://commits.webkit.org/283046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/057f918b8901c5e325f36f77d97a04bf137f52a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15613 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52226 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10782 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14489 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70736 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64250 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56323 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59783 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/ignored-objects (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1068 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86016 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40186 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15164 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41263 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->