### PR TITLE
Remove WebCodecs postTask callback

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
@@ -15,9 +15,15 @@ PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
-FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus complexity too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus packetlossperc too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too small

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
@@ -15,9 +15,15 @@ PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
-FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus complexity too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus packetlossperc too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too small

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
@@ -6,6 +6,6 @@ PASS Test transfering same array buffer twice
 FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.length after detach expected 0 but got 10
 FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
 FAIL Test transfering ArrayBuffer to AudioData promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
-FAIL Encoding from AudioData with transferred buffer assert_unreached: Encoder error Reached unreachable code
+FAIL Encoding from AudioData with transferred buffer promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
 FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
@@ -6,6 +6,6 @@ PASS Test transfering same array buffer twice
 FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.length after detach expected 0 but got 10
 FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
 FAIL Test transfering ArrayBuffer to AudioData promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
-FAIL Encoding from AudioData with transferred buffer assert_unreached: Encoder error Reached unreachable code
+FAIL Encoding from AudioData with transferred buffer promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
 FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -114,6 +114,7 @@ private:
     bool m_isKeyChunkRequired { false };
     Deque<WebCodecsControlMessage<WebCodecsAudioDecoder>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
+    size_t m_decoderCount { 0 };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -117,6 +117,7 @@ private:
     WebCodecsAudioEncoderConfig m_baseConfiguration;
     AudioEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };
+    size_t m_encoderCount { 0 };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -37,6 +37,7 @@
 #include "ScriptExecutionContext.h"
 #include "WebCodecsEncodedVideoChunk.h"
 #include "WebCodecsErrorCallback.h"
+#include "WebCodecsUtilities.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebCodecsVideoFrameOutputCallback.h"
 #include <wtf/ASCIICType.h>
@@ -131,52 +132,45 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
     bool isSupportedCodec = isSupportedDecoderCodec(config.codec, context.settingsValues());
     queueControlMessageAndProcess({ *this, [this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
         m_isMessageQueueBlocked = true;
-        VideoDecoder::PostTaskCallback postTaskCallback = [identifier, weakThis = ThreadSafeWeakPtr { *this }](auto&& task) {
-            ScriptExecutionContext::postTaskTo(identifier, [weakThis, task = WTFMove(task)](auto&) mutable {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis)
-                    return;
-                protectedThis->queueTaskKeepingObjectAlive(*protectedThis, TaskSource::MediaElement, [task = WTFMove(task)]() mutable {
-                    task();
-                });
-            });
-        };
-
         if (!isSupportedCodec) {
-            postTaskCallback([this] {
-                closeDecoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
+            postTaskToCodec<WebCodecsVideoDecoder>(identifier, *this, [] (auto& decoder) {
+                decoder.closeDecoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
             });
             return;
         }
 
-        VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [this](auto&& result) {
-            if (!result.has_value()) {
-                closeDecoder(Exception { ExceptionCode::NotSupportedError, WTFMove(result.error()) });
-                return;
-            }
-            setInternalDecoder(WTFMove(result.value()));
-            m_isMessageQueueBlocked = false;
-            processControlMessageQueue();
-        }, [this](auto&& result) {
-            if (m_state != WebCodecsCodecState::Configured)
-                return;
+        VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [identifier, weakThis = ThreadSafeWeakPtr { *this }] (auto&& result) mutable {
+            postTaskToCodec<WebCodecsVideoDecoder>(identifier, WTFMove(weakThis), [result = WTFMove(result)] (auto& decoder) mutable {
+                if (!result.has_value()) {
+                    decoder.closeDecoder(Exception { ExceptionCode::NotSupportedError, WTFMove(result.error()) });
+                    return;
+                }
+                decoder.setInternalDecoder(WTFMove(result.value()));
+                decoder.m_isMessageQueueBlocked = false;
+                decoder.processControlMessageQueue();
+            });
+        }, [identifier, weakThis = ThreadSafeWeakPtr { *this }, decoderCount = ++m_decoderCount](auto&& result) {
+            postTaskToCodec<WebCodecsVideoDecoder>(identifier, weakThis, [result = WTFMove(result), decoderCount] (auto& decoder) mutable {
+                if (decoder.m_state != WebCodecsCodecState::Configured || decoder.m_decoderCount != decoderCount)
+                    return;
 
-            if (!result.has_value()) {
-                closeDecoder(Exception { ExceptionCode::EncodingError, WTFMove(result).error() });
-                return;
-            }
+                if (!result.has_value()) {
+                    decoder.closeDecoder(Exception { ExceptionCode::EncodingError, WTFMove(result).error() });
+                    return;
+                }
 
-            auto decodedResult = WTFMove(result).value();
-            WebCodecsVideoFrame::BufferInit init;
-            init.codedWidth = decodedResult.frame->presentationSize().width();
-            init.codedHeight = decodedResult.frame->presentationSize().height();
-            init.timestamp = decodedResult.timestamp;
-            init.duration = decodedResult.duration;
-            init.colorSpace = decodedResult.frame->colorSpace();
+                auto decodedResult = WTFMove(result).value();
+                WebCodecsVideoFrame::BufferInit init;
+                init.codedWidth = decodedResult.frame->presentationSize().width();
+                init.codedHeight = decodedResult.frame->presentationSize().height();
+                init.timestamp = decodedResult.timestamp;
+                init.duration = decodedResult.duration;
+                init.colorSpace = decodedResult.frame->colorSpace();
 
-            auto videoFrame = WebCodecsVideoFrame::create(*scriptExecutionContext(), WTFMove(decodedResult.frame), WTFMove(init));
-            m_output->handleEvent(WTFMove(videoFrame));
-        }, WTFMove(postTaskCallback));
+                auto videoFrame = WebCodecsVideoFrame::create(*decoder.scriptExecutionContext(), WTFMove(decodedResult.frame), WTFMove(init));
+                decoder.m_output->handleEvent(WTFMove(videoFrame));
+            });
+        });
     } });
     return { };
 }
