### PR TITLE
[Navigation] Handle handler callback throwing an exception

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-crash-set-exception-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-crash-set-exception-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: error
 
 PASS An exception thrown during a transition shouldn't crash.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt
@@ -1,7 +1,6 @@
-CONSOLE MESSAGE: Error: assert_equals: container(target) expected "multiply" but got "normal"
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: container(target) expected "multiply" but got "normal"
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: container(target) expected "multiply" but got "normal"
 
 TIMEOUT position property of pseudo elements Test timed out
 NOTRUN properties of pseudo elements outside of transition

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-skipped-from-invalid-callback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-skipped-from-invalid-callback-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: bar
-
-Harness Error (FAIL), message = ReferenceError: Can't find variable: bar
 
 PASS transition skipped because callback has invalid syntax
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: TypeError: a message
 
-Harness Error (FAIL), message = TypeError: a message
-
-FAIL event.intercept() should abort if the handler throws assert_true: expected true got false
+PASS event.intercept() should abort if the handler throws
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -54,6 +54,7 @@ public:
     CallbackResult<typename IDLUndefined::CallbackReturnType> callbackRequiresThisToPass(typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
     CallbackResult<typename IDLDOMString::CallbackReturnType> callbackWithAReturnValue() override;
     CallbackResult<typename IDLDOMString::CallbackReturnType> callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
+    CallbackResult<typename IDLPromise<IDLUndefined>::CallbackReturnType> callbackThatTreatsExceptionAsRejectedPromise(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
     CallbackResult<typename IDLDOMString::CallbackReturnType> callbackWithThisObject(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLInterface<TestObj>::ParameterType testObjParam) override;
 
 private:

--- a/Source/WebCore/bindings/scripts/test/TestCallbackInterface.idl
+++ b/Source/WebCore/bindings/scripts/test/TestCallbackInterface.idl
@@ -52,5 +52,6 @@ dictionary TestCallbackInterfaceDictionary {
     undefined callbackRequiresThisToPass(long longParam, TestNode testNodeParam);
     DOMString callbackWithAReturnValue();
     [RethrowException] DOMString callbackThatRethrowsExceptions(TestCallbackInterfaceEnum enumParam);
+    Promise<undefined> callbackThatTreatsExceptionAsRejectedPromise(TestCallbackInterfaceEnum enumParam);
     [CallbackThisObject=TestNode] DOMString callbackWithThisObject(TestObj testObjParam);
 };


### PR DESCRIPTION
#### 13f4ac88fbf3059b7323b8ee99274f350031691d
<pre>
[Navigation] Handle handler callback throwing an exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=279061">https://bugs.webkit.org/show_bug.cgi?id=279061</a>

Reviewed by Chris Dumez.

Add IDL logic to treat exceptions being thrown from a callback as a returned promise rejected with that exception, in case the return type is a Promise [1].

The &quot;wait for all&quot; logic in Navigation.cpp knows how to deal with such rejected promises, so intercept-handler-throws.html passes.

[1] <a href="https://webidl.spec.whatwg.org/#js-invoking-callback-functions">https://webidl.spec.whatwg.org/#js-invoking-callback-functions</a> (Step 14.7)

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-crash-set-exception-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-skipped-from-invalid-callback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::JSTestCallbackInterface::callbackThatRethrowsExceptions):
(WebCore::JSTestCallbackInterface::callbackThatTreatsExceptionAsRejectedPromise):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
* Source/WebCore/bindings/scripts/test/TestCallbackInterface.idl:

Canonical link: <a href="https://commits.webkit.org/283560@main">https://commits.webkit.org/283560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e586ff290ae46cd8c45fdfa5d8cee6fa026c3e7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53388 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15034 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72347 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2317 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41793 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->