### PR TITLE
Fix JavaScriptCore API headers to work with the Clang Module Verifier.

### DIFF
--- a/Source/JavaScriptCore/API/JSContext.h
+++ b/Source/JavaScriptCore/API/JSContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,10 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <JavaScriptCore/JavaScript.h>
-#import <JavaScriptCore/WebKitAvailability.h>
+#ifndef JSContext_h
+#define JSContext_h
 
-#if JSC_OBJC_API_ENABLED
+#include <JavaScriptCore/JavaScript.h>
+#include <JavaScriptCore/WebKitAvailability.h>
+
+#if defined(__OBJC__) && JSC_OBJC_API_ENABLED
 
 @class JSScript, JSVirtualMachine, JSValue, JSContext;
 
@@ -238,3 +241,5 @@ JSC_CLASS_AVAILABLE(macos(10.9), ios(7.0))
 @end
 
 #endif
+
+#endif /* JSContext_h */

--- a/Source/JavaScriptCore/API/JSExport.h
+++ b/Source/JavaScriptCore/API/JSExport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#import <JavaScriptCore/JavaScriptCore.h>
+#ifndef JSExport_h
+#define JSExport_h
 
-#if JSC_OBJC_API_ENABLED
+#include <JavaScriptCore/JavaScriptCore.h>
+
+#if defined(__OBJC__) && JSC_OBJC_API_ENABLED
 
 /*!
 @protocol
@@ -144,3 +147,5 @@
     @optional Selector __JS_EXPORT_AS__##PropertyName:(id)argument; @required Selector
 
 #endif
+
+#endif /* JSExport_h */

--- a/Source/JavaScriptCore/API/JSManagedValue.h
+++ b/Source/JavaScriptCore/API/JSManagedValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,10 @@
 #ifndef JSManagedValue_h
 #define JSManagedValue_h
 
-#import <JavaScriptCore/JSBase.h>
-#import <JavaScriptCore/WebKitAvailability.h>
+#include <JavaScriptCore/JSBase.h>
+#include <JavaScriptCore/WebKitAvailability.h>
 
-#if JSC_OBJC_API_ENABLED
+#if defined(__OBJC__) && JSC_OBJC_API_ENABLED
 
 @class JSValue;
 @class JSContext;
@@ -76,6 +76,6 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 
 @end
 
-#endif // JSC_OBJC_API_ENABLED
+#endif
 
-#endif // JSManagedValue_h
+#endif /* JSManagedValue_h */

--- a/Source/JavaScriptCore/API/JSValue.h
+++ b/Source/JavaScriptCore/API/JSValue.h
@@ -26,7 +26,7 @@
 #ifndef JSValue_h
 #define JSValue_h
 
-#if JSC_OBJC_API_ENABLED
+#if defined(__OBJC__) && JSC_OBJC_API_ENABLED
 
 #import <CoreGraphics/CGGeometry.h>
 
@@ -821,4 +821,4 @@ JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorSetKey;
 
 #endif
 
-#endif // JSValue_h
+#endif /* JSValue_h */

--- a/Source/JavaScriptCore/API/JSVirtualMachine.h
+++ b/Source/JavaScriptCore/API/JSVirtualMachine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#import <JavaScriptCore/JavaScriptCore.h>
+#ifndef JSVirtualMachine_h
+#define JSVirtualMachine_h
 
-#if JSC_OBJC_API_ENABLED
+#include <JavaScriptCore/JavaScriptCore.h>
+
+#if defined(__OBJC__) && JSC_OBJC_API_ENABLED
 
 /*!
 @interface
@@ -85,3 +88,5 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @end
 
 #endif
+
+#endif /* JSVirtualMachine_h */

--- a/Source/JavaScriptCore/API/JavaScriptCore.h
+++ b/Source/JavaScriptCore/API/JavaScriptCore.h
@@ -29,14 +29,10 @@
 #include <JavaScriptCore/JavaScript.h>
 #include <JavaScriptCore/JSStringRefCF.h>
 
