### PR TITLE
Render background-clip effects with a transparency layer instead of a buffer

### DIFF
--- a/LayoutTests/fast/backgrounds/background-clip-border-area-alpha-expected.html
+++ b/LayoutTests/fast/backgrounds/background-clip-border-area-alpha-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            display: inline-block;
+            margin: 50px;
+            width: 100px;
+            height: 100px;
+            border: 40px solid green;
+            opacity: 0.5;
+        }
+        
+        .radius {
+            border-radius: 20px;
+        }
+
+        .double {
+            border-right-style: double;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+    <div class="radius box"></div>
+    <div class="double box" ></div>
+    <div class="radius double box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/background-clip-border-area-alpha.html
+++ b/LayoutTests/fast/backgrounds/background-clip-border-area-alpha.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-520" />
+<head>
+    <style>
+        .box {
+            display: inline-block;
+            margin: 50px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            border: 40px solid transparent;
+            background-clip: border-area;
+            opacity: 0.5;
+        }
+        
+        .radius {
+            border-radius: 20px;
+        }
+
+        .double {
+            border-right-style: double;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+    <div class="radius box"></div>
+    <div class="double box" ></div>
+    <div class="radius double box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/background-clip-text-alpha-expected.html
+++ b/LayoutTests/fast/backgrounds/background-clip-text-alpha-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            font-size: 52pt;
+            text-align: center;
+            font-family: ahem;
+        }
+        .box {
+            opacity: 0.5;
+            width: 500px;
+            padding: 20px;
+            color: green;
+        }        
+    </style>
+</head>
+<body>
+    <div class="box">AAA</div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/background-clip-text-alpha.html
+++ b/LayoutTests/fast/backgrounds/background-clip-text-alpha.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            font-size: 52pt;
+            text-align: center;
+            font-family: ahem;
+        }
+        .box {
+            opacity: 0.5;
+            width: 500px;
+            padding: 20px;
+            color: transparent;
+            background-color: green;
+            background-clip: text;
+        }
+    </style>
+</head>
+<body>
+    <div class="box">AAA</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -698,14 +698,11 @@ InterpolationQuality RenderBoxModelObject::chooseInterpolationQuality(GraphicsCo
     return view().imageQualityController().chooseInterpolationQuality(context, const_cast<RenderBoxModelObject*>(this), image, layer, size);
 }
 
-void RenderBoxModelObject::paintMaskForTextFillBox(ImageBuffer* maskImage, const FloatRect& maskRect, const InlineIterator::InlineBoxIterator& inlineBox, const LayoutRect& scrolledPaintRect)
+void RenderBoxModelObject::paintMaskForTextFillBox(GraphicsContext& context, const FloatRect& paintRect, const InlineIterator::InlineBoxIterator& inlineBox, const LayoutRect& scrolledPaintRect)
 {
-    GraphicsContext& maskImageContext = maskImage->context();
-    maskImageContext.translate(-maskRect.location());
-
     // Now add the text to the clip. We do this by painting using a special paint phase that signals to
     // the painter it should just modify the clip.
-    PaintInfo maskInfo(maskImageContext, LayoutRect { maskRect }, PaintPhase::TextClip, PaintBehavior::ForceBlackText);
+    PaintInfo maskInfo(context, LayoutRect { paintRect }, PaintPhase::TextClip, PaintBehavior::ForceBlackText);
     if (inlineBox) {
         auto paintOffset = scrolledPaintRect.location() - toLayoutSize(LayoutPoint(inlineBox->visualRectIgnoringBlockDirection().location()));
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -235,7 +235,7 @@ public:
     InterpolationQuality chooseInterpolationQuality(GraphicsContext&, Image&, const void*, const LayoutSize&) const;
     DecodingMode decodingModeForImageDraw(const Image&, const PaintInfo&) const;
 
-    void paintMaskForTextFillBox(ImageBuffer*, const FloatRect&, const InlineIterator::InlineBoxIterator&, const LayoutRect&);
+    void paintMaskForTextFillBox(GraphicsContext&, const FloatRect&, const InlineIterator::InlineBoxIterator&, const LayoutRect&);
 
     // For RenderBlocks and RenderInlines with m_style->pseudoElementType() == PseudoId::FirstLetter, this tracks their remaining text fragments
     RenderTextFragment* firstLetterRemainingText() const;


### PR DESCRIPTION
#### 9d5ce39e6de489a2292584160d51ef49789d3f00
<pre>
Render background-clip effects with a transparency layer instead of a buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=279070">https://bugs.webkit.org/show_bug.cgi?id=279070</a>
<a href="https://rdar.apple.com/135205084">rdar://135205084</a>

Reviewed by Matt Woodrow.

`BackgroundPainter::paintFillLayer()` currently uses an ImageBuffer and `CompositeOperator::DestinationIn`
to render the masking-based background-clip modes (`text` and `border-area`). Making an ImageBuffer is expensive;
it&apos;s more efficient to do this with transparency layers.

Factor common code into a `setupMaskingBackgroundClip()` lambda, which takes a callback for drawing the
masking content. Previously the code used a transparency layer and an ImageBuffer; now we use two
transparency layers. First we start a transparency layer, and render the masking content. Then we set
the composited operator to SourceIn, and start a second layer which will contain the pixels to be masked.
Two TransparencyLayerScopes ensure we close the layers in the correct order.

Added a test to ensure we didn&apos;t break rendering with alpha.

* LayoutTests/fast/backgrounds/background-clip-border-area-alpha-expected.html: Added.
* LayoutTests/fast/backgrounds/background-clip-border-area-alpha.html: Added.
* LayoutTests/fast/backgrounds/background-clip-text-alpha-expected.html: Added.
* LayoutTests/fast/backgrounds/background-clip-text-alpha.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::paintMaskForTextFillBox): This can just take a GraphicsContxet now.
* Source/WebCore/rendering/RenderBoxModelObject.h:

Canonical link: <a href="https://commits.webkit.org/283135@main">https://commits.webkit.org/283135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dddaf6cb4469250e0ff5846e0cea1160bb77e484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52448 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14793 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9262 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13696 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56589 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60045 "Found 23 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/submit-form, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/extents, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/action/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hypertext/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/hit-test, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/scroll-to ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1309 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->