### PR TITLE
Parse "lang" member of Web Application Manifest

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1142,6 +1142,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/Int32Array.h
     runtime/Int8Array.h
     runtime/InternalFunction.h
+    runtime/IntlObject.h
     runtime/Intrinsic.h
     runtime/IterationKind.h
     runtime/IteratorOperations.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1534,7 +1534,7 @@
 		9B4694391F97439E00CCB3F9 /* BooleanPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC7952350E15EB5600A898AB /* BooleanPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9E72940B190F0514001A91B5 /* BundlePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E72940A190F0514001A91B5 /* BundlePath.h */; };
 		9F63434577274FAFB9336C38 /* ModuleNamespaceAccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CE978E385A8498199052153 /* ModuleNamespaceAccessCase.h */; };
-		A12BBFF21B044A8B00664B69 /* IntlObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A12BBFF11B044A8B00664B69 /* IntlObject.h */; };
+		A12BBFF21B044A8B00664B69 /* IntlObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A12BBFF11B044A8B00664B69 /* IntlObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1587D6E1B4DC14100D69849 /* IntlDateTimeFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = A1587D681B4DC14100D69849 /* IntlDateTimeFormat.h */; };
 		A1587D701B4DC14100D69849 /* IntlDateTimeFormatConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A1587D6A1B4DC14100D69849 /* IntlDateTimeFormatConstructor.h */; };
 		A1587D721B4DC14100D69849 /* IntlDateTimeFormatPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A1587D6C1B4DC14100D69849 /* IntlDateTimeFormatPrototype.h */; };

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -731,6 +731,12 @@ String canonicalizeUnicodeLocaleID(const CString& tag)
     return languageTagForLocaleID(canonicalized->span().data());
 }
 
