### PR TITLE
The download client should be able to determine if a placeholder should be used

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -31,6 +31,7 @@
 #include "MessageSender.h"
 #include "NetworkDataTask.h"
 #include "SandboxExtension.h"
+#include "UseDownloadPlaceholder.h"
 #include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/ResourceRequest.h>
 #include <memory>
@@ -90,7 +91,7 @@ public:
 #endif
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    void publishProgress(const URL&, std::span<const uint8_t>);
+    void publishProgress(const URL&, std::span<const uint8_t>, WebKit::UseDownloadPlaceholder);
 #endif
 
     DownloadID downloadID() const { return m_downloadID; }

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
@@ -129,12 +129,12 @@ void DownloadManager::cancelDownload(DownloadID downloadID, CompletionHandler<vo
 
 #if PLATFORM(COCOA)
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-void DownloadManager::publishDownloadProgress(DownloadID downloadID, const URL& url, std::span<const uint8_t> bookmarkData)
+void DownloadManager::publishDownloadProgress(DownloadID downloadID, const URL& url, std::span<const uint8_t> bookmarkData, WebKit::UseDownloadPlaceholder useDownloadPlaceholder)
 {
     if (auto* download = m_downloads.get(downloadID))
-        download->publishProgress(url, bookmarkData);
+        download->publishProgress(url, bookmarkData, useDownloadPlaceholder);
     else if (auto* pendingDownload = m_pendingDownloads.get(downloadID))
-        pendingDownload->publishProgress(url, bookmarkData);
+        pendingDownload->publishProgress(url, bookmarkData, useDownloadPlaceholder);
 }
 #else
 void DownloadManager::publishDownloadProgress(DownloadID downloadID, const URL& url, SandboxExtension::Handle&& sandboxExtensionHandle)

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -31,6 +31,7 @@
 #include "PendingDownload.h"
 #include "PolicyDecision.h"
 #include "SandboxExtension.h"
+#include "UseDownloadPlaceholder.h"
 #include <WebCore/NotImplemented.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -101,7 +102,7 @@ public:
     void cancelDownload(DownloadID, CompletionHandler<void(std::span<const uint8_t>)>&&);
 #if PLATFORM(COCOA)
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    void publishDownloadProgress(DownloadID, const URL&, std::span<const uint8_t> bookmarkData);
+    void publishDownloadProgress(DownloadID, const URL&, std::span<const uint8_t> bookmarkData, WebKit::UseDownloadPlaceholder);
 #else
     void publishDownloadProgress(DownloadID, const URL&, SandboxExtension::Handle&&);
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -81,11 +81,12 @@ void PendingDownload::cancel(CompletionHandler<void(std::span<const uint8_t>)>&&
 
 #if PLATFORM(COCOA)
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-void PendingDownload::publishProgress(const URL& url, std::span<const uint8_t> bookmarkData)
+void PendingDownload::publishProgress(const URL& url, std::span<const uint8_t> bookmarkData, UseDownloadPlaceholder useDownloadPlaceholder)
 {
     ASSERT(!m_progressURL.isValid());
     m_progressURL = url;
     m_bookmarkData = bookmarkData;
+    m_useDownloadPlaceholder = useDownloadPlaceholder;
 }
 #else
 void PendingDownload::publishProgress(const URL& url, SandboxExtension::Handle&& sandboxExtension)
@@ -101,7 +102,7 @@ void PendingDownload::didBecomeDownload(const std::unique_ptr<Download>& downloa
     if (!m_progressURL.isValid())
         return;
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    download->publishProgress(m_progressURL, m_bookmarkData);
+    download->publishProgress(m_progressURL, m_bookmarkData, m_useDownloadPlaceholder);
 #else
     download->publishProgress(m_progressURL, WTFMove(m_progressSandboxExtension));
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -29,6 +29,7 @@
 #include "MessageSender.h"
 #include "NetworkLoadClient.h"
 #include "SandboxExtension.h"
+#include "UseDownloadPlaceholder.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
@@ -66,7 +67,7 @@ public:
 
 #if PLATFORM(COCOA)
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    void publishProgress(const URL&, std::span<const uint8_t>);
+    void publishProgress(const URL&, std::span<const uint8_t>, UseDownloadPlaceholder);
 #else
     void publishProgress(const URL&, SandboxExtension::Handle&&);
 #endif
@@ -97,6 +98,7 @@ private:
     URL m_progressURL;
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     Vector<uint8_t> m_bookmarkData;
+    UseDownloadPlaceholder m_useDownloadPlaceholder { UseDownloadPlaceholder::No };
 #else
     SandboxExtension::Handle m_progressSandboxExtension;
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -90,7 +90,7 @@ void Download::platformDestroyDownload()
 }
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmarkData)
+void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmarkData, UseDownloadPlaceholder useDownloadPlaceholder)
 {
     if (m_progress) {
         RELEASE_LOG(Network, "Progress is already being published for download.");
@@ -110,7 +110,8 @@ void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmark
     bool shouldEnableModernDownloadProgress = CFPreferencesGetAppBooleanValue(CFSTR("EnableModernDownloadProgress"), CFSTR("com.apple.WebKit"), NULL);
 
     if (shouldEnableModernDownloadProgress) {
-        m_progress = adoptNS([[WKModernDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url]);
+        NSData *accessToken = [NSData data]; // FIXME: replace with actual access token
+        m_progress = adoptNS([[WKModernDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url useDownloadPlaceholder:useDownloadPlaceholder == WebKit::UseDownloadPlaceholder::Yes liveActivityAccessToken:accessToken]);
         [m_progress publish];
     } else {
         m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url sandboxExtension:nullptr]);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -33,6 +33,7 @@
 #include "DownloadManager.h"
 #include "NetworkContentRuleListManager.h"
 #include "QuotaIncreaseRequestIdentifier.h"
+#include "UseDownloadPlaceholder.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebResourceLoadStatisticsStore.h"
 #include "WebsiteData.h"
@@ -483,7 +484,7 @@ private:
     void cancelDownload(DownloadID, CompletionHandler<void(std::span<const uint8_t>)>&&);
 #if PLATFORM(COCOA)
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    void publishDownloadProgress(DownloadID, const URL&, std::span<const uint8_t> bookmarkData);
+    void publishDownloadProgress(DownloadID, const URL&, std::span<const uint8_t> bookmarkData, WebKit::UseDownloadPlaceholder);
 #else
     void publishDownloadProgress(DownloadID, const URL&, SandboxExtensionHandle&&);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -52,9 +52,6 @@ messages -> NetworkProcess LegacyReceiver {
     DownloadRequest(PAL::SessionID sessionID, WebKit::DownloadID downloadID, WebCore::ResourceRequest request, std::optional<WebCore::SecurityOriginData> topOrigin, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, String suggestedFilename)
     ResumeDownload(PAL::SessionID sessionID, WebKit::DownloadID downloadID, std::span<const uint8_t> resumeData, String path, WebKit::SandboxExtensionHandle sandboxExtensionHandle, enum:bool WebKit::CallDownloadDidStart callDownloadDidStart)
     CancelDownload(WebKit::DownloadID downloadID) -> (std::span<const uint8_t> resumeData)
-#if HAVE(MODERN_DOWNLOADPROGRESS)
-    PublishDownloadProgress(WebKit::DownloadID downloadID, URL url, std::span<const uint8_t> bookmarkData)
-#endif
 #if PLATFORM(COCOA) && !HAVE(MODERN_DOWNLOADPROGRESS)
     PublishDownloadProgress(WebKit::DownloadID downloadID, URL url, WebKit::SandboxExtensionHandle sandboxExtensionHandle)
 #endif

--- a/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/WKDownloadDelegatePrivate.h>
 #import <WebKit/WKHistoryDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>

--- a/Source/WebKit/UIProcess/API/APIDownloadClient.h
+++ b/Source/WebKit/UIProcess/API/APIDownloadClient.h
@@ -29,6 +29,7 @@
 #include "AuthenticationChallengeProxy.h"
 #include "AuthenticationDecisionListener.h"
 #include "DownloadID.h"
+#include "DownloadProxy.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
@@ -41,7 +42,6 @@ class ResourceResponse;
 
 namespace WebKit {
 class AuthenticationChallengeProxy;
-class DownloadProxy;
 class WebsiteDataStore;
 class WebProtectionSpace;
 
@@ -60,6 +60,9 @@ public:
     virtual void legacyDidStart(WebKit::DownloadProxy&) { }
     virtual void didReceiveAuthenticationChallenge(WebKit::DownloadProxy&, WebKit::AuthenticationChallengeProxy& challenge) { challenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::Cancel); }
     virtual void didReceiveData(WebKit::DownloadProxy&, uint64_t, uint64_t, uint64_t) { }
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    virtual void decidePlaceholderPolicy(WebKit::DownloadProxy&, CompletionHandler<void(WebKit::UseDownloadPlaceholder)>&& completionHandler) { completionHandler(WebKit::UseDownloadPlaceholder::No); }
+#endif
     virtual void decideDestinationWithSuggestedFilename(WebKit::DownloadProxy&, const WebCore::ResourceResponse&, const WTF::String&, CompletionHandler<void(WebKit::AllowOverwrite, WTF::String)>&& completionHandler) { completionHandler(WebKit::AllowOverwrite::No, { }); }
     virtual void didCreateDestination(WebKit::DownloadProxy&, const WTF::String&) { }
     virtual void didFinish(WebKit::DownloadProxy&) { }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegatePrivate.h
@@ -23,30 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "DownloadProxy.h"
+#import <Foundation/Foundation.h>
+#import <WebKit/WKDownloadDelegate.h>
+#import <WebKit/WKFoundation.h>
 
-#import "NetworkProcessMessages.h"
-#import "NetworkProcessProxy.h"
-#import "WebsiteDataStore.h"
+@class WKDownload;
 
-#import <wtf/cocoa/SpanCocoa.h>
+/* @enum _WKPlaceholderPolicy
+ @abstract The policy for creating a placeholder file in the Downloads directory during downloads.
+ @constant _WKPlaceholderPolicyDisable   Do not create a placeholder file.
+ @constant _WKPlaceholderPolicyEnable    Create a placeholder file.
+ */
+typedef NS_ENUM(NSInteger, _WKPlaceholderPolicy) {
+    _WKPlaceholderPolicyDisable,
+    _WKPlaceholderPolicyEnable,
+} NS_SWIFT_NAME(WKDownload.PlaceholderPolicy) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
-namespace WebKit {
+NS_ASSUME_NONNULL_BEGIN
 
-#if !HAVE(MODERN_DOWNLOADPROGRESS)
-void DownloadProxy::publishProgress(const URL& url)
-{
-    if (!m_dataStore)
-        return;
+WK_SWIFT_UI_ACTOR
+@protocol WKDownloadDelegatePrivate <WKDownloadDelegate>
 
-    auto handle = SandboxExtension::createHandle(url.fileSystemPath(), SandboxExtension::Type::ReadWrite);
-    ASSERT(handle);
-    if (!handle)
-        return;
+@optional
 
-    m_dataStore->networkProcess().send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, url, WTFMove(*handle)), 0);
-    }
-#endif
+/* @abstract Invoked when the download needs a placeholder policy from the client.
+ @param download The download for which we need a placeholder policy
+ @param completionHandler The completion handler that should be invoked with the chosen policy
+ @discussion The placeholder policy specifies whether a placeholder file should be created in
+ the Downloads directory when the download is in progress.
+ */
+- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
-}
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -79,7 +79,9 @@ IGNORE_WARNINGS_END
 
 - (void)publishProgressAtURL:(NSURL *)URL
 {
+#if !HAVE(MODERN_DOWNLOADPROGRESS)
     _download->_download->publishProgress(URL);
+#endif
 }
 
 - (NSURLRequest *)request

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -141,7 +141,7 @@ void DownloadProxy::didReceiveData(uint64_t bytesWritten, uint64_t totalBytesWri
     m_client->didReceiveData(*this, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
 }
 
-void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::ResourceResponse& response, String&& suggestedFilename, CompletionHandler<void(String, SandboxExtension::Handle, AllowOverwrite)>&& completionHandler)
+void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::ResourceResponse& response, String&& suggestedFilename, DecideDestinationCallback&& completionHandler)
 {
     RELEASE_LOG_INFO_IF(!response.expectedContentLength(), Network, "DownloadProxy::decideDestinationWithSuggestedFilename expectedContentLength is null");
 
@@ -161,12 +161,13 @@ void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::Resour
         }
 
         setDestinationFilename(destination);
-        completionHandler(destination, WTFMove(sandboxExtensionHandle), allowOverwrite);
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-        bool shouldEnableModernDownloadProgress = CFPreferencesGetAppBooleanValue(CFSTR("EnableModernDownloadProgress"), CFSTR("com.apple.WebKit"), nullptr);
-        if (!destination.isEmpty() && shouldEnableModernDownloadProgress)
-            publishProgress(URL::fileURLWithFileSystemPath(destination));
+        m_client->decidePlaceholderPolicy(*this, [completionHandler = WTFMove(completionHandler), destination = WTFMove(destination), sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), allowOverwrite] (WebKit::UseDownloadPlaceholder usePlaceholder) mutable {
+            completionHandler(destination, WTFMove(sandboxExtensionHandle), allowOverwrite, usePlaceholder);
+        });
+#else
+        completionHandler(destination, WTFMove(sandboxExtensionHandle), allowOverwrite, WebKit::UseDownloadPlaceholder::No);
 #endif
     });
 }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.messages.in
