### PR TITLE
window.open with noopener shouldn't create page in opener process

### DIFF
--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
@@ -16,8 +16,13 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner)
-                shouldBe("testRunner.windowCount()", "3");
+            if (window.testRunner) {
+                if (testRunner.isWebKit2) {
+                    shouldBe("testRunner.windowCount()", "2");
+                } else {
+                    shouldBe("testRunner.windowCount()", "3");
+                }
+            }
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
@@ -16,8 +16,13 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner)
-                shouldBe("testRunner.windowCount()", "3");
+            if (window.testRunner) {
+                if (testRunner.isWebKit2) {
+                    shouldBe("testRunner.windowCount()", "2");
+                } else {
+                    shouldBe("testRunner.windowCount()", "3");
+                }
+            }
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt
+++ b/LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 3
+PASS testRunner.windowCount() is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html
@@ -15,8 +15,13 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner)
-                shouldBe("testRunner.windowCount()", "3");
+            if (window.testRunner) {
+                if (testRunner.isWebKit2) {
+                    shouldBe("testRunner.windowCount()", "2");
+                } else {
+                    shouldBe("testRunner.windowCount()", "3");
+                }
+            }
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt
+++ b/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt
@@ -1,5 +1,7 @@
 CONSOLE MESSAGE: Not allowed to download due to sandboxing
 CONSOLE MESSAGE: Not allowed to download due to sandboxing
+CONSOLE MESSAGE: Not allowed to download due to sandboxing
+CONSOLE MESSAGE: Not allowed to download due to sandboxing
 This test passes if no download is started.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-coep-sandbox.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-coep-sandbox.https-expected.txt
@@ -1,4 +1,5 @@
 CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
+CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
 
 PASS <iframe sandbox="allow-popups allow-scripts allow-same-origin"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error
 PASS <iframe sandbox="allow-popups allow-scripts"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox.https-expected.txt
@@ -1,4 +1,5 @@
 CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
+CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
 
 PASS <iframe sandbox="allow-popups allow-scripts allow-same-origin"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error
 PASS <iframe sandbox="allow-popups allow-scripts"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error

--- a/LayoutTests/platform/mac-wk1/http/tests/dom/noopener-window-not-targetable-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/dom/noopener-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac-wk1/http/tests/dom/noopener-window-not-targetable2-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/dom/noopener-window-not-targetable2-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS w is null
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac-wk1/http/tests/dom/noreferrer-window-not-targetable-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/dom/noreferrer-window-not-targetable-expected.txt
@@ -1,10 +1,10 @@
-Make sure that windows opened with 'noopener' via an anchor are not targetable. If testing manually, you should see 2 tabs open.
+Make sure that windows opened with 'noreferrer' are not targetable. If testing manually, you should see 2 tabs open.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4686,7 +4686,7 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
     }
 
     // FIXME: Setting the referrer should be the caller's responsibility.
-    String referrer = SecurityPolicy::generateReferrerHeader(openerFrame.document()->referrerPolicy(), request.resourceRequest().url(), openerFrame.loader().outgoingReferrerURL(), OriginAccessPatternsForWebProcess::singleton());
+    String referrer = features.wantsNoReferrer() ? String() :  SecurityPolicy::generateReferrerHeader(openerFrame.document()->referrerPolicy(), request.resourceRequest().url(), openerFrame.loader().outgoingReferrerURL(), OriginAccessPatternsForWebProcess::singleton());
     if (!referrer.isEmpty())
         request.resourceRequest().setHTTPReferrer(referrer);
     FrameLoader::addSameSiteInfoToRequestIfNeeded(request.resourceRequest(), openerFrame.protectedDocument().get());

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -45,6 +45,8 @@
 namespace WebKit {
 
 struct NavigationActionData {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
     WebCore::NavigationType navigationType { WebCore::NavigationType::Other };
     OptionSet<WebEventModifier> modifiers;
     WebMouseEventButton mouseButton { WebMouseEventButton::None };

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -111,7 +111,7 @@ private:
 
     RefPtr<UserInitiatedAction> m_userInitiatedAction;
 
-    WebKit::NavigationActionData m_navigationActionData;
+    const WebKit::NavigationActionData m_navigationActionData;
     RefPtr<Navigation> m_mainFrameNavigation;
 };
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -216,7 +216,7 @@ void WKPageLoadURLWithShouldOpenExternalURLsPolicy(WKPageRef pageRef, WKURLRef U
 void WKPageLoadURLWithUserData(WKPageRef pageRef, WKURLRef URLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, toImpl(userDataRef));
+    toImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, nullptr, toImpl(userDataRef));
 }
 
 void WKPageLoadURLRequest(WKPageRef pageRef, WKURLRequestRef urlRequestRef)
