### PR TITLE
REGRESSION(279868@main) Alaska Airlines sign in popup loads behind the website's search field.

### DIFF
--- a/LayoutTests/compositing/shared-backing/multiple-backing-sharing-providers-expected.html
+++ b/LayoutTests/compositing/shared-backing/multiple-backing-sharing-providers-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div style="width: 200px; height: 250px; background: green"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/shared-backing/multiple-backing-sharing-providers.html
+++ b/LayoutTests/compositing/shared-backing/multiple-backing-sharing-providers.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Multiple backing store providers, checks that overlap test is checked before adding to the back one.</title>
+  <style type="text/css">
+    div {
+      width: 200px;
+      height: 200px;
+      position: relative;
+    }
+
+    /* Composited layer behind to force the rest to composite due to overlap */
+    .composited {
+      position: fixed;
+      background-color: orange;
+      transform: translateZ(0px);
+      height: 250px;
+    }
+
+    /* Composited, but not stacking. Backing store provider. */
+    .provider {
+      background-color: green;
+    }
+    .second {
+      height: 50px;
+      background-color: red;
+    }
+
+    /* Child of first provider, but can't share due to overlapping second provider */
+    .target {
+      background-color: green;
+      top: 50px;
+      z-index: 5;
+    }
+  </style>
+</head>
+<body>
+<div class="composited"></div>
+<div class="provider">
+  <div class="target"></div>
+</div>
+<div class="provider second"></div>
+
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/event-region-scale-transform-shared-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/event-region-scale-transform-shared-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 3
+      (children 4
         (GraphicsLayer
           (position 8.00 508.00)
           (bounds 50.00 50.00)
@@ -40,12 +40,21 @@
         )
         (GraphicsLayer
           (position 30.00 30.00)
-          (bounds 201.00 201.00)
+          (bounds 12.00 12.00)
           (drawsContent 1)
           (event region
             (rect (0,0) width=12 height=12)
-            (rect (51,51) width=100 height=100)
-            (rect (151,151) width=50 height=50)
+          )
+        )
+        (GraphicsLayer
+          (position 81.00 81.00)
+          (anchor 0.00 0.00)
+          (bounds 300.00 300.00)
+          (drawsContent 1)
+          (transform [0.50 0.00 0.00 0.00] [0.00 0.50 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+          (event region
+            (rect (0,0) width=200 height=200)
+            (rect (200,200) width=100 height=100)
           )
         )
       )

--- a/LayoutTests/fast/scrolling/ios/event-region-translate-transform-shared-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/event-region-translate-transform-shared-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 3
+      (children 4
         (GraphicsLayer
           (position 8.00 508.00)
           (bounds 50.00 50.00)
@@ -40,12 +40,21 @@
         )
         (GraphicsLayer
           (position 30.00 30.00)
-          (bounds 451.00 451.00)
+          (bounds 12.00 12.00)
           (drawsContent 1)
           (event region
             (rect (0,0) width=12 height=12)
-            (rect (151,151) width=200 height=200)
-            (rect (351,351) width=100 height=100)
+          )
+        )
+        (GraphicsLayer
+          (position 81.00 81.00)
+          (anchor 0.00 0.00)
+          (bounds 300.00 300.00)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 100.00 0.00 1.00])
+          (event region
+            (rect (0,0) width=200 height=200)
+            (rect (200,200) width=100 height=100)
           )
         )
       )

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -79,6 +79,7 @@
 #include "WillChangeData.h"
 #include <wtf/HexNumber.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/ObjectIdentifier.h>
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
@@ -284,11 +285,22 @@ struct RenderLayerCompositor::UpdateBackingTraversalState {
        with the last scroller. This is not currently supported.
 
     3. Nested scrollers:
-       Similar to overlapping scrollrs, we have to ensure that we add to the right provider (looking a scrolling scope),
+       Similar to overlapping scrollers, we have to ensure that we add to the right provider (looking a scrolling scope),
        and don't break overlap with the nested scroller. This is not currently supported.
+
+    We also track additional backing sharing providers that aren't clipped scrollers. These cannot be added to, since that could expand the bounds of the resulting layer.
+    They are tracked so we can check them for overlap, and continue to add to the scroller backing sharing providers if the new content doesn't overlap.
 
     To debug sharing behavior, enable the "Compositing" log channel and look for the P/p in the hierarchy output.
  */
+
+enum class BackingSharingSequenceIdentifierType { };
+using BackingSharingSequenceIdentifier = ObjectIdentifier<BackingSharingSequenceIdentifierType>;
+
+struct RenderLayerCompositor::BackingSharingSnapshot {
+    BackingSharingSequenceIdentifier sequenceIdentifier;
+    size_t providerCount { 0 };
+};
 
 class RenderLayerCompositor::BackingSharingState {
     WTF_MAKE_NONCOPYABLE(BackingSharingState);
@@ -323,12 +335,18 @@ public:
         m_layersPendingRepaint.add(layer);
     }
 
-    void addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const BackingSharingSnapshot&);
+    void addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const std::optional<BackingSharingSnapshot>&);
     bool isAdditionalProviderCandidate(RenderLayer&, LayoutRect candidateAbsoluteBounds, RenderLayer* stackingContextAncestor) const;
     void startBackingSharingSequence(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext);
     void endBackingSharingSequence(RenderLayer&);
 