@@ -24,8 +24,7 @@ messages -> DownloadProxy {
     DidStart(WebCore::ResourceRequest request, String suggestedFilename)
     DidReceiveAuthenticationChallenge(WebCore::AuthenticationChallenge challenge, WebKit::AuthenticationChallengeIdentifier challengeID)
     WillSendRequest(WebCore::ResourceRequest redirectRequest, WebCore::ResourceResponse redirectResponse) -> (WebCore::ResourceRequest newRequest)
-    DecideDestinationWithSuggestedFilename(WebCore::ResourceResponse response, String suggestedFilename) -> (String filename, WebKit::SandboxExtensionHandle handle, enum:bool WebKit::AllowOverwrite allowOverwrite)
-
+    DecideDestinationWithSuggestedFilename(WebCore::ResourceResponse response, String suggestedFilename) -> (String filename, WebKit::SandboxExtensionHandle handle, enum:bool WebKit::AllowOverwrite allowOverwrite, enum:bool WebKit::UseDownloadPlaceholder useDownloadPlaceholder)
     DidReceiveData(uint64_t bytesWritten, uint64_t totalBytesWritten, uint64_t totalBytesExpectedToWrite)
     DidCreateDestination(String path)
     DidFinish()

--- a/Source/WebKit/UIProcess/Downloads/UseDownloadPlaceholder.h
+++ b/Source/WebKit/UIProcess/Downloads/UseDownloadPlaceholder.h
@@ -23,30 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "DownloadProxy.h"
-
-#import "NetworkProcessMessages.h"
-#import "NetworkProcessProxy.h"
-#import "WebsiteDataStore.h"
-
-#import <wtf/cocoa/SpanCocoa.h>
+#pragma once
 
 namespace WebKit {
 
-#if !HAVE(MODERN_DOWNLOADPROGRESS)
-void DownloadProxy::publishProgress(const URL& url)
-{
-    if (!m_dataStore)
-        return;
+enum class UseDownloadPlaceholder : bool {
+    No,
+    Yes,
+};
 
-    auto handle = SandboxExtension::createHandle(url.fileSystemPath(), SandboxExtension::Type::ReadWrite);
-    ASSERT(handle);
-    if (!handle)
-        return;
-
-    m_dataStore->networkProcess().send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, url, WTFMove(*handle)), 0);
-    }
-#endif
-
-}
+} // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2438,8 +2438,10 @@
 		E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = E31869C22B1A7C2400571519 /* WKProcessExtension.mm */; };
 		E31869C52B1A7C2400571519 /* WKProcessExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = E31869C32B1A7C2400571519 /* WKProcessExtension.h */; };
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
+		E33E8FFD2C7FD2980002BEB3 /* UseDownloadPlaceholder.h in Headers */ = {isa = PBXBuildFile; fileRef = E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */; };
 		E34DAD392B753FA700FABEE2 /* ExtensionProcess.mm in Sources */ = {isa = PBXBuildFile; fileRef = E34DAD372B753FA700FABEE2 /* ExtensionProcess.mm */; };
 		E34DAD3A2B753FA700FABEE2 /* ExtensionProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = E34DAD382B753FA700FABEE2 /* ExtensionProcess.h */; };
