### PR TITLE
Optimize ReadMe and run-webkit-app usage

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -142,6 +142,16 @@ run-safari --debug --ios-simulator
 
 In both cases, if you have built release builds instead, use `--release` instead of `--debug`.
 
+To run other applications, for example MobileMiniBrowser, with your local build of WebKit, run the following command:
+
+``` shell
+Tools/Scripts/run-webkit-app --debug --iphone-simulator <application-path>
+```
+
+#### Using Xcode
+
+Open `WebKit.xcworkspace`, select intended scheme such as MobileMiniBrowser and an iOS simulator as target, click run.
+
 ### Linux Ports
 
 If you have a development build, you can use the `run-minibrowser` script, e.g.:

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -984,9 +984,11 @@ sub determineXcodeSDKPlatformName {
         $xcodeSDKPlatformNameExplanation ||= "via argument, `--simulator`";
         $simulatorIdiom = 'iPhone';
     }
-    if (checkForArgumentAndRemoveFromARGV("--ios-simulator")) {
+    if (checkForArgumentAndRemoveFromARGV("--iphone-simulator") ||
+        checkForArgumentAndRemoveFromARGV("--ios-simulator")) {
+        # `--ios-simulator` option checking is for compatible here.
         $xcodeSDKPlatformName ||= 'iphonesimulator';
-        $xcodeSDKPlatformNameExplanation ||= "via argument, `--ios-simulator`";
+        $xcodeSDKPlatformNameExplanation ||= "via argument, `--iphone-simulator`";
         $simulatorIdiom = 'iPhone';
     }
     if (checkForArgumentAndRemoveFromARGV("--ipad-simulator")) {
@@ -2999,9 +3001,10 @@ sub printHelpAndExitForRunAndDebugWebKitAppIfNeeded
     return unless checkForArgumentAndRemoveFromARGV("--help");
 
     print STDERR <<EOF;
-Usage: @{[basename($0)]} [options] [args ...]
+Usage: @{[basename($0)]} [options] <application-path>
   --help                            Show this help message
   --no-saved-state                  Launch the application without state restoration
+  --debug|release                   build configuration
 
 Options specific to macOS:
   -g|--guard-malloc                 Enable Guard Malloc


### PR DESCRIPTION
#### e2f7bd55eda49489399eb5bf0b10b71cbb6de02c
<pre>
Optimize ReadMe and run-webkit-app usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=278906">https://bugs.webkit.org/show_bug.cgi?id=278906</a>

Reviewed by Jonathan Bedard.

Add the guide of running applications in iOS simulator to ReadMe.
Update the utility `run-webkit-app` usage output.

* ReadMe.md:
* Tools/Scripts/webkitdirs.pm:
(determineXcodeSDKPlatformName):
(printHelpAndExitForRunAndDebugWebKitAppIfNeeded):

Canonical link: <a href="https://commits.webkit.org/285197@main">https://commits.webkit.org/285197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a498b597fb9b0ceec5b6d87d92f66a46e7e18b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15188 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21364 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64942 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77652 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71067 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18880 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64423 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6233 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92852 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47030 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20460 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48101 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->