-    BackingSharingSnapshot snapshot() const { return { m_backingSharingStackingContext, m_backingProviderCandidates.size() }; }
+    std::optional<BackingSharingSnapshot> snapshot() const
+    {
+        if (!m_backingSharingStackingContext)
+            return std::nullopt;
+        return BackingSharingSnapshot { m_sequenceIdentifier, m_backingProviderCandidates.size() };
+    }
+    BackingSharingSequenceIdentifier sequenceIdentifier() const { return m_sequenceIdentifier; }
 
 private:
     void layerWillBeComposited(RenderLayer&);
@@ -337,6 +355,7 @@ private:
 
     Vector<Provider> m_backingProviderCandidates;
     RenderLayer* m_backingSharingStackingContext { nullptr };
+    BackingSharingSequenceIdentifier m_sequenceIdentifier { BackingSharingSequenceIdentifier::generate() };
     SingleThreadWeakHashSet<RenderLayer> m_layersPendingRepaint;
     bool m_allowOverlappingProviders { false };
 };
@@ -351,7 +370,7 @@ void RenderLayerCompositor::BackingSharingState::startBackingSharingSequence(Ren
     m_backingSharingStackingContext = &candidateStackingContext;
 }
 
-void RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const BackingSharingSnapshot& backingSharingSnapshot)
+void RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const std::optional<BackingSharingSnapshot>& backingSharingSnapshot)
 {
     ASSERT_UNUSED(candidateStackingContext, m_backingSharingStackingContext == &candidateStackingContext);
     ASSERT(!m_backingProviderCandidates.containsIf([&](auto& candidate) { return candidate.providerLayer == &candidateLayer; }));
@@ -359,13 +378,13 @@ void RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate(Rend
     // Inserts candidateLayer into the provider list in z-order, using the state snapshot that
     // was taken before any descendant layers were traversed.
 
-    if (m_backingSharingStackingContext != backingSharingSnapshot.backingSharingStackingContext) {
+    if (!backingSharingSnapshot || m_sequenceIdentifier != backingSharingSnapshot->sequenceIdentifier) {
         // If a new sharing sequence has been started since the snapshot was taken, then this candidate
-        // will be before any of the current ones in z-order.
+        // will be before any of the current ones in z-order (which must have been added by descendants of this layer).
         m_backingProviderCandidates.insert(0, { &candidateLayer, { }, candidateAbsoluteBounds });
     } else
         // Otherwise insert it at the position captured in the snapshot
-        m_backingProviderCandidates.insert(backingSharingSnapshot.providerCount, { &candidateLayer, { }, candidateAbsoluteBounds });
+        m_backingProviderCandidates.insert(backingSharingSnapshot->providerCount, { &candidateLayer, { }, candidateAbsoluteBounds });
 }
 
 void RenderLayerCompositor::BackingSharingState::endBackingSharingSequence(RenderLayer& endLayer)
@@ -379,6 +398,7 @@ void RenderLayerCompositor::BackingSharingState::endBackingSharingSequence(Rende
         candidate.providerLayer->backing()->setBackingSharingLayers(WTFMove(candidate.sharingLayers));
     }
     m_backingSharingStackingContext = nullptr;
+    m_sequenceIdentifier = BackingSharingSequenceIdentifier::generate();
 
     issuePendingRepaints();
 }
@@ -425,6 +445,12 @@ auto RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLaye
         return nullptr;
 
     auto& candidate = m_backingProviderCandidates[candidateIndex];
+
+    // Only allow adding to providers that clip their descendants, unless there's only a single provider.
+    // Unclipped providers in-front are tracked for overlap testing only.
+    // FIXME: We could accumulate the union of the overlap bounds for a provider and its sharing layers to avoid this restriction.
+    if (m_backingProviderCandidates.size() > 1 && !candidate.providerLayer->canUseCompositedScrolling())
+        return nullptr;
 
     if (candidateIndex == m_backingProviderCandidates.size() - 1) {
         // No other provider is in front of the candidate, so no need to check for overlap.
@@ -501,6 +527,9 @@ bool RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate(R
         }
         return true;
     }
+
+    if (!m_backingProviderCandidates[0].providerLayer->canUseCompositedScrolling())
+        return false;
 
     if (m_backingProviderCandidates.size() >= 10)
         return false;
@@ -1266,7 +1295,6 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     }
 
     auto backingSharingSnapshot = updateBackingSharingBeforeDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, willBeComposited, compositingState.stackingContextAncestor);
