### PR TITLE
Transitioning Unregistered Custom Properties cause a transition loop

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete-expected.txt
@@ -1,0 +1,3 @@
+
+PASS It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+<meta charset=utf-8>
+<title>CSS Transitions Test: transition of a custom property with "transition-behavior: allows-discrete"</title>
+<meta name="assert" content="Checks that transitioning a custom property with 'transition-behavior: allows-discrete' works as expected">
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#transition-behavior-property">
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<script src="./support/helper.js" type="text/javascript"></script>
+<style>
+  .target {
+    transition: --foo 10s step-start;
+    transition-behavior: allow-discrete;
+    --foo: bar;
+  }
+</style>
+</head>
+<body>
+<div id="log"></div>
+<script>
+promise_test(async t => {
+  const div = addDiv(t, { class: 'target' });
+
+  let transitionCount = 0;
+  div.addEventListener("transitionstart", () => transitionCount++);
+
+  // Wait one frame and set the custom property to trigger a transition.
+  await waitForFrame();
+  div.style.setProperty('--foo', 'baz');
+
+  // Wait two more frames to allow that transition to start and to ensure
+  // only a single transition was started.
+  await waitForFrame();
+  await waitForFrame();
+
+  assert_equals(transitionCount, 1, 'A single "transitionstart" event was dispatched');
+}, 'It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete"');
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4643,15 +4643,9 @@ bool CSSPropertyAnimation::propertiesEqual(const AnimatableCSSProperty& property
             return true;
         }, [&] (const AtomString& customProperty) {
             auto [aCustomPropertyValue, bCustomPropertyValue] = customPropertyValuesForBlending(customProperty, a, b);
-            if (!aCustomPropertyValue && !bCustomPropertyValue)
-                return true;
-            if (!aCustomPropertyValue || !bCustomPropertyValue)
-                return false;
-            if (std::holds_alternative<CSSCustomPropertyValue::SyntaxValueList>(aCustomPropertyValue->value()) && std::holds_alternative<CSSCustomPropertyValue::SyntaxValueList>(bCustomPropertyValue->value()))
+            if (aCustomPropertyValue && bCustomPropertyValue)
                 return aCustomPropertyValue->equals(*bCustomPropertyValue);
-            if (std::holds_alternative<CSSCustomPropertyValue::SyntaxValue>(aCustomPropertyValue->value()) && std::holds_alternative<CSSCustomPropertyValue::SyntaxValue>(bCustomPropertyValue->value()))
-                return aCustomPropertyValue->equals(*bCustomPropertyValue);
-            return false;
+            return !aCustomPropertyValue && !bCustomPropertyValue;
         }
     );
 }


### PR DESCRIPTION
#### 7f45cbdcfbf577be7af7983df00fb20a55d918d6
<pre>
Transitioning Unregistered Custom Properties cause a transition loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=279012">https://bugs.webkit.org/show_bug.cgi?id=279012</a>

Reviewed by Antti Koivisto.

There is no need to have special logic in `CSSPropertyAnimation::propertiesEqual()` to deal with the
various value variants held by `CSSCustomPropertyValue` since `CSSCustomPropertyValue::equals()`
already checks the two values have the same type and then performs the equality check. This will allow
variant types not previously explicitly tested by `CSSPropertyAnimation::propertiesEqual()` to be tested,
such as unregistered properties that have no explicit value type.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete.html: Added.
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimation::propertiesEqual):

Canonical link: <a href="https://commits.webkit.org/283099@main">https://commits.webkit.org/283099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c1d41117b601688f69da8a439f04ec9ae10083d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69234 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52386 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10944 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14693 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70939 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13634 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59715 "Found 4 new test failures: animations/additive-transform-animations.html compositing/animation/keyframe-order.html imported/blink/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-scale.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56505 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59988 "Found 16 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hypertext/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/action/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/hit-test, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/scroll-to, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/extents, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/iterator ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1243 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->