### PR TITLE
Never paginate fixed-positioned objects

### DIFF
--- a/LayoutTests/printing/block-with-overflow-in-bottom-aligned-fixedpos-expected.html
+++ b/LayoutTests/printing/block-with-overflow-in-bottom-aligned-fixedpos-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+</script>
+<p>The word "PASS" should be seen at the bottom of the page, and no red should be seen.</p>
+<div style="position:fixed; left:0; width:100%; bottom:0; height:2em;">
+    PASS
+</div>

--- a/LayoutTests/printing/block-with-overflow-in-bottom-aligned-fixedpos.html
+++ b/LayoutTests/printing/block-with-overflow-in-bottom-aligned-fixedpos.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+if (window.internals)
+    internals.settings.setShouldPrintBackgrounds(true);
+</script>
+<p>The word "PASS" should be seen at the bottom of the page, and no red should be seen.</p>
+<div style="position:fixed; left:0; width:100%; bottom:0; height:2em; background:red;">
+    <div style="background:white;">
+        <span style="vertical-align:top;">PASS</span>
+        <span style="line-height:3em;">&nbsp;</span>
+    </div>
+</div>

--- a/LayoutTests/printing/flexbox-with-overflow-in-bottom-aligned-fixedpos-expected.html
+++ b/LayoutTests/printing/flexbox-with-overflow-in-bottom-aligned-fixedpos-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+</script>
+<p>The word "PASS" should be seen at the bottom of the page, and no red should be seen.</p>
+<div style="position:fixed; left:0; width:100%; bottom:0; height:2em;">
+    PASS
+</div>

--- a/LayoutTests/printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html
+++ b/LayoutTests/printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+if (window.internals)
+    internals.settings.setShouldPrintBackgrounds(true);
+</script>
+<p>The word "PASS" should be seen at the bottom of the page, and no red should be seen.</p>
+<div style="position:fixed; left:0; width:100%; bottom:0; background:red;">
+    <div style="display:flex; height:2em;">
+        <div style="width:100%;">
+            <div style="background:white;">
+                <span style="vertical-align:top;">PASS</span>
+                <span style="line-height:3em;">&nbsp;</span>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5085,6 +5085,7 @@ bool RenderBox::isUnsplittableForPagination() const
         || hasUnsplittableScrollingOverflow()
         || (parent() && isWritingModeRoot())
         || (isFloating() && style().pseudoElementType() == PseudoId::FirstLetter && style().initialLetter().drop() > 0)
+        || isFixedPositioned()
         || shouldApplySizeContainment();
 }
 


### PR DESCRIPTION
#### f81a97e5fff89388fc0564da814d2dcb99218362
<pre>
Never paginate fixed-positioned objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=279060">https://bugs.webkit.org/show_bug.cgi?id=279060</a>
<a href="https://rdar.apple.com/135189288">rdar://135189288</a>

Reviewed by NOBODY (OOPS!).

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/344e69ca2b1f2e20346eeb1f6d3d7d9fad38fd82">https://chromium.googlesource.com/chromium/src.git/+/344e69ca2b1f2e20346eeb1f6d3d7d9fad38fd82</a>

This patch fixes an issue which is long standing, where the fixed-positioned
objects suppose to be repeated on every page but we don&apos;t do it but we
should not paginate them as well, which is is addressed here.

We don&apos;t merge test case `fixedpos-in-transform-at-column-boundary.html`,
since it was converted to web platform tests by Blink in below commit [1]:

[1] <a href="https://chromium.googlesource.com/chromium/src/+/8ddecd73089b2c3f8d4092c699378caefe0d70bd">https://chromium.googlesource.com/chromium/src/+/8ddecd73089b2c3f8d4092c699378caefe0d70bd</a>

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::isUnsplittableForPagination const):
* LayoutTests/printing/block-with-overflow-in-bottom-aligned-fixedpos-expected.html:
* LayoutTests/printing/block-with-overflow-in-bottom-aligned-fixedpos.html:
* LayoutTests/printing/flexbox-with-overflow-in-bottom-aligned-fixedpos-expected.html:
* LayoutTests/printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f81a97e5fff89388fc0564da814d2dcb99218362

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74684 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50884 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93182 "Found 2 new test failures: printing/block-with-overflow-in-bottom-aligned-fixedpos.html printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61880 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88e04e9f-a216-4fb2-b44e-bd7ff2266544) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33288 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27915 "Found 2 new test failures: printing/block-with-overflow-in-bottom-aligned-fixedpos.html printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72678 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103979 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28125 "Found 2 new test failures: printing/block-with-overflow-in-bottom-aligned-fixedpos.html printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131918 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49524 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37695 "Found 2 new test failures: printing/block-with-overflow-in-bottom-aligned-fixedpos.html printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101716 "Found 2 new test failures: printing/block-with-overflow-in-bottom-aligned-fixedpos.html printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49899 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105978 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101584 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46956 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25111 "Found 2 new test failures: printing/block-with-overflow-in-bottom-aligned-fixedpos.html printing/flexbox-with-overflow-in-bottom-aligned-fixedpos.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46295 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->