+		E3607DEA2C7FE92200956766 /* WKDownloadDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = E3607DE92C7FE92200956766 /* WKDownloadDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };
 		E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */; };
@@ -7979,6 +7981,7 @@
 		E31869C22B1A7C2400571519 /* WKProcessExtension.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKProcessExtension.mm; sourceTree = "<group>"; };
 		E31869C32B1A7C2400571519 /* WKProcessExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKProcessExtension.h; sourceTree = "<group>"; };
 		E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuxiliaryProcessProxyCocoa.mm; sourceTree = "<group>"; };
+		E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UseDownloadPlaceholder.h; sourceTree = "<group>"; };
 		E3439B632345463A0011DE0B /* NetworkProcessConnectionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkProcessConnectionInfo.h; path = Network/NetworkProcessConnectionInfo.h; sourceTree = "<group>"; };
 		E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestShim.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestSupport.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7987,6 +7990,7 @@
 		E350A7C52934F1C100A06C29 /* common.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = common.sb; sourceTree = "<group>"; };
 		E350A7C82934F75F00A06C29 /* common.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = common.sb; sourceTree = "<group>"; };
 		E350A7DF29364D3800A06C29 /* util.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = util.sb; sourceTree = "<group>"; };
+		E3607DE92C7FE92200956766 /* WKDownloadDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegatePrivate.h; sourceTree = "<group>"; };
 		E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextTrackRepresentationCocoa.h; sourceTree = "<group>"; };
 		E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextTrackRepresentationCocoa.mm; sourceTree = "<group>"; };
 		E36D701A27B709ED006531B7 /* WebAttachmentElementClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebAttachmentElementClient.h; sourceTree = "<group>"; };
@@ -9493,6 +9497,7 @@
 				E382D57E2C21D500005F7653 /* DownloadProxyCocoa.mm */,
 				1AD25E93167AB08100EA9BCD /* DownloadProxyMap.cpp */,
 				1AD25E94167AB08100EA9BCD /* DownloadProxyMap.h */,
