### PR TITLE
[JSC] Fix checkAliasOfEAX for AIR code generation and apply it for 64bit atomicStrongCAS

### DIFF
--- a/JSTests/stress/atomics-strong-cas.js
+++ b/JSTests/stress/atomics-strong-cas.js
@@ -1,0 +1,8 @@
+//@ requireOptions("--jitPolicyScale=0.01")
+for (let x = 0; x < 1; (function () {
+    for (let i = 0; i < 999999; i++) {
+        if (i >= 300000) quit();
+        Atomics.compareExchange(new Uint8Array(2), 1, x, x);
+    }
+})()
+) { }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -3523,9 +3523,9 @@ public:
         m_assembler.orl_im(0, 0, X86Registers::esp);
     }
 
-    ALWAYS_INLINE RegisterID checkAliasOfEAX(RegisterID newValue)
+    ALWAYS_INLINE RegisterID checkAliasOfEAX(RegisterID expectedAndResult, RegisterID newValue)
     {
-        if (newValue != X86Registers::eax)
+        if (newValue != X86Registers::eax || expectedAndResult == X86Registers::eax)
             return newValue;
 
         RegisterID tempNewValue = scratchRegister();
@@ -3535,109 +3535,109 @@ public:
 
     void atomicStrongCAS8(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address, RegisterID result)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgb_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS8(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address, RegisterID result)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgb_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     void atomicStrongCAS16(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address, RegisterID result)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgw_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS16(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address, RegisterID result)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgw_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     void atomicStrongCAS32(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address, RegisterID result)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgl_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS32(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address, RegisterID result)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgl_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     void atomicStrongCAS8(RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgb_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS8(RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgb_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     void atomicStrongCAS16(RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgw_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS16(RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgw_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     void atomicStrongCAS32(RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgl_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS32(RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgl_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     Jump branchAtomicStrongCAS8(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgb_rm(newValue, address.offset, address.base); });
     }
 
     Jump branchAtomicStrongCAS8(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgb_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     Jump branchAtomicStrongCAS16(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgw_rm(newValue, address.offset, address.base); });
     }
 
     Jump branchAtomicStrongCAS16(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgw_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     Jump branchAtomicStrongCAS32(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgl_rm(newValue, address.offset, address.base); });
     }
 
     Jump branchAtomicStrongCAS32(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
-        newValue = checkAliasOfEAX(newValue);
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgl_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
@@ -6627,31 +6627,37 @@ public:
     
     void atomicStrongCAS64(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address, RegisterID result)
     {
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgq_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS64(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address, RegisterID result)
     {
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(cond, expectedAndResult, result, address, [&] { m_assembler.cmpxchgq_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     void atomicStrongCAS64(RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgq_rm(newValue, address.offset, address.base); });
     }
 
     void atomicStrongCAS64(RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         atomicStrongCAS(expectedAndResult, address, [&] { m_assembler.cmpxchgq_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 
     Jump branchAtomicStrongCAS64(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, Address address)
     {
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgq_rm(newValue, address.offset, address.base); });
     }
 
     Jump branchAtomicStrongCAS64(StatusCondition cond, RegisterID expectedAndResult, RegisterID newValue, BaseIndex address)
     {
+        newValue = checkAliasOfEAX(expectedAndResult, newValue);
         return branchAtomicStrongCAS(cond, expectedAndResult, address, [&] { m_assembler.cmpxchgq_rm(newValue, address.offset, address.base, address.index, address.scale); });
     }
 


### PR DESCRIPTION
#### 901eee6dc6808ebe82d145b1fcddc5c95a91870a
<pre>
[JSC] Fix checkAliasOfEAX for AIR code generation and apply it for 64bit atomicStrongCAS
<a href="https://bugs.webkit.org/show_bug.cgi?id=279083">https://bugs.webkit.org/show_bug.cgi?id=279083</a>
<a href="https://rdar.apple.com/134963217">rdar://134963217</a>

Reviewed by Yusuke Suzuki.

The X86 &apos;atomicStrongCAS&apos; requires three arguments: &apos;expectedAndResult&apos;,
&apos;newValue&apos;, and &apos;address&apos;. This operation checks if the expected value matches
the value in memory, and if so, it replaces it with the new value. Otherwise,
it loads the memory value into the result. This can be done using cmpxchg[1]
with some additional handling.

If `expectedAndResult` is not in `eax`, a double swap is needed to perform `cmpxchg`
and load the result correctly. However, if `newValue` is in `eax`, the first swap will
overwrite it. That issue was fixed at [2] by using the scratch register.

The current issue is that &apos;atomicStrongCAS&apos; is also used in AIR code generation, which
doesn&apos;t allow for a scratch register. However, by reviewing the usage of `atomicStrongCAS`
in AIR for X86, it turns out that `eax` is always used as expectedAndResult. In this case,
there&apos;s no clobbering issue with `newValue` since the double swap between `expectedAndResult`
and `eax` won&apos;t occur.

This patch does two things:
1. Propose a simple fix by adding another alias check between `expectedAndResult` and `eax`
   for the fast path in `checkAliasOfEAX` to avoid the use of the scratch register.
2. Apply `checkAliasOfEAX` for 64-bit `atomicStrongCAS`.

[1] <a href="https://www.felixcloutier.com/x86/cmpxchg">https://www.felixcloutier.com/x86/cmpxchg</a>
[2] <a href="https://commits.webkit.org/281565@main">https://commits.webkit.org/281565@main</a>

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::checkAliasOfEAX):
(JSC::MacroAssemblerX86_64::atomicStrongCAS8):
(JSC::MacroAssemblerX86_64::atomicStrongCAS16):
(JSC::MacroAssemblerX86_64::atomicStrongCAS32):
(JSC::MacroAssemblerX86_64::branchAtomicStrongCAS8):
(JSC::MacroAssemblerX86_64::branchAtomicStrongCAS16):
(JSC::MacroAssemblerX86_64::branchAtomicStrongCAS32):
(JSC::MacroAssemblerX86_64::atomicStrongCAS64):
(JSC::MacroAssemblerX86_64::branchAtomicStrongCAS64):

Canonical link: <a href="https://commits.webkit.org/283138@main">https://commits.webkit.org/283138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71554503bc5c8ba3f5752a6f17be49cbb26ff99a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69388 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/15970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/15970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68430 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14847 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58477 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71093 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64608 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9348 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/7692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86375 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9908 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/15213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->