### PR TITLE
[appearance: base] Parse CSS value behind preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -994,6 +994,20 @@ CSSAnchorPositioningEnabled:
     WebCore:
       default: false
 
+CSSAppearanceBaseEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS appearance: base"
+  humanReadableDescription: "Enable base value for CSS appearance"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSBackgroundClipBorderAreaEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -315,6 +315,8 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
         return CSSValueNone;
     case StyleAppearance::Auto:
         return CSSValueAuto;
+    case StyleAppearance::Base:
+        return CSSValueBase;
     case StyleAppearance::Checkbox:
         return CSSValueCheckbox;
     case StyleAppearance::Radio:
@@ -391,7 +393,7 @@ template<> constexpr StyleAppearance fromCSSValueID(CSSValueID valueID)
     if (valueID == CSSValueAuto)
         return StyleAppearance::Auto;
 
-    return StyleAppearance(valueID - CSSValueCheckbox + static_cast<unsigned>(StyleAppearance::Checkbox));
+    return StyleAppearance(valueID - CSSValueBase + static_cast<unsigned>(StyleAppearance::Base));
 }
 
 #define TYPE BackfaceVisibility

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6492,6 +6492,10 @@
                 "searchfield",
                 "textfield",
                 "textarea",
+                {
+                    "value": "base",
+                    "settings-flag": "cssAppearanceBaseEnabled"
+                },
                 "auto",
                 "none",
                 {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -903,7 +903,8 @@ anywhere
 
 // -webkit-appearance
 // The order here must match the order in the StyleAppearance enum in StyleAppearance.h.
-// All appearance values that should be accepted by the parser should be listed between 'checkbox' and 'textarea':
+// All appearance values that should be accepted by the parser should be listed between 'base' and 'textarea':
+base
 checkbox
 radio
 push-button

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -55,6 +55,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     if (isUASheetBehavior(mode)) {
+        cssAppearanceBaseEnabled = true;
         cssTextUnderlinePositionLeftRightEnabled = true;
         lightDarkEnabled = true;
         popoverAttributeEnabled = true;
@@ -88,6 +89,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , transformStyleOptimized3DEnabled { document.settings().cssTransformStyleOptimized3DEnabled() }
 #endif
     , masonryEnabled { document.settings().masonryEnabled() }
+    , cssAppearanceBaseEnabled { document.settings().cssAppearanceBaseEnabled() }
     , cssNestingEnabled { document.settings().cssNestingEnabled() }
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
     , cssScopeAtRuleEnabled { document.settings().cssScopeAtRuleEnabled() }
@@ -126,28 +128,29 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.transformStyleOptimized3DEnabled          << 5
 #endif
         | context.masonryEnabled                            << 6
-        | context.cssNestingEnabled                         << 7
-        | context.cssPaintingAPIEnabled                     << 8
-        | context.cssScopeAtRuleEnabled                     << 9
-        | context.cssShapeFunctionEnabled                   << 10
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 11
-        | context.cssBackgroundClipBorderAreaEnabled        << 12
-        | context.cssWordBreakAutoPhraseEnabled             << 13
-        | context.popoverAttributeEnabled                   << 14
-        | context.sidewaysWritingModesEnabled               << 15
-        | context.cssTextWrapPrettyEnabled                  << 16
-        | context.highlightAPIEnabled                       << 17
-        | context.grammarAndSpellingPseudoElementsEnabled   << 18
-        | context.customStateSetEnabled                     << 19
-        | context.thumbAndTrackPseudoElementsEnabled        << 20
+        | context.cssAppearanceBaseEnabled                  << 7
+        | context.cssNestingEnabled                         << 8
+        | context.cssPaintingAPIEnabled                     << 9
+        | context.cssScopeAtRuleEnabled                     << 10
+        | context.cssShapeFunctionEnabled                   << 11
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 12
+        | context.cssBackgroundClipBorderAreaEnabled        << 13
+        | context.cssWordBreakAutoPhraseEnabled             << 14
+        | context.popoverAttributeEnabled                   << 15
+        | context.sidewaysWritingModesEnabled               << 16
+        | context.cssTextWrapPrettyEnabled                  << 17
+        | context.highlightAPIEnabled                       << 18
+        | context.grammarAndSpellingPseudoElementsEnabled   << 19
+        | context.customStateSetEnabled                     << 20
+        | context.thumbAndTrackPseudoElementsEnabled        << 21
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 21
+        | context.imageControlsEnabled                      << 22
 #endif
-        | context.colorLayersEnabled                        << 22
-        | context.lightDarkEnabled                          << 23
-        | context.targetTextPseudoElementEnabled            << 24
-        | context.viewTransitionTypesEnabled                << 25
-        | (uint32_t)context.mode                            << 26; // This is multiple bits, so keep it last.
+        | context.colorLayersEnabled                        << 23
+        | context.lightDarkEnabled                          << 24
+        | context.targetTextPseudoElementEnabled            << 25
+        | context.viewTransitionTypesEnabled                << 26
+        | (uint32_t)context.mode                            << 27; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -80,6 +80,7 @@ struct CSSParserContext {
     bool transformStyleOptimized3DEnabled : 1 { false };
 #endif
     bool masonryEnabled : 1 { false };
+    bool cssAppearanceBaseEnabled : 1 { false };
     bool cssNestingEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssScopeAtRuleEnabled : 1 { false };

--- a/Source/WebCore/platform/StyleAppearance.cpp
+++ b/Source/WebCore/platform/StyleAppearance.cpp
@@ -39,6 +39,9 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::Auto:
         ts << "auto";
         break;
+    case StyleAppearance::Base:
+        ts << "base";
+        break;
     case StyleAppearance::Checkbox:
         ts << "checkbox";
         break;

--- a/Source/WebCore/platform/StyleAppearance.h
+++ b/Source/WebCore/platform/StyleAppearance.h
@@ -35,6 +35,7 @@ namespace WebCore {
 enum class StyleAppearance : uint8_t {
     None,
     Auto,
+    Base,
     Checkbox,
     Radio,
     PushButton,

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -193,7 +193,7 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
     auto autoAppearance = autoAppearanceForElement(style, element);
     auto appearance = adjustAppearanceForElement(style, element, autoAppearance);
 
-    if (appearance == StyleAppearance::None)
+    if (appearance == StyleAppearance::None || appearance == StyleAppearance::Base)
         return;
 
     // Force inline and table display styles to be inline-block (except for table- which is block)
@@ -536,6 +536,7 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     switch (appearance) {
     case StyleAppearance::None:
     case StyleAppearance::Auto:
+    case StyleAppearance::Base:
         break;
 
     case StyleAppearance::Checkbox:
@@ -876,7 +877,7 @@ bool RenderTheme::paintBorderOnly(const RenderBox& box, const PaintInfo& paintIn
 
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(rect);
-    return box.style().usedAppearance() != StyleAppearance::None;
+    return box.style().usedAppearance() != StyleAppearance::None && box.style().usedAppearance() != StyleAppearance::Base;
 #else
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, box.document().deviceScaleFactor());
     // Call the appropriate paint method based off the appearance value.

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -256,7 +256,8 @@ inline bool RenderStyle::hasAnimationsOrTransitions() const { return hasAnimatio
 inline bool RenderStyle::hasAnyFixedBackground() const { return backgroundLayers().hasImageWithAttachment(FillAttachment::FixedBackground); }
 inline bool RenderStyle::hasAnyLocalBackground() const { return backgroundLayers().hasImageWithAttachment(FillAttachment::LocalBackground); }
 inline bool RenderStyle::hasAnyPublicPseudoStyles() const { return m_nonInheritedFlags.hasAnyPublicPseudoStyles(); }
-inline bool RenderStyle::hasAppearance() const { return appearance() != StyleAppearance::None; }
+// FIXME: Rename this function.
+inline bool RenderStyle::hasAppearance() const { return appearance() != StyleAppearance::None && appearance() != StyleAppearance::Base; }
 inline bool RenderStyle::hasAppleColorFilter() const { return !appleColorFilter().isEmpty(); }
 inline bool RenderStyle::hasAspectRatio() const { return aspectRatioType() == AspectRatioType::Ratio || aspectRatioType() == AspectRatioType::AutoAndRatio; }
 inline bool RenderStyle::hasAttrContent() const { return m_nonInheritedData->miscData->hasAttrContent; }
@@ -281,7 +282,8 @@ inline bool RenderStyle::hasBorderRadius() const { return border().hasBorderRadi
 inline bool RenderStyle::hasClip() const { return m_nonInheritedData->rareData->hasClip; }
 inline bool RenderStyle::hasContent() const { return contentData(); }
 inline bool RenderStyle::hasDisplayAffectedByAnimations() const { return m_nonInheritedData->miscData->hasDisplayAffectedByAnimations; }
-inline bool RenderStyle::hasUsedAppearance() const { return usedAppearance() != StyleAppearance::None; }
+// FIXME: Rename this function.
+inline bool RenderStyle::hasUsedAppearance() const { return usedAppearance() != StyleAppearance::None && usedAppearance() != StyleAppearance::Base; }
 inline bool RenderStyle::hasUsedContentNone() const { return !contentData() && (m_nonInheritedFlags.hasContentNone || pseudoElementType() == PseudoId::Before || pseudoElementType() == PseudoId::After); }
 inline bool RenderStyle::hasExplicitlySetBorderBottomLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomLeftRadius; }
 inline bool RenderStyle::hasExplicitlySetBorderBottomRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomRightRadius; }


### PR DESCRIPTION
#### 99b543382e3319efc6fd8de52d20b96d19c81d9a
<pre>
[appearance: base] Parse CSS value behind preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=279069">https://bugs.webkit.org/show_bug.cgi?id=279069</a>
<a href="https://rdar.apple.com/135203123">rdar://135203123</a>

Reviewed by Aditya Keerthi.

Add basic parsing for `appearance: base` behind a preference, so we can prototype upon it.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/platform/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/StyleAppearance.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::paintBorderOnly):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasAppearance const):
(WebCore::RenderStyle::hasUsedAppearance const):

Canonical link: <a href="https://commits.webkit.org/283106@main">https://commits.webkit.org/283106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef5d73c0bd870613c0158cfe80027c61b9cb9f4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10974 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14727 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58357 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70973 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64487 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9196 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56534 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60011 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/ignored-objects, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/attributes, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1271 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40423 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15196 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41500 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->