### PR TITLE
[ iOS MacOS ] http/tests/navigation/page-cache-shared-worker.html is a flaky timeout

### DIFF
--- a/LayoutTests/http/tests/navigation/page-cache-shared-worker.html
+++ b/LayoutTests/http/tests/navigation/page-cache-shared-worker.html
@@ -19,14 +19,20 @@ window.addEventListener("pageshow", async function(event) {
         restoredFromPageCache = true;
 
         sw1.port.postMessage('counter');
-        const counter = await new Promise(resolve => sw1.port.onmessage = (event) => resolve(event.data));
+        const counter = await new Promise(resolve => {
+            sw1.port.onmessage = (event) => resolve(event.data);
+            setTimeout(() => reject("counter timed out"), 5000);
+        });
         if (counter < 100)
             testPassed("counter is below 100");
         else
             testFailed("counter is above 100");
 
         sw2.port.postMessage('getState');
-        state = await new Promise(resolve => sw2.port.onmessage = (event) => resolve(event.data));
+        state = await new Promise((resolve, reject) => {
+            sw2.port.onmessage = (event) => resolve(event.data);
+            setTimeout(() => reject("state timed out, counter is " + counter), 5000);
+        });
         shouldBeEqualToString("state", "hungry");
 
         setTimeout(finishJSTest, 0);

--- a/LayoutTests/http/tests/navigation/resources/page-cache-helper-for-sharedworker.html
+++ b/LayoutTests/http/tests/navigation/resources/page-cache-helper-for-sharedworker.html
@@ -2,7 +2,7 @@ This page should go back. If a test outputs the contents of this
 page, then the test page failed to enter the page cache.
 <script>
 var channel = new BroadcastChannel('shared-worker');
-async function doTest(counter)
+async function doSW1Test(counter)
 {
     if (!counter)
         counter = 0;
@@ -16,17 +16,25 @@ async function doTest(counter)
              clearTimeout(myTimer);
              // We received a message from shared worker, let's call doTest to retry.
              await new Promise(resolve => setTimeout(resolve, 50));
-             doTest(++counter).then(resolve, reject);
+             doSW1Test(++counter).then(resolve, reject);
          };
     });
+}
 
+async function doSW2Test(counter)
+{
     const sw2 = new SharedWorker('shared-worker-script.js?2');
     sw2.port.postMessage({ action: 'setState', state: 'hungry' });
     await new Promise(resolve => sw2.port.onmessage = resolve);
 }
 
 window.addEventListener("load", async () => {
-    await doTest();
+    try {
+        await doSW1Test();
+        await doSW2Test();
+    } catch (e) {
+        console.log(e);
+    }
     history.back();
 }, false);
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7444,9 +7444,6 @@ fast/text/text-underline-position-under.html [ ImageOnlyFailure ]
 # webkit.org/b/269496 [ iOS17 ] fast/forms/datalist/datalist-option-labels.html is a flaky timeout
 fast/forms/datalist/datalist-option-labels.html [ Pass Timeout ]
 
-# webkit.org/b/277986 [ iOS MacOS ] http/tests/navigation/page-cache-shared-worker.html is a flaky timeout
-http/tests/navigation/page-cache-shared-worker.html [ Pass Timeout ]
-
 # webkit.org/b/277989 [ iOS ] 3x imported/w3c/web-platform-tests/mathml/presentation-markup/* (layout-tests) are flaky failures
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/stretch-along-block-axis-001.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001.html [ Pass Failure ]

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -132,9 +132,6 @@ webkit.org/b/271712 fast/forms/datalist/datalist-textinput-dynamically-add-optio
 # webkit.org/b/269496 [ iOS17 ] fast/forms/datalist/datalist-option-labels.html is a flaky timeout
 fast/forms/datalist/datalist-option-labels.html [ Pass Timeout ]
 
-# webkit.org/b/277986 [ iOS MacOS ] http/tests/navigation/page-cache-shared-worker.html is a flaky timeout
-http/tests/navigation/page-cache-shared-worker.html [ Pass Timeout ]
-
 # webkit.org/b/277989 [ iOS ] 3x imported/w3c/web-platform-tests/mathml/presentation-markup/* (layout-tests) are flaky failures
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/stretch-along-block-axis-001.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2404,9 +2404,6 @@ webkit.org/b/276624 fast/dynamic/layer-hit-test-crash.html [ Pass Failure ]
 
 webkit.org/b/276906 imported/w3c/web-platform-tests/IndexedDB/storage-buckets.https.any.worker.html [ Pass Failure ]
 
-# webkit.org/b/277986 [ iOS MacOS ] http/tests/navigation/page-cache-shared-worker.html is a flaky timeout
-http/tests/navigation/page-cache-shared-worker.html [ Pass Timeout ]
-
 # webkit.org/b/278052 REGRESSION (282158@main): [macOS] inspector/console/webcore-logging.html is a flaky failure
 inspector/console/webcore-logging.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 10dd471a6f3687be773c2802af5875ecc7d37cff
<pre>
[ iOS MacOS ] http/tests/navigation/page-cache-shared-worker.html is a flaky timeout
<a href="https://rdar.apple.com/133720855">rdar://133720855</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277986">https://bugs.webkit.org/show_bug.cgi?id=277986</a>

Reviewed by Chris Dumez.

LayoutTests/http/tests/navigation/resources/page-cache-helper-for-sharedworker.html was creating sw2 and sending it a message in a 50 ms async loop.
This is not needed as we only need to set the state once.
This may also add up to 100 events to sw2 which might delay the processing of the getState message (the one that is timing out), especially on slow bots.
We update the test to only set the hungry state once.

We almost make the test more robust by rejecting the test promises after 5 seconds with a message and making sure to call history.back even if sending the message pong is taking more than one second.

* LayoutTests/http/tests/navigation/page-cache-shared-worker.html:
* LayoutTests/http/tests/navigation/resources/page-cache-helper-for-sharedworker.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/283085@main">https://commits.webkit.org/283085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140edfcc5b63e51554155420d49b5dd4c682bd88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15673 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52267 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70796 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59596 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56377 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59856 "Found 120 new API test failures: /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.GeolocationBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PageLoadBasic, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14372 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1123 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40246 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->