@@ -230,7 +230,7 @@ void WKPageLoadURLRequestWithUserData(WKPageRef pageRef, WKURLRequestRef urlRequ
 {
     CRASH_IF_SUSPENDED;
     auto resourceRequest = toImpl(urlRequestRef)->resourceRequest();
-    toImpl(pageRef)->loadRequest(WTFMove(resourceRequest), WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, toImpl(userDataRef));
+    toImpl(pageRef)->loadRequest(WTFMove(resourceRequest), WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, nullptr, toImpl(userDataRef));
 }
 
 void WKPageLoadFile(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -349,18 +349,13 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
     if (uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeaturesAsync) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:completionHandler:));
 
-        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker), relatedWebView = uiDelegate->m_webView.get(), openerInfo] (WKWebView *webView) mutable {
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker), openerInfo] (WKWebView *webView) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
 
             if (!webView)
                 return completionHandler(nullptr);
-
-            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            if ([webView->_configuration _relatedWebView] != relatedWebView.get())
-                [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
-            ALLOW_DEPRECATED_DECLARATIONS_END
 
             // FIXME: Move this to WebPageProxy once rdar://134317255 and rdar://134317400 are resolved.
             if (openerInfo != webView->_configuration->_pageConfiguration->openerInfo())
@@ -376,11 +371,6 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
     RetainPtr<WKWebView> webView = [delegate webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:wrapper(configuration) forNavigationAction:wrapper(navigationAction) windowFeatures:wrapper(apiWindowFeatures)];
     if (!webView)
         return completionHandler(nullptr);
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([webView.get()->_configuration _relatedWebView] != uiDelegate->m_webView.get().get())
-        [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
-    ALLOW_DEPRECATED_DECLARATIONS_END
 
     // FIXME: Move this to WebPageProxy once rdar://134317255 and rdar://134317400 are resolved.
     if (openerInfo != webView.get()->_configuration->_pageConfiguration->openerInfo())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -835,9 +835,13 @@ public:
     void closePage();
 
     void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
+
+    // Default values are in cpp file to avoid including headers from this header.
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&);
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy);
-    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, API::Object* userData = nullptr);
+    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback);
+    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, std::unique_ptr<NavigationActionData>&&, API::Object* userData = nullptr);
+
     RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
     RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr);
     RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldOpenExternalURLsPolicy);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -493,10 +493,13 @@ DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, webPageCounter, ("WebPage")
 
 Ref<WebPage> WebPage::create(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 {
+    String openedMainFrameName = parameters.openedMainFrameName;
     auto page = adoptRef(*new WebPage(pageID, WTFMove(parameters)));
 
     if (RefPtr injectedBundle = WebProcess::singleton().injectedBundle())
         injectedBundle->didCreatePage(page);
+
+    page->corePage()->mainFrame().tree().setSpecifiedName(AtomString(openedMainFrameName));
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     setHasLaunchedWebContentProcess();
@@ -1110,8 +1113,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     if (parameters.windowFeatures) {
         m_page->applyWindowFeatures(*parameters.windowFeatures);
         m_page->chrome().show();
+        m_page->setOpenedByDOM();
     }
-    m_page->mainFrame().tree().setSpecifiedName(AtomString(parameters.openedMainFrameName));
 }
 
 void WebPage::updateAfterDrawingAreaCreation(const WebPageCreationParameters& parameters)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -1441,7 +1441,7 @@ TEST(ProcessSwap, CrossSiteWindowOpenWithOpener)
 
 enum class ExpectSwap : bool { No, Yes };
 enum class WindowHasName : bool { No, Yes };
-static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, ExpectSwap expectSwap)
+static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -1482,10 +1482,7 @@ static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, Expec
     EXPECT_TRUE(!!pid2);
 
     // Since there is no opener, we process-swap, even though the navigation is same-site.
