### PR TITLE
Use fewer raw pointers for data members in WebKit/WebProcess

### DIFF
--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -40,6 +40,8 @@
 namespace WebCore {
 
 class ColorInputType final : public BaseClickableWithKeyInputType, private ColorChooserClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ColorInputType);
 public:
     static Ref<ColorInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -63,9 +63,10 @@ class PageDebugger;
 class WebInjectedScriptManager;
 struct PageAgentContext;
 
-class InspectorController final : public Inspector::InspectorEnvironment {
+class InspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<InspectorController> {
     WTF_MAKE_NONCOPYABLE(InspectorController);
     WTF_MAKE_TZONE_ALLOCATED(InspectorController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorController);
 public:
     InspectorController(Page&, std::unique_ptr<InspectorClient>&&);
     ~InspectorController() override;

--- a/Source/WebCore/platform/ColorChooserClient.h
+++ b/Source/WebCore/platform/ColorChooserClient.h
@@ -31,6 +31,7 @@
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -38,7 +39,9 @@ namespace WebCore {
 class Color;
 class IntRect;
 
-class ColorChooserClient {
+class ColorChooserClient : public CanMakeCheckedPtr<ColorChooserClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ColorChooserClient);
 public:
     virtual ~ColorChooserClient() = default;
 

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -74,6 +74,12 @@ public:
     virtual HostWindow* hostWindow() const = 0;
 
     virtual Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) = 0;
+
+    // CheckedPtr interface.
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 };
 
 }

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -48,6 +48,12 @@ public:
 
     HTMLSelectElement& selectElement() const;
 
