### PR TITLE
[JSC] Implement `Iterator.prototype.toArray` from Iterator Helpers Proposal

### DIFF
--- a/JSTests/stress/iterator-prototype-toArray.js
+++ b/JSTests/stress/iterator-prototype-toArray.js
@@ -1,0 +1,132 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function sameArray(a, b) {
+    sameValue(JSON.stringify(a), JSON.stringify(b));
+}
+
+function shouldThrow(fn, error, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+    }
+}
+
+{
+    class Iter extends Iterator {
+        i = 1;
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        }
+    }
+    const iter = new Iter();
+    const arr = iter.toArray();
+    sameArray(arr, [1, 2, 3, 4, 5]);
+}
+
+{
+    const iter = {
+        i: 1,
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        },
+    };
+    const arr = Iterator.prototype.toArray.call(iter);
+    sameArray(arr, [1, 2, 3, 4, 5]);
+}
+
+{
+    let nextGetCount = 0;
+    class Iter extends Iterator {
+        get next() {
+            nextGetCount++;
+            let i = 1;
+            return function() {
+                if (i > 5)
+                    return { value: i, done: true }
+                return { value: i++, done: false }
+            }
+        };
+    };
+    const iter = new Iter();
+    sameValue(nextGetCount, 0);
+    const arr = iter.toArray();
+    sameValue(nextGetCount, 1);
+    sameArray(arr, [1, 2, 3, 4, 5]);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+        yield 4;
+        yield 5;
+    }
+    const iter = gen();
+    const arr = iter.toArray();
+    sameArray(arr, [1, 2, 3, 4, 5]);
+}
+
+{
+    const arr1 = [1, 2, 3, 4, 5];
+    const arr2 = arr1[Symbol.iterator]().toArray();
+    sameValue(arr1 === arr2, false);
+    sameArray(arr1, arr2);
+}
+
+{
+    const arr1 = [1, 2, 3, 4, 5];
+    const arr2 = Iterator.prototype.toArray.call(arr1);
+    sameValue(arr1 === arr2, false);
+    sameArray(arr1, arr2);
+}
+
+{
+    const invalidIterators = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    for (const invalidIterator of invalidIterators) {
+        shouldThrow(function () {
+            Iterator.prototype.toArray.call(3);
+        }, TypeError, "Iterator.prototype.toArray requires that |this| be an Object.");
+    }
+}
+
+{
+    const iter = {};
+    shouldThrow(function () {
+        Iterator.prototype.toArray.call(iter);
+    }, TypeError, "Type error");
+}
+
+{
+    const iter = { next() { return 3; }};
+    shouldThrow(function () {
+        Iterator.prototype.toArray.call(iter);
+    }, TypeError, "Iterator result interface is not an object.")
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -58,9 +58,6 @@ test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
 test/built-ins/Function/prototype/toString/built-in-function-object.js:
   default: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
   strict mode: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
-test/built-ins/Iterator/from/get-next-method-only-once.js:
-  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
 test/built-ins/Iterator/prototype/drop/argument-effect-order.js:
   default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
   strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
@@ -916,48 +913,6 @@ test/built-ins/Iterator/prototype/take/underlying-iterator-closed-in-parallel.js
 test/built-ins/Iterator/prototype/take/underlying-iterator-closed.js:
   default: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
   strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
-test/built-ins/Iterator/prototype/toArray/callable.js:
-  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
-test/built-ins/Iterator/prototype/toArray/get-next-method-only-once.js:
-  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-test/built-ins/Iterator/prototype/toArray/get-next-method-throws.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/toArray/is-function.js:
-  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
-test/built-ins/Iterator/prototype/toArray/iterator-already-exhausted.js:
-  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-test/built-ins/Iterator/prototype/toArray/length.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-test/built-ins/Iterator/prototype/toArray/name.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-test/built-ins/Iterator/prototype/toArray/next-method-returns-throwing-done.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/toArray/next-method-returns-throwing-value-done.js:
-  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
-test/built-ins/Iterator/prototype/toArray/next-method-returns-throwing-value.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/toArray/next-method-throws.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/toArray/prop-desc.js:
-  default: 'Test262Error: obj should have an own property toArray'
-  strict mode: 'Test262Error: obj should have an own property toArray'
-test/built-ins/Iterator/prototype/toArray/proto.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.toArray)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.toArray)')"
-test/built-ins/Iterator/prototype/toArray/this-plain-iterator.js:
-  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
 test/built-ins/Object/entries/order-after-define-property-with-function.js:
   default: 'Test262Error: Expected [a, name] and [name, a] to have the same contents. '
   strict mode: 'Test262Error: Expected [a, name] and [name, a] to have the same contents. '

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -276,6 +276,7 @@
     macro(timeStyle) \
     macro(timeZone) \
     macro(timeZoneName) \
+    macro(toArray) \
     macro(toExponential) \
     macro(toFixed) \
     macro(toISOString) \

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -236,6 +236,11 @@ IterationRecord iteratorForIterable(JSGlobalObject* globalObject, JSValue iterab
     return { iterator, nextMethod };
 }
 
+IterationRecord iteratorDirect(JSGlobalObject* globalObject, JSValue object)
+{
+    return { object, object.get(globalObject, globalObject->vm().propertyNames->next) };
+}
+
 IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterable, JSValue symbolIterator)
 {
     if (!isJSArray(iterable))

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -51,6 +51,7 @@ Structure* createIteratorResultObjectStructure(VM&, JSGlobalObject&);
 JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSObject*, JSValue iteratorMethod);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSValue iterable);