@@ -266,8 +260,6 @@ void WebCodecsVideoDecoder::isConfigSupported(ScriptExecutionContext& context, W
             }
         });
     }, [](auto&&) {
-    }, [] (auto&& task) {
-        task();
     });
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -112,6 +112,7 @@ private:
     bool m_isKeyChunkRequired { false };
     Deque<WebCodecsControlMessage<WebCodecsVideoDecoder>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
+    size_t m_decoderCount { 0 };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -118,6 +118,7 @@ private:
     WebCodecsVideoEncoderConfig m_baseConfiguration;
     VideoEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };
+    size_t m_encoderCount { 0 };
 };
 
 }

--- a/Source/WebCore/platform/AudioDecoder.cpp
+++ b/Source/WebCore/platform/AudioDecoder.cpp
@@ -59,16 +59,15 @@ bool AudioDecoder::isCodecSupported(const StringView& codec)
     return result;
 }
 
-void AudioDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
+void AudioDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
 #if USE(GSTREAMER)
-    GStreamerAudioDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+    GStreamerAudioDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback));
     return;
 #else
     UNUSED_PARAM(codecName);
     UNUSED_PARAM(config);
     UNUSED_PARAM(outputCallback);
-    UNUSED_PARAM(postCallback);
 #endif
 
     callback(makeUnexpected("Not supported"_s));

--- a/Source/WebCore/platform/AudioDecoder.h
+++ b/Source/WebCore/platform/AudioDecoder.h
@@ -59,15 +59,14 @@ public:
         Ref<PlatformRawAudioData> data;
     };
 
-    using PostTaskCallback = Function<void(Function<void()>&&)>;
     using OutputCallback = Function<void(Expected<DecodedData, String>&&)>;
     using CreateResult = Expected<UniqueRef<AudioDecoder>, String>;
     using CreateCallback = Function<void(CreateResult&&)>;
 
-    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&);
     WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);
 
-    static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&);
 
     using DecodePromise = NativePromise<void, String>;
     virtual Ref<DecodePromise> decode(EncodedData&&) = 0;

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -79,12 +79,11 @@ public:
     };
     using CreateResult = Expected<UniqueRef<AudioEncoder>, String>;
 
