### PR TITLE
Remove PKPaymentSetupFeatureSupportedOptions SPI now that minimum supported internal SDK has it

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
@@ -109,25 +109,6 @@ typedef NS_ENUM(NSUInteger, PKPaymentRequestType) {
 @property (nonatomic, copy) NSString *installmentGroupIdentifier;
 @end
 
-// FIXME: The SPIs above can be declared by WebKit without causing redeclaration errors on Catalina
-// internal SDKs because we can avoid including the SPIs' private headers from PassKit, but we can't
-// avoid importing PKPaymentSetupFeature.h due to how many other private headers include it. To avoid
-// redeclaration errors while continuing to support all Catalina SDKs, declare -supportedOptions
-// only when building against an internal SDK without PKPaymentInstallmentConfiguration.h (so that we
-// can implement a -respondsToSelector: check). The __has_include portion of this check can be
-// removed once the minimum supported Catalina internal SDK is known to contain this private header.
-#if !__has_include(<PassKitCore/PKPaymentInstallmentConfiguration.h>)
-
-typedef NS_OPTIONS(NSInteger, PKPaymentSetupFeatureSupportedOptions) {
-    PKPaymentSetupFeatureSupportedOptionsInstallments = 1 << 0,
-};
-
-@interface PKPaymentSetupFeature ()
-@property (nonatomic, assign, readonly) PKPaymentSetupFeatureSupportedOptions supportedOptions;
-@end
-
-#endif // !__has_include(<PassKitCore/PKPaymentInstallmentConfiguration.h>)
-
 #endif // !USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(PASSKIT_INSTALLMENTS)


### PR DESCRIPTION
<pre>Remove PKPaymentSetupFeatureSupportedOptions SPI now that minimum supported internal SDK has it
https://bugs.webkit.org/show_bug.cgi?id=278998

Reviewed by NOBODY (OOPS!).

Remove PKPaymentSetupFeatureSupportedOptions

* Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h: Remove FIXME with SPI.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01d7598e3ee0eb8f5ed6a42d0a58c535e254cf50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65030 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44397 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17644 "Hash 01d7598e for PR 33014 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69054 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/15636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67148 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52180 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15918 "Hash 01d7598e for PR 33014 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52244 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/15636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68096 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/52180 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/17644 "Hash 01d7598e for PR 33014 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32866 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/52180 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/17644 "Hash 01d7598e for PR 33014 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14512 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/52180 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/17644 "Hash 01d7598e for PR 33014 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70759 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8982 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/15918 "Hash 01d7598e for PR 33014 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59571 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9014 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/17644 "Hash 01d7598e for PR 33014 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59804 "Failed to checkout and rebase branch from PR 33014") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/17644 "Hash 01d7598e for PR 33014 does not build (failure)") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/41030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->