+JS_EXPORT_PRIVATE IterationRecord iteratorDirect(JSGlobalObject*, JSValue);
 
 JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
 JS_EXPORT_PRIVATE bool hasIteratorMethod(JSGlobalObject*, JSValue);
@@ -59,30 +60,35 @@ JS_EXPORT_PRIVATE IterationMode getIterationMode(VM&, JSGlobalObject*, JSValue i
 JS_EXPORT_PRIVATE IterationMode getIterationMode(VM&, JSGlobalObject*, JSValue iterable, JSValue symbolIterator);
 
 template<typename CallBackType>
-void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, const CallBackType& callback)
+static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSValue iterable, JSArray* array, const CallBackType& callback)
+{
+    UNUSED_PARAM(iterable);
+
+    auto& vm = getVM(globalObject);
+    ASSERT(getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    for (unsigned index = 0; index < array->length(); ++index) {
+        JSValue nextValue = array->getIndex(globalObject, index);
+        RETURN_IF_EXCEPTION(scope, void());
+        callback(vm, globalObject, nextValue);
+        if (UNLIKELY(scope.exception())) {
+            scope.release();
+            JSArrayIterator* iterator = JSArrayIterator::create(vm, globalObject->arrayIteratorStructure(), array, IterationKind::Values);
+            iterator->internalField(JSArrayIterator::Field::Index).setWithoutWriteBarrier(jsNumber(index + 1));
+            iteratorClose(globalObject, iterator);
+            return;
+        }
+    }
+}
+
+template<typename CallBackType>
+static ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, IterationRecord iterationRecord, const CallBackType& callback)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray) {
-        auto* array = jsCast<JSArray*>(iterable);
-        for (unsigned index = 0; index < array->length(); ++index) {
-            JSValue nextValue = array->getIndex(globalObject, index);
-            RETURN_IF_EXCEPTION(scope, void());
-            callback(vm, globalObject, nextValue);
-            if (UNLIKELY(scope.exception())) {
-                scope.release();
-                JSArrayIterator* iterator = JSArrayIterator::create(vm, globalObject->arrayIteratorStructure(), array, IterationKind::Values);
-                iterator->internalField(JSArrayIterator::Field::Index).setWithoutWriteBarrier(jsNumber(index + 1));
-                iteratorClose(globalObject, iterator);
-                return;
-            }
-        }
-        return;
-    }
-
-    IterationRecord iterationRecord = iteratorForIterable(globalObject, iterable);
-    RETURN_IF_EXCEPTION(scope, void());
     while (true) {
         JSValue next = iteratorStep(globalObject, iterationRecord);
         if (UNLIKELY(scope.exception()) || next.isFalse())
@@ -98,6 +104,25 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, const Cal
             return;
         }
     }
+}
+
+template<typename CallBackType>
+void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, const CallBackType& callback)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray) {
+        auto* array = jsCast<JSArray*>(iterable);
+        forEachInFastArray(globalObject, iterable, array, callback);
+        RETURN_IF_EXCEPTION(scope, void());
+        return;
+    }
+
+    IterationRecord iterationRecord = iteratorForIterable(globalObject, iterable);
+    RETURN_IF_EXCEPTION(scope, void());
+    scope.release();
+    forEachInIterationRecord(globalObject, iterationRecord, callback);
 }
 
 template<typename CallBackType>
@@ -140,6 +165,25 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
             return;
         }
     }
+}
+
+template<typename CallBackType>
+void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, const CallBackType& callback)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray) {
+        auto* array = jsCast<JSArray*>(iterable);
+        forEachInFastArray(globalObject, iterable, array, callback);
+        RETURN_IF_EXCEPTION(scope, void());
+        return;
+    }
+
+    IterationRecord iterationRecord = iteratorDirect(globalObject, iterable);
+    RETURN_IF_EXCEPTION(scope, void());
+    scope.release();
+    forEachInIterationRecord(globalObject, iterationRecord, callback);
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 73a351ca150f54231be35ab3c4fb06b3e28daf78
<pre>
[JSC] Implement `Iterator.prototype.toArray` from Iterator Helpers Proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=278979">https://bugs.webkit.org/show_bug.cgi?id=278979</a>

Reviewed by Yusuke Suzuki.

This patch implements `Iterator.prototype.toArray`[1] from Iterator
Helpers Proposal[2].

[1]: <a href="https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray">https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray</a>
[2]: <a href="https://github.com/tc39/proposal-iterator-helpers">https://github.com/tc39/proposal-iterator-helpers</a>

* JSTests/stress/iterator-prototype-toArray.js: Added.
(assert):
(sameArray):
(shouldThrow):
(throw.new.Error.Iter.prototype.next):
(throw.new.Error.Iter):
(throw.new.Error):
(sameArray.Iter.prototype.get next):
(sameArray.Iter):
(sameArray.gen):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::iteratorDirect):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIteratorProtocol):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSIteratorPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/283381@main">https://commits.webkit.org/283381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/938fbb7418aad81aaa56870cd9561edf8809c284

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53004 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14543 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15516 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59145 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71765 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65275 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60614 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14583 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1888 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87042 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41212 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15317 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->