-    if (expectSwap == ExpectSwap::Yes)
-        EXPECT_NE(pid1, pid2);
-    else
-        EXPECT_EQ(pid1, pid2);
+    EXPECT_NE(pid1, pid2);
 
     done = false;
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/popup2.html"]];
@@ -1503,15 +1500,12 @@ static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, Expec
 TEST(ProcessSwap, SameSiteWindowOpenNoOpener)
 {
     // We process-swap even though the navigation is same-site, because the popup has no opener.
-    runSameSiteWindowOpenNoOpenerTest(WindowHasName::No, ExpectSwap::Yes);
+    runSameSiteWindowOpenNoOpenerTest(WindowHasName::No);
 }
 
 TEST(ProcessSwap, SameSiteWindowOpenWithNameNoOpener)
 {
-    // We currently do no process-swap when navigating same-site a popup without opener if the window
-    // has a name. We should be able to support this but we would need to pass the window name over
-    // to the new process.
-    runSameSiteWindowOpenNoOpenerTest(WindowHasName::Yes, ExpectSwap::No);
+    runSameSiteWindowOpenNoOpenerTest(WindowHasName::Yes);
 }
 
 TEST(ProcessSwap, CrossSiteBlankTargetWithOpener)


### PR DESCRIPTION
#### 9fcc0a6c7237291ae714b3a67fce464c96997062
<pre>
window.open with noopener shouldn&apos;t create page in opener process
<a href="https://bugs.webkit.org/show_bug.cgi?id=279031">https://bugs.webkit.org/show_bug.cgi?id=279031</a>
<a href="https://rdar.apple.com/135438724">rdar://135438724</a>

Reviewed by Charlie Wolfe.

We used to make a page in the opener process then navigate it and immediately discard it.
That doesn&apos;t play well with site isolation&apos;s process accounting.  JS can&apos;t observe this
because window.open returns null in such a case.

In order to implement this, I need to only call API::PageConfiguration::setRelatedPage
if there is actually an opener, and I need to remove the now duplicate checks that verify
the API client is using the provided WKWebViewConfiguration by checking the related page.
There is already another check that verifies using the opener info.

The referrer set in WebCore::createWindow needs to check WindowFeatures::wantsNoReferrer
like the one in LocalDOMWindow::createWindow.  This referrer was never used because until
now LocalDOMWindow::createWindow made a second FrameLoadRequest with the correct referrer,
but now the referrer in WebCore::createWindow needs to be correct because that is what is
sent to another process now to be the referrer of the initial request of the new page.

A few layout tests in http/tests/dom count the number of windows in the process that is
finishing the test.  Since one of the windows is now opening in another process in modern
WebKit, the count goes from 3 to 2.  WebKitLegacy test expectations are unchanged for
those three tests.  Same with a few other tests that now have an error printed in multiple
processes.

* LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt:
* LayoutTests/http/tests/dom/noopener-window-not-targetable.html:
* LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt:
* LayoutTests/http/tests/dom/noopener-window-not-targetable2.html:
* LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt:
* LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html:
* LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-coep-sandbox.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox.https-expected.txt:
* LayoutTests/platform/mac-wk1/http/tests/dom/noopener-window-not-targetable-expected.txt: Copied from LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt.
* LayoutTests/platform/mac-wk1/http/tests/dom/noopener-window-not-targetable2-expected.txt: Copied from LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt.
* LayoutTests/platform/mac-wk1/http/tests/dom/noreferrer-window-not-targetable-expected.txt: Copied from LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::createWindow):
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageLoadURLWithUserData):
(WKPageLoadURLRequestWithUserData):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::createNewPage):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::create):
(WebKit::m_textAnimationController):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, SameSiteWindowOpenNoOpener)):
((ProcessSwap, SameSiteWindowOpenWithNameNoOpener)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, OpenWithNoopener)):

Canonical link: <a href="https://commits.webkit.org/285310@main">https://commits.webkit.org/285310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/758fdffc37154c90b356ce57eeded1bcdcdf7c7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56868 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21653 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77939 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19110 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65343 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_block_downloads.tentative.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64601 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6460 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11083 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2097 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->