### PR TITLE
[css-transitions] update CSS Transitions WPT checkout to a8d8c61

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -6331,6 +6331,8 @@
         "web-platform-tests/css/css-transitions/crashtests/transition-large-word-spacing-001.html",
         "web-platform-tests/css/css-transitions/inherit-background-color-transition-ref.html",
         "web-platform-tests/css/css-transitions/no-transition-from-ua-to-blocking-stylesheet-ref.html",
+        "web-platform-tests/css/css-transitions/pseudo-element-transform-ref.html",
+        "web-platform-tests/css/css-transitions/reference/transition-test-ref.html",
         "web-platform-tests/css/css-transitions/render-blocking/no-transition-from-ua-to-blocking-stylesheet-ref.html",
         "web-platform-tests/css/css-transitions/root-color-transition-ref.html",
         "web-platform-tests/css/css-typed-om/rotate-by-added-angle-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+features:
+- name: starting-style
+  files:
+  - starting-style-*
+- name: transition-behavior
+  files:
+  - transition-behavior.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+features:
+- name: starting-style
+  files:
+  - starting-style-*
+- name: transition-behavior
+  files:
+  - transition-behavior.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<title>Reference for transition on pseudo-element</title>
+<link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content">
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background: rgb(255, 191, 0);
+}
+div::before {
+  content: "";
+  background: rgb(184, 115, 51);
+  width: 100px;
+  height: 100px;
+  transform: ScaleX(0.5);
+  display: block;
+  will-change: transform;
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<title>Reference for transition on pseudo-element</title>
+<link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content">
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background: rgb(255, 191, 0);
+}
+div::before {
+  content: "";
+  background: rgb(184, 115, 51);
+  width: 100px;
+  height: 100px;
+  transform: ScaleX(0.5);
+  display: block;
+  will-change: transform;
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Transition on pseudo-element</title>
+<link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content">
+<link rel="match" href="pseudo-element-transform-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background: rgb(255, 191, 0);
+}
+div::before {
+  content: "";
+  background: rgb(184, 115, 51);
+  width: 100px;
+  height: 100px;
+  transition-property: transform;
+  transition-duration: 10000s;
+  /* This timing-function has zero-slope at progress = 0.5 preventing drift */
+  transition-timing-function: cubic-bezier(0, 1, 1, 0);
+  transform: ScaleX(0);
+  /* Make the pseudo element "transformable" as per
+   * https://www.w3.org/TR/css-transforms-1/#transformable-element.
+   */
+  display: block;
+}
+
+div.animated::before {
+  transform: scaleX(1);
+}
+</style>
+<div></div>
+<script>
+// This is a regression test for crbug.com/40475833
+// Ported to WPT in an effort to prune browser-specific tests.
+window.onload = async () => {
+  requestAnimationFrame(() => {
+    const target = document.querySelector('div');
+    target.classList.add('animated');
+    const anim = document.getAnimations()[0];
+    anim.ready.then(() => {
+      const duration = anim.effect.getTiming().duration;
+      anim.currentTime = duration / 2;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(takeScreenshot);
+      });
+    });
+  });
+};
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/transition-test-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/transition-test-ref.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Transition Reference File</title>
+    <link rel="author" title="Oleg Janeiko" href="mailto:oleg@the-incredible.me">
+    <style type="text/css">
+        .container {
+            background-color: red;
+            height: 200px;
+            width: 200px;
+        }
+        .box {
+            width: 100px;
+            height: 100px;
+            background-color: green;
+
+            transition-property: width;
+            transition-duration: 0;
+        }
+        .box.transition {
+            width: 200px;
+            height: 200px;
+        }
+    </style>
+    <script type="text/javascript" charset="utf-8">
+        function ready(){
+            var box = document.querySelector('.box');
+            box.className = 'box transition';
+        }
+    </script>
+</head>
+<body onload="ready();">
+    <div>
+        <p>You should not see a red background during the transition. Note: if the test passes transition is instant.</p>
+    </div>
+    <div class="container">
+        <div class="box"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/transition-test-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
@@ -4,4 +4,5 @@ PASS @starting-style with higher specificity
 PASS Starting style does not inherit from parent starting style
 PASS Starting style inheriting from parent's after-change style
 PASS Starting style inheriting from parent's after-change style while parent transitioning