-    using PostTaskCallback = Function<void(Function<void()>&&)>;
     using DescriptionCallback = Function<void(ActiveConfiguration&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;
     using CreateCallback = Function<void(CreateResult&&)>;
 
-    static void create(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
     using EncodePromise = NativePromise<void, String>;
     virtual Ref<EncodePromise> encode(RawFrame&&) = 0;

--- a/Source/WebCore/platform/VideoDecoder.cpp
+++ b/Source/WebCore/platform/VideoDecoder.cpp
@@ -46,13 +46,13 @@ void VideoDecoder::setCreatorCallback(CreatorFunction&& function)
     s_customCreator = WTFMove(function);
 }
 
-void VideoDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
+void VideoDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
     if (s_customCreator) {
-        s_customCreator(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        s_customCreator(codecName, config, WTFMove(callback), WTFMove(outputCallback));
         return;
     }
-    createLocalDecoder(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+    createLocalDecoder(codecName, config, WTFMove(callback), WTFMove(outputCallback));
 }
 
 #define LE_CHR(a, b, c, d) (((a)<<24) | ((b)<<16) | ((c)<<8) | (d))
@@ -68,35 +68,34 @@ String VideoDecoder::fourCCToCodecString(uint32_t fourCC)
     }
 }
 
-void VideoDecoder::createLocalDecoder(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
+void VideoDecoder::createLocalDecoder(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
 #if USE(LIBWEBRTC) && PLATFORM(COCOA)
     if (codecName == "vp8"_s) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP8, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP8, config, WTFMove(callback), WTFMove(outputCallback));
         return;
     }
     if (codecName.startsWith("vp09.00"_s)) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9, config, WTFMove(callback), WTFMove(outputCallback));
         return;
     }
     if (codecName.startsWith("vp09.02"_s)) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(outputCallback));
         return;
     }
 #if ENABLE(AV1)
     if (codecName.startsWith("av01."_s)) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::AV1, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::AV1, config, WTFMove(callback), WTFMove(outputCallback));
         return;
     }
 #endif
 #elif USE(GSTREAMER)
-    GStreamerVideoDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+    GStreamerVideoDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback));
     return;
 #else
     UNUSED_PARAM(codecName);
     UNUSED_PARAM(config);
     UNUSED_PARAM(outputCallback);
-    UNUSED_PARAM(postCallback);
 #endif
 
     callback(makeUnexpected("Not supported"_s));

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -62,16 +62,15 @@ public:
         std::optional<uint64_t> duration;
     };
 
-    using PostTaskCallback = Function<void(Function<void()>&&)>;
     using OutputCallback = Function<void(Expected<DecodedFrame, String>&&)>;
     using CreateResult = Expected<UniqueRef<VideoDecoder>, String>;
     using CreateCallback = Function<void(CreateResult&&)>;
 
-    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&);
     WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);
 
-    static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
-    WEBCORE_EXPORT static void createLocalDecoder(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&);
+    WEBCORE_EXPORT static void createLocalDecoder(const String&, const Config&, CreateCallback&&, OutputCallback&&);
 
     using DecodePromise = NativePromise<void, String>;
     virtual Ref<DecodePromise> decode(EncodedFrame&&) = 0;

--- a/Source/WebCore/platform/VideoEncoder.cpp
+++ b/Source/WebCore/platform/VideoEncoder.cpp
@@ -45,45 +45,44 @@ void VideoEncoder::setCreatorCallback(CreatorFunction&& function)
     s_customCreator = WTFMove(function);
 }
 
