### PR TITLE
[UIProcess] Replace UITextWritingDirection with NSWritingDirection

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
@@ -121,12 +121,10 @@
     return result;
 }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-- (UITextWritingDirection)writingDirection
+- (NSWritingDirection)writingDirection
 {
-    return _selectionGeometry.direction() == WebCore::TextDirection::LTR ? UITextWritingDirectionLeftToRight : UITextWritingDirectionRightToLeft;
+    return _selectionGeometry.direction() == WebCore::TextDirection::LTR ? NSWritingDirectionLeftToRight : NSWritingDirectionRightToLeft;
 }
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (UITextRange *)range
 {

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -160,9 +160,9 @@ static const float GroupOptionTextColorAlpha = 0.5;
 
     [self _setMagnifierEnabled:NO];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    UITextWritingDirection writingDirection = UITextWritingDirectionLeftToRight;
+    NSWritingDirection writingDirection = NSWritingDirectionLeftToRight;
     // FIXME: retrieve from WebProcess writing direction.
-    _textAlignment = (writingDirection == UITextWritingDirectionLeftToRight) ? NSTextAlignmentLeft : NSTextAlignmentRight;
+    _textAlignment = (writingDirection == NSWritingDirectionLeftToRight) ? NSTextAlignmentLeft : NSTextAlignmentRight;
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self setAllowsMultipleSelection:_allowsMultipleSelection];

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
@@ -48,16 +48,15 @@ static NSString* WKPopoverTableViewCellReuseIdentifier  = @"WKPopoverTableViewCe
 - (CGRect)contentRectForBounds:(CGRect)bounds;
 @end
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static NSString *stringWithWritingDirection(NSString *string, UITextWritingDirection writingDirection, bool override)
+static NSString *stringWithWritingDirection(NSString *string, NSWritingDirection writingDirection, bool override)
 {
-    if (![string length] || writingDirection == UITextWritingDirectionNatural)
+    if (![string length] || writingDirection == NSWritingDirectionNatural)
         return string;
     
     if (!override) {
         UCharDirection firstCharacterDirection = u_charDirection([string characterAtIndex:0]);
-        if ((firstCharacterDirection == U_LEFT_TO_RIGHT && writingDirection == UITextWritingDirectionLeftToRight)
-            || (firstCharacterDirection == U_RIGHT_TO_LEFT && writingDirection == UITextWritingDirectionRightToLeft))
+        if ((firstCharacterDirection == U_LEFT_TO_RIGHT && writingDirection == NSWritingDirectionLeftToRight)
+            || (firstCharacterDirection == U_RIGHT_TO_LEFT && writingDirection == NSWritingDirectionRightToLeft))
             return string;
     }
     
@@ -68,14 +67,13 @@ static NSString *stringWithWritingDirection(NSString *string, UITextWritingDirec
     const unichar rightToLeftOverride = 0x202E;
     
     unichar directionalFormattingCharacter;
-    if (writingDirection == UITextWritingDirectionLeftToRight)
+    if (writingDirection == NSWritingDirectionLeftToRight)
         directionalFormattingCharacter = (override ? leftToRightOverride : leftToRightEmbedding);
     else
         directionalFormattingCharacter = (override ? rightToLeftOverride : rightToLeftEmbedding);
     
     return [NSString stringWithFormat:@"%C%@%C", directionalFormattingCharacter, string, popDirectionalFormatting];
 }
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 @class WKSelectPopover;
 
@@ -127,18 +125,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         currentIndex++;
     }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    UITextWritingDirection writingDirection = _contentView.focusedElementInformation.isRTL ? UITextWritingDirectionRightToLeft : UITextWritingDirectionLeftToRight;
+    NSWritingDirection writingDirection = _contentView.focusedElementInformation.isRTL ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
     BOOL override = NO;
-    _textAlignment = (writingDirection == UITextWritingDirectionLeftToRight) ? NSTextAlignmentLeft : NSTextAlignmentRight;
+    _textAlignment = (writingDirection == NSWritingDirectionLeftToRight) ? NSTextAlignmentLeft : NSTextAlignmentRight;
 
     // Typically UIKit apps have their writing direction follow the system
     // language. However WebKit wants to follow the content direction.
     // For that reason we have to override what the system thinks.
-    if (writingDirection == UITextWritingDirectionRightToLeft)
+    if (writingDirection == NSWritingDirectionRightToLeft)
         self.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
     [self setTitle:stringWithWritingDirection(_contentView.focusedElementInformation.title, writingDirection, override)];
-ALLOW_DEPRECATED_DECLARATIONS_END
 
     return self;
 }


### PR DESCRIPTION
#### b28461d7668bd49b1b95fc715416a63432be6f7a
<pre>
[UIProcess] Replace UITextWritingDirection with NSWritingDirection
<a href="https://bugs.webkit.org/show_bug.cgi?id=278995">https://bugs.webkit.org/show_bug.cgi?id=278995</a>

Reviewed by Tim Nguyen.

UITextWritingDirection is long deprecated, and NSWritingDirection is
easier to understand anyway, and easy to use in-place of
UITextWritingDirection.

* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm:
  (-[WKTextSelectionRect writingDirection]): Replace
  UITextWritingDirection with the NSWritingDirection counterpart.
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
  (-[WKMultipleSelectPicker initWithView:]): Ditto.
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
  (stringWithWritingDirection):
  (-[WKSelectTableViewController initWithView:hasGroups:]): Ditto.

Canonical link: <a href="https://commits.webkit.org/283045@main">https://commits.webkit.org/283045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6817fa28588f76520037bfee6c8222ac098b00b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52233 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10790 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37708 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8970 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13460 "Found 1 new test failure: media/video-webkit-playsinline.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56333 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59792 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1078 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40197 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42455 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->