-#if defined(__OBJC__) && JSC_OBJC_API_ENABLED
-
-#import <JavaScriptCore/JSContext.h>
-#import <JavaScriptCore/JSValue.h>
-#import <JavaScriptCore/JSManagedValue.h>
-#import <JavaScriptCore/JSVirtualMachine.h>
-#import <JavaScriptCore/JSExport.h>
-
-#endif
+#include <JavaScriptCore/JSContext.h>
+#include <JavaScriptCore/JSValue.h>
+#include <JavaScriptCore/JSManagedValue.h>
+#include <JavaScriptCore/JSVirtualMachine.h>
+#include <JavaScriptCore/JSExport.h>
 
 #endif /* JavaScriptCore_h */

--- a/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
+++ b/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+// Copyright (C) 2009-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -24,6 +24,11 @@
 #include "BaseTarget.xcconfig"
 
 DEFINES_MODULE = YES;
+ENABLE_MODULE_VERIFIER = $(USE_INTERNAL_SDK);
+OTHER_MODULE_VERIFIER_FLAGS = $(OTHER_MODULE_VERIFIER_FLAGS_$(WK_EMPTY_$(WK_OVERRIDE_FRAMEWORKS_DIR)));
+OTHER_MODULE_VERIFIER_FLAGS_ = -- -iframework $(WK_PRIVATE_SDK_DIR)$(WK_OVERRIDE_FRAMEWORKS_DIR) -isystem $(WK_PRIVATE_SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH);
+MODULE_VERIFIER_VERBOSE = NO;
+MODULE_VERIFIER_SUPPORTED_LANGUAGES = objective-c objective-c++ c c++;
 MODULEMAP_FILE = $(SRCROOT)/JavaScriptCore.modulemap;
 
 WK_SUPPORTS_OTHER_TAPI_FLAGS_STATICLIBS = $(WK_SUPPORTS_OTHER_TAPI_FLAGS_STATICLIBS_$(WK_PLATFORM_NAME));

--- a/Source/JavaScriptCore/JavaScriptCore.modulemap
+++ b/Source/JavaScriptCore/JavaScriptCore.modulemap
@@ -1,4 +1,4 @@
-framework module JavaScriptCore [extern_c] {
+framework module JavaScriptCore {
   umbrella header "JavaScriptCore.h"
 
   export *


### PR DESCRIPTION
#### fc2e779ba915c68637aa2b57e0ab38545c0d299a
<pre>
Fix JavaScriptCore API headers to work with the Clang Module Verifier.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279072">https://bugs.webkit.org/show_bug.cgi?id=279072</a>
<a href="https://rdar.apple.com/131335204">rdar://131335204</a>

Reviewed by Elliott Williams, Tim Horton, and Keith Miller.

Changes requires by the Clang Module Verifier:
1. Removed [extern_c] from the module map declaration.
2. Fixed the top level umbrella JavaScriptCore.h to not contain any conditional includes.

Additional changes:
3. As a consequence of (2), changed #import&apos;s to #include&apos;s and added header guards to all the relevant files.
4. As a clean up, changed use of C++ style // comments to C style /* */ comments.
5. To prevent future regressions, added running the Clang Module Verifier to JavaScriptCore.xcconfig.

* Source/JavaScriptCore/API/JSContext.h:
* Source/JavaScriptCore/API/JSExport.h:
* Source/JavaScriptCore/API/JSManagedValue.h:
* Source/JavaScriptCore/API/JSValue.h:
* Source/JavaScriptCore/API/JSVirtualMachine.h:
* Source/JavaScriptCore/API/JavaScriptCore.h:
* Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig:
* Source/JavaScriptCore/JavaScriptCore.modulemap:

Canonical link: <a href="https://commits.webkit.org/283128@main">https://commits.webkit.org/283128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333f2d61402dd8b97b20b880118aa5a1928e68c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65247 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69271 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15853 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52414 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33037 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14730 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58360 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70976 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64490 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59740 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60014 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1273 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86258 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9907 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40426 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15197 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->