+FAIL Starting style inheriting from parent's after-change style while ancestor is transitioning assert_equals: Transition started from parent's after-change style color, inherited from ancestors after-change color expected "rgb(0, 192, 0)" but got "rgb(0, 160, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade.html
@@ -40,6 +40,16 @@
   @starting-style {
     #t5 > div { color: inherit; }
   }
+
+  #t6 { color: green; }
+  @starting-style {
+    #t6 { color: black; }
+  }
+  #t6 .color-transition { color: lime; }
+  @starting-style {
+    #t6 .color-transition { color: inherit; }
+  }
+
 </style>
 <div id="t1" hidden class="color-transition"></div>
 <div id="t2" hidden class="color-transition"></div>
@@ -51,6 +61,11 @@
 </div>
 <div id="t5" hidden class="color-transition">
   <div class="color-transition"></div>
+</div>
+<div id="t6" hidden class="color-transition">
+  <div>
+    <div class="color-transition"></div>
+  </div>
 </div>
 <script>
   setup(() => {
@@ -98,4 +113,16 @@
     assert_equals(getComputedStyle(t5.firstElementChild).color, "rgb(0, 192, 0)",
                   "Transition started from parent's after-change style color");
   }, "Starting style inheriting from parent's after-change style while parent transitioning");
+
+  promise_test(async t => {
+    t6.removeAttribute("hidden");
+    await waitForAnimationFrames(2);
+    assert_equals(getComputedStyle(t6).color, "rgb(0, 64, 0)",
+                  "Parent transition started");
+    assert_equals(getComputedStyle(t6.firstElementChild).color, "rgb(0, 64, 0)",
+                  "Inherited effect from parent transition");
+    assert_equals(getComputedStyle(t6.firstElementChild.firstElementChild).color, "rgb(0, 192, 0)",
+                  "Transition started from parent's after-change style color, inherited from ancestors after-change color");
+  }, "Starting style inheriting from parent's after-change style while ancestor is transitioning");
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container-expected.txt
@@ -1,3 +1,4 @@
 
 PASS Triggered transition from first style update based on up-to-date container query
+PASS Triggered transition from the display change inside the up-to-date container query
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container.html
@@ -1,36 +1,62 @@
 <!DOCTYPE html>
 <title>CSS Transitions Test: @starting-style inside size @container</title>
 <link rel="help" href="https://drafts.csswg.org/css-transitions-2/#defining-before-change-style-the-starting-style-rule">
-<link rel="help" href="https://drafts.csswg.org/css-contain-3/#animated-containers">
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#animated-containers">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-transitions/support/helper.js"></script>
-<div id="container" style="width: 200px">
-  <div id="target" style="display: none"></div>
-</div>
+<body>
+</body>
 <style>
   #container {
     container-type: inline-size;
+    width: 100px;
   }
   #target {
     transition-property: background-color;
     transition-duration: 100s;
     transition-timing-function: steps(2, start);
     background-color: lime;
+    display: none;
   }
   @container (width > 300px) {
     @starting-style {
       #target { background-color: white; }
     }
   }
-  @container (width < 300px) {
+  @container ((width > 200px) and (width < 300px)) {
+    #target {
+      display: block;
+    }
+    @starting-style {
+      #target { background-color: white; }
+    }
+  }
+  @container (width < 200px) {
     @starting-style {
       #target { background-color: red; }
     }
   }
 </style>
 <script>