+				E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */,
 			);
 			path = Downloads;
 			sourceTree = "<group>";
@@ -11585,6 +11590,7 @@
 				DF0C5F24252ECB8D00D921DB /* WKDownload.h */,
 				DF0C5F23252ECB8D00D921DB /* WKDownload.mm */,
 				DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */,
+				E3607DE92C7FE92200956766 /* WKDownloadDelegatePrivate.h */,
 				DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */,
 				1AF4592D19464B2000F9D4A2 /* WKError.h */,
 				1AF4592C19464B2000F9D4A2 /* WKError.mm */,
@@ -16820,6 +16826,7 @@
 				93D1EEF529669D74009B31D6 /* UnifiedOriginStorageLevel.h in Headers */,
 				1A64245E12DE29A100CAAE2C /* UpdateInfo.h in Headers */,
 				5C19A5201FD0B29500EEA323 /* URLSchemeTaskParameters.h in Headers */,
+				E33E8FFD2C7FD2980002BEB3 /* UseDownloadPlaceholder.h in Headers */,
 				1AC1336818565B5700F3EC05 /* UserData.h in Headers */,
 				CD491B081E70D05F00009066 /* UserMediaCaptureManager.h in Headers */,
 				CD491B0E1E732E4D00009066 /* UserMediaCaptureManagerMessages.h in Headers */,