-void VideoEncoder::create(const String& codecName, const Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
+void VideoEncoder::create(const String& codecName, const Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
     if (s_customCreator) {
-        s_customCreator(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+        s_customCreator(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
         return;
     }
-    createLocalEncoder(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+    createLocalEncoder(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
 }
 
-void VideoEncoder::createLocalEncoder(const String& codecName, const Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
+void VideoEncoder::createLocalEncoder(const String& codecName, const Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
 #if USE(LIBWEBRTC) && PLATFORM(COCOA)
     if (codecName == "vp8"_s) {
-        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP8, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP8, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
         return;
     }
     if (codecName.startsWith("vp09.00"_s)) {
-        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP9, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP9, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
         return;
     }
     if (codecName.startsWith("vp09.02"_s)) {
-        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
         return;
     }
 #if ENABLE(AV1)
     if (codecName.startsWith("av01."_s)) {
-        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::AV1, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::AV1, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
         return;
     }
 #endif
 #elif USE(GSTREAMER)
-    GStreamerVideoEncoder::create(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
+    GStreamerVideoEncoder::create(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
     return;
 #else
     UNUSED_PARAM(codecName);
     UNUSED_PARAM(config);
     UNUSED_PARAM(descriptionCallback);
     UNUSED_PARAM(outputCallback);
-    UNUSED_PARAM(postCallback);
 #endif
 
     callback(makeUnexpected("Not supported"_s));

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -66,16 +66,15 @@ public:
     };
     using CreateResult = Expected<UniqueRef<VideoEncoder>, String>;
 
-    using PostTaskCallback = Function<void(Function<void()>&&)>;
     using DescriptionCallback = Function<void(ActiveConfiguration&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;
     using CreateCallback = Function<void(CreateResult&&)>;
 
-    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
     WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);
 
-    static void create(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
-    WEBCORE_EXPORT static void createLocalEncoder(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
+    WEBCORE_EXPORT static void createLocalEncoder(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
     using EncodePromise = NativePromise<void, String>;
     virtual Ref<EncodePromise> encode(RawFrame&&, bool shouldGenerateKeyFrame) = 0;

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
@@ -34,9 +34,9 @@ class GStreamerAudioDecoder : public ThreadSafeRefCounted<GStreamerAudioDecoder>
     WTF_MAKE_TZONE_ALLOCATED(GStreamerAudioDecoder);
 
 public:
-    static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&);
 
-    GStreamerAudioDecoder(const String& codecName, const Config&, OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
+    GStreamerAudioDecoder(const String& codecName, const Config&, OutputCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerAudioDecoder();
 
 private:

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
@@ -34,9 +34,9 @@ class GStreamerInternalAudioEncoder;
 class GStreamerAudioEncoder : public AudioEncoder {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerAudioEncoder);
 public:
-    static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
-    GStreamerAudioEncoder(DescriptionCallback&&,  OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
+    GStreamerAudioEncoder(DescriptionCallback&&,  OutputCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerAudioEncoder();
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -48,9 +48,9 @@ class GStreamerInternalVideoDecoder : public ThreadSafeRefCounted<GStreamerInter
     WTF_MAKE_TZONE_ALLOCATED_INLINE(GStreamerInternalVideoDecoder);
 
 public:
-    static Ref<GStreamerInternalVideoDecoder> create(const String& codecName, const VideoDecoder::Config& config, VideoDecoder::OutputCallback&& outputCallback, VideoDecoder::PostTaskCallback&& postTaskCallback, GRefPtr<GstElement>&& element)
+    static Ref<GStreamerInternalVideoDecoder> create(const String& codecName, const VideoDecoder::Config& config, VideoDecoder::OutputCallback&& outputCallback, GRefPtr<GstElement>&& element)
     {
-        return adoptRef(*new GStreamerInternalVideoDecoder(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element)));
+        return adoptRef(*new GStreamerInternalVideoDecoder(codecName, config, WTFMove(outputCallback), WTFMove(element)));
     }
     ~GStreamerInternalVideoDecoder()
     {
@@ -61,7 +61,6 @@ public:
         GST_DEBUG("Disposing un-configured video decoder");
     }
 
-    void postTask(Function<void()>&& task) { m_postTaskCallback(WTFMove(task)); }
     Ref<VideoDecoder::DecodePromise> decode(std::span<const uint8_t>, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration);
     void flush();
     void close() { m_isClosed = true; }
@@ -71,10 +70,9 @@ public:
     GstElement* harnessedElement() const { return m_harness->element(); }
 
 private:
-    GStreamerInternalVideoDecoder(const String& codecName, const VideoDecoder::Config&, VideoDecoder::OutputCallback&&, VideoDecoder::PostTaskCallback&&, GRefPtr<GstElement>&&);
+    GStreamerInternalVideoDecoder(const String& codecName, const VideoDecoder::Config&, VideoDecoder::OutputCallback&&, GRefPtr<GstElement>&&);
 
     VideoDecoder::OutputCallback m_outputCallback;
-    VideoDecoder::PostTaskCallback m_postTaskCallback;
 
     RefPtr<GStreamerElementHarness> m_harness;
     FloatSize m_presentationSize;
@@ -84,7 +82,7 @@ private:
     GRefPtr<GstCaps> m_inputCaps;
 };
 
-void GStreamerVideoDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback)
+void GStreamerVideoDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback)
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
@@ -95,34 +93,28 @@ void GStreamerVideoDecoder::create(const String& codecName, const Config& config
     auto lookupResult = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codecName);
     if (!lookupResult) {
         GST_WARNING("No decoder found for codec %s", codecName.utf8().data());
-        postTaskCallback([callback = WTFMove(callback), codecName]() mutable {
-            callback(makeUnexpected(makeString("No decoder found for codec "_s, codecName)));
-        });
+        callback(makeUnexpected(makeString("No decoder found for codec "_s, codecName)));
         return;
     }
 
     GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
-    auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element));
+    auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(element));
     auto internalDecoder = decoder->m_internalDecoder;
     if (!internalDecoder->isConfigured()) {
         GST_WARNING("Internal video decoder failed to configure for codec %s", codecName.utf8().data());
-        internalDecoder->postTask([callback = WTFMove(callback), codecName]() mutable {
-            callback(makeUnexpected(makeString("Internal video decoder failed to configure for codec "_s, codecName)));
-        });
+        callback(makeUnexpected(makeString("Internal video decoder failed to configure for codec "_s, codecName)));
         return;
     }
 
     gstDecoderWorkQueue().dispatch([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
         auto internalDecoder = decoder->m_internalDecoder;
-        internalDecoder->postTask([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
-            GST_DEBUG_OBJECT(decoder->m_internalDecoder->harnessedElement(), "Video decoder created");
-            callback(UniqueRef<VideoDecoder> { WTFMove(decoder) });
-        });
+        GST_DEBUG_OBJECT(decoder->m_internalDecoder->harnessedElement(), "Video decoder created");
+        callback(UniqueRef<VideoDecoder> { WTFMove(decoder) });
     });
 }
 
-GStreamerVideoDecoder::GStreamerVideoDecoder(const String& codecName, const Config& config, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback, GRefPtr<GstElement>&& element)
-    : m_internalDecoder(GStreamerInternalVideoDecoder::create(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element)))
+GStreamerVideoDecoder::GStreamerVideoDecoder(const String& codecName, const Config& config, OutputCallback&& outputCallback, GRefPtr<GstElement>&& element)
+    : m_internalDecoder(GStreamerInternalVideoDecoder::create(codecName, config, WTFMove(outputCallback), WTFMove(element)))
 {
 }
 
@@ -156,9 +148,8 @@ void GStreamerVideoDecoder::close()
     m_internalDecoder->close();
 }
 
-GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codecName, const VideoDecoder::Config& config, VideoDecoder::OutputCallback&& outputCallback, VideoDecoder::PostTaskCallback&& postTaskCallback, GRefPtr<GstElement>&& element)
+GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codecName, const VideoDecoder::Config& config, VideoDecoder::OutputCallback&& outputCallback, GRefPtr<GstElement>&& element)
     : m_outputCallback(WTFMove(outputCallback))
-    , m_postTaskCallback(WTFMove(postTaskCallback))
 {
     GST_DEBUG_OBJECT(element.get(), "Configuring decoder for codec %s", codecName.ascii().data());
     configureVideoDecoderForHarnessing(element);
@@ -232,23 +223,15 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
         if (m_presentationSize.isEmpty())
             m_presentationSize = getVideoResolutionFromCaps(stream.outputCaps().get()).value_or(FloatSize { 0, 0 });
 
-        m_postTaskCallback([weakThis = WeakPtr { *this }, this, outputSample = WTFMove(outputSample)]() mutable {
-            if (!weakThis)
-                return;
+        auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+        auto duration = m_duration.value_or(GST_BUFFER_DURATION(outputBuffer));
+        auto timestamp = static_cast<int64_t>(GST_BUFFER_PTS(outputBuffer));
+        if (timestamp == -1)
+            timestamp = m_timestamp;
 
-            if (m_isClosed)
-                return;
-
-            auto outputBuffer = gst_sample_get_buffer(outputSample.get());
-            auto duration = m_duration.value_or(GST_BUFFER_DURATION(outputBuffer));
-            auto timestamp = static_cast<int64_t>(GST_BUFFER_PTS(outputBuffer));
-            if (timestamp == -1)
-                timestamp = m_timestamp;
-
-            GST_TRACE_OBJECT(m_harness->element(), "Handling decoded frame with PTS: %" GST_TIME_FORMAT " and duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(timestamp), GST_TIME_ARGS(duration));
-            auto videoFrame = VideoFrameGStreamer::create(WTFMove(outputSample), m_presentationSize, fromGstClockTime(timestamp));
-            m_outputCallback(VideoDecoder::DecodedFrame { WTFMove(videoFrame), timestamp, duration });
-        });
+        GST_TRACE_OBJECT(m_harness->element(), "Handling decoded frame with PTS: %" GST_TIME_FORMAT " and duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(timestamp), GST_TIME_ARGS(duration));
+        auto videoFrame = VideoFrameGStreamer::create(WTFMove(outputSample), m_presentationSize, fromGstClockTime(timestamp));
+        m_outputCallback(VideoDecoder::DecodedFrame { WTFMove(videoFrame), timestamp, duration });
     });
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
@@ -35,9 +35,9 @@ class GStreamerVideoDecoder : public ThreadSafeRefCounted<GStreamerVideoDecoder>
     WTF_MAKE_TZONE_ALLOCATED(GStreamerVideoDecoder);
 
 public:
-    static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&);
 
-    GStreamerVideoDecoder(const String& codecName, const Config&, OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
+    GStreamerVideoDecoder(const String& codecName, const Config&, OutputCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerVideoDecoder();
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
@@ -33,9 +33,9 @@ class GStreamerInternalVideoEncoder;
 class GStreamerVideoEncoder : public VideoEncoder {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerVideoEncoder);
 public:
-    static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
-    GStreamerVideoEncoder(const Config&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    GStreamerVideoEncoder(const Config&, DescriptionCallback&&, OutputCallback&&);
     ~GStreamerVideoEncoder();
 
 private:

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -46,9 +46,9 @@ public:
         AV1
 #endif
     };
-    static void create(Type, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(Type, const Config&, CreateCallback&&, OutputCallback&&);
 
-    LibWebRTCVPXVideoDecoder(Type, const Config&, OutputCallback&&, PostTaskCallback&&);
+    LibWebRTCVPXVideoDecoder(Type, const Config&, OutputCallback&&);
     ~LibWebRTCVPXVideoDecoder();
 
 private:

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -46,9 +46,9 @@ public:
         AV1
 #endif
     };
-    static void create(Type, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(Type, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
 
-    LibWebRTCVPXVideoEncoder(Type, OutputCallback&&, PostTaskCallback&&);
+    LibWebRTCVPXVideoEncoder(Type, OutputCallback&&);
     ~LibWebRTCVPXVideoEncoder();
 
 private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
@@ -42,8 +42,8 @@ public:
     ~RemoteVideoCodecFactory();
 
 private:
-    static void createDecoder(const String&, const WebCore::VideoDecoder::Config&, WebCore::VideoDecoder::CreateCallback&&, WebCore::VideoDecoder::OutputCallback&&, WebCore::VideoDecoder::PostTaskCallback&&);
-    static void createEncoder(const String&, const WebCore::VideoEncoder::Config&, WebCore::VideoEncoder::CreateCallback&&, WebCore::VideoEncoder::DescriptionCallback&&, WebCore::VideoEncoder::OutputCallback&&, WebCore::VideoEncoder::PostTaskCallback&&);
+    static void createDecoder(const String&, const WebCore::VideoDecoder::Config&, WebCore::VideoDecoder::CreateCallback&&, WebCore::VideoDecoder::OutputCallback&&);
+    static void createEncoder(const String&, const WebCore::VideoEncoder::Config&, WebCore::VideoEncoder::CreateCallback&&, WebCore::VideoEncoder::DescriptionCallback&&, WebCore::VideoEncoder::OutputCallback&&);
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 4df3b2c79f1a919714853a55fba17a9a2826b08f
<pre>
Remove WebCodecs postTask callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=279073">https://bugs.webkit.org/show_bug.cgi?id=279073</a>
<a href="https://rdar.apple.com/135206937">rdar://135206937</a>

Reviewed by Jean-Yves Avenard.

We remove postTask callback since we are moving towards using more NativePromise in the future.
For now, we remove passing the postTask callback to video/audio encoder/decoder objects.
Instead, we do that directly at WebCodecs object level.

We introduce a m_decoderCounter/m_encoderCounter to keep track of configure calls so that the reset/configure flow gives the expected result of not providing frames of the past encoder/decoder.
We have to rebase a few tests as the creation of audio encoder/decoder objects is now failing asynchronously instead of synchronously like before.

Covered by existing tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::configure):
(WebCore::WebCodecsAudioDecoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
(WebCore::WebCodecsAudioEncoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h: Copied from Source/WebCore/platform/AudioEncoder.cpp.
(WebCore::postTaskToCodec):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/AudioDecoder.cpp:
(WebCore::AudioDecoder::create):
* Source/WebCore/platform/AudioDecoder.h:
* Source/WebCore/platform/AudioEncoder.cpp:
(WebCore::AudioEncoder::create):
* Source/WebCore/platform/AudioEncoder.h:
* Source/WebCore/platform/VideoDecoder.cpp:
(WebCore::VideoDecoder::create):
(WebCore::VideoDecoder::createLocalDecoder):
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/VideoEncoder.cpp:
(WebCore::VideoEncoder::create):
(WebCore::VideoEncoder::createLocalEncoder):
* Source/WebCore/platform/VideoEncoder.h:
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioDecoder::create):
(WebCore::GStreamerAudioDecoder::create):
(WebCore::GStreamerAudioDecoder::GStreamerAudioDecoder):
(WebCore::GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder):
(WebCore::GStreamerInternalAudioDecoder::postTask): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::create):
(WebCore::GStreamerAudioEncoder::create):
(WebCore::GStreamerAudioEncoder::GStreamerAudioEncoder):
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
(WebCore::GStreamerInternalAudioEncoder::postTask): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::initializeVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::create):
(WebCore::GStreamerVideoDecoder::create):
(WebCore::GStreamerVideoDecoder::GStreamerVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::postTask): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::GStreamerVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::postTask): Deleted.
(WebCore::GStreamerVideoEncoder::~GStreamerVideoEncoder): Deleted.
(WebCore::GStreamerVideoEncoder::encode): Deleted.
(WebCore::GStreamerVideoEncoder::flush): Deleted.
(WebCore::GStreamerVideoEncoder::setRates): Deleted.
(WebCore::GStreamerVideoEncoder::reset): Deleted.
(WebCore::GStreamerVideoEncoder::close): Deleted.
(WebCore::retrieveTemporalIndex): Deleted.
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder): Deleted.
(WebCore::GStreamerInternalVideoEncoder::~GStreamerInternalVideoEncoder): Deleted.
(WebCore::GStreamerInternalVideoEncoder::initialize): Deleted.
(WebCore::GStreamerInternalVideoEncoder::encode): Deleted.
(WebCore::GStreamerInternalVideoEncoder::setRates): Deleted.
(WebCore::GStreamerInternalVideoEncoder::applyRates): Deleted.
(WebCore::GStreamerInternalVideoEncoder::flush): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::create):
(WebCore::LibWebRTCVPXVideoDecoder::create):
(WebCore::LibWebRTCVPXVideoDecoder::LibWebRTCVPXVideoDecoder):
(WebCore::LibWebRTCVPXInternalVideoDecoder::LibWebRTCVPXInternalVideoDecoder):
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):
(WebCore::LibWebRTCVPXInternalVideoDecoder::postTask): Deleted.
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoEncoder::create):
(WebCore::LibWebRTCVPXVideoEncoder::create):
(WebCore::LibWebRTCVPXVideoEncoder::LibWebRTCVPXVideoEncoder):
(WebCore::LibWebRTCVPXInternalVideoEncoder::LibWebRTCVPXInternalVideoEncoder):
(WebCore::LibWebRTCVPXInternalVideoEncoder::OnEncodedImage):
(WebCore::LibWebRTCVPXInternalVideoEncoder::postTask): Deleted.
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoderCallbacks::create):
(WebKit::RemoteVideoEncoderCallbacks::create):
(WebKit::RemoteVideoCodecFactory::createDecoder):
(WebKit::RemoteVideoCodecFactory::createEncoder):
(WebKit::RemoteVideoDecoderCallbacks::RemoteVideoDecoderCallbacks):
(WebKit::RemoteVideoDecoderCallbacks::notifyDecodingResult):
(WebKit::RemoteVideoEncoderCallbacks::RemoteVideoEncoderCallbacks):
(WebKit::RemoteVideoEncoderCallbacks::notifyEncodedChunk):
(WebKit::RemoteVideoEncoderCallbacks::notifyEncoderDescription):
(WebKit::RemoteVideoDecoderCallbacks::postTask): Deleted.
(WebKit::RemoteVideoEncoderCallbacks::postTask): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h:

Canonical link: <a href="https://commits.webkit.org/283198@main">https://commits.webkit.org/283198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/981ff0760304d66cc04677ab04418512f4287d2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52503 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14870 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71116 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60102 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14446 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1375 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40567 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->