### PR TITLE
Do more bounds checking in IPC::Encoder

### DIFF
--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -88,7 +88,7 @@ public:
         return *this;
     }
 
-    std::span<const uint8_t> span() const { return { m_buffer, m_bufferSize }; }
+    std::span<const uint8_t> span() const { return m_capacityBuffer.first(m_bufferSize); }
 
     void addAttachment(Attachment&&);
     Vector<Attachment> releaseAttachments();
@@ -97,7 +97,7 @@ public:
     static constexpr bool isIPCEncoder = true;
 
 private:
-    uint8_t* grow(size_t alignment, size_t);
+    std::span<uint8_t> grow(size_t alignment, size_t);
 
     bool hasAttachments() const;
 
@@ -105,16 +105,15 @@ private:
     const OptionSet<MessageFlags>& messageFlags() const;
     OptionSet<MessageFlags>& messageFlags();
 
+    void freeBufferIfNecessary();
+
     MessageName m_messageName;
     uint64_t m_destinationID;
 
-    uint8_t m_inlineBuffer[512];
+    std::array<uint8_t, 512> m_inlineBuffer;
 
-    uint8_t* m_buffer { m_inlineBuffer };
-    uint8_t* m_bufferPointer { m_inlineBuffer };
-    
+    std::span<uint8_t> m_capacityBuffer { m_inlineBuffer };
     size_t m_bufferSize { 0 };
-    size_t m_bufferCapacity { sizeof(m_inlineBuffer) };
 
     Vector<Attachment> m_attachments;
 };
@@ -126,8 +125,8 @@ inline void Encoder::encodeSpan(std::span<T, Extent> span)
     constexpr size_t alignment = alignof(T);
     ASSERT(!(reinterpret_cast<uintptr_t>(bytes.data()) % alignment));
 
-    uint8_t* buffer = grow(alignment, bytes.size());
-    memcpy(buffer, bytes.data(), bytes.size());
+    auto buffer = grow(alignment, bytes.size());
+    memcpySpan(buffer, bytes);
 }
 
 template<typename T>


### PR DESCRIPTION
#### 28a9b7ab2497cd01532e0aac682e52b90b344510
<pre>
Do more bounds checking in IPC::Encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=278996">https://bugs.webkit.org/show_bug.cgi?id=278996</a>

Reviewed by Darin Adler.

* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::allocBuffer):
(IPC::freeBuffer):
(IPC::Encoder::~Encoder):
(IPC::Encoder::freeBufferIfNecessary):
(IPC::Encoder::wrapForTesting):
(IPC::Encoder::reserve):
(IPC::Encoder::messageFlags):
(IPC::Encoder::messageFlags const):
(IPC::Encoder::grow):
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::encodeSpan):

Canonical link: <a href="https://commits.webkit.org/283076@main">https://commits.webkit.org/283076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e339ba7a54fb6aa0099a7b481361d97baed37da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15741 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52327 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37815 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14617 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14092 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9087 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59658 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56442 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1184 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9876 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40314 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->