### PR TITLE
Take a background task when handling web push actions

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h
@@ -27,6 +27,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSUInteger UIBackgroundTaskIdentifier;
+
 @class UNNotificationResponse;
 
 WK_EXTERN NSString * const _WKWebPushActionTypePushEvent;
@@ -43,6 +45,8 @@ WK_EXTERN
 @property (nonatomic, readonly) NSNumber *version;
 @property (nonatomic, readonly) NSString *pushPartition;
 @property (nonatomic, readonly) NSString *type;
+
+- (UIBackgroundTaskIdentifier)beginBackgroundTaskForHandling;
 
 @end
 


### PR DESCRIPTION
#### 23ffada2529984583b48f7ca35b837c426df7d8b
<pre>
Take a background task when handling web push actions
<a href="https://rdar.apple.com/135201512">rdar://135201512</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279067">https://bugs.webkit.org/show_bug.cgi?id=279067</a>

Reviewed by Ben Nham.

Client apps should not have to worry about this; WebKit can manage it.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _handleNextPushMessageWithCompletionHandler:]):
(-[WKWebsiteDataStore _handleWebPushAction:]):
(-[WKWebsiteDataStore _handleNextPushMessage]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(+[_WKWebPushAction _webPushActionWithNotificationResponse:]):
(-[_WKWebPushAction _nameForBackgroundTaskAndLogging]):
(-[_WKWebPushAction beginBackgroundTaskForHandling]):

Canonical link: <a href="https://commits.webkit.org/283129@main">https://commits.webkit.org/283129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e33aae6c948e5cf7e0df9535ae9817fd4df0638

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15870 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52424 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10983 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37915 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9216 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13673 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60022 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14396 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1276 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40443 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->