### PR TITLE
_WKDownload client should be able to publish progress

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -52,8 +52,13 @@ messages -> NetworkProcess LegacyReceiver {
     DownloadRequest(PAL::SessionID sessionID, WebKit::DownloadID downloadID, WebCore::ResourceRequest request, std::optional<WebCore::SecurityOriginData> topOrigin, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, String suggestedFilename)
     ResumeDownload(PAL::SessionID sessionID, WebKit::DownloadID downloadID, std::span<const uint8_t> resumeData, String path, WebKit::SandboxExtensionHandle sandboxExtensionHandle, enum:bool WebKit::CallDownloadDidStart callDownloadDidStart)
     CancelDownload(WebKit::DownloadID downloadID) -> (std::span<const uint8_t> resumeData)
-#if PLATFORM(COCOA) && !HAVE(MODERN_DOWNLOADPROGRESS)
+#if PLATFORM(COCOA)
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    PublishDownloadProgress(WebKit::DownloadID downloadID, URL url, std::span<const uint8_t> bookmarkData, enum:bool WebKit::UseDownloadPlaceholder useDownloadPlaceholder)
+#endif
+#if !HAVE(MODERN_DOWNLOADPROGRESS)
     PublishDownloadProgress(WebKit::DownloadID downloadID, URL url, WebKit::SandboxExtensionHandle sandboxExtensionHandle)
+#endif
 #endif
     DataTaskWithRequest(WebKit::WebPageProxyIdentifier pageID, PAL::SessionID sessionID, WebCore::ResourceRequest request, std::optional<WebCore::SecurityOriginData> topOrigin, IPC::FormDataReference requestBody) -> (WebKit::DataTaskIdentifier taskIdentifier)
     CancelDataTask(WebKit::DataTaskIdentifier taskIdentifier, PAL::SessionID sessionID) -> ()

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -79,9 +79,7 @@ IGNORE_WARNINGS_END
 
 - (void)publishProgressAtURL:(NSURL *)URL
 {
-#if !HAVE(MODERN_DOWNLOADPROGRESS)
     _download->_download->publishProgress(URL);
-#endif
 }
 
 - (NSURLRequest *)request

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -96,11 +96,7 @@ public:
     void setDestinationFilename(const String& d) { m_destinationFilename = d; }
 
 #if PLATFORM(COCOA)
-#if HAVE(MODERN_DOWNLOADPROGRESS)
-    void publishProgress(const URL&, UseDownloadPlaceholder = UseDownloadPlaceholder::No);
-#else
     void publishProgress(const URL&);
-#endif
     void setProgress(NSProgress *progress) { m_progress = progress; }
     NSProgress *progress() const { return m_progress.get(); }
 #endif


### PR DESCRIPTION
#### 307823d4b18290a30bd50e763949a145135140dd
<pre>
_WKDownload client should be able to publish progress
<a href="https://bugs.webkit.org/show_bug.cgi?id=278997">https://bugs.webkit.org/show_bug.cgi?id=278997</a>
<a href="https://rdar.apple.com/135116654">rdar://135116654</a>

Reviewed by Brady Eidson.

_WKDownload clients should be able to publish progress for a specific URL. The commit
<a href="https://commits.webkit.org/283043@main">https://commits.webkit.org/283043@main</a> removed this ability, since progress publishing
will be handled by WebKit and not the client when MODERN_DOWNLOADPROGRESS is enabled.
The code is being compiled in for this feature, but the feature is currently disabled
by a runtime check. This means it is too early to remove this capability for
_WKDownload clients. We can remove this capability once <a href="https://rdar.apple.com/125569813">rdar://125569813</a> has landed.
This patch is essentially reverting a small part of 283043@main.

* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload publishProgressAtURL:]):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::publishProgress):

Canonical link: <a href="https://commits.webkit.org/283110@main">https://commits.webkit.org/283110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88b254f3f0d9f042fef05668432cdc7077ece1c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15634 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52245 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10795 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37716 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14510 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59628 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIRuntime.ConnectFromContentScriptWithImmediateMessage (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70757 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59805 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1088 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9896 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40207 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->