+String canonicalizeUnicodeLocaleID(const StringView tag)
+{
+    ASSERT(tag.containsOnlyASCII());
+    return canonicalizeUnicodeLocaleID(tag.utf8());
+}
+
 Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue locales)
 {
     // CanonicalizeLocaleList (locales)

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -27,8 +27,8 @@
 
 #pragma once
 
-#include "JSCJSValueInlines.h"
-#include "JSObject.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/JSObject.h>
 #include <wtf/RobinHoodHashSet.h>
 
 struct UFieldPositionIterator;
@@ -154,8 +154,9 @@ bool isUnicodeScriptSubtag(StringView);
 bool isUnicodeRegionSubtag(StringView);
 bool isUnicodeVariantSubtag(StringView);
 bool isUnicodeLanguageId(StringView);
-bool isStructurallyValidLanguageTag(StringView);
+JS_EXPORT_PRIVATE bool isStructurallyValidLanguageTag(StringView);
 String canonicalizeUnicodeLocaleID(const CString& languageTag);
+JS_EXPORT_PRIVATE String canonicalizeUnicodeLocaleID(const StringView);
 
 bool isWellFormedCurrencyCode(StringView);
 

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -70,6 +70,7 @@ struct ApplicationManifest {
 
     String rawJSON;
     Direction dir;
+    String lang;
     String name;
     String shortName;
     String description;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -51,6 +51,7 @@ private:
     ApplicationManifest::Direction parseDir(const JSON::Object&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
     const std::optional<ScreenOrientationLockType> parseOrientation(const JSON::Object&);
+    String parseLang(const JSON::Object&);
     String parseName(const JSON::Object&);
     String parseDescription(const JSON::Object&);
     String parseShortName(const JSON::Object&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1296,6 +1296,7 @@ enum class WebCore::ScreenOrientationLockType : uint8_t {
 struct WebCore::ApplicationManifest {
     String rawJSON
     WebCore::ApplicationManifest::Direction dir
+    String lang
     String name
     String shortName
     String description

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -74,6 +74,7 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 
 @property (nonatomic, readonly, nullable, copy) NSString *rawJSON;
 @property (nonatomic, readonly) _WKApplicationManifestDirection dir;
+@property (nonatomic, readonly, nullable, copy) NSString *lang;
 @property (nonatomic, readonly, nullable, copy) NSString *name;
 @property (nonatomic, readonly, nullable, copy) NSString *shortName;
 @property (nonatomic, readonly, nullable, copy) NSString *applicationDescription;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -270,6 +270,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     NSInteger dir = [aDecoder decodeIntegerForKey:@"dir"];
     // FIXME: <https://webkit.org/b/278619> Remove this assert after further manifest IPC hardening.
     RELEASE_ASSERT(dir >= 0 && dir <= 2);
+    String lang = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"lang"];
     String name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
     String shortName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"short_name"];
     String description = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
@@ -292,6 +293,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     WebCore::ApplicationManifest coreApplicationManifest {
         WTF::move(rawJSON),
         static_cast<WebCore::ApplicationManifest::Direction>(dir),
+        WTF::move(lang),
         WTF::move(name),
         WTF::move(shortName),
         WTF::move(description),
@@ -328,6 +330,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 {
     [aCoder encodeObject:self.rawJSON forKey:@"raw_json"];
     [aCoder encodeInteger:static_cast<NSInteger>(_applicationManifest->applicationManifest().dir) forKey:@"dir"];
+    [aCoder encodeObject:self.lang forKey:@"lang"];
     [aCoder encodeObject:self.name forKey:@"name"];
     [aCoder encodeObject:self.shortName forKey:@"short_name"];
     [aCoder encodeObject:self.applicationDescription forKey:@"description"];
@@ -383,6 +386,11 @@ static RetainPtr<NSString> nullableNSString(const WTF::String& string)
     }
 
     ASSERT_NOT_REACHED();
+}
+
+- (NSString *)lang
+{
+    return nullableNSString(_applicationManifest->applicationManifest().lang).autorelease();
 }
 
 - (NSString *)name

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -203,6 +203,11 @@ public:
         EXPECT_EQ(expectedValue, value);
     }
 
+    void testLang(const String& rawJSON, const String& expectedValue)
+    {
+        EXPECT_EQ(expectedValue, parseTopLevelProperty("lang"_s, rawJSON).lang);
+    }
+
     void testName(const String& rawJSON, const String& expectedValue)
     {
         auto manifest = parseTopLevelProperty("name"_s, rawJSON);
@@ -348,7 +353,6 @@ public:
         auto value = manifest.id;
         EXPECT_STREQ(expectedValue.utf8().data(), value.string().utf8().data());
     }
-
 };
 
 static void assertManifestHasDefaultValues(const URL& manifestURL, const URL& documentURL, const ApplicationManifest& manifest)
@@ -520,6 +524,39 @@ TEST_F(ApplicationManifestParserTest, Orientation)
     testOrientation("\"portrait\""_s, WebCore::ScreenOrientationLockType::Portrait);
     testOrientation("\"portrait-primary\""_s, WebCore::ScreenOrientationLockType::PortraitPrimary);
     testOrientation("\"portrait-secondary\""_s, WebCore::ScreenOrientationLockType::PortraitSecondary);
+}
+
+TEST_F(ApplicationManifestParserTest, Lang)
+{
+    testLang("123"_s, String());
+    testLang("null"_s, String());
+    testLang("true"_s, String());
+    testLang("{ }"_s, String());
+    testLang("[ ]"_s, String());
+    testLang("\"\""_s, String());
+
+    // Invalid language tags should be ignored.
+    testLang("\"invalid-language-tag\""_s, String());
+
+    testLang("\"en\""_s, "en"_s);
+    testLang("\" en \""_s, "en"_s);
+    testLang("\"en-AU\""_s, "en-AU"_s);
+    testLang("\"zh-Hans-CN\""_s, "zh-Hans-CN"_s);
+    testLang("\"en-x-custom\""_s, "en-x-custom"_s);
+
+    // Language tags should be canonicalized.
+    testLang("\"DE-DE\""_s, "de-DE"_s);
+    testLang("\" DE-DE \""_s, "de-DE"_s);
+
+    // ISO-8859-1 characters.
+    testLang(String::fromUTF8("\"en-Latn-US-àéîöü\""), String());
+    testLang(String::fromUTF8("\"frçñch\""), String());
+
+    // Unicode characters beyond ISO-8859-1.
+    testLang(String::fromUTF8("\"zh-中文\""), String());
+    testLang(String::fromUTF8("\"ja-日本語\""), String());
+    testLang(String::fromUTF8("\"ko-한국어\""), String());
+    testLang(String::fromUTF8("\"ar-العربية\""), String());
 }
 
 TEST_F(ApplicationManifestParserTest, Name)


### PR DESCRIPTION
#### e95d02b6d9505be0cc0507109990fd3a56240321
<pre>
Parse &quot;lang&quot; member of Web Application Manifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=278984">https://bugs.webkit.org/show_bug.cgi?id=278984</a>

Reviewed by Anne van Kesteren, Darin Adler, and Yusuke Suzuki.

Implements the &quot;lang&quot; member to the web application manifest parser per spec:
<a href="https://www.w3.org/TR/appmanifest/#lang-member">https://www.w3.org/TR/appmanifest/#lang-member</a>
Along with the required encoders/decoders and API tests.

Adds a helper function to IntlObject to canonicalize language tags without the overhead of UTF-8 conversion.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeUnicodeLocaleID):
* Source/JavaScriptCore/runtime/IntlObject.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
(WebCore::ApplicationManifestParser::parseLang):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest lang]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(ApplicationManifestParserTest::testLang):
(ApplicationManifestParserTest::testId):
(TEST_F(ApplicationManifestParserTest, Lang)):

Canonical link: <a href="https://commits.webkit.org/307465@main">https://commits.webkit.org/307465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c542199f880b92dd8b71ee4d124ffe99448f668

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153184 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111124 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147477 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92036 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/630 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136505 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155497 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5323 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/17045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119126 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119482 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/15313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127681 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22287 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16667 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175802 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16612 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->