@@ -17327,6 +17334,7 @@
 				DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */,
 				5C2EBDFA2564380B00D55B05 /* WKDownloadClient.h in Headers */,
 				DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */,
+				E3607DEA2C7FE92200956766 /* WKDownloadDelegatePrivate.h in Headers */,
 				DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */,
 				637281A221ADC744009E0DE6 /* WKDownloadProgress.h in Headers */,
 				1AB7D78D1288CD9A00CFD08C /* WKDownloadRef.h in Headers */,

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
@@ -23,12 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/WKDownloadDelegatePrivate.h>
 #import <WebKit/WebKit.h>
 
 enum class DownloadCallback : uint8_t {
     WillRedirect,
     AuthenticationChallenge,
     DecideDestination,
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    DecidePlaceholderPolicy,
+#endif
     DidFinish,
     DidFailWithError,
     NavigationActionBecameDownload,
@@ -37,7 +41,7 @@ enum class DownloadCallback : uint8_t {
     NavigationResponse,
 };
 
-@interface TestDownloadDelegate : NSObject<WKDownloadDelegate, WKNavigationDelegate>
+@interface TestDownloadDelegate : NSObject<WKDownloadDelegatePrivate, WKNavigationDelegate>
 
 @property (nonatomic, copy) void (^willPerformHTTPRedirection)(WKDownload *, NSHTTPURLResponse *, NSURLRequest *, void (^)(WKDownloadRedirectPolicy));
 @property (nonatomic, copy) void (^didReceiveAuthenticationChallenge)(WKDownload *, NSURLAuthenticationChallenge *, void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential*));

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
@@ -58,6 +58,14 @@
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
 }
 
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy))completionHandler
+{
+    _callbackRecord.append(DownloadCallback::DecidePlaceholderPolicy);
+    completionHandler(_WKPlaceholderPolicyDisable);
+}
+#endif
+
 - (void)downloadDidFinish:(WKDownload *)download
 {
     _callbackRecord.append(DownloadCallback::DidFinish);


### PR DESCRIPTION
#### 3c3c719fec7ed8efcfa40f778d58b143aef97780
<pre>
The download client should be able to determine if a placeholder should be used
<a href="https://bugs.webkit.org/show_bug.cgi?id=278737">https://bugs.webkit.org/show_bug.cgi?id=278737</a>
<a href="https://rdar.apple.com/134794671">rdar://134794671</a>

Reviewed by Alex Christensen.

The download client should be able to determine if a placeholder should be used for the final location of the
download. This patch prepares for this by passing the value from the UI process to the Networking process.

This was previously landed in &lt;<a href="https://commits.webkit.org/283043@main">https://commits.webkit.org/283043@main</a>&gt;. This version addresses a build error.

* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp:
(WebKit::DownloadManager::publishDownloadProgress):
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::publishProgress):
(WebKit::PendingDownload::didBecomeDownload):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::publishProgress):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::publishDownloadProgress):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload publishProgressAtURL:]):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload setDelegate:]):
* Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegatePrivate.h: Added.
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::decideDestinationWithSuggestedFilename):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
(WebKit::DownloadProxy::setUseDownloadPlaceholder):
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::publishProgress):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::DecidePlaceholderPolicy)):
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm:
(-[TestDownloadDelegate _download:decidePlaceholderPolicy:]):

Canonical link: <a href="https://commits.webkit.org/283071@main">https://commits.webkit.org/283071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81cbb74659c256cb9d5663560feda01d8778218c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52317 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13742 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14605 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59647 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56431 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59905 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1173 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9874 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40302 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->