+  function setup(test) {
+    let container = document.createElement("div");
+    container.id = "container";
+    document.body.appendChild(container);
+
+    let target = document.createElement("div");
+    target.id = "target";
+    container.appendChild(target);
+
+    test.add_cleanup(() => {
+      target.remove();
+      container.remove();
+    });
+    return [container, target];
+  }
+
   promise_test(async t => {
+    let [container, target] = setup(t);
     await waitForAnimationFrames(2);
     assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 255, 0)",
                   "No transition while display:none");
@@ -38,6 +64,21 @@
     target.style.display = "block";
     await waitForAnimationFrames(2);
     assert_equals(getComputedStyle(target).backgroundColor, "rgb(128, 255, 128)",
-                  "@starting-style based on the size query evaluation from the same frame");
-  }, "Triggered transition from first style update based on up-to-date container query");
+                  "@starting-style based on the size query evaluation from " +
+                  "the same frame");
+  }, "Triggered transition from first style update based on up-to-date " +
+     "container query");
+
+  promise_test(async t => {
+    let [container, target] = setup(t);
+    await waitForAnimationFrames(2);
+    assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 255, 0)",
+                  "No transition while display:none");
+    container.style.width = "250px";
+    await waitForAnimationFrames(2);
+    assert_equals(getComputedStyle(target).backgroundColor, "rgb(128, 255, 128)",
+                  "@starting-style based on the size query evaluation from " +
+                  "the same frame");
+  }, "Triggered transition from the display change inside the up-to-date " +
+     "container query");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget-expected.txt
@@ -1,0 +1,4 @@
+x
+
+PASS Retargeting a transition should cause the old transition to be cancelled
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>Retargeted CSS transition</title>
+<link rel="help" href="https://www.w3.org/TR/css-transitions-1/#starting">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="element">x</div>
+<style>
+    #element {
+        transition: transform 2000ms;
+        transition-timing-function: linear;
+    }
+</style>
+<script>
+promise_test(function(t) {
+    element.offsetTop; // Force recalc
+    element.style.transform = "rotateX(180deg)";
+    element.offsetTop; // Force recalc
+
+    assert_equals(element.getAnimations().length, 1, 'Transition creates an animation');
+    var animation = element.getAnimations()[0];
+
+    return animation.ready.then(function() {
+        assert_equals(element.getAnimations().length, 1, 'No new animations yet');
+        assert_equals(element.getAnimations()[0], animation);
+
+        element.style.transform = "rotateX(360deg)";
+        element.offsetTop; // Force recalc
+
+        assert_equals(element.getAnimations().length, 1, 'Retargeting transition results in only one animation');
+
+        var newAnimation = element.getAnimations()[0];
+        assert_not_equals(newAnimation, animation);
+    });
+}, 'Retargeting a transition should cause the old transition to be cancelled');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/w3c-import.log
@@ -19,6 +19,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-currentTime.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-effect.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-finished.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-ready.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-startTime.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-transitionProperty.tentative.html
@@ -30,6 +31,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-target.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/README.md
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/before-load-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-002.html
@@ -67,12 +69,16 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-elements-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-elements-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/retargetted-transition-with-box-sizing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/root-color-transition-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/root-color-transition-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/root-color-transition.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-of-transitions-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade.html
@@ -101,4 +107,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitionevent-interface.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/zero-duration-multiple-transition.html


### PR DESCRIPTION
#### 62c40ce48382bc4a2b21dca4ef4216c129884922
<pre>
[css-transitions] update CSS Transitions WPT checkout to a8d8c61
<a href="https://bugs.webkit.org/show_bug.cgi?id=279058">https://bugs.webkit.org/show_bug.cgi?id=279058</a>
<a href="https://rdar.apple.com/135188967">rdar://135188967</a>

Reviewed by Anne van Kesteren.

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/transition-test-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/reference/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitions-retarget.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/283098@main">https://commits.webkit.org/283098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13e9235cdd077cc0087162d21f31af7ab207a3b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15821 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52391 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10949 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56448 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33014 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14698 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70944 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9167 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13636 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59993 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1247 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9887 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40394 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41471 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->