-    auto preDescendantProviderStartLayer = backingSharingState.firstProviderCandidateLayer();
 
 #if ASSERT_ENABLED
     LayerListMutationDetector mutationChecker(layer);
@@ -1389,7 +1417,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     // Compute state passed to the caller.
     descendantHas3DTransform |= anyDescendantHas3DTransform || layer.has3DTransform();
     compositingState.updateWithDescendantStateAndLayer(currentState, layer, ancestorLayer, layerExtent);
-    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, preDescendantProviderStartLayer, compositingState.stackingContextAncestor, backingSharingSnapshot);
+    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, compositingState.stackingContextAncestor, backingSharingSnapshot);
 
     bool layerContributesToOverlap = (currentState.compositingAncestor && !currentState.compositingAncestor->isRenderViewLayer()) || currentState.backingSharingAncestor;
     updateOverlapMap(overlapMap, layer, layerExtent, didPushOverlapContainer, layerContributesToOverlap, becameCompositedAfterDescendantTraversal && !descendantsAddedToOverlap);
@@ -1468,7 +1496,6 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
     }
 
     auto backingSharingSnapshot = updateBackingSharingBeforeDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, layerIsComposited, compositingState.stackingContextAncestor);
-    auto preDescendantProviderStartLayer = backingSharingState.firstProviderCandidateLayer();
 
 #if ASSERT_ENABLED
     LayerListMutationDetector mutationChecker(layer);
@@ -1496,7 +1523,7 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
 
     ASSERT(!currentState.fullPaintOrderTraversalRequired);
     compositingState.updateWithDescendantStateAndLayer(currentState, layer, ancestorLayer, layerExtent, true);
-    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, preDescendantProviderStartLayer, compositingState.stackingContextAncestor, backingSharingSnapshot);
+    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, compositingState.stackingContextAncestor, backingSharingSnapshot);
 
     bool layerContributesToOverlap = (currentState.compositingAncestor && !currentState.compositingAncestor->isRenderViewLayer()) || currentState.backingSharingAncestor;
     updateOverlapMap(overlapMap, layer, layerExtent, didPushOverlapContainer, layerContributesToOverlap);
@@ -1697,7 +1724,7 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
     layer.clearUpdateBackingOrHierarchyTraversalState();
 }
 
-RenderLayerCompositor::BackingSharingSnapshot RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, bool willBeComposited, RenderLayer* stackingContextAncestor)
+std::optional<RenderLayerCompositor::BackingSharingSnapshot> RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, bool willBeComposited, RenderLayer* stackingContextAncestor)
 {
     UNUSED_PARAM(depth);
 
@@ -1726,7 +1753,7 @@ RenderLayerCompositor::BackingSharingSnapshot RenderLayerCompositor::updateBacki
     return sharingState.snapshot();
 }
 