+    // CheckedPtr interface.
+    uint32_t ptrCount() const final { return RenderFlexibleBox::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return RenderFlexibleBox::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { RenderFlexibleBox::incrementPtrCount(); }
+    void decrementPtrCount() const final { RenderFlexibleBox::decrementPtrCount(); }
+
 #if !PLATFORM(IOS_FAMILY)
     bool popupIsVisible() const { return m_popupIsVisible; }
 #endif

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -46,6 +46,12 @@ public:
     void hidePopup();
     WEBCORE_EXPORT std::span<const RecentSearch> recentSearches();
 
+    // CheckedPtr interface.
+    uint32_t ptrCount() const final { return RenderTextControlSingleLine::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return RenderTextControlSingleLine::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { RenderTextControlSingleLine::incrementPtrCount(); }
+    void decrementPtrCount() const final { RenderTextControlSingleLine::decrementPtrCount(); }
+
 private:
     void willBeDestroyed() override;
     LayoutUnit computeControlLogicalHeight(LayoutUnit lineHeight, LayoutUnit nonContentHeight) const override;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -110,7 +110,7 @@ header: "RemoteLayerBackingStore.h"
 #endif
 };
 
-[LegacyPopulateFromEmptyConstructor] class WebKit::RemoteLayerTreeTransaction {
+[LegacyPopulateFromEmptyConstructor, DisableMissingMemberCheck] class WebKit::RemoteLayerTreeTransaction {
 {
     Markable<WebCore::PlatformLayerIdentifier> m_rootLayerID;
     WebKit::ChangedLayers m_changedLayers;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -40,6 +40,7 @@
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -75,8 +76,9 @@ struct ChangedLayers {
     ~ChangedLayers();
 };
 
-class RemoteLayerTreeTransaction {
+class RemoteLayerTreeTransaction : public CanMakeCheckedPtr<RemoteLayerTreeTransaction> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeTransaction);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeTransaction);
 public:
     struct LayerCreationProperties {
         struct NoAdditionalData { };

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -32,7 +32,7 @@
 #include "WebEvent.h"
 #include "WebEventModifier.h"
 #include "WebEventType.h"
-
+#include <wtf/CheckedPtr.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
@@ -47,8 +47,9 @@ class Encoder;
 
 namespace WebKit {
 
-class WebEvent {
+class WebEvent : public CanMakeCheckedPtr<WebEvent> {
     WTF_MAKE_TZONE_ALLOCATED(WebEvent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEvent);
 public:
     WebEvent(WebEventType, OptionSet<WebEventModifier>, WallTime timestamp, WTF::UUID authorizationToken);
     WebEvent(WebEventType, OptionSet<WebEventModifier>, WallTime timestamp);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
@@ -66,7 +66,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorClient);
 
 WebInspectorClient::WebInspectorClient(WebPage* page)
     : m_page(page)
-    , m_highlightOverlay(nullptr)
 {
 }
 
@@ -138,14 +137,14 @@ void WebInspectorClient::highlight()
     }
 
 #if !PLATFORM(IOS_FAMILY)
-    if (!m_highlightOverlay) {
-        auto highlightOverlay = PageOverlay::create(*this);
-        m_highlightOverlay = highlightOverlay.ptr();
-        page->corePage()->pageOverlayController().installPageOverlay(WTFMove(highlightOverlay), PageOverlay::FadeMode::Fade);
-        m_highlightOverlay->setNeedsDisplay();
+    if (RefPtr highlightOverlay = m_highlightOverlay.get()) {
+        highlightOverlay->stopFadeOutAnimation();
+        highlightOverlay->setNeedsDisplay();
     } else {
-        m_highlightOverlay->stopFadeOutAnimation();
-        m_highlightOverlay->setNeedsDisplay();
+        Ref newHighlightOverlay = PageOverlay::create(*this);
+        m_highlightOverlay = newHighlightOverlay.ptr();
+        page->corePage()->pageOverlayController().installPageOverlay(newHighlightOverlay.copyRef(), PageOverlay::FadeMode::Fade);
+        newHighlightOverlay->setNeedsDisplay();
     }
 #else
     InspectorOverlay::Highlight highlight;
@@ -171,8 +170,8 @@ void WebInspectorClient::hideHighlight()
 #endif
 
 #if !PLATFORM(IOS_FAMILY)
-    if (m_highlightOverlay)
-        page->corePage()->pageOverlayController().uninstallPageOverlay(*m_highlightOverlay, PageOverlay::FadeMode::Fade);
+    if (RefPtr highlightOverlay = m_highlightOverlay.get())
+        page->corePage()->pageOverlayController().uninstallPageOverlay(*highlightOverlay, PageOverlay::FadeMode::Fade);
 #else
     page->hideInspectorHighlight();
 #endif

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
@@ -89,7 +89,7 @@ private:
     void animationEndedForLayer(const WebCore::GraphicsLayer*);
 
     WeakPtr<WebPage> m_page;
-    WebCore::PageOverlay* m_highlightOverlay;
+    WeakPtr<WebCore::PageOverlay> m_highlightOverlay;
     
     RefPtr<WebCore::PageOverlay> m_paintRectOverlay;
     std::unique_ptr<RepaintIndicatorLayerClient> m_paintIndicatorLayerClient;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -72,11 +72,11 @@ void WebInspectorUI::establishConnection(WebPageProxyIdentifier inspectedPageIde
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (!m_extensionController)
-        m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this, m_page.identifier());
+        m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this, m_page->identifier());
 #endif
 
     m_frontendAPIDispatcher->reset();
-    m_frontendController = &m_page.corePage()->inspectorController();
+    m_frontendController = &m_page->corePage()->inspectorController();
     m_frontendController->setInspectorFrontendClient(this);
 
     updateConnection();
@@ -105,7 +105,7 @@ void WebInspectorUI::windowObjectCleared()
     if (m_frontendHost)
         m_frontendHost->disconnectClient();
 
-    m_frontendHost = InspectorFrontendHost::create(this, m_page.corePage());
+    m_frontendHost = InspectorFrontendHost::create(this, m_page->corePage());
     m_frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorld());
 }
 
@@ -131,9 +131,9 @@ void WebInspectorUI::startWindowDrag()
 
 void WebInspectorUI::moveWindowBy(float x, float y)
 {
-    FloatRect frameRect = m_page.corePage()->chrome().windowRect();
+    FloatRect frameRect = m_page->corePage()->chrome().windowRect();
     frameRect.move(x, y);
-    m_page.corePage()->chrome().setWindowRect(frameRect);
+    m_page->corePage()->chrome().setWindowRect(frameRect);
 }
 
 void WebInspectorUI::bringToFront()
@@ -188,7 +188,7 @@ void WebInspectorUI::effectiveAppearanceDidChange(WebCore::InspectorFrontendClie
 
 WebCore::UserInterfaceLayoutDirection WebInspectorUI::userInterfaceLayoutDirection() const
 {
-    return m_page.corePage()->userInterfaceLayoutDirection();
+    return m_page->corePage()->userInterfaceLayoutDirection();
 }
 
 bool WebInspectorUI::supportsDockSide(DockSide dockSide)
@@ -328,12 +328,12 @@ void WebInspectorUI::setInspectorPageDeveloperExtrasEnabled(bool enabled)
 #if ENABLE(INSPECTOR_TELEMETRY)
 bool WebInspectorUI::supportsDiagnosticLogging()
 {
-    return m_page.corePage()->settings().diagnosticLoggingEnabled();
+    return m_page->corePage()->settings().diagnosticLoggingEnabled();
 }
 
 void WebInspectorUI::logDiagnosticEvent(const String& eventName, const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    m_page.corePage()->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(eventName, "Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    m_page->corePage()->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(eventName, "Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void WebInspectorUI::setDiagnosticLoggingAvailable(bool available)
@@ -462,7 +462,7 @@ String WebInspectorUI::targetProductVersion() const
 
 WebCore::Page* WebInspectorUI::frontendPage()
 {
-    return m_page.corePage();
+    return m_page->corePage();
 }
 
 #if !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN) && !ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -182,13 +182,13 @@ private:
 
     void didEstablishConnection();
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     Ref<WebCore::InspectorFrontendAPIDispatcher> m_frontendAPIDispatcher;
     RefPtr<WebCore::InspectorFrontendHost> m_frontendHost;
 
     // Keep a pointer to the frontend's inspector controller rather than going through
     // corePage(), since we may need it after the frontend's page has started destruction.
-    WebCore::InspectorController* m_frontendController { nullptr };
+    CheckedPtr<WebCore::InspectorController> m_frontendController;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     std::unique_ptr<WebInspectorUIExtensionController> m_extensionController;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    NetscapePlugInStreamLoader* streamLoader() { return m_streamLoader; }
+    NetscapePlugInStreamLoader* streamLoader() { return m_streamLoader.get(); }
     void setStreamLoader(NetscapePlugInStreamLoader* loader) { m_streamLoader = loader; }
     void clearStreamLoader();
     void addData(std::span<const uint8_t> data) { m_accumulatedData.append(data); }
@@ -84,7 +84,7 @@ private:
     size_t m_count { 0 };
     DataRequestCompletionHandler m_completionHandler;
     Vector<uint8_t> m_accumulatedData;
-    NetscapePlugInStreamLoader* m_streamLoader { nullptr };
+    WeakPtr<NetscapePlugInStreamLoader> m_streamLoader;
 };
 
 #pragma mark -

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -28,6 +28,7 @@
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #include <WebCore/EventListener.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakPtr.h>
@@ -45,7 +46,9 @@ namespace WebKit {
 
 class PDFPluginBase;
 
-class PDFPluginAnnotation : public RefCounted<PDFPluginAnnotation> {
+class PDFPluginAnnotation : public RefCounted<PDFPluginAnnotation>, public CanMakeCheckedPtr<PDFPluginAnnotation> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPluginAnnotation);
 public:
     static RefPtr<PDFPluginAnnotation> create(PDFAnnotation *, PDFPluginBase*);
     virtual ~PDFPluginAnnotation();
@@ -94,7 +97,7 @@ private:
 
         void handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event&) override;
 
-        PDFPluginAnnotation* m_annotation;
+        CheckedPtr<PDFPluginAnnotation> m_annotation;
     };
 
     WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_parent;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h
@@ -38,6 +38,8 @@ OBJC_CLASS PDFAnnotationChoiceWidget;
 namespace WebKit {
 
 class PDFPluginChoiceAnnotation : public PDFPluginAnnotation {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPluginChoiceAnnotation);
 public:
     static Ref<PDFPluginChoiceAnnotation> create(PDFAnnotation *, PDFPluginBase*);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.h
@@ -32,6 +32,8 @@
 namespace WebKit {
 
 class PDFPluginPasswordForm : public PDFPluginAnnotation {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPluginPasswordForm);
 public:
     static Ref<PDFPluginPasswordForm> create(PDFPluginBase*);
     virtual ~PDFPluginPasswordForm();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
@@ -40,6 +40,8 @@ OBJC_CLASS PDFAnnotationTextWidget;
 namespace WebKit {
 
 class PDFPluginTextAnnotation : public PDFPluginAnnotation {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPluginTextAnnotation);
 public:
     static Ref<PDFPluginTextAnnotation> create(PDFAnnotation *, PDFPluginBase*);
     virtual ~PDFPluginTextAnnotation();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp
@@ -50,7 +50,7 @@ WebColorChooser::~WebColorChooser()
     if (!m_page)
         return;
 
-    m_page->setActiveColorChooser(0);
+    m_page->setActiveColorChooser(nullptr);
 }
 
 void WebColorChooser::didChooseColor(const Color& color)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
@@ -63,7 +63,7 @@ public:
     void endChooser() override;
 
 private:
-    WebCore::ColorChooserClient* m_colorChooserClient;
+    CheckedPtr<WebCore::ColorChooserClient> m_colorChooserClient;
     WeakPtr<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
@@ -56,7 +56,7 @@ WebPage* WebPopupMenu::page()
 
 void WebPopupMenu::disconnectClient()
 {
-    m_popupClient = 0;
+    m_popupClient = nullptr;
 }
 
 void WebPopupMenu::didChangeSelectedIndex(int newIndex)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -48,7 +48,7 @@ public:
     void didChangeSelectedIndex(int newIndex);
     void setTextForIndex(int newIndex);
 #if PLATFORM(GTK)
-    WebCore::PopupMenuClient* client() const { return m_popupClient; }
+    WebCore::PopupMenuClient* client() const { return m_popupClient.get(); }
 #endif
 
     void show(const WebCore::IntRect&, WebCore::LocalFrameView&, int selectedIndex) override;
@@ -62,7 +62,7 @@ private:
     Vector<WebPopupItem> populateItems();
     void setUpPlatformData(const WebCore::IntRect& pageCoordinates, PlatformPopupMenuData&);
 
-    WebCore::PopupMenuClient* m_popupClient;
+    CheckedPtr<WebCore::PopupMenuClient> m_popupClient;
     WeakPtr<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -116,7 +116,7 @@ private:
 #endif
 
     WeakPtr<WebPage> m_webPage;
-    WebCore::PageOverlay* m_findPageOverlay { nullptr };
+    WeakPtr<WebCore::PageOverlay> m_findPageOverlay;
 
     // Whether the UI process is showing the find indicator. Note that this can be true even if
     // the find indicator isn't showing, but it will never be false when it is showing.

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -283,7 +283,7 @@ private:
 
     LayerProperties m_properties;
     WebCore::PlatformCALayerList m_children;
-    PlatformCALayerRemote* m_superlayer { nullptr };
+    WeakPtr<PlatformCALayerRemote> m_superlayer;
     HashMap<String, RefPtr<WebCore::PlatformCAAnimation>> m_animations;
 
     bool m_acceleratesDrawing { false };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -371,7 +371,7 @@ void PlatformCALayerRemote::copyContentsFromLayer(PlatformCALayer* layer)
 
 PlatformCALayer* PlatformCALayerRemote::superlayer() const
 {
-    return m_superlayer;
+    return m_superlayer.get();
 }
 
 void PlatformCALayerRemote::removeFromSuperlayer()
@@ -398,7 +398,7 @@ void PlatformCALayerRemote::setSublayers(const PlatformCALayerList& list)
 
     for (const auto& layer : list) {
         layer->removeFromSuperlayer();
-        downcast<PlatformCALayerRemote>(*layer).m_superlayer = this;
+        downcast<PlatformCALayerRemote>(*layer).m_superlayer = *this;
     }
 
     m_properties.notePropertiesChanged(LayerChange::ChildrenChanged);
@@ -419,7 +419,7 @@ void PlatformCALayerRemote::appendSublayer(PlatformCALayer& layer)
 
     layer.removeFromSuperlayer();
     m_children.append(&layer);
-    downcast<PlatformCALayerRemote>(layer).m_superlayer = this;
+    downcast<PlatformCALayerRemote>(layer).m_superlayer = *this;
     m_properties.notePropertiesChanged(LayerChange::ChildrenChanged);
 }
 
@@ -429,7 +429,7 @@ void PlatformCALayerRemote::insertSublayer(PlatformCALayer& layer, size_t index)
 
     layer.removeFromSuperlayer();
     m_children.insert(index, &layer);
-    downcast<PlatformCALayerRemote>(layer).m_superlayer = this;
+    downcast<PlatformCALayerRemote>(layer).m_superlayer = *this;
     m_properties.notePropertiesChanged(LayerChange::ChildrenChanged);
 }
 
@@ -443,7 +443,7 @@ void PlatformCALayerRemote::replaceSublayer(PlatformCALayer& reference, Platform
     if (referenceIndex != notFound) {
         m_children[referenceIndex]->removeFromSuperlayer();
         m_children.insert(referenceIndex, &layer);
-        downcast<PlatformCALayerRemote>(layer).m_superlayer = this;
+        downcast<PlatformCALayerRemote>(layer).m_superlayer = *this;
     }
 
     m_properties.notePropertiesChanged(LayerChange::ChildrenChanged);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -129,7 +129,7 @@ private:
 
     WebCore::LayerPool m_layerPool;
 
-    RemoteLayerTreeTransaction* m_currentTransaction { nullptr };
+    CheckedPtr<RemoteLayerTreeTransaction> m_currentTransaction;
 
     bool m_nextRenderingUpdateRequiresSynchronousImageDecoding { false };
     bool m_useDynamicContentScalingDisplayListsForDOMRendering { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3443,11 +3443,11 @@ public:
 
     ~CurrentEvent()
     {
-        g_currentEvent = m_previousCurrentEvent;
+        g_currentEvent = m_previousCurrentEvent.get();
     }
 
 private:
-    const WebEvent* m_previousCurrentEvent;
+    CheckedPtr<const WebEvent> m_previousCurrentEvent;
 };
 
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -103,11 +103,13 @@ private:
 
     PlaybackSessionInterfaceContext(PlaybackSessionManager&, PlaybackSessionContextIdentifier);
 
-    PlaybackSessionManager* m_manager;
+    CheckedPtr<PlaybackSessionManager> m_manager;
     PlaybackSessionContextIdentifier m_contextId;
 };
 
-class PlaybackSessionManager : public RefCounted<PlaybackSessionManager>, private IPC::MessageReceiver {
+class PlaybackSessionManager : public RefCounted<PlaybackSessionManager>, private IPC::MessageReceiver, public CanMakeCheckedPtr<PlaybackSessionManager> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionManager);
 public:
     static Ref<PlaybackSessionManager> create(WebPage&);
     virtual ~PlaybackSessionManager();

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -56,7 +56,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionInterfaceContext);
 
 PlaybackSessionInterfaceContext::PlaybackSessionInterfaceContext(PlaybackSessionManager& manager, PlaybackSessionContextIdentifier contextId)
-    : m_manager(&manager)
+    : m_manager(manager)
     , m_contextId(contextId)
 {
 }
@@ -67,104 +67,104 @@ PlaybackSessionInterfaceContext::~PlaybackSessionInterfaceContext()
 
 void PlaybackSessionInterfaceContext::durationChanged(double duration)
 {
-    if (m_manager)
-        m_manager->durationChanged(m_contextId, duration);
+    if (RefPtr manager = m_manager.get())
+        manager->durationChanged(m_contextId, duration);
 }
 
 void PlaybackSessionInterfaceContext::currentTimeChanged(double currentTime, double anchorTime)
 {
-    if (m_manager)
-        m_manager->currentTimeChanged(m_contextId, currentTime, anchorTime);
+    if (RefPtr manager = m_manager.get())
+        manager->currentTimeChanged(m_contextId, currentTime, anchorTime);
 }
 
 void PlaybackSessionInterfaceContext::bufferedTimeChanged(double bufferedTime)
 {
-    if (m_manager)
-        m_manager->bufferedTimeChanged(m_contextId, bufferedTime);
+    if (RefPtr manager = m_manager.get())
+        manager->bufferedTimeChanged(m_contextId, bufferedTime);
 }
 
 void PlaybackSessionInterfaceContext::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
 {
-    if (m_manager)
-        m_manager->rateChanged(m_contextId, playbackState, playbackRate, defaultPlaybackRate);
+    if (RefPtr manager = m_manager.get())
+        manager->rateChanged(m_contextId, playbackState, playbackRate, defaultPlaybackRate);
 }
 
 void PlaybackSessionInterfaceContext::playbackStartedTimeChanged(double playbackStartedTime)
 {
-    if (m_manager)
-        m_manager->playbackStartedTimeChanged(m_contextId, playbackStartedTime);
+    if (RefPtr manager = m_manager.get())
+        manager->playbackStartedTimeChanged(m_contextId, playbackStartedTime);
 }
 
 void PlaybackSessionInterfaceContext::seekableRangesChanged(const WebCore::TimeRanges& ranges, double lastModifiedTime, double liveUpdateInterval)
 {
-    if (m_manager)
-        m_manager->seekableRangesChanged(m_contextId, ranges, lastModifiedTime, liveUpdateInterval);
+    if (RefPtr manager = m_manager.get())
+        manager->seekableRangesChanged(m_contextId, ranges, lastModifiedTime, liveUpdateInterval);
 }
 
 void PlaybackSessionInterfaceContext::canPlayFastReverseChanged(bool value)
 {
-    if (m_manager)
-        m_manager->canPlayFastReverseChanged(m_contextId, value);
+    if (RefPtr manager = m_manager.get())
+        manager->canPlayFastReverseChanged(m_contextId, value);
 }
 
 void PlaybackSessionInterfaceContext::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
 {
-    if (m_manager)
-        m_manager->audioMediaSelectionOptionsChanged(m_contextId, options, selectedIndex);
+    if (RefPtr manager = m_manager.get())
+        manager->audioMediaSelectionOptionsChanged(m_contextId, options, selectedIndex);
 }
 
 void PlaybackSessionInterfaceContext::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex)
 {
-    if (m_manager)
-        m_manager->legibleMediaSelectionOptionsChanged(m_contextId, options, selectedIndex);
+    if (RefPtr manager = m_manager.get())
+        manager->legibleMediaSelectionOptionsChanged(m_contextId, options, selectedIndex);
 }
 
 void PlaybackSessionInterfaceContext::audioMediaSelectionIndexChanged(uint64_t selectedIndex)
 {
-    if (m_manager)
-        m_manager->audioMediaSelectionIndexChanged(m_contextId, selectedIndex);
+    if (RefPtr manager = m_manager.get())
+        manager->audioMediaSelectionIndexChanged(m_contextId, selectedIndex);
 }
 
 void PlaybackSessionInterfaceContext::legibleMediaSelectionIndexChanged(uint64_t selectedIndex)
 {
-    if (m_manager)
-        m_manager->legibleMediaSelectionIndexChanged(m_contextId, selectedIndex);
+    if (RefPtr manager = m_manager.get())
+        manager->legibleMediaSelectionIndexChanged(m_contextId, selectedIndex);
 }
 
 void PlaybackSessionInterfaceContext::externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType type, const String& localizedDeviceName)
 {
-    if (m_manager)
-        m_manager->externalPlaybackChanged(m_contextId, enabled, type, localizedDeviceName);
+    if (RefPtr manager = m_manager.get())
+        manager->externalPlaybackChanged(m_contextId, enabled, type, localizedDeviceName);
 }
 
 void PlaybackSessionInterfaceContext::wirelessVideoPlaybackDisabledChanged(bool disabled)
 {
-    if (m_manager)
-        m_manager->wirelessVideoPlaybackDisabledChanged(m_contextId, disabled);
+    if (RefPtr manager = m_manager.get())
+        manager->wirelessVideoPlaybackDisabledChanged(m_contextId, disabled);
 }
 
 void PlaybackSessionInterfaceContext::mutedChanged(bool muted)
 {
-    if (m_manager)
-        m_manager->mutedChanged(m_contextId, muted);
+    if (RefPtr manager = m_manager.get())
+        manager->mutedChanged(m_contextId, muted);
 }
 
 void PlaybackSessionInterfaceContext::isPictureInPictureSupportedChanged(bool supported)
 {
-    if (m_manager)
-        m_manager->isPictureInPictureSupportedChanged(m_contextId, supported);
+    if (RefPtr manager = m_manager.get())
+        manager->isPictureInPictureSupportedChanged(m_contextId, supported);
 }
 
 void PlaybackSessionInterfaceContext::volumeChanged(double volume)
 {
-    if (m_manager)
-        m_manager->volumeChanged(m_contextId, volume);
+    if (RefPtr manager = m_manager.get())
+        manager->volumeChanged(m_contextId, volume);
 }
 
 void PlaybackSessionInterfaceContext::isInWindowFullscreenActiveChanged(bool isInWindow)
 {
-    if (m_manager)
-        m_manager->isInWindowFullscreenActiveChanged(m_contextId, isInWindow);
+    if (RefPtr manager = m_manager.get())
+        manager->isInWindowFullscreenActiveChanged(m_contextId, isInWindow);
 }
 
 #pragma mark - PlaybackSessionManager

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -87,7 +87,7 @@ private:
     String m_pushPartition;
 
     RetainPtr<xpc_connection_t> m_connection;
-    const char* m_serviceName;
+    ASCIILiteral m_serviceName;
 };
 
 } // namespace WebPushTool

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -69,9 +69,9 @@ Connection::Connection(PreferTestService preferTestService, String bundleIdentif
     , m_pushPartition(pushPartition)
 {
     if (preferTestService == PreferTestService::Yes)
-        m_serviceName = "org.webkit.webpushtestdaemon.service";
+        m_serviceName = "org.webkit.webpushtestdaemon.service"_s;
     else
-        m_serviceName = "com.apple.webkit.webpushd.service";
+        m_serviceName = "com.apple.webkit.webpushd.service"_s;
 }
 
 void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
@@ -91,7 +91,7 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
     if (waitForServiceToExist == WaitForServiceToExist::Yes) {
         auto result = maybeConnectToService(m_serviceName);
         if (result == MACH_PORT_NULL)
-            printf("Waiting for service '%s' to be available\n", m_serviceName);
+            printf("Waiting for service '%s' to be available\n", m_serviceName.characters());
 
         while (result == MACH_PORT_NULL) {
             usleep(1000);
@@ -99,7 +99,7 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
         }
     }
 
-    printf("Connecting to service '%s'\n", m_serviceName);
+    printf("Connecting to service '%s'\n", m_serviceName.characters());
     xpc_connection_activate(m_connection.get());
 
     sendAuditToken();


### PR DESCRIPTION
#### 759113c082b47e2a55e7285cd71cfa50876e617d
<pre>
Use fewer raw pointers for data members in WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279037">https://bugs.webkit.org/show_bug.cgi?id=279037</a>

Reviewed by Darin Adler.

* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/platform/ColorChooserClient.h:
* Source/WebCore/platform/PopupMenuClient.h:
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp:
(WebKit::WebInspectorClient::WebInspectorClient):
(WebKit::WebInspectorClient::highlight):
(WebKit::WebInspectorClient::hideHighlight):
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::establishConnection):
(WebKit::WebInspectorUI::windowObjectCleared):
(WebKit::WebInspectorUI::moveWindowBy):
(WebKit::WebInspectorUI::userInterfaceLayoutDirection const):
(WebKit::WebInspectorUI::supportsDiagnosticLogging):
(WebKit::WebInspectorUI::logDiagnosticEvent):
(WebKit::WebInspectorUI::frontendPage):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::streamLoader):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp:
(WebKit::WebColorChooser::~WebColorChooser):
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp:
(WebKit::WebPopupMenu::disconnectClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
(WebKit::WebPopupMenu::client const):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::updateFindUIAfterPageScroll):
(WebKit::FindController::hideFindUI):
(WebKit::FindController::willMoveToPage):
(WebKit::FindController::didInvalidateFindRects):
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::superlayer const):
(WebKit::PlatformCALayerRemote::setSublayers):
(WebKit::PlatformCALayerRemote::appendSublayer):
(WebKit::PlatformCALayerRemote::insertSublayer):
(WebKit::PlatformCALayerRemote::replaceSublayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::CurrentEvent::~CurrentEvent):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionInterfaceContext::PlaybackSessionInterfaceContext):
(WebKit::PlaybackSessionInterfaceContext::durationChanged):
(WebKit::PlaybackSessionInterfaceContext::currentTimeChanged):
(WebKit::PlaybackSessionInterfaceContext::bufferedTimeChanged):
(WebKit::PlaybackSessionInterfaceContext::rateChanged):
(WebKit::PlaybackSessionInterfaceContext::playbackStartedTimeChanged):
(WebKit::PlaybackSessionInterfaceContext::seekableRangesChanged):
(WebKit::PlaybackSessionInterfaceContext::canPlayFastReverseChanged):
(WebKit::PlaybackSessionInterfaceContext::audioMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionInterfaceContext::legibleMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionInterfaceContext::audioMediaSelectionIndexChanged):
(WebKit::PlaybackSessionInterfaceContext::legibleMediaSelectionIndexChanged):
(WebKit::PlaybackSessionInterfaceContext::externalPlaybackChanged):
(WebKit::PlaybackSessionInterfaceContext::wirelessVideoPlaybackDisabledChanged):
(WebKit::PlaybackSessionInterfaceContext::mutedChanged):
(WebKit::PlaybackSessionInterfaceContext::isPictureInPictureSupportedChanged):
(WebKit::PlaybackSessionInterfaceContext::volumeChanged):
(WebKit::PlaybackSessionInterfaceContext::isInWindowFullscreenActiveChanged):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::Connection):
(WebPushTool::Connection::connectToService):

Canonical link: <a href="https://commits.webkit.org/283091@main">https://commits.webkit.org/283091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1df33349a10235a3efed039993566e1c42ec02eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52341 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10899 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14632 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59727 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIRuntime.ConnectFromContentScriptWithImmediateMessage (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9102 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13588 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59672 "Found 1 new test failure: webanimations/accelerated-animation-easing-update-steps-after-pause.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56457 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59954 "Found 1 new API test failure: /WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1199 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9884 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40329 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->