-void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, const RenderLayer* preDescendantProviderStartLayer, RenderLayer*  stackingContextAncestor, const BackingSharingSnapshot& backingSharingSnapshot)
+void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, RenderLayer* stackingContextAncestor, const std::optional<BackingSharingSnapshot>& backingSharingSnapshot)
 {
     UNUSED_PARAM(depth);
     LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << &layer << " updateBackingSharingAfterDescendantTraversal for layer - is composited " << layer.isComposited() << " has composited descendant " << layer.hasCompositingDescendant());
@@ -1776,7 +1803,8 @@ void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(Backing
     layer.backing()->clearBackingSharingLayers();
     LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << " - is composited; maybe ending existing backing sequence with candidates " << sharingState.backingProviderCandidates() << " stacking context " << sharingState.backingSharingStackingContext());
 
-    if (preDescendantProviderStartLayer && preDescendantProviderStartLayer == sharingState.firstProviderCandidateLayer())
+    // A layer that composites resets backing-sharing, since subsequent layers need to composite to overlap it. If a descendant didn't already end the sharing sequence that was current when processing of this layer started, end it now.
+    if (backingSharingSnapshot && backingSharingSnapshot->sequenceIdentifier == sharingState.sequenceIdentifier())
         sharingState.endBackingSharingSequence(layer);
 }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -446,13 +446,10 @@ private:
     void updateOverlapMap(LayerOverlapMap&, const RenderLayer&, OverlapExtent&, bool didPushContainer, bool addLayerToOverlap, bool addDescendantsToOverlap = false) const;
     bool layerOverlaps(const LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
 
-    struct BackingSharingSnapshot {
-        RenderLayer* backingSharingStackingContext;
-        size_t providerCount;
-    };
+    struct BackingSharingSnapshot;
 
-    BackingSharingSnapshot updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
-    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor, const BackingSharingSnapshot&);
+    std::optional<BackingSharingSnapshot> updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
+    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, RenderLayer* stackingContextAncestor, const std::optional<BackingSharingSnapshot>&);
 
     void clearBackingProviderSequencesInStackingContextOfLayer(RenderLayer&);
 


### PR DESCRIPTION
#### 73e553cb35754cc9fea44929e20199de4fa0cb6b
<pre>
REGRESSION(279868@main) Alaska Airlines sign in popup loads behind the website&apos;s search field.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279036">https://bugs.webkit.org/show_bug.cgi?id=279036</a>
&lt;<a href="https://rdar.apple.com/134911588">rdar://134911588</a>&gt;

Reviewed by Simon Fraser.

This webpage had multiple backing store providers, and content was incorrectly
added to the back one, despite overlapping the front one.

The overlap test uses the bounds of the provider, not the to-be-added layer to
check if it overlaps, and the providers themselves didn&apos;t overlap.

This restricts multiple backing store providers to only be used when they&apos;re
clipped (as was previously the case), so we can be sure the added layer doesn&apos;t
extend beyond the bounds of the provider. This shouldn&apos;t break the performance
improvement, since we still allow other composited layers to be added infront.

It does mean in some cases we keep the scroll clipped backing store provider
open, and prevent accumulating sharing layers into a further forward unclipped
backing provider. I think given the support for multiple open clipped providers,
this is a good tradeoff.

Ideally, we&apos;d allow accumulating bounds and adding to any provider, but that
seems like a riskier change, as we have to account for scrolling.

This also does a bit of cleanup, unifying the BackingSharingSnapshot and
preDescendantProviderStartLayer using a generation counter. It also adds a few
more comments, as I found the logic of why we end backing sharing sequences to
be hard to follow.

* LayoutTests/compositing/shared-backing/multiple-backing-sharing-providers-expected.html: Added.
* LayoutTests/compositing/shared-backing/multiple-backing-sharing-providers.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::snapshot const):
(WebCore::RenderLayerCompositor::BackingSharingState::generation const):
(WebCore::RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate):
(WebCore::RenderLayerCompositor::BackingSharingState::endBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::traverseUnchangedSubtree):
(WebCore::RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal):
(WebCore::RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/283515@main">https://commits.webkit.org/283515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e1f5d10a73f9e15192b1ebc2e976447318ec0fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17436 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38949 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16030 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72279 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/10500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/10532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14686 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->