### PR TITLE
[WebGPU] RenderBundleEncoder fails to replay commands on invalid encoder

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279086-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279086-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279086.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279086.html
@@ -1,0 +1,20219 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAARhtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAABLKAGuYQTmZeVIu8RbaTYlLT6M37Azp2RAe3IEIV023n83eXSVUMBx7Y2iB8wAu3zfquCloEP/+/JCmDAPfYZQ6IAABA7GhAAJuF0QAAAAJgIB0HgoHi8ghf1U50bda3ZQlpx6HFJAXQEZAAP2AAv4AB9wAENAAAAAIgIB4PCQPIPL0ghVUsCXBQwADOgAI2AAQkAAroABXwJKA64AAAAjAgHgeJh6HoPD0whVUsCWiBgADvgAKiAAacAAy4ABmQKKBEwAAAAjAgHhaNB6DwHr0whVUsCWiBgADvgAKiAAacAAy4ABmQKKBEwAAAQ8bW9vdgAAAGxtdmhkAAAAAOLnqjHi56oxAAACWAAAC7gAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAA8h0cmFrAAAAXHRraGQAAAAP4ueqMeLnqjEAAAABAAAAAAAAC7gAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAQAAAAEAAAAAAABEdGFwdAAAABRjbGVmAAAAAAEAAAABAAAAAAAAFHByb2YAAAAAAQAAAAEAAAAAAAAUZW5vZgAAAAABAAAAAQAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAC7gAAAAAAAEAAAAAAvxtZGlhAAAAIG1kaGQAAAAA4ueqMeLnqjEAAAJYAAALuFXEAAAAAAAxaGRscgAAAABtaGxydmlkZWFwcGwAAAAAAAAAABBDb3JlIE1lZGlhIFZpZGVvAAACo21pbmYAAAAUdm1oZAAAAAEAQIAAgACAAAAAADhoZGxyAAAAAGRobHJhbGlzYXBwbAAAAAAAAAAAF0NvcmUgTWVkaWEgRGF0YSBIYW5kbGVyAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAABAAAADGFsaXMAAAABAAACK3N0YmwAAADpc3RzZAAAAAAAAAABAAAA2Wh2YzEAAAAAAAAAAQAAAAAAAAAAAAACAAAAAgABAAEAAEgAAABIAAAAAAAAAAEESEVWQwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY//8AAABtaHZjQwEECAAAAL3IAAAAAFrwAPz8+PgAAAsDoAABABdAAQwB//8ECAAAAwC9yAAAAwAAWhXAkKEAAQAhQgEBBAgAAAMAvcgAAAMAAFrAICAQFiBXuRZVNwEHBwCAogABAAdEAcAsvBTJAAAAEmNvbHJuY2xjAAEABwAHAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAHIAAAAqAAAAJgAAACcAAAAnAAAAJHN0Y28AAAAAAAAABQAAACQAAACWAAAAwAAAAOYAAAEN`,
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter();
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u0d5d\uc05a\u9a59\u5af1\u01b3',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    minStorageBufferOffsetAlignment: 256,
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 3442046,
+    maxStorageBufferBindingSize: 151045538,
+  },
+});
+let texture0 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 182},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 92},
+  aspect: 'all',
+}, new Uint8Array(103_340).fill(183), /* required buffer size: 103_340 */
+{offset: 88, bytesPerRow: 173, rowsPerImage: 26}, {width: 9, height: 25, depthOrArrayLayers: 23});
+} catch {}
+let commandEncoder0 = device0.createCommandEncoder({});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u3504\u{1ff74}\u215c\u6f16\u2ef9\u{1f820}\u2629\u803c',
+  entries: [
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let texture1 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u3e18\u45b8\u0833',
+  entries: [
+    {
+      binding: 267,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView0 = texture1.createView({});
+let texture2 = device0.createTexture({
+  size: [8, 10, 1],
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(194).fill(156), /* required buffer size: 194 */
+{offset: 194, bytesPerRow: 39, rowsPerImage: 47}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let texture3 = device0.createTexture({
+  size: [8, 10, 81],
+  sampleCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture4 = device0.createTexture({
+  label: '\ua69e\uc33d\u0aeb',
+  size: [16],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler0 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 35.74,
+  lodMaxClamp: 74.09,
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 285,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 444});
+let textureView1 = texture3.createView({dimension: '2d', baseArrayLayer: 0});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u0501\u{1f7bc}\u0e43\u2a37\u73aa'});
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 93.49,
+  lodMaxClamp: 94.38,
+  compare: 'greater',
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let buffer0 = device0.createBuffer({
+  size: 3266,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder2 = device0.createCommandEncoder();
+let texture5 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 420},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView2 = texture5.createView({baseMipLevel: 0});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer0, offset: 256, size: 112}}],
+});
+let textureView3 = texture5.createView({arrayLayerCount: 1});
+let texture6 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 85},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(3823), 431, 0);
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 461});
+let texture7 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView4 = texture3.createView({baseArrayLayer: 8, arrayLayerCount: 24});
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 384 */
+  offset: 384,
+  bytesPerRow: 768,
+  rowsPerImage: 441,
+  buffer: buffer0,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'unspecified', transfer: 'unspecified'} });
+let buffer1 = device0.createBuffer({
+  size: 9475,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView5 = texture6.createView({format: 'r16sint', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet1, 84, 13, buffer0, 256);
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView0},
+    {binding: 59, resource: {buffer: buffer0, offset: 1792, size: 248}},
+  ],
+});
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u018e\u{1fedc}\u2d21\ue0c1\u0114\u9bc5\u58a1\u1284\u0caa\u06c0', bindGroupLayouts: []});
+let querySet2 = device0.createQuerySet({label: '\u075b\u0ad5\u0c3d', type: 'occlusion', count: 350});
+let textureView6 = texture6.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder1 = commandEncoder4.beginComputePass();
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer0, offset: 512, size: 196}}],
+});
+let buffer2 = device0.createBuffer({
+  size: 2477,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder5 = device0.createCommandEncoder();
+let texture8 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 36},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler2 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.56,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder0.clearBuffer(buffer2, 140, 516);
+} catch {}
+await gc();
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder6 = device0.createCommandEncoder({});
+let texture9 = device0.createTexture({
+  size: [4, 5, 5],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+let buffer3 = device0.createBuffer({size: 1764, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture10 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 88},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder2 = commandEncoder5.beginComputePass({label: '\u{1fec3}\u0233\ue070\u1766'});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+let textureView7 = texture6.createView({mipLevelCount: 1});
+let sampler3 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 9.901,
+  lodMaxClamp: 32.13,
+});
+try {
+commandEncoder0.insertDebugMarker('\u{1fe69}');
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u0f4c\u{1f693}\u{1f96c}',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @align(2) f0: atomic<i32>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer4: T0;
+struct VertexOutput0 {
+  @location(9) @interpolate(perspective, centroid) f0: f32,
+  @location(15) f1: vec3f,
+  @location(7) @interpolate(flat, center) f2: vec2u,
+  @builtin(position) f3: vec4f
+}
+
+@vertex
+fn vertex0(@location(4) @interpolate(flat) a0: vec4i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f0 = f32(a0[2]);
+  return out;
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(frag_depth) f1: f32,
+  @location(0) f2: i32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 >>= u32(9);
+  return out;
+}
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 142,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 92,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 111,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 238, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 293,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView8 = texture7.createView({dimension: '2d', baseArrayLayer: 2});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(624), 168, 0);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer0, 580, buffer3, 8, 100);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1424 */
+  offset: 1424,
+  rowsPerImage: 568,
+  buffer: buffer2,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer5 = device0.createBuffer({size: 12222, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder7 = device0.createCommandEncoder();
+let texture11 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler4 = device0.createSampler({
+  label: '\u{1fb38}\ue654\u074a\u{1f98f}\u{1ff8c}\u0943',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.44,
+  lodMaxClamp: 93.39,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(244), 16, 0);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u6618\ueb0f\ub21b\u89d1\uc5a2'});
+let commandBuffer0 = commandEncoder2.finish({});
+let texture12 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder0.beginComputePass({});
+let texture13 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 7},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u{1fbd1}\u7b05\uc176\u{1f898}'});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup2);
+} catch {}
+let buffer6 = device0.createBuffer({size: 4141, usage: GPUBufferUsage.VERTEX});
+let texture14 = device0.createTexture({
+  size: [4, 5, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder8.beginComputePass({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.13,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 732, new DataView(new ArrayBuffer(3096)), 50, 160);
+} catch {}
+try {
+adapter0.label = '\ub411\ud680\u{1fe57}';
+} catch {}
+let textureView9 = texture14.createView({dimension: '2d-array'});
+let computePassEncoder6 = commandEncoder3.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(2066), 442, 0);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let img0 = await imageWithData(28, 58, '#10101010', '#20202020');
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView10 = texture11.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 0});
+let textureView11 = texture12.createView({aspect: 'all'});
+let computePassEncoder7 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet0, 224, 25, buffer0, 256);
+} catch {}
+let buffer7 = device0.createBuffer({size: 9325, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let textureView12 = texture14.createView({label: '\u747b\uebd0', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+commandEncoder9.resolveQuerySet(querySet2, 328, 6, buffer0, 768);
+} catch {}
+document.body.append(img0);
+let texture15 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte240m', transfer: 'unspecified'} });
+let buffer8 = device0.createBuffer({
+  label: '\u7b0b\u16a8\u{1feff}\u052b\u0552\u0e41',
+  size: 12112,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer1 = commandEncoder9.finish({});
+let textureView13 = texture14.createView({dimension: '2d-array'});
+let sampler6 = device0.createSampler({
+  label: '\u0034\ue245\ueb98',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.75,
+  lodMaxClamp: 52.41,
+  compare: 'greater-equal',
+});
+let promise1 = shaderModule0.getCompilationInfo();
+let buffer9 = device0.createBuffer({size: 15409, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture16 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 52},
+  dimension: '2d',
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView14 = texture12.createView({label: '\u0e72\u0617\u9074\u{1fe5c}\u0110\u0a86\u69d7\u75d6\u88af\ud93e\u648b'});
+let computePassEncoder8 = commandEncoder8.beginComputePass({});
+let commandEncoder10 = device0.createCommandEncoder({});
+let computePassEncoder9 = commandEncoder10.beginComputePass();
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 80.94,
+  lodMaxClamp: 82.54,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup1, new Uint32Array(245), 83, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+texture16.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer1, offset: 0, size: 1488}}],
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 4},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer2 = commandEncoder11.finish({});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup3, new Uint32Array(661), 97, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer1, offset: 0, size: 632}}],
+});
+let buffer10 = device0.createBuffer({size: 1637, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 52, resource: {buffer: buffer10, offset: 768, size: 46}},
+    {binding: 142, resource: textureView14},
+    {binding: 111, resource: textureView8},
+    {binding: 92, resource: textureView8},
+    {binding: 238, resource: sampler3},
+    {binding: 1, resource: textureView13},
+    {binding: 293, resource: textureView10},
+    {binding: 13, resource: textureView12},
+    {binding: 65, resource: {buffer: buffer0, offset: 768, size: 268}},
+  ],
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer11 = device0.createBuffer({size: 7432, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: true});
+let texture18 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView15 = texture11.createView({dimension: 'cube-array', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 6});
+document.body.prepend(img0);
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u562e\ubaf7\u04d5'});
+let computePassEncoder10 = commandEncoder12.beginComputePass({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+device0.queue.writeBuffer(buffer3, 136, new Int16Array(1967), 403, 120);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView1}, {binding: 267, resource: textureView2}],
+});
+let textureView16 = texture7.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let buffer12 = device0.createBuffer({size: 3669, usage: GPUBufferUsage.MAP_WRITE});
+let textureView17 = texture5.createView({baseArrayLayer: 0});
+try {
+device0.queue.submit([commandBuffer2, commandBuffer1]);
+} catch {}
+let buffer13 = device0.createBuffer({label: '\ua9b6\u4748', size: 2516, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder13 = device0.createCommandEncoder({label: '\uee5b\u5e86\u0bd1\u6fc9\u{1f7c5}'});
+let textureView18 = texture9.createView({dimension: '2d'});
+let textureView19 = texture7.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, baseArrayLayer: 10});
+let computePassEncoder11 = commandEncoder13.beginComputePass({});
+let buffer14 = device0.createBuffer({
+  label: '\u0d1d\u{1fbb9}\u{1f761}\u{1fdef}\ucb45\uf94f\u2901\uab45\u351c',
+  size: 3635,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture19 = device0.createTexture({
+  size: [2, 2, 70],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView20 = texture12.createView({mipLevelCount: 1});
+let sampler8 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.98,
+  lodMaxClamp: 48.37,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 13, resource: textureView12},
+    {binding: 142, resource: textureView20},
+    {binding: 92, resource: textureView8},
+    {binding: 293, resource: textureView10},
+    {binding: 65, resource: {buffer: buffer2, offset: 0, size: 264}},
+    {binding: 1, resource: textureView9},
+    {binding: 238, resource: sampler4},
+    {binding: 111, resource: textureView8},
+    {binding: 52, resource: {buffer: buffer14, offset: 512, size: 1110}},
+  ],
+});
+let buffer15 = device0.createBuffer({size: 7221, usage: GPUBufferUsage.MAP_WRITE});
+let texture20 = device0.createTexture({
+  label: '\u{1fed0}\ue0ba',
+  size: {width: 4, height: 5, depthOrArrayLayers: 44},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder12 = commandEncoder0.beginComputePass({});
+try {
+querySet0.destroy();
+} catch {}
+let videoFrame2 = new VideoFrame(videoFrame1, {timestamp: 0});
+let bindGroup8 = device0.createBindGroup({
+  label: '\udb3b\ud323\u7577',
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer0, offset: 256, size: 388}}],
+});
+let buffer16 = device0.createBuffer({
+  label: '\u0a5b\uacdd\u7ce2\ud269\ua61c\u090e\u5216\u0bc3\u07ba\u{1fc3b}',
+  size: 11969,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: [8, 10, 1],
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView21 = texture10.createView({baseMipLevel: 0});
+let sampler9 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 81.03,
+  compare: 'greater',
+});
+let imageData0 = new ImageData(12, 44);
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt709', transfer: 'smpte170m'} });
+let texture22 = device0.createTexture({
+  label: '\u{1f77a}\u{1fbb8}\u{1fd2f}\u{1f61b}\u5727\ua876\udf1d\u078c\u{1fd94}',
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView22 = texture6.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup5, new Uint32Array(129), 1, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 424, new DataView(new ArrayBuffer(413)), 89, 0);
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+  label: '\uf325\u8d81\u09b9\u52e9',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, constants: {}},
+});
+let buffer17 = device0.createBuffer({
+  label: '\u32b7\u{1faeb}\u1c66',
+  size: 4250,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let computePassEncoder13 = commandEncoder15.beginComputePass();
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer17, 332, buffer3, 92, 236);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 244 */
+  offset: 244,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(37).fill(212), /* required buffer size: 37 */
+{offset: 37}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture23 = device0.createTexture({
+  label: '\u6144\u7c86\u90e4',
+  size: [2, 2, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder14 = commandEncoder14.beginComputePass({});
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(110_091).fill(129), /* required buffer size: 110_091 */
+{offset: 163, bytesPerRow: 91, rowsPerImage: 151}, {width: 0, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let buffer18 = device0.createBuffer({size: 15977, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(1, bindGroup7, new Uint32Array(3215), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer16, 1_888); };
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({
+  size: [256, 256, 18],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup4);
+} catch {}
+let arrayBuffer0 = buffer11.getMappedRange(368, 88);
+let canvas0 = document.createElement('canvas');
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView0},
+    {binding: 59, resource: {buffer: buffer1, offset: 3328, size: 2568}},
+  ],
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup8, []);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup2, new Uint32Array(6574), 3_047, 0);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer16, offset: 0, size: 8540}}],
+});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 173});
+let texture25 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture26 = device0.createTexture({
+  label: '\u{1f653}\uc940',
+  size: [4, 5, 65],
+  sampleCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+await gc();
+let textureView23 = texture23.createView({label: '\u05b1\u{1f9f2}\uc64a\ud883\u{1f77c}\ufed9'});
+let texture27 = device0.createTexture({
+  size: [2, 2, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder16.resolveQuerySet(querySet0, 32, 57, buffer0, 0);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u{1f7d8}');
+} catch {}
+document.body.append(img0);
+let texture28 = device0.createTexture({
+  label: '\uf334\ucf29\u7cda\u{1fefc}\u{1f66e}\ubec3\u9cf8\uf83b\u098b\u32a3',
+  size: [4, 5, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture9.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder16.beginComputePass({});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let sampler10 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.05,
+  lodMaxClamp: 61.47,
+  compare: 'never',
+});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4184 */
+  offset: 4184,
+  buffer: buffer17,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1604 */
+  offset: 1604,
+  bytesPerRow: 512,
+  buffer: buffer14,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData1 = new ImageData(12, 44);
+try {
+canvas0.getContext('2d');
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  label: '\u0fe7\u1544\u7469\u095b',
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView18}, {binding: 267, resource: textureView3}],
+});
+let textureView25 = texture14.createView({dimension: '2d-array'});
+let texture29 = device0.createTexture({
+  size: [8, 10, 17],
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView26 = texture7.createView({baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder16 = commandEncoder17.beginComputePass({});
+let sampler11 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.51,
+  lodMaxClamp: 94.36,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup4, new Uint32Array(810), 48, 0);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\uaa93\u1802\u0d69\u232f\u{1fead}\u{1f765}\u44b2',
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer0, offset: 0, size: 372}}],
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView27 = texture10.createView({baseArrayLayer: 0});
+let computePassEncoder17 = commandEncoder18.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer3, 124, new BigUint64Array(8553), 418, 44);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({label: '\u{1f7d9}\uee44\u1b40\ueed4\u1392'});
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  label: '\u{1fac3}\u{1f82a}\u{1f7b2}\uf41c\u{1fd0a}\ucaa1',
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView18}, {binding: 267, resource: textureView3}],
+});
+let buffer19 = device0.createBuffer({size: 9654, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder20 = device0.createCommandEncoder();
+let texture30 = device0.createTexture({
+  label: '\u5784\ue511\u{1fedb}\u2e04\u4ce9\u098f\u052d\u86c7\u0735\u{1fa2f}',
+  size: {width: 2, height: 2, depthOrArrayLayers: 55},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2592 */
+  offset: 2592,
+  bytesPerRow: 768,
+  rowsPerImage: 980,
+  buffer: buffer8,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer2, 584, 1020);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet1, 104, 7, buffer0, 0);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let computePassEncoder18 = commandEncoder20.beginComputePass({label: '\u5fe8\u87b9\u{1f688}\ue62c\u96c2'});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.61,
+  lodMaxClamp: 99.76,
+  maxAnisotropy: 1,
+});
+let arrayBuffer1 = buffer11.getMappedRange(48, 28);
+await gc();
+let img1 = await imageWithData(58, 22, '#10101010', '#20202020');
+let bindGroup14 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer1, offset: 256, size: 5008}}],
+});
+let texture31 = device0.createTexture({
+  label: '\u7d04\u06d5\u2d28\u{1f916}\u94f3\uac15\u031a\ue7a8\u0092',
+  size: [8, 10, 10],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture32 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder19 = commandEncoder19.beginComputePass({label: '\u0e54\ue7d2\u0e6e\uae1a\u{1fc14}'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', stencilReadOnly: true});
+let renderBundle1 = renderBundleEncoder1.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 1721});
+let texture33 = device0.createTexture({
+  label: '\u8a9d\u03a6\u7962\u0762\u{1fe21}\u8d5a\u{1ffa7}\u4b38\u8796\ub696\ua0c5',
+  size: {width: 4, height: 5, depthOrArrayLayers: 21},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView28 = texture7.createView({aspect: 'stencil-only', baseArrayLayer: 1, arrayLayerCount: 1});
+let arrayBuffer2 = buffer11.getMappedRange(168, 80);
+try {
+externalTexture0.label = '\u0864\u0bf0';
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture34 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup7, new Uint32Array(24), 5, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer8, 4748, buffer3, 12, 1480);
+} catch {}
+try {
+computePassEncoder4.pushDebugGroup('\u7fe3');
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(7, 168);
+let bindGroup15 = device0.createBindGroup({
+  label: '\u0834\u7087\u92f8\ueaae\ubef1\uf156\u0590\u0786\u5f7c\u{1fc9f}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer2, offset: 0, size: 968}}],
+});
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u0d4a\u055e\u1d75\u7fa9\ub985\u005d', bindGroupLayouts: [bindGroupLayout2]});
+let buffer20 = device0.createBuffer({
+  size: 5985,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder22 = device0.createCommandEncoder({label: '\ua5c5\uf44c\u853c\u0e78\u0f6f\uf4d5\uda78'});
+let computePassEncoder20 = commandEncoder21.beginComputePass({});
+let sampler13 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.933,
+  lodMaxClamp: 86.39,
+});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u78f8\u134f\u047b\u0a39\u6da3\u1c69\u9ded\u08f9\u0b91',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 111, resource: textureView8},
+    {binding: 1, resource: textureView25},
+    {binding: 142, resource: textureView20},
+    {binding: 65, resource: {buffer: buffer16, offset: 3072, size: 1400}},
+    {binding: 52, resource: {buffer: buffer14, offset: 1024, size: 227}},
+    {binding: 92, resource: textureView8},
+    {binding: 13, resource: textureView23},
+    {binding: 238, resource: sampler11},
+    {binding: 293, resource: textureView10},
+  ],
+});
+let buffer21 = device0.createBuffer({size: 6462, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder21 = commandEncoder22.beginComputePass({});
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.59,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer1, 4_668); };
+} catch {}
+document.body.append(img0);
+let textureView29 = texture24.createView({dimension: 'cube', mipLevelCount: 1});
+let sampler15 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  lodMinClamp: 59.66,
+  lodMaxClamp: 98.10,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(151).fill(150), /* required buffer size: 151 */
+{offset: 151}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer22 = device0.createBuffer({
+  size: 15648,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: u32,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: atomic<i32>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer23: atomic<u32>;
+struct VertexOutput1 {
+  @location(5) @interpolate(linear, centroid) f4: vec3h,
+  @builtin(position) f5: vec4f,
+  @location(0) @interpolate(flat, center) f6: vec4f,
+  @location(1) f7: vec4h,
+  @location(9) @interpolate(linear, centroid) f8: vec4f,
+  @location(14) @interpolate(perspective) f9: vec4f,
+  @location(4) f10: vec3h,
+  @location(7) f11: i32
+}
+
+@vertex
+fn vertex0() -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f9 /= vec4f(0.2380, 0.2268, 0.01553, 0.1015);
+  out.f7 %= vec4h(-34063.4);
+  out.f4 -= vec3h(-46693.5);
+  out.f8 = vec4f(0.1555, 0.3720, 0.1226, 0.1291);
+  return out;
+}`,
+  sourceMap: {},
+});
+let texture35 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 4},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 80.08,
+});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup6, new Uint32Array(561), 25, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(3); };
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+let texture36 = device0.createTexture({
+  size: [256, 256, 18],
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler17 = device0.createSampler({
+  label: '\u{1f836}\u3817\u{1ff11}\u0c94\u{1faef}\ub98c\u6c51\u7ce9\u178e\u04ad',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.76,
+  lodMaxClamp: 97.21,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup13);
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u6186\ua10e\u43c0\u0a2c',
+  colorFormats: ['rgb10a2uint'],
+  sampleCount: 1,
+  stencilReadOnly: false,
+});
+let renderBundle2 = renderBundleEncoder2.finish({label: '\u25ca\u{1fcda}\uaac8'});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup10, new Uint32Array(1786), 88, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer24 = device0.createBuffer({
+  size: 19798,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder23 = device0.createCommandEncoder();
+let texture37 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 3},
+  mipLevelCount: 3,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler18 = device0.createSampler({
+  label: '\u80a3\ua03d\u560c\u{1fb06}\u1966\u{1f656}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.10,
+  lodMaxClamp: 88.69,
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer0, 944); };
+} catch {}
+let buffer25 = device0.createBuffer({
+  size: 20848,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView30 = texture1.createView({});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup9, new Uint32Array(546), 36, 0);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1676 */
+  offset: 1676,
+  buffer: buffer19,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder4.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 9, y: 24, z: 1},
+  aspect: 'all',
+}, new Uint8Array(657).fill(194), /* required buffer size: 657 */
+{offset: 21, bytesPerRow: 84}, {width: 3, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'iec6196624'} });
+let computePassEncoder22 = commandEncoder23.beginComputePass({});
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let computePassEncoder23 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup13, new Uint32Array(1011), 21, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 636, new BigUint64Array(8978), 308, 80);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<atomic<u32>, 1>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer26: i32;
+
+@vertex
+fn vertex0(@location(7) a0: vec2i, @location(11) a1: f16, @location(15) @interpolate(flat, centroid) a2: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+struct FragmentOutput1 {
+  @location(5) f0: vec2i,
+  @location(0) @interpolate(flat) f1: vec4u,
+  @location(7) @interpolate(flat) f2: vec4u
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec3f) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup17 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer24, offset: 512, size: 3228}}],
+});
+let buffer27 = device0.createBuffer({
+  size: 15056,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let buffer28 = device0.createBuffer({
+  size: 2423,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 559});
+try {
+device0.queue.writeBuffer(buffer20, 64, new Int16Array(10972), 291, 292);
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({label: '\uba38\uefc9', layout: pipelineLayout4, compute: {module: shaderModule0, constants: {}}});
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer28, offset: 256, size: 48}}],
+});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 1727});
+let textureView31 = texture27.createView({label: '\u6779\ue6b2\u32eb\uccf1\u{1f98b}\u7044\u4108\u4a9f\uca0d\ub997', dimension: '2d'});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture38 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup16, new Uint32Array(882), 215, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1732 */
+  offset: 1732,
+  buffer: buffer14,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @size(4) f0: array<array<array<f16, 1>, 1>>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer29: atomic<i32>;
+struct S0 {
+  @location(0) @interpolate(flat) f0: vec4f
+}
+struct FragmentOutput2 {
+  @location(0) @interpolate(flat, centroid) f0: vec4u,
+  @location(5) @interpolate(flat, center) f1: vec2u
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec4h, @location(9) a1: vec4f, @location(5) a2: vec3h, a3: S0) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u) {
+  _ = atomicExchange(&buffer29, 91);
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1(@builtin(workgroup_id) a0: vec3u, @builtin(local_invocation_index) a1: u32) {
+  if bool(a0[2]) {
+    return;
+  }
+}`,
+});
+let bindGroup19 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 59, resource: {buffer: buffer2, offset: 0, size: 60}},
+    {binding: 97, resource: textureView30},
+  ],
+});
+let texture39 = device0.createTexture({size: [256, 256, 18], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let sampler19 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 66.40,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture40 = device0.createTexture({
+  size: [8],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 45.79,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+window.someLabel = textureView1.label;
+} catch {}
+let texture41 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder24 = commandEncoder25.beginComputePass();
+let sampler21 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.35,
+  lodMaxClamp: 82.45,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer9, 592, buffer25, 1016, 284);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer5, offset: 0, size: 124}}],
+});
+let textureView32 = texture7.createView({dimension: 'cube', format: 'depth32float-stencil8', baseArrayLayer: 1});
+let texture42 = device0.createTexture({size: [2, 2, 15], format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let computePassEncoder25 = commandEncoder26.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer1, 1_704); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 4, y: 35, z: 4},
+  aspect: 'all',
+}, new Uint8Array(6_501).fill(91), /* required buffer size: 6_501 */
+{offset: 129, bytesPerRow: 304}, {width: 73, height: 21, depthOrArrayLayers: 1});
+} catch {}
+let buffer30 = device0.createBuffer({
+  label: '\u5719\u2d7d\u{1f90e}\u5fca\ubeb6\u08c3\u0055\u0b7f',
+  size: 14856,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture43 = device0.createTexture({size: [4, 5, 44], mipLevelCount: 2, dimension: '3d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8'});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer7, 'uint16', 1_284, 2_780);
+} catch {}
+let imageData2 = new ImageData(56, 4);
+try {
+window.someLabel = textureView6.label;
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+  size: [16, 20, 34],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView33 = texture35.createView({arrayLayerCount: 1});
+let computePassEncoder26 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 828, new BigUint64Array(8532), 1939, 8);
+} catch {}
+try {
+window.someLabel = buffer13.label;
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({size: [8, 10, 1], format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let texture46 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder27 = commandEncoder28.beginComputePass();
+let renderBundle3 = renderBundleEncoder3.finish({label: '\u1f09\u09cc\u{1fd44}'});
+let texture47 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+let renderBundle4 = renderBundleEncoder4.finish({});
+let sampler22 = device0.createSampler({
+  label: '\u0006\u6967\uc218\u{1ff98}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.67,
+  lodMaxClamp: 97.59,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup8);
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'unspecified', transfer: 'smpteSt4281'} });
+let commandEncoder29 = device0.createCommandEncoder();
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 33});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer24, 852); };
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer21, 624, 72);
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  label: '\u03a3\u{1ff83}\u2c7b',
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule3, targets: [{format: 'rgb10a2uint'}]},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+});
+let offscreenCanvas1 = new OffscreenCanvas(163, 568);
+let textureView34 = texture5.createView({baseMipLevel: 0});
+let computePassEncoder28 = commandEncoder29.beginComputePass();
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.92,
+  lodMaxClamp: 43.15,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup14, new Uint32Array(2180), 160, 0);
+} catch {}
+try {
+computePassEncoder28.insertDebugMarker('\u23bd');
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer5, offset: 5632, size: 1528}}],
+});
+let buffer31 = device0.createBuffer({size: 6904, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let textureView35 = texture45.createView({dimension: '2d-array', aspect: 'all'});
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer3 = buffer31.getMappedRange(552, 3868);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let sampler24 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.872,
+  lodMaxClamp: 78.32,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\uceea');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(2_219).fill(42), /* required buffer size: 2_219 */
+{offset: 19, bytesPerRow: 110, rowsPerImage: 4}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470m', transfer: 'unspecified'} });
+let promise4 = adapter0.requestAdapterInfo();
+let buffer32 = device0.createBuffer({size: 1078, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder30 = device0.createCommandEncoder({});
+let computePassEncoder29 = commandEncoder30.beginComputePass({});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3, new Uint32Array(290), 62, 0);
+} catch {}
+let buffer33 = device0.createBuffer({size: 38292, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u0095\udd10\u5be3\u0ee2\u4668\u0158'});
+let textureView36 = texture28.createView({mipLevelCount: 1});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup20);
+} catch {}
+let arrayBuffer4 = buffer11.getMappedRange(248, 8);
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+document.body.prepend(img0);
+try {
+window.someLabel = computePassEncoder19.label;
+} catch {}
+let texture48 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler25 = device0.createSampler({
+  label: '\u04fd\u0e8d\u0fa7\u63c7\u{1feb0}\ua315\u9370\u0c21',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 18.72,
+  lodMaxClamp: 58.12,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 80, y: 54, z: 1},
+  aspect: 'all',
+}, new Uint8Array(11_599).fill(167), /* required buffer size: 11_599 */
+{offset: 89, bytesPerRow: 90}, {width: 40, height: 128, depthOrArrayLayers: 1});
+} catch {}
+let texture49 = device0.createTexture({
+  size: [4, 5, 14],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(3, bindGroup17, new Uint32Array(315), 35, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer0, 864); };
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer5 = buffer11.getMappedRange(712, 1432);
+try {
+commandEncoder31.copyBufferToBuffer(buffer25, 3884, buffer24, 1020, 1832);
+} catch {}
+let computePassEncoder30 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(1867), 46, 0);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture50 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 177},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView37 = texture50.createView({label: '\u172a\ud71a\u0a8b\u{1fa0f}\uadad\u{1fd27}\u0ab0', dimension: '3d', baseArrayLayer: 0});
+let renderPassEncoder0 = commandEncoder32.beginRenderPass({
+  label: '\u9d1d\u02b0\u9baf\u0941\u{1ffd0}\u05b5\uf2ac\uf8f9\u{1fa1b}\ud7d3\ud8ba',
+  colorAttachments: [{view: textureView37, depthSlice: 79, loadOp: 'clear', storeOp: 'discard'}],
+});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup1, new Uint32Array(1193), 249, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+let buffer34 = device0.createBuffer({
+  label: '\u{1fafd}\u2a18\u97e2\u0168\u882c',
+  size: 8851,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler26 = device0.createSampler({
+  label: '\u{1f66a}\ufd72\u{1f609}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.11,
+  lodMaxClamp: 96.39,
+  compare: 'equal',
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(0, bindGroup20, new Uint32Array(569), 19, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup4, new Uint32Array(761), 97, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer22, 384); };
+} catch {}
+try {
+renderPassEncoder0.setViewport(5.2683492094797675, 12.435256583114814, 5.567545356545731, 0.3854459556672466, 0.577944308902145, 0.6202555564795051);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture51 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView38 = texture10.createView({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(821), 33, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(14.404446516938426, 10.379518389997298, 1.4349174977721253, 8.847250813664843, 0.5178069734737684, 0.6136322703948607);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 1_446, 1_212);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer17);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, colorSpace: 'display-p3'});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise4;
+} catch {}
+let sampler27 = device0.createSampler({
+  label: '\u{1fcf2}\u033a\u56b4\u1be0\ue456\u02da\u0625\uab45',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.26,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup15, new Uint32Array(2961), 1_076, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle5, renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer30, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 316, new BigUint64Array(33305), 2146, 48);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({});
+let texture52 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder31 = commandEncoder33.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup19, new Uint32Array(561), 63, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setViewport(4.607643670848244, 14.983035104195473, 6.123675517151971, 0.4166305688582461, 0.8787457253406095, 0.9753969751200845);
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+  label: '\u{1f727}\u0bcf\u3829\u0f01\u0031',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  label: '\u5335\ub057\u3e7c\u1b0d\u6141\u0d53\uba0b\u0ab5\u6117\ua589',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView0},
+    {binding: 59, resource: {buffer: buffer5, offset: 0, size: 2708}},
+  ],
+});
+let buffer35 = device0.createBuffer({size: 34252, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder34 = device0.createCommandEncoder();
+let sampler28 = device0.createSampler({
+  label: '\u09a2\u03b1\u{1fffe}\uaa03\u0a9f\u75ab\u04e5\u0e77\u6f22\u7d57\u0588',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 55.39,
+  lodMaxClamp: 92.87,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup14, new Uint32Array(1354), 12, 0);
+} catch {}
+try {
+commandEncoder34.insertDebugMarker('\u0542');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let computePassEncoder32 = commandEncoder34.beginComputePass({label: '\ub3f9\u{1fe4c}\u05f0\u5f1f\u{1fd69}'});
+let sampler29 = device0.createSampler({
+  label: '\u2041\u4c8d\u08cd\uec14\u4b99\u8818\uebf6\ue02d\u{1f6d7}\u0509',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.83,
+  lodMaxClamp: 99.84,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup12, new Uint32Array(743), 91, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let texture53 = device0.createTexture({
+  size: [16, 20, 5],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView39 = texture42.createView({baseArrayLayer: 5, arrayLayerCount: 1});
+let sampler30 = device0.createSampler({
+  label: '\u2236\u021e\u7de5\u{1f9c4}\u8970',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.42,
+  lodMaxClamp: 96.92,
+});
+try {
+computePassEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2, new Uint32Array(1217), 50, 0);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(282).fill(192), /* required buffer size: 282 */
+{offset: 282, bytesPerRow: 60, rowsPerImage: 17}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: atomic<u32>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer36: vec2h;
+struct S1 {
+  @location(7) @interpolate(flat) f0: i32,
+  @location(13) @interpolate(flat) f1: f32
+}
+struct VertexOutput2 {
+  @location(1) f12: vec4f,
+  @builtin(position) f13: vec4f
+}
+
+@vertex
+fn vertex0(@location(2) a0: f32, a1: S1, @location(0) @interpolate(flat, centroid) a2: u32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f12 %= vec4f(bitcast<f32>(a2));
+  return out;
+}
+struct VertexOutput3 {
+  @location(9) f14: vec3h,
+  @builtin(position) f15: vec4f,
+  @location(5) f16: f16,
+  @location(15) f17: vec4i
+}
+
+@vertex
+fn vertex1() -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f16 += f16(-59684.7);
+  return out;
+}
+struct FragmentOutput3 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) @interpolate(flat, sample) f1: i32
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4f, @location(4) @interpolate(linear, center) a1: vec3h) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(num_workgroups) a0: vec3u) {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup23 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 92, resource: textureView36},
+    {binding: 1, resource: textureView9},
+    {binding: 65, resource: {buffer: buffer28, offset: 0, size: 88}},
+    {binding: 238, resource: sampler23},
+    {binding: 111, resource: textureView19},
+    {binding: 142, resource: textureView20},
+    {binding: 293, resource: textureView32},
+    {binding: 52, resource: {buffer: buffer14, offset: 0, size: 1321}},
+    {binding: 13, resource: textureView31},
+  ],
+});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0, new Uint32Array(690), 240, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer15.destroy();
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let sampler31 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 85.87,
+  lodMaxClamp: 90.59,
+});
+try {
+computePassEncoder13.pushDebugGroup('\ua5f7');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: [16, 20, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer0, 956, buffer3, 4, 760);
+} catch {}
+let buffer37 = device0.createBuffer({
+  size: 2415,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder37 = device0.createCommandEncoder();
+let commandBuffer3 = commandEncoder35.finish({});
+let sampler32 = device0.createSampler({
+  label: '\u97c8\u7059\ud801\u8b04\u780e\u0818\uc96e\u2a04\u{1ff16}\u{1f8f5}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 94.32,
+  lodMaxClamp: 96.04,
+});
+let arrayBuffer6 = buffer31.getMappedRange(4424, 212);
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let texture55 = device0.createTexture({size: [256, 256, 10], dimension: '3d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture56 = device0.createTexture({size: [2], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let renderPassEncoder1 = commandEncoder36.beginRenderPass({
+  label: '\u0d69\u02da\u{1f814}\uc315\u099a\u3fa1',
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 98,
+  clearValue: { r: -503.6, g: 931.8, b: 601.4, a: -595.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 322250317,
+});
+let sampler33 = device0.createSampler({
+  label: '\u0acf\u{1fa55}\u02bd\u631d\uec86\u6b9f\u5310',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 33.70,
+  lodMaxClamp: 88.96,
+});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+buffer6.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer38 = device0.createBuffer({size: 1672, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let texture57 = device0.createTexture({
+  size: [2, 2, 1],
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.48,
+  lodMaxClamp: 86.64,
+  compare: 'never',
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup4, new Uint32Array(171), 22, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer0, 440); };
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 381,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 414,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder38 = device0.createCommandEncoder({});
+let texture58 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 81},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder33 = commandEncoder37.beginComputePass({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+let sampler35 = device0.createSampler({
+  label: '\u3b98\u9af4\u72c3\u0ba3',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.17,
+  lodMaxClamp: 90.43,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer22, 172); };
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer30, 0);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\ubaed');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise5 = adapter0.requestAdapterInfo();
+let commandEncoder39 = device0.createCommandEncoder({});
+let texture59 = device0.createTexture({
+  label: '\u8822\u0eae\u8182\ubb4f\ud8e3\u7761',
+  size: [4, 5, 1],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture60 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 81},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView40 = texture56.createView({});
+let computePassEncoder34 = commandEncoder38.beginComputePass({});
+let renderPassEncoder2 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 70,
+  clearValue: { r: 37.74, g: -591.8, b: 292.1, a: -114.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer16, offset: 1024, size: 776}}],
+});
+let buffer39 = device0.createBuffer({
+  size: 7468,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandEncoder40 = device0.createCommandEncoder();
+let textureView41 = texture58.createView({dimension: '2d', baseArrayLayer: 4});
+let texture61 = device0.createTexture({size: [256, 256, 18], format: 'depth32float-stencil8', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder35 = commandEncoder40.beginComputePass({});
+let sampler36 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 71.96,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup12, new Uint32Array(1034), 453, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'logSqrt'} });
+let texture62 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle6 = renderBundleEncoder6.finish({});
+let sampler37 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.48,
+  lodMaxClamp: 64.45,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup15, new Uint32Array(2747), 697, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+let img2 = await imageWithData(42, 92, '#10101010', '#20202020');
+let imageBitmap0 = await createImageBitmap(videoFrame6);
+let commandEncoder41 = device0.createCommandEncoder();
+let computePassEncoder36 = commandEncoder41.beginComputePass({});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.10,
+  lodMaxClamp: 83.14,
+  maxAnisotropy: 5,
+});
+let externalTexture1 = device0.importExternalTexture({label: '\u00a6\u0aae\u4b61', source: videoFrame1});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 30},
+  aspect: 'all',
+}, new Uint8Array(5_440).fill(70), /* required buffer size: 5_440 */
+{offset: 358, bytesPerRow: 33, rowsPerImage: 14}, {width: 0, height: 1, depthOrArrayLayers: 12});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView41},
+    {binding: 79, resource: textureView41},
+    {binding: 381, resource: textureView23},
+  ],
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let computePassEncoder37 = commandEncoder42.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(219);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let pipeline4 = await device0.createRenderPipelineAsync({
+  label: '\u080a\uc5dc\u{1f897}\uff3b\uffbe\u{1f888}\u{1f6fa}\uae8d\u3bb1\u5c61\ud530',
+  layout: pipelineLayout6,
+  fragment: {module: shaderModule0, targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 1233309679,
+    stencilWriteMask: 589050470,
+    depthBiasSlopeScale: 907.1132420188109,
+    depthBiasClamp: 816.1033932474893,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex1', buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let textureView42 = texture21.createView({label: '\u97c5\u8dc5\uad55\u8f8b', aspect: 'stencil-only'});
+let sampler39 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.86,
+  lodMaxClamp: 90.80,
+  maxAnisotropy: 17,
+});
+let commandEncoder43 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder43.finish({});
+let texture63 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 49},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(0, 2, 3, 2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48_666).fill(166), /* required buffer size: 48_666 */
+{offset: 66, bytesPerRow: 81, rowsPerImage: 300}, {width: 0, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder();
+let computePassEncoder38 = commandEncoder44.beginComputePass({});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u5c96\u{1f8ad}\u2ff7\u{1f8aa}\u0736\u27d5\u5dc7\u03b8\u61e0\u{1ffdf}\u9dd1',
+  colorFormats: ['rgb10a2uint'],
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup0, new Uint32Array(1520), 40, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(0, 2, 2, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(15.88234587251933, 0.9898972268578032, 0.11168609255963367, 13.390074910580168, 0.7022450848656472, 0.950008459680777);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup1, new Uint32Array(801), 177, 0);
+} catch {}
+try {
+  await promise5;
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let buffer40 = device0.createBuffer({
+  size: 8192,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup16, new Uint32Array(2017), 317, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer34, 0, 2_082);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup22, []);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(3_244).fill(70), /* required buffer size: 3_244 */
+{offset: 44, bytesPerRow: 8, rowsPerImage: 16}, {width: 0, height: 0, depthOrArrayLayers: 26});
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 201,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 142, resource: textureView11},
+    {binding: 52, resource: {buffer: buffer14, offset: 1024, size: 53}},
+    {binding: 293, resource: textureView10},
+    {binding: 92, resource: textureView8},
+    {binding: 13, resource: textureView12},
+    {binding: 111, resource: textureView8},
+    {binding: 238, resource: sampler37},
+    {binding: 65, resource: {buffer: buffer20, offset: 0, size: 1740}},
+    {binding: 1, resource: textureView25},
+  ],
+});
+let buffer41 = device0.createBuffer({size: 16689, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let commandEncoder45 = device0.createCommandEncoder({});
+let texture64 = device0.createTexture({
+  size: {width: 2, height: 270, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView43 = texture54.createView({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup22, new Uint32Array(1229), 309, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer28, 'uint32', 4, 680);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte240m', transfer: 'smpte170m'} });
+let bindGroup27 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 79, resource: textureView41},
+    {binding: 414, resource: textureView42},
+    {binding: 381, resource: textureView31},
+  ],
+});
+let textureView44 = texture64.createView({label: '\u158d\u{1fc95}\uf4a1\u66ba\udfe3\u9c78'});
+let renderPassEncoder3 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{view: textureView37, depthSlice: 21, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 196330955,
+});
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({
+  size: [16, 20, 1],
+  format: 'etc2-rgb8a1unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView45 = texture51.createView({baseArrayLayer: 0});
+let renderPassEncoder4 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 80,
+  clearValue: { r: 133.9, g: -860.9, b: -917.6, a: -644.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 429318794,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup22, new Uint32Array(953), 0, 0);
+} catch {}
+try {
+adapter0.label = '\u0995\u{1fb65}\u59e3\u0f9d\u0277\uf825';
+} catch {}
+let textureView46 = texture34.createView({aspect: 'stencil-only', baseArrayLayer: 0});
+let sampler40 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.16,
+  lodMaxClamp: 72.66,
+  compare: 'always',
+  maxAnisotropy: 9,
+});
+let bindGroup28 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 142, resource: textureView14},
+    {binding: 111, resource: textureView8},
+    {binding: 65, resource: {buffer: buffer2, offset: 0, size: 776}},
+    {binding: 1, resource: textureView13},
+    {binding: 13, resource: textureView12},
+    {binding: 92, resource: textureView8},
+    {binding: 52, resource: {buffer: buffer24, offset: 256, size: 331}},
+    {binding: 238, resource: sampler14},
+    {binding: 293, resource: textureView10},
+  ],
+});
+let texture66 = device0.createTexture({
+  size: [4, 5, 1],
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7, renderBundle5, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView44}]});
+let texture67 = device0.createTexture({
+  size: [256, 256, 18],
+  mipLevelCount: 3,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView47 = texture26.createView({aspect: 'stencil-only', baseArrayLayer: 2, arrayLayerCount: 14});
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer9, 1_048);
+} catch {}
+try {
+computePassEncoder13.popDebugGroup();
+} catch {}
+let buffer42 = device0.createBuffer({
+  size: 8648,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let texture68 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup7, new Uint32Array(545), 220, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer34, 'uint32', 2_872, 470);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer17, 572);
+} catch {}
+try {
+  await promise6;
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup10, new Uint32Array(3521), 1_467, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer22, 452);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer34, 0, 1_044);
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView46},
+    {binding: 381, resource: textureView31},
+    {binding: 79, resource: textureView41},
+  ],
+});
+let buffer43 = device0.createBuffer({size: 10056, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.draw(231, 399, 1_879_546_842, 268_233_135);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(71, 288, 19, 442_254_644, 443_762_556);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 40, 417);
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer44 = device0.createBuffer({
+  size: 39427,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup10, new Uint32Array(598), 201, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer3, 'uint16', 34, 38);
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView36},
+    {binding: 79, resource: textureView41},
+    {binding: 381, resource: textureView31},
+  ],
+});
+let texture69 = device0.createTexture({
+  size: [4, 5, 2],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer34, 0, 1_993);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u{1fb7e}');
+} catch {}
+let textureView48 = texture34.createView({aspect: 'depth-only', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 1_128);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer7, 356);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer3);
+} catch {}
+let imageData3 = new ImageData(136, 68);
+try {
+computePassEncoder9.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.draw(329, 310, 75_518_874, 1_630_647_939);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 165});
+let textureView49 = texture1.createView({});
+let computePassEncoder39 = commandEncoder47.beginComputePass({});
+try {
+renderPassEncoder4.setBlendConstant({ r: -572.5, g: -343.4, b: -264.4, a: -63.47, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(3, 33, 5, 251_514_672, 204_442_149);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer44, 3_672);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer24, 3_372);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder40 = commandEncoder48.beginComputePass({});
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder2.draw(399, 64, 1_123_345_943, 88_723_999);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer37, 'uint16', 268, 132);
+} catch {}
+try {
+externalTexture0.label = '\u0f71\u{1f856}\ucfb3';
+} catch {}
+let texture70 = device0.createTexture({
+  label: '\u33e4\uabdd\u056d\u60cd\u9851\u06ad',
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup14, new Uint32Array(586), 4, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer20, 84); };
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 3_892);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 1116, new DataView(new ArrayBuffer(172)));
+} catch {}
+await gc();
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  size: [2, 2, 1],
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture72 = gpuCanvasContext1.getCurrentTexture();
+let textureView50 = texture67.createView({dimension: 'cube', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.draw(60, 63, 1_639_607_244, 684_681_883);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer24, 1_828);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer37, 'uint16', 50, 87);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 4, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer5 = commandEncoder49.finish({});
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.54,
+  lodMaxClamp: 80.62,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(0, bindGroup12, new Uint32Array(1591), 234, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer22, 328); };
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup3, new Uint32Array(569), 123, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer7, 456);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let buffer45 = device0.createBuffer({
+  label: '\u{1f8dc}\u02ec\u{1fc6e}\ua938\u0217\u{1fbf0}\u090a\u0ceb\u{1fc67}',
+  size: 20680,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture73 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup24, new Uint32Array(528), 53, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer37, 'uint16', 10, 33);
+} catch {}
+document.body.append(img0);
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt2020', transfer: 'unspecified'} });
+let bindGroup32 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 97, resource: textureView30}, {binding: 59, resource: {buffer: buffer45, offset: 2560}}],
+});
+let buffer46 = device0.createBuffer({
+  size: 554,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler42 = device0.createSampler({addressModeW: 'repeat', magFilter: 'nearest', minFilter: 'nearest', lodMaxClamp: 96.24});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup7, new Uint32Array(580), 12, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup6, new Uint32Array(4807), 268, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(301, 483, 670_375_557, 917_940_650);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer10, 100);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+buffer10.label = '\uc57d\u{1fc5b}\uac38\u{1fcbc}\uff65\u{1fc16}\ucdcc\uc20b\ua0cb\u0e59\u0f4e';
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u0dcc\u{1fd5d}\u{1fced}\u2ea8\u{1faa0}\u073f\u594a',
+  code: `
+enable f16;
+/* target size: 16 max align: 16 */
+struct T0 {
+  @size(16) f0: f16,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @size(4) f0: f16,
+}
+/* target size: 4 max align: 4 */
+struct T2 {
+  f0: array<u32>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer47: array<i32, 1>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(workgroup_id) a0: vec3u, @builtin(local_invocation_index) a1: u32) {
+}`,
+  hints: {},
+});
+let sampler43 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.41,
+  lodMaxClamp: 29.88,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(3, bindGroup19, new Uint32Array(589), 280, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup27, new Uint32Array(1266), 132, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer14, 648);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer24, 3_280);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 5680, new Int16Array(21011), 2374, 1112);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let textureView51 = texture47.createView({aspect: 'stencil-only', baseArrayLayer: 4, arrayLayerCount: 4});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup21, new Uint32Array(560), 39, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer22, 548);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 1, y: 51, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 160 */
+  offset: 160,
+  bytesPerRow: 256,
+  buffer: buffer24,
+}, {width: 3, height: 51, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6, new Uint32Array(378), 116, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer10, 80);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 492);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer17);
+} catch {}
+let arrayBuffer7 = buffer27.getMappedRange(0, 3548);
+try {
+commandEncoder50.resolveQuerySet(querySet5, 40, 14, buffer45, 5120);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer5, offset: 1280, size: 88}}],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5]});
+let sampler44 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  compare: 'never',
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(3, 1); };
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(808), 74, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer14, 1_448);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer0, 880, buffer32, 528, 92);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2440 */
+  offset: 388,
+  bytesPerRow: 512,
+  buffer: buffer17,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 4, height: 5, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder38.pushDebugGroup('\ue432');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer24, offset: 4352, size: 4052}}],
+});
+let commandEncoder51 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder50.finish({});
+let computePassEncoder41 = commandEncoder51.beginComputePass();
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup2, new Uint32Array(1539), 154, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 2_536);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer14, 3_616);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer25, 'uint32', 404, 3_881);
+} catch {}
+let promise8 = shaderModule4.getCompilationInfo();
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'etc2-rgb8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData4 = new ImageData(88, 80);
+let commandEncoder52 = device0.createCommandEncoder({});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup29, new Uint32Array(24), 6, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(136, 891, 1_975_781_253, 536_125_465);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 2_100);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 20, y: 69, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder52.insertDebugMarker('\ub763');
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder53 = device0.createCommandEncoder({});
+let sampler45 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.32,
+  lodMaxClamp: 96.30,
+  compare: 'less-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup13, new Uint32Array(1308), 352, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer27, 1_132);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer25, 'uint32', 3_612, 7_726);
+} catch {}
+try {
+computePassEncoder38.pushDebugGroup('\u23e1');
+} catch {}
+try {
+  await promise8;
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({});
+let renderPassEncoder5 = commandEncoder53.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 90,
+  clearValue: { r: -551.5, g: -868.3, b: -171.6, a: -280.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 513942157,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup10, new Uint32Array(3732), 48, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(374, 656, 206_560_953, 548_055_699);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 5_376);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer44, 1_320);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer34);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer39, 192, buffer21, 812, 180);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1184 */
+  offset: 1184,
+  bytesPerRow: 256,
+  buffer: buffer21,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 1786;
+let imageData5 = new ImageData(4, 4);
+let buffer48 = device0.createBuffer({
+  label: '\u{1f8b1}\u{1ff99}\u0ae6\u{1fc66}\u7247\u{1f7da}',
+  size: 22483,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let textureView52 = texture59.createView({dimension: '2d'});
+try {
+renderPassEncoder2.draw(28, 563, 353_214_363, 359_946_720);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 2_792);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer19, 352, 1524);
+} catch {}
+let texture74 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 14},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderPassEncoder6 = commandEncoder54.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 74,
+  clearValue: { r: -584.1, g: 479.4, b: -682.0, a: 913.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 439114256,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup0, new Uint32Array(2401), 1_213, 0);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer28, 80);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer14, 'uint16', 30, 422);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer30, 104, 145);
+} catch {}
+let bindGroup35 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView44}]});
+let computePassEncoder42 = commandEncoder55.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup8, new Uint32Array(231), 147, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8, new Uint32Array(1899), 237, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder2.draw(85, 712, 400_052_447, 148_346_791);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 238, 2, 554_371_877, 726_125_973);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer10, 440);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 548 */
+  offset: 544,
+  buffer: buffer10,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'stencil-only',
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(querySet2, 29, 114, buffer27, 1536);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(3).fill(92), /* required buffer size: 3 */
+{offset: 3}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let textureView53 = texture44.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.82,
+  lodMaxClamp: 80.05,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder2.drawIndexed(4, 123, 4, 72_730_316, 423_584_521);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer10, 244);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer41, 788, buffer40, 68, 36);
+} catch {}
+try {
+commandEncoder56.insertDebugMarker('\u{1fb2f}');
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u{1fee2}');
+} catch {}
+let bindGroup36 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 285, resource: {buffer: buffer39, offset: 7424}}]});
+let textureView54 = texture24.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 9});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup28, new Uint32Array(1309), 292, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup13, new Uint32Array(509), 183, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(56, 315, 125, -2_016_493_965, 316_547_805);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer9, 'uint16', 4_486, 4_615);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer37, 368);
+} catch {}
+try {
+commandEncoder52.insertDebugMarker('\u0eaf');
+} catch {}
+let img3 = await imageWithData(17, 19, '#10101010', '#20202020');
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer2, offset: 256, size: 696}}],
+});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1f73f}\u{1fcba}\u3614\u3f47\u{1fe84}\u0a91\u023b\u{1f63f}\u18c9'});
+let texture75 = device0.createTexture({size: [256], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let textureView55 = texture10.createView({aspect: 'all', baseMipLevel: 0});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.draw(227, 547, 385_451_751, 222_756_699);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 109, 1, -1_902_785_929, 383_007_132);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer5, 'uint16', 762, 3_207);
+} catch {}
+try {
+renderPassEncoder5.pushDebugGroup('\udff0');
+} catch {}
+document.body.prepend(canvas1);
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'jedecP22Phosphors', transfer: 'smpteSt4281'} });
+let commandEncoder58 = device0.createCommandEncoder({});
+let textureView56 = texture34.createView({format: 'depth24plus-stencil8'});
+let computePassEncoder43 = commandEncoder58.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup11, new Uint32Array(496), 260, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(49, 146, 419_857_426, 3_214_301_097);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(471, 156, 177, 838_824_092, 50_815_973);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 1024 widthInBlocks: 256 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1176 */
+  offset: 1176,
+  bytesPerRow: 1792,
+  buffer: buffer2,
+}, {width: 256, height: 256, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u{1fc36}');
+} catch {}
+await gc();
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'film', transfer: 'logSqrt'} });
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture76 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture77 = device0.createTexture({
+  label: '\u7455\u2235\u38c4\u07fe\u0f2c\u{1fb21}\u{1f81f}\u0fd7\u1238\u{1febe}\udfab',
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView57 = texture75.createView({baseArrayLayer: 0});
+let computePassEncoder44 = commandEncoder56.beginComputePass({});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint']});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(16);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 48);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer46, 164);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer3, 1_072);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer3, 0, 26);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView49},
+    {binding: 59, resource: {buffer: buffer16, offset: 1536, size: 7544}},
+  ],
+});
+let buffer49 = device0.createBuffer({
+  size: 22787,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 466});
+let computePassEncoder45 = commandEncoder3.beginComputePass();
+let sampler47 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 77.29});
+try {
+renderPassEncoder4.drawIndexed(1_352, 2, 23, -2_144_642_220, 757_191_389);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer46, 0, 8);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer25, 'uint32', 1_720, 4_761);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline2);
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer5, offset: 2816, size: 36}}],
+});
+let buffer50 = device0.createBuffer({
+  size: 9926,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder60 = device0.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder60.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup23, new Uint32Array(1272), 96, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(17, 51, 722_403_830, 725_760_296);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer45, 16);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer46, 36);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup20, new Uint32Array(1648), 67, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(2, 103, 496, -1_491_903_603, 539_488_547);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer9, 'uint32', 5_196, 5_637);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet0, 3, 58, buffer45, 2560);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 1448, new Int16Array(9158), 2772, 572);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer51 = device0.createBuffer({label: '\udc10\u2318', size: 4449, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder61 = device0.createCommandEncoder({});
+let textureView58 = texture70.createView({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.00,
+  lodMaxClamp: 47.99,
+  compare: 'greater-equal',
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder2.draw(22, 663, 810_233_203, 732_058_215);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer42, 'uint32', 4_376, 885);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer42, 1_648);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer0, 1152, buffer18, 8, 48);
+} catch {}
+try {
+renderPassEncoder5.popDebugGroup();
+} catch {}
+let buffer52 = device0.createBuffer({
+  label: '\u045d\u3038',
+  size: 8491,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle5, renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 208);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer37, 'uint32', 360, 32);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder8.draw(11, 175, 257_036_666, 1_713_918_945);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer50, 2_360);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer16, 0, 927);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 2808, new Float32Array(536), 50, 228);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(195).fill(118), /* required buffer size: 195 */
+{offset: 195, rowsPerImage: 98}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\ue949\u01ff\ub047'});
+let texture78 = device0.createTexture({
+  label: '\u1971\u2feb\u41d8\uae98\uca6d\u{1fba9}\u345e\ud051\u{1ff89}',
+  size: [2, 2, 5],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder47 = commandEncoder62.beginComputePass();
+let renderPassEncoder7 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 63,
+  clearValue: { r: 177.0, g: -8.450, b: 276.4, a: -967.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 35637838,
+});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup19, new Uint32Array(439), 58, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(22, 197, 703, 1_210_989_787, 155_398_397);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 8);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer30, 'uint16', 2_140, 3_557);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer40, 120, 2_322);
+} catch {}
+document.body.append(img2);
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'smpteSt4281'} });
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: i32,
+}
+/* target size: 16 max align: 16 */
+struct T1 {
+  @size(16) f0: T0,
+}
+@group(0) @binding(285) var<storage, read_write> buffer53: atomic<u32>;
+struct VertexOutput4 {
+  @location(15) f18: f16,
+  @location(7) f19: vec4f,
+  @location(11) f20: vec4h,
+  @builtin(position) f21: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput4 {
+  var out: VertexOutput4;
+  return out;
+}`,
+});
+let texture79 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 62},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder48 = commandEncoder52.beginComputePass();
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 103, 1, 746_666_753, 1_025_951_587);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer10, 212);
+} catch {}
+try {
+computePassEncoder38.popDebugGroup();
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  label: '\u0251\u{1f89d}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer20, offset: 3072, size: 572}}],
+});
+let textureView59 = texture12.createView({});
+let computePassEncoder49 = commandEncoder57.beginComputePass();
+try {
+computePassEncoder42.setBindGroup(3, bindGroup6, new Uint32Array(784), 54, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup6, new Uint32Array(350), 183, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let texture80 = device0.createTexture({
+  label: '\u{1febc}\ucab8\uca89\ue0e1',
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+let sampler49 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.24,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer28, 'uint16', 16, 523);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer40);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup14, new Uint32Array(173), 31, 0);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 48, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 1024 widthInBlocks: 256 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3520 */
+  offset: 2496,
+  buffer: buffer39,
+}, {width: 256, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer20, offset: 256, size: 580}}],
+});
+let buffer54 = device0.createBuffer({
+  size: 18505,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder63 = device0.createCommandEncoder({});
+let textureView60 = texture19.createView({dimension: '2d', baseArrayLayer: 13});
+let computePassEncoder50 = commandEncoder59.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.draw(120, 157, 306_760_149, 776_392_280);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer34, 'uint32', 204, 316);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup38, new Uint32Array(2576), 329, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 356, new Float32Array(6265), 1346, 192);
+} catch {}
+let video0 = await videoWithData(12);
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 92, resource: textureView8},
+    {binding: 238, resource: sampler23},
+    {binding: 293, resource: textureView10},
+    {binding: 142, resource: textureView14},
+    {binding: 111, resource: textureView56},
+    {binding: 1, resource: textureView9},
+    {binding: 52, resource: {buffer: buffer44, offset: 5888, size: 4793}},
+    {binding: 13, resource: textureView60},
+    {binding: 65, resource: {buffer: buffer52, offset: 3328, size: 124}},
+  ],
+});
+try {
+computePassEncoder48.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandBuffer7 = commandEncoder63.finish({label: '\u0773\u187a\uecb0'});
+let texture81 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 44},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup4, new Uint32Array(1481), 199, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup30, new Uint32Array(3360), 556, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer54, 128);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer14, 400, buffer34, 8, 204);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(109).fill(40), /* required buffer size: 109 */
+{offset: 109}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView18}, {binding: 267, resource: textureView17}],
+});
+let buffer55 = device0.createBuffer({
+  label: '\uaffd\udf30\u874a\u{1ffa9}\u033f\u{1fc4b}',
+  size: 12696,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let computePassEncoder51 = commandEncoder42.beginComputePass({});
+let renderBundle9 = renderBundleEncoder9.finish();
+try {
+renderPassEncoder4.drawIndexed(672, 115, 84, -1_606_274_071, 242_392_980);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer37, 'uint16', 1_586, 27);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'linear'} });
+let textureView61 = texture10.createView({label: '\ud27a\u{1fc7f}', arrayLayerCount: 1});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(68, 52, 221, -1_208_130_884, 1_691_501_820);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint16', 1_212, 1_026);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+computePassEncoder38.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 232, new Float32Array(7648), 464, 112);
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  label: '\u0544\u{1f7ce}\u{1feb9}\u4ab6\u6218\u9165\u5a09\u5bac\u0751',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView42},
+    {binding: 381, resource: textureView23},
+    {binding: 79, resource: textureView41},
+  ],
+});
+let texture82 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 19},
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView62 = texture55.createView({arrayLayerCount: 1});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup38, new Uint32Array(2423), 536, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer14, 476);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer0, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(17, 104, 135, 964_344_774, 34_105_709);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer14, 48);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer9, 'uint32', 3_144, 209);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer49);
+} catch {}
+await gc();
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u2d40\u80bf\u{1fd86}\u064c\u{1f95a}\u{1fd4a}\u{1ffbb}\u59a2\ucbfa',
+  entries: [
+    {
+      binding: 554,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup45 = device0.createBindGroup({
+  label: '\u6c04\u3e0d\u0f59\u0d9d\u01f3',
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer25, offset: 1536}}],
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let texture83 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 6,
+  format: 'eac-rg11unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture84 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 1864},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder52 = commandEncoder64.beginComputePass({});
+let sampler50 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 56.96,
+  lodMaxClamp: 61.47,
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroupsIndirect(buffer16, 1_152); };
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+textureView41.label = '\u{1fb21}\u{1f93a}\u594c\u26a2\u{1fc6c}\u9d04\u0bd9';
+} catch {}
+let texture85 = device0.createTexture({
+  label: '\u{1fdb2}\u0f7a\u5072\u5d5c\u884e\u{1f981}\uc007\ue2f7\u3221',
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  format: 'etc2-rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture86 = device0.createTexture({
+  size: [4, 5, 30],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler51 = device0.createSampler({
+  label: '\u03eb\u098e\u{1fd95}\ueb89\u8572\udf4c\u{1ff6f}\u099c\u0b55\uff20',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 1.955,
+  lodMaxClamp: 43.83,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder3.draw(423, 202, 1_098_490_591, 368_272_052);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 228, 2, 393_697_138, 1_196_769_916);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer20, 764);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer49, 'uint32', 5_084, 5_362);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView63 = texture65.createView({label: '\u047d\ubddb\ue960\u0b87\u8758\u9f4b\u{1ff5e}\u7158'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup28, new Uint32Array(403), 26, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup41, new Uint32Array(1272), 558, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(3, 118, 25, 61_724_664, 19_738_651);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer30, 'uint32', 1_664, 6_622);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer49, 0);
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 951});
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer54, 5_600);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer56 = device0.createBuffer({size: 7391, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture87 = gpuCanvasContext2.getCurrentTexture();
+let textureView64 = texture66.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer27, 3_488); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(90, 111, 43, 1_338_337_206, 119_553_014);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer10, 392);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer42, 'uint16', 1_412, 1_414);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer17, 0);
+} catch {}
+let arrayBuffer8 = buffer27.getMappedRange(3552, 608);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let textureView65 = texture64.createView({});
+try {
+renderPassEncoder4.draw(13, 217, 1_442_895_508, 24_244_961);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer27, 3_688);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer7, 328);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'unspecified'} });
+let videoFrame15 = new VideoFrame(videoFrame6, {timestamp: 0});
+let bindGroup46 = device0.createBindGroup({
+  label: '\u9423\u094e\u91ef\u0ae0\u5ab4\u{1f6c4}\u4483',
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView1}, {binding: 267, resource: textureView3}],
+});
+let buffer57 = device0.createBuffer({
+  size: 10164,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder65 = device0.createCommandEncoder({label: '\u5d60\u71d5'});
+let texture88 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 177},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup2, new Uint32Array(745), 59, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder3.draw(34, 38, 75_069_843, 473_856_407);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer27, 584);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer49, 'uint16', 174, 7_331);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 173,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer58 = device0.createBuffer({
+  label: '\u{1f811}\u0400\u271c\u1fe7\u0be9\u38a6\u8196\u1468\ua1d5\ue9e3',
+  size: 11655,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture89 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder53 = commandEncoder65.beginComputePass();
+let sampler52 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 73.71,
+  lodMaxClamp: 80.94,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(1, bindGroup22, new Uint32Array(2869), 169, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder2.draw(186, 86, 844_215_480, 1_496_770_610);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(167, 1_000, 188, 60_669_105, 4_164_530_855);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer45, 124);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder66 = device0.createCommandEncoder();
+let textureView66 = texture65.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 0});
+let texture90 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView67 = texture26.createView({aspect: 'stencil-only', baseMipLevel: 0, baseArrayLayer: 14, arrayLayerCount: 22});
+let computePassEncoder54 = commandEncoder66.beginComputePass({});
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.draw(51, 275, 123_775_927, 2_223_961_201);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(120, 137, 129, 293_992_057, 798_006_307);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 5300, new Float32Array(12512), 549, 1756);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 11 },
+  flipY: false,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture1.label = '\u3cf0\u{1f8cc}\u5dc4\u019c\ue913\u{1fbd1}\u{1fbfb}\u6c66';
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup46, new Uint32Array(4322), 681, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+document.body.append(canvas0);
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+computePassEncoder16.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup29, new Uint32Array(1125), 161, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(84, 16, 241_497_610, 157_897_200);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(276, 92, 862, -2_065_104_870, 652_763_966);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer54, 496);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 1_132);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData2);
+let videoFrame16 = new VideoFrame(videoFrame4, {timestamp: 0});
+let bindGroup47 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView0},
+    {binding: 59, resource: {buffer: buffer16, offset: 1024, size: 1864}},
+  ],
+});
+let commandEncoder67 = device0.createCommandEncoder();
+let textureView68 = texture67.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer57, 7_864); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(4161), 1_251, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(632, 207, 1_658, 42_284_572, 556_361_540);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer10, 236);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'stencil-only',
+}, new Uint8Array(75).fill(199), /* required buffer size: 75 */
+{offset: 75}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video0);
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'logSqrt'} });
+let bindGroup48 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView17}, {binding: 126, resource: textureView1}],
+});
+let computePassEncoder55 = commandEncoder67.beginComputePass({label: '\u646d\ue749\u32dd\u{1fa3e}'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u0c37\ub716\u0513\ub1d9\u{1fc53}\u36cc',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer54, 1_900);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 496);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer45);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({});
+let textureView69 = texture42.createView({dimension: 'cube', baseArrayLayer: 1});
+let sampler53 = device0.createSampler({
+  label: '\u572e\ub48a\uaed8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.61,
+  lodMaxClamp: 95.12,
+});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer7, 3_928);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer42, 368);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, undefined, 1_552_346_322);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup43, new Uint32Array(5495), 1_176, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer9, 'uint32', 340, 2_824);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let computePassEncoder56 = commandEncoder68.beginComputePass({label: '\u02bd\u{1f7ca}\u0c67\uab92'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\u095c\u9f1d\u{1f961}', colorFormats: ['r8unorm']});
+let renderBundle10 = renderBundleEncoder11.finish({label: '\u{1f692}\u48f6\u078f\u76d0'});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2, renderBundle2, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.draw(92, 43, 1_079_434_755, 889_384_163);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(733, 206, 386, 10_413_538, 2_673_951_901);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer20, 3_020);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 2_212);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 19},
+  aspect: 'all',
+}, new Uint8Array(35_272).fill(174), /* required buffer size: 35_272 */
+{offset: 124, bytesPerRow: 116, rowsPerImage: 99}, {width: 0, height: 7, depthOrArrayLayers: 4});
+} catch {}
+try {
+  await promise9;
+} catch {}
+let buffer59 = device0.createBuffer({
+  size: 1294,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder69 = device0.createCommandEncoder({});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint32', 44, 373);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer17);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup21, []);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup4, new Uint32Array(127), 65, 0);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer57, 7_768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 824, new BigUint64Array(6881), 282, 24);
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  label: '\u{1fe42}\ube1c\u111e\u4504\ua5a8\u{1fcab}',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'replace'},
+    stencilWriteMask: 2221857061,
+    depthBiasClamp: 839.4610194895165,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 172, shaderLocation: 2},
+          {format: 'sint32', offset: 8, shaderLocation: 7},
+          {format: 'float32', offset: 4, shaderLocation: 13},
+          {format: 'uint32x4', offset: 8, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', unclippedDepth: true},
+});
+let bindGroup49 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 381, resource: textureView31},
+    {binding: 414, resource: textureView8},
+    {binding: 79, resource: textureView41},
+  ],
+});
+let texture91 = device0.createTexture({
+  size: [16, 20, 4],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup19, new Uint32Array(887), 129, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(32, 187, 22, 29_398_706, 1_332_833_211);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer54, 11_740);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer0, 956, 237);
+} catch {}
+try {
+adapter0.label = '\u{1fee4}\u{1f88e}\u2d7d\u38a3\u{1f890}\ue794\u7538\u{1fcd5}\u0672\u{1f701}\u6fda';
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({label: '\u3634\u0bac\ud748'});
+let computePassEncoder57 = commandEncoder69.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup42, new Uint32Array(1373), 103, 0);
+} catch {}
+let computePassEncoder58 = commandEncoder70.beginComputePass({});
+let renderBundle11 = renderBundleEncoder10.finish({});
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.45,
+  lodMaxClamp: 97.38,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup3, new Uint32Array(233), 39, 0);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -338.5, g: -66.62, b: -397.6, a: -105.5, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(7.963556613344666, 12.811119585113769, 4.738696073685794, 1.5374964436187315, 0.8291246281251831, 0.8508439836153413);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer55, 'uint32', 288, 4_205);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer58, 0, 2_028);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder16.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer46, 16);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 64);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let textureView70 = texture9.createView({label: '\u9c46\ufecc\u{1f98f}\uf7a5\u0f37', dimension: '2d'});
+let sampler55 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.43,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder4.dispatchWorkgroupsIndirect(buffer22, 10_444);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 264);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 5_568);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let shaderModule7 = device0.createShaderModule({
+  label: '\u5585\u43e0\u0e91\ua849',
+  code: `
+enable f16;
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: i32,
+}
+@group(0) @binding(285) var<storage, read_write> buffer60: T0;
+struct S2 {
+  @location(15) f0: vec4h,
+  @location(14) f1: vec2h,
+  @location(12) @interpolate(perspective, center) f2: f16,
+  @location(0) @interpolate(flat, center) f3: vec3i
+}
+struct VertexOutput5 {
+  @builtin(position) f22: vec4f
+}
+
+@vertex
+fn vertex0(a0: S2) -> VertexOutput5 {
+  var out: VertexOutput5;
+  return out;
+}
+struct FragmentOutput4 {
+  @location(4) f0: i32,
+  @location(0) f1: vec3f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0() {
+  _ = buffer60.f0;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+}`,
+  hints: {},
+});
+let sampler56 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 7.624,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer9, 'uint32', 208, 3_716);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u59bc');
+} catch {}
+await gc();
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(214);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer28, 'uint32', 404, 649);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer58, 0, 5_817);
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+let textureView71 = texture65.createView({dimension: '2d-array'});
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 95.65,
+  lodMaxClamp: 96.36,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(16, 9, 207, -2_075_892_532, 875_710_007);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.label = '\u0e11\ufb0c\u7d27\ub211\u0d89\u{1f9a1}\u07d2\u14e1\u{1f75b}\u{1f72b}';
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u{1f90e}\u{1f661}\ud523\u{1fe79}\u03d2\u{1fbf9}\u{1fb45}\u{1fe3b}\ud357',
+  entries: [
+    {binding: 172, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let texture92 = device0.createTexture({size: [4], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler58 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 93.69,
+  lodMaxClamp: 98.48,
+});
+try {
+renderPassEncoder2.draw(164, 95, 102_950_977, 262_359_451);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(299, 51, 71, -1_925_218_635, 1_075_869_258);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer14, 256);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup34, new Uint32Array(3123), 138, 0);
+} catch {}
+video0.height = 35;
+let bindGroup50 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 111, resource: textureView36},
+    {binding: 92, resource: textureView42},
+    {binding: 293, resource: textureView32},
+    {binding: 238, resource: sampler29},
+    {binding: 13, resource: textureView31},
+    {binding: 65, resource: {buffer: buffer57, offset: 768}},
+    {binding: 52, resource: {buffer: buffer42, offset: 1792, size: 213}},
+    {binding: 1, resource: textureView25},
+    {binding: 142, resource: textureView59},
+  ],
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let texture93 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0, new Uint32Array(1001), 157, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup24, new Uint32Array(1124), 60, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(5, 5, 1, 1);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(105);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer50, 2_460);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 3_928);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer58);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer30);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let texture94 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder59 = commandEncoder71.beginComputePass({});
+let renderBundle12 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup6, new Uint32Array(110), 64, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer45, 6_380, 4_811);
+} catch {}
+try {
+renderPassEncoder2.draw(214, 61, 845_351_778, 953_224_846);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(101, 130, 121, 579_820_725, 479_256_499);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 1_924);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 1_100);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer45);
+} catch {}
+try {
+  await buffer56.mapAsync(GPUMapMode.WRITE, 0, 2092);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u470b');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 168, new BigUint64Array(2221), 247, 280);
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  label: '\ua31e\uce5a\u{1f7ed}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView18}, {binding: 267, resource: textureView34}],
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup47, new Uint32Array(3842), 333, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 568);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer57, 'uint32', 1_096, 2_520);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(1_278).fill(198), /* required buffer size: 1_278 */
+{offset: 9, bytesPerRow: 27, rowsPerImage: 47}, {width: 3, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 21},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView72 = texture91.createView({dimension: '2d'});
+let sampler59 = device0.createSampler({
+  label: '\u7038\u42dd\u{1fc00}\uf6bf\u9cf7\u0af8\u239b\u03c9\u4ffa\u092f',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.42,
+  lodMaxClamp: 85.09,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(167, 196, 52, 15_461_096, 1_049_164_454);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 3_260);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 172, new Float32Array(13234), 293, 4);
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView1}, {binding: 267, resource: textureView2}],
+});
+let textureView73 = texture52.createView({dimension: 'cube-array', aspect: 'all', arrayLayerCount: 6});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup48, new Uint32Array(344), 14, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer52, 0, 612);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'gamma28curve'} });
+let bindGroup53 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView66}]});
+let buffer61 = device0.createBuffer({
+  size: 28380,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture95 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 28},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['depth32float-stencil8'],
+});
+let textureView74 = texture10.createView({});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup38, new Uint32Array(236), 21, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup35, new Uint32Array(2717), 1_023, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(371, 341, 7, 205_779_953, 244_980_863);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = sampler10.label;
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let texture96 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(2, 3, 0, 3);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer42, 'uint32', 1_204, 1_055);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer55, 0, 10_824);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 1488, new Int16Array(17603), 369, 64);
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView1}, {binding: 267, resource: textureView2}],
+});
+let textureView75 = texture96.createView({baseMipLevel: 0});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+let renderBundle13 = renderBundleEncoder13.finish();
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder2.draw(0, 79, 594_663_567, 692_492_126);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer14, 284);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer45, 0, 223);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.append(canvas1);
+let bindGroup55 = device0.createBindGroup({
+  label: '\u6cd8\u{1f72b}\u5312\u{1fcee}\u0c19',
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer28, offset: 0, size: 24}}],
+});
+let texture97 = device0.createTexture({
+  label: '\ufa5c\u{1f6b9}\u7766',
+  size: {width: 4, height: 5, depthOrArrayLayers: 8},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle2, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder2.draw(204, 44, 254_843_523, 31_019_383);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(122, 3, 41, 197_290_824, 25_917_431);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer37, 'uint16', 118, 134);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer45);
+} catch {}
+let bindGroup56 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView44}]});
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer9, 0, 4_380);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let commandEncoder72 = device0.createCommandEncoder();
+let texture98 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView76 = texture53.createView({dimension: '2d', aspect: 'depth-only', arrayLayerCount: 1});
+let renderPassEncoder8 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 2,
+  clearValue: { r: -305.5, g: -488.3, b: -764.4, a: -603.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet8,
+});
+let sampler60 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 22.43,
+  lodMaxClamp: 76.51,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup17, new Uint32Array(1269), 257, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(28, 93, 21_561_930, 820_598_858);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView77 = texture71.createView({label: '\u{1fd9c}\u{1fac1}\ucc67\u{1fd3d}\u{1f876}\u04d7\u05e2', aspect: 'stencil-only'});
+let sampler61 = device0.createSampler({
+  label: '\ub4e7\u4388\ud27a\ueade',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.71,
+  lodMaxClamp: 62.02,
+});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup24, new Uint32Array(27), 0, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(8, 27, 189_999_656, 443_449_887);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer54, 2_804);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2_258).fill(200), /* required buffer size: 2_258 */
+{offset: 38, bytesPerRow: 5, rowsPerImage: 20}, {width: 0, height: 5, depthOrArrayLayers: 23});
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder();
+let sampler62 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 15.55,
+  lodMaxClamp: 50.01,
+});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(110, 300, 409, 41_013_833, 1_183_060_177);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer61, 2_576);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer45);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  label: '\u0655\u4a77\u2858\ucd7a\u059f\u0dcb\uae4d',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 238, resource: sampler58},
+    {binding: 13, resource: textureView31},
+    {binding: 111, resource: textureView19},
+    {binding: 293, resource: textureView32},
+    {binding: 52, resource: {buffer: buffer45, offset: 2560, size: 1901}},
+    {binding: 92, resource: textureView8},
+    {binding: 1, resource: textureView13},
+    {binding: 142, resource: textureView20},
+    {binding: 65, resource: {buffer: buffer54, offset: 4096, size: 1480}},
+  ],
+});
+let buffer62 = device0.createBuffer({size: 3030, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder74 = device0.createCommandEncoder({});
+let renderPassEncoder9 = commandEncoder73.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 34,
+  clearValue: { r: 878.2, g: -1.233, b: 500.4, a: -101.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(687, 68, 16, 12_087_335, 640_049_151);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 20},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({});
+let computePassEncoder60 = commandEncoder74.beginComputePass({});
+let externalTexture4 = device0.importExternalTexture({label: '\u03e2\u6219\u6f4f\u9154\u0232\uc6a6\u5212\u02a2\u2207\ub16e', source: videoFrame13});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup48, new Uint32Array(553), 1, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup33, new Uint32Array(192), 19, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(116, 213, 62, 620_287_100, 345_199_596);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer50, 3_724);
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 87, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let buffer63 = device0.createBuffer({
+  size: 214,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder76 = device0.createCommandEncoder();
+let renderPassEncoder10 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 85,
+  clearValue: { r: 763.4, g: -443.2, b: -224.6, a: -733.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup39, new Uint32Array(493), 30, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(11, 109, 135, 421_927_934, 569_951_498);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer44, 2_140);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer14, 'uint16', 204, 960);
+} catch {}
+let promise11 = shaderModule2.getCompilationInfo();
+try {
+commandEncoder75.copyBufferToBuffer(buffer8, 80, buffer40, 4, 1440);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1472 */
+  offset: 1472,
+  buffer: buffer0,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'stencil-only',
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  label: '\u0a94\u0781\ubd8b\u{1fe65}\u5ae7',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 59, resource: {buffer: buffer16, offset: 2304, size: 1344}},
+    {binding: 97, resource: textureView30},
+  ],
+});
+let texture99 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder61 = commandEncoder75.beginComputePass({});
+let sampler63 = device0.createSampler({
+  label: '\u1de7\u07ca\u3e77\u{1fd39}\u{1ff88}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 92.68,
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup55, new Uint32Array(6360), 876, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup9, new Uint32Array(1920), 15, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(34, 72, 8_722_934, 689_734_413);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer57, 'uint16', 3_378, 1_176);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer34, 3_844);
+} catch {}
+let arrayBuffer9 = buffer42.getMappedRange(0, 584);
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(747).fill(58), /* required buffer size: 747 */
+{offset: 467, bytesPerRow: 28, rowsPerImage: 5}, {width: 0, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView49},
+    {binding: 59, resource: {buffer: buffer57, offset: 5120, size: 1456}},
+  ],
+});
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder77 = device0.createCommandEncoder();
+let textureView78 = texture54.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder62 = commandEncoder77.beginComputePass({});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(1, bindGroup30, new Uint32Array(753), 112, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder2.draw(41, 373, 96_163_937, 1_128_141_396);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer10, 384);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer30, 'uint32', 2_556, 1_486);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer62, 1_208, 153);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer64 = device0.createBuffer({size: 9052, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup53, new Uint32Array(1634), 44, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer63, 60);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer25, 'uint16', 6_324, 2_239);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, undefined, 0, 430_428_164);
+} catch {}
+try {
+buffer25.destroy();
+} catch {}
+let arrayBuffer10 = buffer31.getMappedRange(4640, 40);
+let promise12 = adapter0.requestAdapterInfo();
+let textureView79 = texture96.createView({label: '\ub2fb\u0197\u{1fa52}', mipLevelCount: 1});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint']});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.draw(292, 11, 980_648_986, 443_591_620);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer37, 220, 46);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer65 = device0.createBuffer({
+  label: '\u257b\u0a2f\u8d90\u00b8\u355c\u595c\ue2f9',
+  size: 3772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture100 = device0.createTexture({size: {width: 2}, dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup18, new Uint32Array(2310), 801, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(87, 467, 74, 499_183_941, 33_586_008);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer30, 'uint32', 428, 215);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline2);
+} catch {}
+document.body.prepend(video0);
+let commandEncoder78 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 373});
+let texture101 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder63 = commandEncoder78.beginComputePass();
+try {
+computePassEncoder63.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer62, 172);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer34, 'uint16', 780, 621);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer5, 'uint32', 7_580, 392);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({});
+let renderPassEncoder11 = commandEncoder79.beginRenderPass({colorAttachments: [{view: textureView37, depthSlice: 100, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder2.drawIndexed(212, 56, 3, 74_428_852, 718_738_892);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 2_032);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer63, 4);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer55, 'uint32', 296, 2_222);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer45, 312);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer9, 'uint32', 64, 4_745);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer64, 1844, new DataView(new ArrayBuffer(62606)), 11359, 20);
+} catch {}
+let imageData6 = new ImageData(4, 128);
+let bindGroup60 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView63}]});
+let textureView80 = texture74.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(0, bindGroup55, new Uint32Array(1800), 107, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer63, 'uint32', 32, 42);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer65, 0, 84);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas1.width = 333;
+let commandEncoder80 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: [4, 5, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder64 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder64.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup19, new Uint32Array(2363), 457, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(85, 160, 771_796_713, 1_862_921_917);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer54, 284);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer57, 300);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer14, 'uint32', 112, 71);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer50);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer49, 60, 3_292);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 21},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup61 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 173, resource: textureView19}]});
+let commandEncoder81 = device0.createCommandEncoder({label: '\u{1fe74}\u0135\u14ed\u9ddf\u0664'});
+let computePassEncoder65 = commandEncoder81.beginComputePass();
+try {
+computePassEncoder65.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.draw(435, 57, 331_471_858, 284_607_650);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(26, 32, 64, -2_050_091_740, 474_834_613);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer59, 124);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint16', 64, 56);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline2);
+} catch {}
+let bindGroup62 = device0.createBindGroup({label: '\u4d7a\u4b47', layout: bindGroupLayout8, entries: [{binding: 173, resource: textureView63}]});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup37, new Uint32Array(5121), 260, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(42, 113, 1_619_214_118, 635_523_809);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 5_732);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer27, 676);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer30, 'uint32', 1_140, 1_952);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer3, 1_032, 169);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(6, buffer16, 5_540, 113);
+} catch {}
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView65}]});
+let buffer66 = device0.createBuffer({
+  size: 16996,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder82 = device0.createCommandEncoder();
+let textureView81 = texture65.createView({label: '\u54dd\u0db1\u6c49\u0526\u0837\u{1fdeb}', dimension: '2d-array', arrayLayerCount: 1});
+let texture103 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder66 = commandEncoder82.beginComputePass({label: '\u0d8a\ud262\u4012'});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(3, bindGroup18, new Uint32Array(2166), 447, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 2016, new DataView(new ArrayBuffer(4658)), 2011, 304);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 381, resource: textureView23},
+    {binding: 414, resource: textureView56},
+    {binding: 79, resource: textureView41},
+  ],
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView82 = texture57.createView({dimension: '2d-array'});
+let renderPassEncoder12 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: 824.5, g: -816.8, b: -377.6, a: 639.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 126489352,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+renderPassEncoder2.draw(159, 154, 2_279_601_447, 85_294_951);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(49, 161, 63, 98_798_118, 934_458_550);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 640);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer28, 'uint32', 336, 162);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer50, 880, 369);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 52, resource: {buffer: buffer34, offset: 512, size: 1076}},
+    {binding: 111, resource: textureView36},
+    {binding: 142, resource: textureView11},
+    {binding: 92, resource: textureView56},
+    {binding: 238, resource: sampler55},
+    {binding: 65, resource: {buffer: buffer16, offset: 256, size: 4000}},
+    {binding: 293, resource: textureView32},
+    {binding: 13, resource: textureView58},
+    {binding: 1, resource: textureView25},
+  ],
+});
+let buffer67 = device0.createBuffer({size: 13936, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture105 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 7},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let textureView83 = texture14.createView({aspect: 'all'});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup52, new Uint32Array(4773), 32, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer55, 'uint32', 148, 7_976);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline2);
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer10, offset: 1536, size: 8}}],
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+let computePassEncoder67 = commandEncoder84.beginComputePass();
+try {
+computePassEncoder48.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup19, new Uint32Array(1349), 301, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(6, 174, 103_107_727, 500_237_403);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer28, 540);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer55, 'uint16', 270, 4_448);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'stencil-only',
+}, new Uint8Array(3_934).fill(6), /* required buffer size: 3_934 */
+{offset: 70, bytesPerRow: 92, rowsPerImage: 21}, {width: 4, height: 0, depthOrArrayLayers: 3});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture106 = device0.createTexture({
+  label: '\u{1f6be}\u0bee\u{1f86c}\u824e',
+  size: [256, 256, 18],
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture107 = device0.createTexture({
+  label: '\u0696\u04ed\u{1f980}\u0b79\u{1fe27}\u{1f701}\ue277',
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 960);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer63, 'uint32', 0, 39);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(241, 231, 132, 31_715_603, 1_534_377_367);
+} catch {}
+try {
+renderBundleEncoder15.drawIndirect(buffer28, 260);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline2);
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder();
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 295});
+let textureView84 = texture98.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(6, 39, 6, 138_839_258, 158_089_582);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer46, 24);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 4_616);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup35, new Uint32Array(523), 157, 0);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(458, 233, 268, 79_409_037, 385_070_423);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer7, 1_248);
+} catch {}
+try {
+renderBundleEncoder15.drawIndirect(buffer63, 20);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(3, buffer9, 852, 217);
+} catch {}
+try {
+commandEncoder85.copyTextureToBuffer({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2048 */
+  offset: 2048,
+  rowsPerImage: 935,
+  buffer: buffer44,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 69 max align: 1 */
+struct T0 {
+  @align(1) @size(69) f0: array<vec2i, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @align(1) f0: atomic<i32>,
+}
+/* target size: 4 max align: 4 */
+struct T2 {
+  f0: array<array<array<array<atomic<u32>, 1>, 1>, 1>, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T3 {
+  f0: atomic<i32>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer68: T1;
+struct VertexOutput6 {
+  @builtin(position) f23: vec4f,
+  @location(12) f24: i32
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2h, @builtin(vertex_index) a1: u32) -> VertexOutput6 {
+  var out: VertexOutput6;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) @interpolate(perspective, centroid) vec3i {
+  var out: vec3i;
+  return out;
+}
+struct FragmentOutput5 {
+  @location(0) f0: vec4u,
+  @location(7) @interpolate(linear, center) f1: vec3f
+}
+
+@fragment
+fn fragment1(@location(15) a0: f16, @location(11) @interpolate(perspective, center) a1: vec4h) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  return out;
+}`,
+  hints: {},
+});
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer24, offset: 5632, size: 6486}}],
+});
+let computePassEncoder68 = commandEncoder85.beginComputePass({label: '\u5851\u{1f960}\u0142\u0744\u{1fb18}\uc97e\ufb68\u7621\u5f91\u7d71\u91cd'});
+let renderBundle15 = renderBundleEncoder15.finish();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup15, new Uint32Array(178), 18, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(314, 57, 803_524_255, 1_226_750_906);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 2_832);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer66, 3_212);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let textureView85 = texture82.createView({baseArrayLayer: 4, arrayLayerCount: 4});
+let sampler64 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.00,
+  lodMaxClamp: 99.66,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup27, new Uint32Array(5807), 273, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.draw(107, 48, 1_579_982_919, 2_045_593_267);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 30, 10, 416_075_627, 232_189_689);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 3_112);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer3, 'uint32', 148, 398);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(386).fill(18), /* required buffer size: 386 */
+{offset: 386, bytesPerRow: 61, rowsPerImage: 26}, {width: 8, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = computePassEncoder27.label;
+} catch {}
+let buffer69 = device0.createBuffer({size: 5006, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer63, 36);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer27, 0, 4_563);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise10;
+} catch {}
+let texture108 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 177},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture109 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer63, 88);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer25, 'uint16', 952, 531);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer58, 808, 25);
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte432', transfer: 'pq'} });
+let sampler65 = device0.createSampler({
+  label: '\ub466\u0f42\u8394\u{1fb40}\ud9b8\u0720\u486f\u099d\u95a1\u{1f69d}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 66.93,
+  lodMaxClamp: 99.72,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroupsIndirect(buffer45, 732); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup61, new Uint32Array(4114), 367, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer57, 1_340);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer34, 'uint16', 1_718, 935);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+let buffer70 = device0.createBuffer({
+  size: 3754,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 459});
+let texture110 = device0.createTexture({
+  size: [8, 10, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder66.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 5_548);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer57, 'uint16', 1_852, 1_690);
+} catch {}
+let arrayBuffer11 = buffer11.getMappedRange(456, 56);
+let texture111 = device0.createTexture({size: {width: 16}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup62, new Uint32Array(373), 30, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(20, 29, 0, 258_703_038, 519_893_525);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 64);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 8},
+  aspect: 'all',
+}, new Uint8Array(49_575).fill(152), /* required buffer size: 49_575 */
+{offset: 137, bytesPerRow: 66, rowsPerImage: 107}, {width: 1, height: 1, depthOrArrayLayers: 8});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder2.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(2, bindGroup18, new Uint32Array(2310), 170, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup33, new Uint32Array(1322), 71, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(21, 72, 61_381_196, 55_096_338);
+} catch {}
+let arrayBuffer12 = buffer43.getMappedRange();
+let buffer71 = device0.createBuffer({size: 11045, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder86 = device0.createCommandEncoder();
+let textureView86 = texture28.createView({dimension: '2d-array'});
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer16, 2_816);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(7.280972223133029, 14.267297426553169, 5.378431488486783, 4.9650363395970025, 0.8977626188507727, 0.9509812104708695);
+} catch {}
+try {
+renderPassEncoder11.draw(7, 57, 2_560_786, 745_168_039);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(205, 441, 301, 4_506_627, 493_004_394);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer42, 'uint32', 1_640, 35);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2168 */
+  offset: 2168,
+  buffer: buffer69,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder86.finish({});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint']});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup42, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroupsIndirect(buffer62, 412); };
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle15, renderBundle15, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 15_396);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer65, 'uint16', 1_444, 167);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer13 = buffer65.getMappedRange();
+try {
+commandEncoder87.copyBufferToBuffer(buffer39, 72, buffer27, 1764, 948);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+let bindGroup68 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 285, resource: {buffer: buffer40, offset: 768}}]});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 1342});
+let textureView87 = texture59.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder69 = commandEncoder87.beginComputePass({});
+let sampler66 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.799,
+  lodMaxClamp: 88.01,
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup37, new Uint32Array(1518), 15, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup4, new Uint32Array(1720), 245, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(34, 32, 1, 255_571_126, 1_558_213);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 2_272);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer49, 'uint32', 2_140, 2_889);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer37, 1_428, 167);
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder88.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: -736.1, g: 698.6, b: -15.56, a: 640.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 44941359,
+});
+try {
+computePassEncoder12.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer37, 'uint32', 200, 547);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer37, 0, 7);
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\uf1cd');
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 784, new Int16Array(474), 86, 192);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer16, offset: 3584, size: 2208}}],
+});
+let textureView88 = texture88.createView({});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({label: '\u0304\u{1fd8a}', colorFormats: ['r8unorm']});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer62, 84);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer50, 2_088);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup9, new Uint32Array(21), 2, 0);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await promise13;
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let renderPassEncoder14 = commandEncoder89.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 64,
+  clearValue: { r: -60.02, g: -951.1, b: -705.7, a: -394.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer59, 52);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer57, 'uint32', 796, 500);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({});
+let texture112 = device0.createTexture({
+  size: [4, 5, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle16 = renderBundleEncoder16.finish({label: '\u471d\u68fc\u99b3\u0ba8\u{1fd8b}\u{1f8f0}'});
+try {
+renderPassEncoder11.draw(133, 138, 559_968_842, 977_978_277);
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1942 */
+  offset: 1942,
+  buffer: buffer0,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ube75\u05dc\u04c7\ua1b9\u0d15\u9f44\u{1f9df}\u{1fbe2}\u{1f816}\u036d\u0e71';
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 75,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer72 = device0.createBuffer({size: 5083, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView89 = texture96.createView({aspect: 'all'});
+let texture113 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder70 = commandEncoder90.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup20, new Uint32Array(2899), 359, 0);
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+  label: '\u09c0\u6793\u8d74\u0b92\u{1f9b2}\u9852',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, constants: {}},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+externalTexture2.label = '\u066b\u0478\u074a\u013f\u7de2\u{1feb9}\uab6b\u5138\ud041\u{1f80a}\ud3ba';
+} catch {}
+let texture114 = device0.createTexture({
+  size: [8, 10, 73],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer10, 104);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer46, 92);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\uff12');
+} catch {}
+document.body.append(canvas0);
+let textureView90 = texture58.createView({
+  label: '\ufd4f\u6041\u21fa\u{1fb4d}\u0839\u0ea9\ubbe5\ue0d5\u005a',
+  baseArrayLayer: 14,
+  arrayLayerCount: 9,
+});
+let texture115 = device0.createTexture({
+  label: '\ud6d7\u{1f9a9}\u0e1f\u{1f6e1}\u0ac2\uf9e1\ue84b\u{1f794}\u2d22\u24d4',
+  size: {width: 256, height: 256, depthOrArrayLayers: 422},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.draw(253, 21, 28_385_580, 413_120_541);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer46, 8);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer54, 96);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup22, new Uint32Array(166), 17, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(7, undefined, 2_584_497_337, 610_555_049);
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt2020', transfer: 'bt2020_12bit'} });
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 404,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder91 = device0.createCommandEncoder();
+let texture116 = device0.createTexture({
+  size: [256, 256, 2],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder15 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 42,
+  clearValue: { r: 826.7, g: -607.2, b: 704.6, a: 981.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup67, new Uint32Array(450), 2, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder9.draw(59, 1, 3_671_670_344, 83_552_883);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer30, 'uint32', 528, 5_518);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup39, new Uint32Array(2990), 1_319, 0);
+} catch {}
+document.body.append(video0);
+let textureView91 = texture114.createView({baseArrayLayer: 10, arrayLayerCount: 13});
+let texture117 = device0.createTexture({
+  label: '\ud0eb\ub3e0\u{1fb25}',
+  size: [4],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle17 = renderBundleEncoder17.finish();
+try {
+computePassEncoder31.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(23, 210, 3, 129_061_665, 206_838_118);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer27, 364);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer49, 'uint32', 1_136, 3_140);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer58);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 9, y: 0 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 2, y: 16, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer73 = device0.createBuffer({
+  size: 4965,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView92 = texture116.createView({});
+let textureView93 = texture18.createView({});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle10, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer50, 2_504);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer73, offset: 0, size: 112}}],
+});
+let texture118 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 285},
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture119 = device0.createTexture({
+  label: '\u08ce\u{1f743}\ue788\u163b\u{1f73d}\u1b14\u42d6\u27e6\u604e\u{1fd94}\uc13e',
+  size: [4, 5, 27],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView94 = texture17.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer27, 380);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer42, 2_248);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [{binding: 75, resource: textureView91}, {binding: 121, resource: {buffer: buffer61, offset: 2816}}],
+});
+let textureView95 = texture118.createView({label: '\u80e0\u3c59\u33b6\ucf36'});
+let texture120 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 7},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder13.executeBundles([renderBundle17, renderBundle13, renderBundle10, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer54, 392);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView96 = texture8.createView({dimension: '2d', aspect: 'depth-only', format: 'depth32float', baseArrayLayer: 8});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup62, new Uint32Array(2300), 100, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer73, 1_988);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer52, 608, 308);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 781,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let textureView97 = texture34.createView({arrayLayerCount: 1});
+let computePassEncoder71 = commandEncoder92.beginComputePass();
+try {
+computePassEncoder33.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer7, 2_564);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer73, 0, 250);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(video0);
+let bindGroup72 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 121, resource: {buffer: buffer57, offset: 1792, size: 1048}},
+    {binding: 75, resource: textureView91},
+  ],
+});
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder71.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(0, 102, 0, 390_756_844, 567_087_452);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer46, 64);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer45, 0, 407);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 128, new DataView(new ArrayBuffer(2847)), 735, 32);
+} catch {}
+let textureView98 = texture30.createView({dimension: 'cube', aspect: 'depth-only', baseArrayLayer: 3});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup52, new Uint32Array(3097), 39, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+renderPassEncoder15.draw(68, 139, 1_182_908_710, 1_672_351_773);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer73, 412);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer49, 'uint16', 1_822, 1_319);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(3, bindGroup48, new Uint32Array(837), 91, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer14, 2_000);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer66, 'uint16', 1_194, 7_509);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder44.pushDebugGroup('\ufff5');
+} catch {}
+let buffer75 = device0.createBuffer({size: 4498, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let commandEncoder93 = device0.createCommandEncoder({});
+let renderPassEncoder16 = commandEncoder93.beginRenderPass({colorAttachments: [{view: textureView88, depthSlice: 61, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup61, new Uint32Array(1390), 378, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup29, new Uint32Array(137), 21, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle16, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder15.draw(117, 907, 1_082_796_032, 1_279_245_500);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 36, 0, -2_042_515_334, 393_027_185);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer10, 4);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'film', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroup73 = device0.createBindGroup({
+  label: '\u0012\uf921\u08b9\ub085\ub558\u5135\ucc93\u{1f971}',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView41},
+    {binding: 381, resource: textureView60},
+    {binding: 79, resource: textureView52},
+  ],
+});
+let buffer76 = device0.createBuffer({size: 9828, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let commandEncoder94 = device0.createCommandEncoder({});
+let commandBuffer9 = commandEncoder94.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroupsIndirect(buffer45, 360); };
+} catch {}
+try {
+renderPassEncoder9.setViewport(15.202684407942591, 0.43232464270878346, 0.20843354735907724, 12.415631583442707, 0.9481210497017901, 0.9888890234558321);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(3, 179, 11, -1_917_616_662, 414_859_198);
+} catch {}
+try {
+computePassEncoder44.popDebugGroup();
+} catch {}
+try {
+computePassEncoder7.setBindGroup(2, bindGroup66);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(6, 3, 1, 3);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer62, 180);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer3, 0, 418);
+} catch {}
+try {
+computePassEncoder38.pushDebugGroup('\ud029');
+} catch {}
+try {
+computePassEncoder66.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder19.dispatchWorkgroupsIndirect(buffer72, 152);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -400.4, g: -639.8, b: 644.3, a: -936.4, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 11, 23, 353_440_206, 67_574_404);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer37, 'uint32', 236, 724);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 1,
+  origin: {x: 7, y: 21, z: 2},
+  aspect: 'all',
+}, new Uint8Array(7_345).fill(17), /* required buffer size: 7_345 */
+{offset: 449, bytesPerRow: 52, rowsPerImage: 126}, {width: 8, height: 7, depthOrArrayLayers: 2});
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder();
+let textureView99 = texture19.createView({
+  label: '\uae33\u608f\u{1f877}\uab8a\u6618\u71e6\ueb03\u0070\u5d8b\u5b43\u0c7c',
+  dimension: 'cube',
+  format: 'r16sint',
+  baseArrayLayer: 1,
+});
+let texture121 = device0.createTexture({
+  size: [4, 5, 1],
+  sampleCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView100 = texture36.createView({format: 'rgb9e5ufloat', baseArrayLayer: 1, arrayLayerCount: 7});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup23, new Uint32Array(699), 201, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(164, 243, 1_261_627_939, 79_281_367);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(0, 127, 1, 1_684_849_519, 1_915_284_008);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer66, 132);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer62, 608);
+} catch {}
+let buffer77 = device0.createBuffer({size: 8956, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer22, 60);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup74 = device0.createBindGroup({
+  label: '\ue2f5\u0417\u0730\ua76c',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView52},
+    {binding: 79, resource: textureView52},
+    {binding: 381, resource: textureView23},
+  ],
+});
+let computePassEncoder72 = commandEncoder95.beginComputePass({});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup37, new Uint32Array(2197), 45, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup52, new Uint32Array(2472), 182, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle7, renderBundle7, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder15.draw(89, 201, 97_998_764, 161_979_206);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer62, 76);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer3, 0);
+} catch {}
+let bindGroup75 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 173, resource: textureView49}]});
+let textureView101 = texture92.createView({label: '\u0c27\ucf74\u758b\u6a73\u{1ffd6}\uc7b6\u315a\u05de\u{1fdee}\u{1fde2}'});
+let externalTexture6 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup35, new Uint32Array(357), 268, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup54, new Uint32Array(18), 1, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(68);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer44, 15_584);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer74, 'uint16', 60, 222);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup40, new Uint32Array(542), 195, 0);
+} catch {}
+try {
+renderPassEncoder15.draw(232, 210, 132_999_987, 629_858_263);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer50, 2_180);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer24, 2_064);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer63, offset: 0, size: 70}}],
+});
+let commandEncoder96 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder73 = commandEncoder96.beginComputePass({});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup69, new Uint32Array(957), 34, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 584, 2, 438_547_543, 151_917_338);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer42, 120);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 1252, new BigUint64Array(20891), 932, 32);
+} catch {}
+let texture123 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder1.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 638, 5, -1_321_231_329, 356_940_740);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer16, 1_628);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer55, 'uint16', 82, 231);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  label: '\u0563\uc976\u{1f69b}\u0c07\u{1fe4d}\u14bf\u{1fd7d}',
+  layout: bindGroupLayout8,
+  entries: [{binding: 173, resource: textureView30}],
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(0, bindGroup55, new Uint32Array(758), 111, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup74, new Uint32Array(1790), 619, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer65, 'uint16', 926, 446);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer58);
+} catch {}
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 79, resource: textureView52},
+    {binding: 414, resource: textureView97},
+    {binding: 381, resource: textureView58},
+  ],
+});
+let computePassEncoder74 = commandEncoder97.beginComputePass({label: '\u{1faf0}\u{1f647}\u0042\u780e\u2d22\u{1f982}\u01bc\u0c0b\u0e90'});
+try {
+computePassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup63, new Uint32Array(889), 41, 0);
+} catch {}
+try {
+renderPassEncoder15.draw(52, 280, 889_367_190, 526_143_868);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer50, 2_552);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(144).fill(187), /* required buffer size: 144 */
+{offset: 144}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer78 = device0.createBuffer({size: 5373, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC, mappedAtCreation: false});
+let commandEncoder98 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: [2, 2, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder75 = commandEncoder98.beginComputePass();
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup67, new Uint32Array(385), 85, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(7, 126, 2, 47_730_233, 503_717_811);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer9, 'uint16', 482, 1_492);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let textureView102 = texture116.createView({label: '\u4864\u{1fe82}\u67ed\u{1f779}'});
+let texture125 = device0.createTexture({
+  size: [256, 256, 18],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture126 = gpuCanvasContext3.getCurrentTexture();
+let textureView103 = texture44.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler67 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 94.84,
+  lodMaxClamp: 95.96,
+});
+let externalTexture7 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer0, 176); };
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup34, new Uint32Array(483), 26, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(0, 50, 65, 70_241_091, 508_027_114);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer72, 804);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 328, new Float32Array(17515), 7076, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.draw(500, 11, 182_230_379, 512_430_257);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer10, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer65, 0, 334);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+adapter0.label = '\u{1f8d3}\ua7c9\u{1f7db}\u{1fa9d}\u{1ff8e}\u044c\u0ec8\u0ba3\u64cd';
+} catch {}
+let texture127 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup77, new Uint32Array(886), 78, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(167, 338, 760_588_802, 1_149_631_144);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer65, 'uint32', 728, 485);
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 88 max align: 8 */
+struct T0 {
+  @size(88) f0: array<f16>,
+}
+@group(0) @binding(414) var tex1: texture_3d<f32>;
+@group(0) @binding(79) var st0: texture_storage_3d<rgba32float, read>;
+@group(0) @binding(381) var tex0: texture_2d<i32>;
+struct VertexOutput7 {
+  @location(9) f25: vec3f,
+  @builtin(position) f26: vec4f,
+  @location(13) f27: vec4u,
+  @location(8) @interpolate(linear, center) f28: vec2f
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(8) @interpolate(flat, centroid) a1: vec2i) -> VertexOutput7 {
+  var out: VertexOutput7;
+  _ = a0;
+  if bool(textureLoad(tex1, vec3i(), 0)[3]) {
+    var v: vec4f;
+  }
+  if bool(a1[1]) {
+    out.f27 = vec4u(bitcast<u32>(a0));
+  }
+  return out;
+}
+struct FragmentOutput6 {
+  @location(0) @interpolate(flat, centroid) f0: i32,
+  @location(2) f1: vec3f,
+  @builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 31});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle17, renderBundle10, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder15.draw(209, 137, 2_790_243_858, 719_491_070);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer46);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 4648, new Int16Array(26163), 630, 3524);
+} catch {}
+try {
+externalTexture4.label = '\ub4dd\u9d2a\u0210\u0205\u13cc\u97b4\ue4c1\u{1fc67}\u588d\u0304';
+} catch {}
+try {
+window.someLabel = textureView99.label;
+} catch {}
+let buffer79 = device0.createBuffer({
+  label: '\ucb40\u{1f96e}',
+  size: 2100,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture128 = device0.createTexture({
+  label: '\u0532\ucdb5\u0423\u0e07\u{1fe5a}\u08ef\u7784',
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.00,
+  lodMaxClamp: 95.31,
+  maxAnisotropy: 9,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer7, 780); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup65, new Uint32Array(27), 1, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 25, 0, 618_076_814, 539_731_697);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 25},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder99 = device0.createCommandEncoder({});
+let computePassEncoder76 = commandEncoder99.beginComputePass({label: '\u{1f8e1}\u1ce7\u2e15\u{1fbee}\ufd98\u8938\u04d2'});
+try {
+computePassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(31);
+} catch {}
+try {
+renderPassEncoder11.draw(21, 16, 592_192_670, 2_117_945_192);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer42, 292);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer70, 356, 13);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'logSqrt'} });
+try {
+externalTexture6.label = '\u53f0\uca79\u00f2\u{1fda4}\u0a97\u0238\u440a\u{1fbf6}\ub0b9\u01c5\u0716';
+} catch {}
+let textureView104 = texture118.createView({label: '\u06d0\u0443\u237f\u{1fd3d}\u5e4d\u0865'});
+let texture129 = device0.createTexture({
+  size: [16, 20, 177],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder65); computePassEncoder65.dispatchWorkgroups(1, 3, 1); };
+} catch {}
+try {
+renderPassEncoder2.draw(42, 110, 588_642_141, 256_925_180);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 91, 1, 253_236_364, 799_882_717);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer16, 5_052);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer72, 'uint32', 192, 469);
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture130 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 44},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer46, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer72, 40, 918);
+} catch {}
+let textureView105 = texture85.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 9});
+let renderBundle18 = renderBundleEncoder18.finish({label: '\u066c\u{1f7d8}\u55dd\u7786\u6eea\u{1fde4}'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup21, new Uint32Array(894), 65, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(489);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 153, 1, 14_659_433, 1_343_269_242);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer65, 0, 442);
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3148 */
+  offset: 3148,
+  bytesPerRow: 1536,
+  buffer: buffer56,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 26, y: 16, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 121, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder100.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3400 */
+  offset: 3400,
+  bytesPerRow: 512,
+  buffer: buffer52,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer80 = device0.createBuffer({size: 8522, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let texture131 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 43},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView106 = texture65.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder77 = commandEncoder100.beginComputePass({});
+try {
+computePassEncoder77.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer28, 900);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer74, 48);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint16', 1_016, 3_251);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer37, 724);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer14 = buffer55.getMappedRange();
+let buffer81 = device0.createBuffer({
+  size: 30918,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder101 = device0.createCommandEncoder();
+let texture132 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 20},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView107 = texture15.createView({dimension: '2d-array', aspect: 'depth-only', format: 'depth32float'});
+let computePassEncoder78 = commandEncoder101.beginComputePass({label: '\u{1f7b5}\u{1fc4a}\u6353\u{1feb9}\u7a62\u119e\u2bf9\u{1f7bd}\ufe29\u33ff'});
+try {
+computePassEncoder78.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 311, 22, 131_250_195, 629_267_025);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer74, 44);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer49, 'uint32', 932, 4_384);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer79, 264);
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder();
+let computePassEncoder79 = commandEncoder102.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+renderPassEncoder11.setViewport(5.233218214871863, 17.65158256993857, 4.653079149906121, 1.761438687532741, 0.11340628651687146, 0.5795698607830815);
+} catch {}
+try {
+renderPassEncoder10.draw(360, 124, 3_776_314_767, 745_962_507);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(7, 113, 0, 107_883_857, 171_531_921);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint32', 44, 5);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 75, resource: textureView91},
+    {binding: 121, resource: {buffer: buffer2, offset: 256, size: 264}},
+  ],
+});
+let textureView108 = texture114.createView({baseArrayLayer: 5, arrayLayerCount: 11});
+let texture133 = device0.createTexture({size: [256], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(302, 33, 1, 91_701_759, 714_431_891);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer62, 396);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer15 = buffer27.getMappedRange(10368, 864);
+let buffer82 = device0.createBuffer({
+  size: 573,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder2.draw(52, 87, 99_075_885, 223_798_610);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer0, 124);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer57, 228);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder59.insertDebugMarker('\u49af');
+} catch {}
+let buffer83 = device0.createBuffer({
+  size: 5354,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture134 = device0.createTexture({
+  size: [16, 20, 1],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView109 = texture92.createView({});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup27, new Uint32Array(816), 3, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @align(1) f0: i32,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @size(4) f0: f16,
+}
+@group(0) @binding(285) var<storage, read_write> buffer84: array<atomic<u32>>;`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup80 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 270, resource: textureView92},
+    {binding: 116, resource: textureView102},
+    {binding: 30, resource: textureView95},
+    {binding: 404, resource: textureView19},
+    {binding: 54, resource: {buffer: buffer34, offset: 512, size: 502}},
+    {binding: 6, resource: sampler43},
+  ],
+});
+let buffer85 = device0.createBuffer({
+  size: 20366,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture135 = device0.createTexture({
+  label: '\u56ff\u{1fd83}\u0e5d\udee1\ub548\u0c03\u49c0\u06d9',
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler69 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  lodMinClamp: 58.25,
+  lodMaxClamp: 90.25,
+  compare: 'always',
+});
+try {
+renderPassEncoder15.draw(128, 28, 166_205_730, 1_268_935_959);
+} catch {}
+try {
+texture134.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8Array(257).fill(58), /* required buffer size: 257 */
+{offset: 249}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 64});
+let texture136 = device0.createTexture({size: [16], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView110 = texture29.createView({baseArrayLayer: 0, arrayLayerCount: 4});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer28, 352); };
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder10.draw(241, 5, 930_762_930, 317_870_786);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer46, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 57, y: 5, z: 1},
+  aspect: 'all',
+}, new Uint8Array(437).fill(60), /* required buffer size: 437 */
+{offset: 437, bytesPerRow: 216}, {width: 53, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let texture137 = device0.createTexture({size: [4], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let texture138 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder34.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle16, renderBundle16, renderBundle2, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 136.9, g: -902.1, b: -215.2, a: 963.9, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 34, 7, 59_733_132, 904_478_882);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer0, 0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let textureView111 = texture100.createView({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+renderPassEncoder2.drawIndexed(3, 431, 11, 364_883_476, 80_499_978);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer83, 1_440);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer27, 16, 2_749);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer63, 20, new Int16Array(39806), 13388, 12);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView0},
+    {binding: 59, resource: {buffer: buffer74, offset: 0, size: 44}},
+  ],
+});
+let commandEncoder103 = device0.createCommandEncoder({label: '\u3a60\u77e1\u{1ff29}\u404a\u{1f75f}\u{1fd53}\ue98a\ua2ca\u0165\ua496\u{1f9e8}'});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 207});
+let textureView112 = texture95.createView({label: '\ua6fe\u0485', dimension: '2d'});
+try {
+computePassEncoder75.setBindGroup(2, bindGroup7, new Uint32Array(1270), 382, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(65, 139, 11, 764_105_336, 52_207_654);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer74, 156);
+} catch {}
+try {
+computePassEncoder38.popDebugGroup();
+} catch {}
+await gc();
+try {
+texture25.label = '\u0f22\u{1fe14}\u3d88\u{1fdf9}';
+} catch {}
+let bindGroup82 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 75, resource: textureView91},
+    {binding: 121, resource: {buffer: buffer49, offset: 4608, size: 3780}},
+  ],
+});
+let texture139 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 177},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder80 = commandEncoder103.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup51, new Uint32Array(187), 26, 0);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup64);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup18, new Uint32Array(536), 3, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(66, 210, 501_509_810, 929_238_540);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(71, 60, 194, 436_376_010, 282_825_829);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer50, 1_232);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer45);
+} catch {}
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let bindGroup83 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView63}]});
+let textureView113 = texture18.createView({dimension: '2d-array'});
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup9, new Uint32Array(624), 68, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer37, 'uint16', 290, 299);
+} catch {}
+try {
+  await shaderModule5.getCompilationInfo();
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(156).fill(9), /* required buffer size: 156 */
+{offset: 121, bytesPerRow: 7}, {width: 0, height: 24, depthOrArrayLayers: 1});
+} catch {}
+let querySet18 = device0.createQuerySet({label: '\uea87\u0ee7\uf10a\u{1fe44}', type: 'occlusion', count: 206});
+let textureView114 = texture111.createView({});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup22, new Uint32Array(1631), 53, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+renderPassEncoder11.draw(88, 34, 3_946_406_396, 643_521_903);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(21, 63, 12, 500_098_110, 10_429_004);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer42, 'uint16', 758, 218);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer55, 3_348);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup84 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 103, resource: textureView89}]});
+let texture140 = device0.createTexture({
+  label: '\u8b99\u4e6e\uec95\u66f1\ud43b\ue323\u07bf\ufab8\u{1f637}\u5e75\u50a9',
+  size: [8, 10, 1],
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder70.setBindGroup(3, bindGroup70, new Uint32Array(1910), 14, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(9, 432, 24, -2_101_784_515, 2_319_419_213);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 51},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup85 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer39, offset: 512, size: 596}}],
+});
+let texture141 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup23, []);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer20, 2_772);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(33).fill(169), /* required buffer size: 33 */
+{offset: 33, bytesPerRow: 61}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.createRenderPipelineAsync({
+  label: '\u8c0b\u002c\u{1fd20}\u0274',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule1, constants: {}, buffers: []},
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle5, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(11, 468, 12, -1_987_261_759, 1_203_973_115);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer27, 1_840);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+let texture142 = device0.createTexture({
+  label: '\u6d4d\u428b\u0989\u0334',
+  size: {width: 16, height: 20, depthOrArrayLayers: 177},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let texture143 = gpuCanvasContext0.getCurrentTexture();
+let textureView115 = texture61.createView({dimension: '2d', baseArrayLayer: 8});
+try {
+renderPassEncoder15.drawIndirect(buffer54, 7_012);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint16', 546, 710);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer34, 0);
+} catch {}
+let arrayBuffer16 = buffer42.getMappedRange(3672, 792);
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder({});
+let textureView116 = texture3.createView({baseArrayLayer: 3, arrayLayerCount: 17});
+let textureView117 = texture83.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 1});
+try {
+renderPassEncoder14.setScissorRect(1, 4, 2, 2);
+} catch {}
+try {
+renderPassEncoder10.draw(9, 29, 859_504_757, 548_650_929);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(3, 114, 12, 116_058_767, 68_170_861);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer46, 168);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 268 widthInBlocks: 67 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 916 */
+  offset: 916,
+  bytesPerRow: 512,
+  buffer: buffer51,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 38, y: 126, z: 0},
+  aspect: 'all',
+}, {width: 67, height: 40, depthOrArrayLayers: 0});
+} catch {}
+let texture144 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView118 = texture39.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+try {
+computePassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup66, new Uint32Array(479), 151, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer74);
+} catch {}
+try {
+commandEncoder104.copyBufferToBuffer(buffer27, 444, buffer63, 84, 40);
+} catch {}
+try {
+commandEncoder104.copyTextureToBuffer({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3980 */
+  offset: 3980,
+  buffer: buffer83,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder104.insertDebugMarker('\u0cf1');
+} catch {}
+let promise15 = adapter0.requestAdapterInfo();
+let buffer86 = device0.createBuffer({
+  size: 6252,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandEncoder105 = device0.createCommandEncoder({});
+let textureView119 = texture55.createView({});
+let renderPassEncoder17 = commandEncoder104.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 69,
+  clearValue: { r: -625.8, g: -608.6, b: -65.97, a: 87.46, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup80, new Uint32Array(4021), 651, 0);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -43.28, g: -316.7, b: -121.1, a: 380.6, });
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  label: '\u{1fecc}\u7988\u9723\ud7b3\u0003\uec80',
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer77, offset: 2560}}],
+});
+let buffer87 = device0.createBuffer({
+  label: '\u5fd5\u{1fc11}\uaf31\u0a1b\u0fdb\u0acb\uca3d\u09e7\u0a68',
+  size: 6832,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder106 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 184});
+let computePassEncoder81 = commandEncoder105.beginComputePass({});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup74, new Uint32Array(7352), 2_005, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer86, 3_028);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer79, 308);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer73, 'uint16', 1_724, 693);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video0);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+device0.queue.label = '\ufa60\u0e7c\u0b11\ufacf\u037c\u7601\u{1ff76}\u{1f698}\u08e1\u{1fc0c}';
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 87, resource: {buffer: buffer1, offset: 0, size: 1548}}],
+});
+let texture145 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 94},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView120 = texture118.createView({});
+let renderPassEncoder18 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{view: textureView88, depthSlice: 126, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet15,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup3, new Uint32Array(2527), 92, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(21, 269, 708_524_708, 613_497_871);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(21, 142, 18, -2_096_490_554, 156_073_939);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer82, 76);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer82, 4);
+} catch {}
+let imageData7 = new ImageData(32, 128);
+let bindGroup88 = device0.createBindGroup({
+  label: '\uaa11\ufd1f\u{1f7e4}\u35cd\u684a\u89ee\u05a6\u04c7',
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer42, offset: 1536}}],
+});
+let buffer88 = device0.createBuffer({size: 7306, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder107 = device0.createCommandEncoder({});
+let texture146 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer73, 'uint32', 896, 540);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 404, resource: textureView19},
+    {binding: 30, resource: textureView95},
+    {binding: 116, resource: textureView102},
+    {binding: 270, resource: textureView92},
+    {binding: 6, resource: sampler34},
+    {binding: 54, resource: {buffer: buffer59, offset: 256, size: 17}},
+  ],
+});
+let texture147 = device0.createTexture({
+  label: '\u0690\u76ce\u{1ff75}\u2048\u056e\u08f1',
+  size: {width: 4, height: 5, depthOrArrayLayers: 11},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture148 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder82 = commandEncoder107.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup38, []);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup12, new Uint32Array(2055), 246, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup46, new Uint32Array(2839), 12, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(1);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 414, resource: textureView56},
+    {binding: 381, resource: textureView60},
+    {binding: 79, resource: textureView52},
+  ],
+});
+let commandEncoder108 = device0.createCommandEncoder({label: '\u{1f62d}\u409c\u16e6\u58e1\u01bb\ua04c'});
+let commandBuffer10 = commandEncoder108.finish();
+try {
+computePassEncoder45.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.draw(587, 61, 1_107_073_704, 1_197_485_216);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer0, 164);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView2}, {binding: 126, resource: textureView18}],
+});
+let texture149 = device0.createTexture({
+  label: '\u0c8a\u0d4e',
+  size: {width: 4, height: 5, depthOrArrayLayers: 40},
+  sampleCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder10.setViewport(4.490813966166156, 12.971862502974265, 8.24331691557308, 4.3139819443095195, 0.9733333817890786, 0.9825051202688582);
+} catch {}
+try {
+renderPassEncoder10.draw(102, 35, 199_880_798, 420_282_604);
+} catch {}
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup38, new Uint32Array(234), 75, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup30, new Uint32Array(2016), 49, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+let commandEncoder109 = device0.createCommandEncoder({});
+let textureView121 = texture73.createView({baseArrayLayer: 0});
+let computePassEncoder83 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(1, bindGroup31, new Uint32Array(5104), 492, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(193, 396, 1_637_423_944, 51_156_151);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer57, 7_584);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer0, 232);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer83, 'uint32', 300, 1_593);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer58, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.insertDebugMarker('\u{1fa03}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(25).fill(163), /* required buffer size: 25 */
+{offset: 25}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video0.width = 62;
+let imageData8 = new ImageData(48, 16);
+let commandEncoder110 = device0.createCommandEncoder({});
+let textureView122 = texture78.createView({arrayLayerCount: 1});
+let computePassEncoder84 = commandEncoder110.beginComputePass({label: '\udd01\u0bc0\ue6d0\uc5e4\uf875\u3cf6\u0e52'});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup91, new Uint32Array(1989), 21, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(3, 88, 33, 692_434_652, 489_663_671);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer88, 748);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer57, 816);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer9, 'uint16', 2_106, 1_571);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup52, new Uint32Array(97), 0, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let textureView123 = texture22.createView({aspect: 'all', format: 'r16sint', baseMipLevel: 0, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup8, new Uint32Array(669), 138, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer83, 456);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup47);
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView2}, {binding: 126, resource: textureView70}],
+});
+let commandEncoder111 = device0.createCommandEncoder({});
+let renderBundle20 = renderBundleEncoder20.finish({label: '\u{1ff00}\u5950\u0687\u8928\u05e8\u{1fc4e}\u263f\u135b'});
+let sampler70 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.60,
+  lodMaxClamp: 77.35,
+  compare: 'greater-equal',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup74, new Uint32Array(912), 284, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroupsIndirect(buffer82, 192); };
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder11.draw(160, 115, 1_056_439_423, 574_870_373);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer70, 2_784);
+} catch {}
+let imageData9 = new ImageData(52, 40);
+let bindGroup93 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 103, resource: textureView79}]});
+let commandEncoder112 = device0.createCommandEncoder({});
+let commandBuffer11 = commandEncoder111.finish({label: '\u67e6\ub679'});
+let sampler71 = device0.createSampler({
+  label: '\uf31c\u0c2e\u054d\ud175\uc8fe',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 96.62,
+  lodMaxClamp: 99.79,
+});
+try {
+computePassEncoder83.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle19, renderBundle2, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(887);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(40, 14, 80, 947_063_947, 261_406_115);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer20, 504);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer10, 832);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer57, 732);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 160, new DataView(new ArrayBuffer(6467)), 103, 1388);
+} catch {}
+let pipeline7 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule4, constants: {}}});
+let pipeline8 = await promise14;
+let texture150 = device0.createTexture({size: [8], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView124 = texture127.createView({dimension: '2d-array', aspect: 'depth-only'});
+let computePassEncoder85 = commandEncoder112.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(2, 55, 5, 1_641_150_013, 887_409_101);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer10, 496);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer65, 0, 348);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'unspecified'} });
+let commandEncoder113 = device0.createCommandEncoder();
+try {
+computePassEncoder36.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(11, 50, 139, 322_290_988, 471_862_318);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer46, 192);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let imageData10 = new ImageData(60, 20);
+let bindGroup94 = device0.createBindGroup({
+  label: '\u{1fea8}\u0dcb\u74d9\u5f4d\u0ad4\u6740\u03c8\u08cd\ubd2d\ucd56\uebd8',
+  layout: bindGroupLayout0,
+  entries: [{binding: 97, resource: textureView0}, {binding: 59, resource: {buffer: buffer86, offset: 256}}],
+});
+let buffer89 = device0.createBuffer({
+  size: 3972,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandBuffer12 = commandEncoder113.finish({});
+try {
+computePassEncoder85.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup44, new Uint32Array(2332), 2, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(102, 30, 692_285_818, 427_207_508);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(13, 227, 21, -1_713_940_507, 338_186_435);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer37, 'uint16', 60, 883);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'display-p3'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 1,
+  origin: {x: 0, y: 26, z: 3},
+  aspect: 'stencil-only',
+}, new Uint8Array(40_176).fill(137), /* required buffer size: 40_176 */
+{offset: 172, bytesPerRow: 137, rowsPerImage: 73}, {width: 128, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture151 = device0.createTexture({
+  size: [2, 2, 3],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler72 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.02,
+  lodMaxClamp: 68.61,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup60, []);
+} catch {}
+try {
+renderPassEncoder15.draw(222, 890, 1_795_516_825, 465_055_048);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(15, 3, 25, 41_224_985, 376_666_369);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer73, 356);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer49, 0, 648);
+} catch {}
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let bindGroup95 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView66}]});
+let texture152 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 28},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 2_664);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer45, 0);
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpteSt4281', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\ue89a\u9b23\ue9d5\uba55\ubb08\u3705\u899c\u3824\ub979',
+  entries: [
+    {binding: 9, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let sampler73 = device0.createSampler({
+  label: '\uacfb\u05ab\u05af\u0e26',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.88,
+  lodMaxClamp: 41.01,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup14, new Uint32Array(411), 123, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2, renderBundle11, renderBundle2, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder10.draw(707, 155, 761_858_031, 286_313_726);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(195, 77, 117, 10_085_726, 71_817_263);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer82, 112);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer52, 700);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\u{1f838}\u4a8d\u169a\u671a\u0c7b\u{1f679}\u1d89\ud122',
+  entries: [
+    {
+      binding: 46,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer90 = device0.createBuffer({
+  size: 14592,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder114 = device0.createCommandEncoder({});
+let texture153 = gpuCanvasContext1.getCurrentTexture();
+let textureView125 = texture18.createView({dimension: '2d-array'});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup79);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle10, renderBundle13, renderBundle10, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder15.draw(22, 163, 3_007_535_980, 88_777_327);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer88, 'uint32', 3_128, 849);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet18, 103, 5, buffer58, 3584);
+} catch {}
+try {
+commandEncoder114.insertDebugMarker('\u5349');
+} catch {}
+let textureView126 = texture58.createView({dimension: '2d', format: 'rg32uint', baseArrayLayer: 7});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer10, 316); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(25, 488, 2, 127_106_236, 968_398_154);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer83, 928);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 49},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup96 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView66}]});
+let commandEncoder115 = device0.createCommandEncoder({label: '\u04f6\u5dda\u{1f704}\u{1fd88}\ub450\u7ad3\u{1fe1f}\u{1f9fc}\u044c\ud525\u0975'});
+let texture154 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 12},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView127 = texture133.createView({});
+let computePassEncoder86 = commandEncoder114.beginComputePass({});
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer14, 188);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer7, 1_040);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer74, 'uint16', 28, 99);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+let buffer91 = device0.createBuffer({
+  label: '\u023b\u{1f80e}\ue6b6\u{1f7fc}\u0e47\u052f\u0dcf',
+  size: 5804,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView128 = texture34.createView({aspect: 'depth-only'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2, renderBundle5, renderBundle19, renderBundle7, renderBundle2, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 792.0, g: -85.18, b: 667.4, a: 512.2, });
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(21, 268, 8, -1_806_492_189, 320_080_664);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer44, 2_600);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+try {
+computePassEncoder28.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup21, new Uint32Array(1460), 111, 0);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  label: '\u0f1e\u0bcd\u{1fb6c}\u{1f7ce}\uaaf6',
+  layout: bindGroupLayout8,
+  entries: [{binding: 173, resource: textureView63}],
+});
+let textureView129 = texture112.createView({
+  label: '\u{1fd01}\uf6c1\ua1e8\u539d\u{1fc1a}\u0019\ue6e3\u5de3\u0380\u86b1\u{1fbdf}',
+  dimension: '2d-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup82, new Uint32Array(3083), 674, 0);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder15.draw(19, 639, 296_973_811, 3_486_541_593);
+} catch {}
+let buffer92 = device0.createBuffer({size: 5475, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture155 = device0.createTexture({
+  label: '\u0320\u0532\u2c21\u4664',
+  size: [2, 2, 32],
+  sampleCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder87 = commandEncoder115.beginComputePass({});
+try {
+computePassEncoder87.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup38, new Uint32Array(1376), 771, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(29, 104, 119, -1_435_861_041, 161_362_094);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer63, 24);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer57, 180);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: canvas2,
+  origin: { x: 22, y: 9 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer69, offset: 0, size: 2330}}],
+});
+let texture156 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup96);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 16, 4, 247_472_959, 675_208_464);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer83, 24);
+} catch {}
+let bindGroup99 = device0.createBindGroup({
+  label: '\ue3d7\u0ba3\u02ba\u07c3\u02ce\u{1f951}\uc32c\u1fb4',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 238, resource: sampler65},
+    {binding: 1, resource: textureView9},
+    {binding: 65, resource: {buffer: buffer82, offset: 0, size: 4}},
+    {binding: 52, resource: {buffer: buffer82, offset: 0, size: 33}},
+    {binding: 142, resource: textureView14},
+    {binding: 13, resource: textureView23},
+    {binding: 111, resource: textureView19},
+    {binding: 293, resource: textureView10},
+    {binding: 92, resource: textureView42},
+  ],
+});
+let externalTexture8 = device0.importExternalTexture({label: '\u097e\u052d\u0639\uddaf\uc4ea', source: videoFrame13, colorSpace: 'display-p3'});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup95);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(0, bindGroup0, new Uint32Array(3907), 1_325, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(502);
+} catch {}
+try {
+renderPassEncoder11.draw(367, 63, 634_719_732, 762_858_420);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(9, 78, 11, 1_559_802_423, 76_386_708);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+  await promise15;
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({});
+let texture157 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 22},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder9.draw(98, 121, 755_803_514, 370_105_126);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer46, 152);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer24, 420);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer30, 'uint16', 2_286, 4_082);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 3520, new Int16Array(5694), 417, 224);
+} catch {}
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let buffer93 = device0.createBuffer({
+  size: 3510,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView130 = texture83.createView({mipLevelCount: 2, baseArrayLayer: 1, arrayLayerCount: 5});
+let computePassEncoder88 = commandEncoder116.beginComputePass({});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup78, new Uint32Array(1763), 1_207, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup76);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(30, 68, 3, 611_305_240, 32_246_423);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer59, 508);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer73, 4_156);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 33, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas3);
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView117}]});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup22, new Uint32Array(844), 257, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(29, 79, 3, 39_396_568, 428_840_668);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer54, 5_372);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let texture158 = device0.createTexture({size: [16, 20, 1], mipLevelCount: 5, format: 'rgb10a2uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView131 = texture93.createView({label: '\u8bbc\u0ee7', format: 'rgb10a2uint'});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup64, new Uint32Array(2153), 23, 0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer45, 0, 4_897);
+} catch {}
+document.body.prepend(video0);
+video0.height = 29;
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer94 = device0.createBuffer({
+  label: '\u9005\u72e4\u019a\uec85\u81c7\u078e',
+  size: 2124,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView132 = texture111.createView({
+  label: '\u{1ff17}\u{1faa7}\u{1f6c5}\u2a20\u2a9e\u05d8\u53a2\u6d99\u{1fb13}\uc3a8',
+  format: 'rgb10a2uint',
+});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup53, new Uint32Array(6045), 2_909, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(63, 116, 759_199_771, 1_111_292_929);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 845});
+let textureView133 = texture5.createView({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(0, bindGroup15, new Uint32Array(272), 10, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder10.draw(193, 73, 1_325_944_093, 60_143_990);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer95 = device0.createBuffer({size: 3980, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder117 = device0.createCommandEncoder({});
+let renderPassEncoder19 = commandEncoder117.beginRenderPass({colorAttachments: [{view: textureView122, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup74);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(0, bindGroup40, new Uint32Array(732), 27, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(4);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(9, 93, 1, 5_938_962, 679_883_439);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer59, 708);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer66, 'uint32', 3_724, 349);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer17, 2_836, 147);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+let buffer96 = device0.createBuffer({size: 8810, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture159 = device0.createTexture({
+  label: '\u056a\ub654\u0ba1\u902f\u{1fc5f}\u0d22\u5171\u{1fbf1}\u39d7\u0407\u9819',
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 586, 1, 1_836_738_832, 2_762_659_743);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer91);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 5},
+  aspect: 'stencil-only',
+}, new Uint8Array(15_010).fill(164), /* required buffer size: 15_010 */
+{offset: 154, bytesPerRow: 53, rowsPerImage: 70}, {width: 16, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let textureView134 = texture129.createView({});
+let computePassEncoder89 = commandEncoder118.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer70, 0);
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 6, resource: sampler44},
+    {binding: 404, resource: textureView128},
+    {binding: 54, resource: {buffer: buffer27, offset: 1536, size: 80}},
+    {binding: 30, resource: textureView95},
+    {binding: 116, resource: textureView92},
+    {binding: 270, resource: textureView102},
+  ],
+});
+try {
+computePassEncoder4.dispatchWorkgroupsIndirect(buffer72, 140);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(7, 9, 1, 1_262_669_008, 267_633_079);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer42, 1_592);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+let bindGroup102 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 381, resource: textureView23},
+    {binding: 414, resource: textureView52},
+    {binding: 79, resource: textureView126},
+  ],
+});
+let buffer97 = device0.createBuffer({size: 1113, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder89.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup0, new Uint32Array(2134), 173, 0);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(317);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+document.body.append(video0);
+let videoFrame26 = videoFrame12.clone();
+let bindGroup103 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView3}, {binding: 126, resource: textureView1}],
+});
+let textureView135 = texture69.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer50, 600); };
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer10, 576);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer70, 1_340);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture160 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 35},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler74 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.95,
+});
+try {
+computePassEncoder82.setBindGroup(2, bindGroup1, new Uint32Array(770), 35, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle17, renderBundle10, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer7, 4_208);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer72, 0, 278);
+} catch {}
+try {
+computePassEncoder87.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup77, new Uint32Array(3260), 604, 0);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 130, 11, -2_131_192_455, 37_814_876);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer72, 12);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer86, 'uint32', 640, 545);
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule0, targets: [{format: 'r16sint', writeMask: GPUColorWrite.RED}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'equal', failOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 3167017141,
+    stencilWriteMask: 1397717890,
+    depthBias: 1041905504,
+    depthBiasSlopeScale: 0.34719689560508016,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 208, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 452, shaderLocation: 13},
+          {format: 'uint8x4', offset: 188, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 568, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let commandEncoder119 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder119.beginComputePass();
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 10_720);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 1120, new BigUint64Array(10024), 1040, 248);
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<array<atomic<u32>, 1>>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer98: array<i32>;
+struct VertexOutput8 {
+  @location(6) f29: vec3u,
+  @builtin(position) f30: vec4f,
+  @location(3) @interpolate(linear, center) f31: vec2h,
+  @location(7) f32: vec4f,
+  @location(9) @interpolate(flat, sample) f33: vec4i,
+  @location(15) @interpolate(flat, centroid) f34: i32
+}
+
+@vertex
+fn vertex0() -> VertexOutput8 {
+  var out: VertexOutput8;
+  out.f29 = vec3u(96, 8, 105);
+  return out;
+}
+struct FragmentOutput7 {
+  @location(0) f0: vec2i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  _ = buffer98[0];
+  _ = buffer98[arrayLength(&buffer98)];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer5, offset: 3072, size: 984}}],
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup43, []);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(2, bindGroup5, new Uint32Array(6512), 512, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer54, 4_328); };
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup48, new Uint32Array(994), 272, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(569, 57, 372_761_409, 1_099_420_028);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer42, 1_144);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer34, 'uint32', 1_808, 10);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let imageData11 = new ImageData(160, 56);
+let commandEncoder120 = device0.createCommandEncoder();
+let textureView136 = texture150.createView({});
+let computePassEncoder91 = commandEncoder120.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer82, 80);
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup105 = device0.createBindGroup({
+  label: '\u0724\u{1fdb6}\u2891\u053b\u89cf\u{1fca5}\ue8b5',
+  layout: bindGroupLayout4,
+  entries: [{binding: 33, resource: {buffer: buffer73, offset: 768, size: 472}}],
+});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer28, 1_356); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup12, new Uint32Array(84), 15, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer30, 'uint16', 3_164, 2_383);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+let textureView137 = texture112.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler75 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 4.784,
+  lodMaxClamp: 81.14,
+  compare: 'less',
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(3, bindGroup44, new Uint32Array(507), 42, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroupsIndirect(buffer74, 160); };
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer93, 'uint16', 94, 672);
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer71, 4376, new DataView(new ArrayBuffer(3572)), 126, 60);
+} catch {}
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 6});
+let textureView138 = texture128.createView({
+  label: '\u085e\u23bb\uff57\uafe1\ubb1e\u6327\u5b64\ubb38\u34c4',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+});
+let sampler76 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.68,
+  lodMaxClamp: 92.13,
+  compare: 'always',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer72, 892);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer34, 'uint32', 152, 11);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer89, 672, 1_424);
+} catch {}
+let buffer99 = device0.createBuffer({size: 4034, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture161 = device0.createTexture({
+  size: [256, 256, 18],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView139 = texture44.createView({label: '\ud838\u5487\u{1fcf4}\ua82e\uba8d\u2169\u47b1', dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder8.setViewport(4.35667166119689, 3.709532997265408, 4.636212288692586, 16.25777603127576, 0.5095098616372974, 0.7488011786410471);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(61, 201, 14, 182_268_939, 617_942_592);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer83, 1_380);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle15, renderBundle15, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(0.4089431264145975, 0.8056528057706871, 0.3312146195868845, 0.8460051331798681, 0.17657442842884818, 0.5930108279786994);
+} catch {}
+try {
+renderPassEncoder14.draw(34, 70, 358_172_273, 71_303_051);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 56, 16, 126_229_787, 922_932_232);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer83, 88);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video1 = await videoWithData(68);
+let buffer100 = device0.createBuffer({size: 17166, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder121 = device0.createCommandEncoder({});
+let textureView140 = texture155.createView({dimension: '2d', baseArrayLayer: 9});
+let renderPassEncoder20 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: 218.5, g: -560.0, b: -411.0, a: -917.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 589660493,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup39, new Uint32Array(3616), 851, 0);
+} catch {}
+try {
+computePassEncoder25.dispatchWorkgroupsIndirect(buffer72, 1_500);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(122, 362, 36, -2_099_813_580, 868_812_277);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer24, 5_280);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline8);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+try {
+computePassEncoder72.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(0, bindGroup2, new Uint32Array(10000), 199, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer88, 2_988); };
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup80, new Uint32Array(1811), 140, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(30, 7, 764_375_125, 439_782_690);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer91, 196);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline8);
+} catch {}
+let video2 = await videoWithData(120);
+let buffer101 = device0.createBuffer({
+  size: 1825,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler77 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.98,
+  lodMaxClamp: 98.89,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder11.drawIndirect(buffer82, 60);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer37, 'uint16', 1_100, 60);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer79, 0, 20);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u71ef\u0bdc\u0288\u8fd4\u{1fdbb}\u102f\u{1f9bb}\u60db\u7612\u{1fcb7}\u{1ff86}';
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer57, 'uint16', 32, 1_269);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\ud4f7\u63b5\ub9e9\u0590\u015c',
+  entries: [
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let texture162 = device0.createTexture({
+  size: {width: 16},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView141 = texture19.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 8, arrayLayerCount: 12});
+let sampler78 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 12.27,
+  lodMaxClamp: 61.87,
+  compare: 'equal',
+});
+try {
+renderPassEncoder19.setIndexBuffer(buffer55, 'uint32', 44, 751);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise18;
+} catch {}
+document.body.prepend(img2);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let commandEncoder122 = device0.createCommandEncoder({});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup99);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(17, 134, 27, 283_380_286, 632_004_740);
+} catch {}
+try {
+commandEncoder122.insertDebugMarker('\u{1fc2c}');
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpte240m', transfer: 'bt2020_10bit'} });
+let commandEncoder123 = device0.createCommandEncoder({});
+let sampler79 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMinClamp: 97.28, lodMaxClamp: 98.44});
+try {
+renderPassEncoder11.setIndexBuffer(buffer88, 'uint32', 2_032, 817);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder124 = device0.createCommandEncoder({});
+let texture163 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 137},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder92 = commandEncoder122.beginComputePass({});
+let renderPassEncoder21 = commandEncoder124.beginRenderPass({
+  label: '\u4f1f\u088c\u4fc3\u0b99\u2211\uec2b\u8834',
+  colorAttachments: [{view: textureView88, depthSlice: 131, loadOp: 'load', storeOp: 'store'}],
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer27, 3_940); };
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.draw(167, 104, 122_772_763, 892_057_022);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(8, 0, 23, 194_769_821, 411_849_042);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer63, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer37, 'uint16', 910, 24);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView142 = texture106.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder93 = commandEncoder123.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.draw(233, 276, 13_819_793, 1_351_308_751);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer63, 56);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer57, 'uint32', 308, 215);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer79);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: video1,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let computePassEncoder94 = commandEncoder125.beginComputePass({label: '\udb9d\u06f8'});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8'});
+let sampler80 = device0.createSampler({addressModeW: 'clamp-to-edge', magFilter: 'linear', minFilter: 'nearest', mipmapFilter: 'nearest'});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup66);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(1, bindGroup74, new Uint32Array(4442), 891, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(1, 1, 1, 2);
+} catch {}
+try {
+renderPassEncoder12.draw(173, 222, 1_119_371_615, 227_615_575);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer73, 300);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4, buffer101, 208, 7);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 217,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder126 = device0.createCommandEncoder();
+let textureView143 = texture92.createView({});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup55, new Uint32Array(1705), 252, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer74, 52);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer14, 'uint16', 248, 146);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup30, []);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let arrayBuffer17 = buffer90.getMappedRange(248);
+try {
+commandEncoder126.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u0915');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer102 = device0.createBuffer({
+  label: '\u0f7a\u95d4\u004a\ub937\u1324\u{1fc11}\u0111\u0bd1\u{1f6b0}\u4704',
+  size: 20268,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder127 = device0.createCommandEncoder({});
+let computePassEncoder95 = commandEncoder126.beginComputePass({label: '\u6354\ua8da\u26bb\u{1fb03}\u589d\ub971\u64ee'});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup84);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup31, new Uint32Array(270), 60, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(89, 609, 22, -1_585_852_832, 837_528_169);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer101, 0, 22);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup25, new Uint32Array(2066), 131, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer90, 'uint32', 188, 1_653);
+} catch {}
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer27, offset: 256, size: 1698}}],
+});
+let computePassEncoder96 = commandEncoder127.beginComputePass({});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup69, new Uint32Array(142), 2, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.draw(131, 25, 448_457_732, 247_149_358);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup106);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup56, new Uint32Array(1591), 260, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer14, 'uint32', 360, 117);
+} catch {}
+let buffer103 = device0.createBuffer({
+  size: 3368,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup104);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup4, new Uint32Array(5849), 943, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(20, 254, 142, 527_422_121, 133_013_942);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer45, 196);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer102, 'uint16', 3_834, 8_748);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer57);
+} catch {}
+let textureView144 = texture39.createView({dimension: '2d-array', format: 'rgb10a2uint', arrayLayerCount: 2});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup74, new Uint32Array(1915), 1_014, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup92, new Uint32Array(1965), 39, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(286, 129, 1_062_038_495, 497_712_510);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer83, 1_456);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let buffer104 = device0.createBuffer({
+  size: 11906,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder128 = device0.createCommandEncoder({});
+let computePassEncoder97 = commandEncoder128.beginComputePass({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle21 = renderBundleEncoder21.finish({label: '\u9723\u011e\u5a19\ua231'});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup85, new Uint32Array(893), 28, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(2_717, 33, 550, -1_909_573_641, 652_199_385);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer63, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer90, 1_392);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer65, 'uint32', 396, 56);
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  label: '\u07ec\u{1f630}\ud6d7\u952d\u77ad\u{1fc1a}\u{1fb89}\u0191',
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 270, resource: textureView92},
+    {binding: 6, resource: sampler52},
+    {binding: 404, resource: textureView36},
+    {binding: 116, resource: textureView92},
+    {binding: 54, resource: {buffer: buffer101, offset: 256, size: 419}},
+    {binding: 30, resource: textureView104},
+  ],
+});
+try {
+computePassEncoder97.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+computePassEncoder86.setBindGroup(3, bindGroup19, new Uint32Array(1842), 9, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup24, new Uint32Array(4124), 1_381, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer42, 1_816);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer14, 'uint32', 72, 2_067);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer83, 'uint32', 1_764, 280);
+} catch {}
+try {
+  await promise16;
+} catch {}
+await gc();
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'unspecified'} });
+let commandEncoder129 = device0.createCommandEncoder({});
+let textureView145 = texture50.createView({});
+let computePassEncoder98 = commandEncoder129.beginComputePass({});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 57.91,
+  compare: 'equal',
+});
+let externalTexture10 = device0.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder97.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.draw(140, 429, 165_154_873, 1_945_071_816);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer72, 308);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer81, 'uint32', 6_008, 158);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(0, buffer101, 132, 330);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 44, new BigUint64Array(9424), 769, 164);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let textureView146 = texture161.createView({dimension: 'cube'});
+let sampler82 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.41,
+  lodMaxClamp: 92.86,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup29, new Uint32Array(1140), 23, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder2.draw(402, 24, 1_015_333_844, 775_441_605);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(1_122, 97, 28, 77_519_240, 300_310_405);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer44, 5_464);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer37, 'uint16', 62, 320);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup107, new Uint32Array(192), 27, 0);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer57, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 720, new Int16Array(18009), 350, 496);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 652,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 277,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder130 = device0.createCommandEncoder();
+let querySet22 = device0.createQuerySet({label: '\ue9a6\udcd4\u{1f8ba}\ue172\ub8cb\u{1fa67}', type: 'occlusion', count: 843});
+let renderBundle22 = renderBundleEncoder22.finish({label: '\ueaee\u{1f9d1}\u07b8\u043f\ub5ed\u08a3\u{1fe8a}\u02c2\u{1fccd}\u00f4'});
+let sampler83 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.77,
+  compare: 'equal',
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder9.draw(187, 78, 1_086_014_433, 165_265_763);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(18, 518, 6, 818_993_190, 231_446_127);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer104, 1_020);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer63, 104);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer28, 'uint32', 36, 792);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer45);
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({});
+let computePassEncoder99 = commandEncoder131.beginComputePass({});
+try {
+computePassEncoder96.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2, renderBundle2, renderBundle16, renderBundle2, renderBundle5, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder9.draw(292, 11, 173_675_545, 515_070_905);
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  label: '\u005a\ub605\u7375\u0eb2\u82d8\ud58f\u74ec\u84ad\u01b8\uc8b1',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<f32>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer105: u32;
+struct S3 {
+  @location(6) f0: vec3u
+}
+struct S4 {
+  @location(15) @interpolate(flat, centroid) f0: i32
+}
+struct S5 {
+  @location(3) @interpolate(linear) f0: vec2h
+}
+struct FragmentOutput8 {
+  @location(1) f0: f32,
+  @location(0) f1: vec4u,
+  @location(3) @interpolate(flat, center) f2: i32
+}
+
+@fragment
+fn fragment0(@location(7) @interpolate(flat, centroid) a0: vec4f, a1: S3, a2: S4, a3: S5) -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  if bool(a1.f0[0]) {
+    discard;
+  }
+  return out;
+}
+struct FragmentOutput9 {
+  @location(2) f0: vec2u,
+  @location(3) @interpolate(flat, centroid) f1: u32,
+  @location(0) @interpolate(flat) f2: vec4i,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment1() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder132 = device0.createCommandEncoder({label: '\u0f99\u05fb\ucbda\ue9ce'});
+let computePassEncoder100 = commandEncoder130.beginComputePass({});
+let sampler84 = device0.createSampler({
+  label: '\u0a57\u0281\ube2c\u53f7\u0ce2\u{1fd14}',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 83.51,
+  lodMaxClamp: 87.70,
+});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer83, 1_100); };
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder18.draw(445, 91, 43_472_929, 1_642_073_492);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(584, 231, 8, 735_304_143, 487_796_761);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer45, 3_644);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer93, 264);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer37, 0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 1,
+  origin: {x: 0, y: 39, z: 2},
+  aspect: 'all',
+}, new Uint8Array(1_612).fill(158), /* required buffer size: 1_612 */
+{offset: 216, bytesPerRow: 424}, {width: 31, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 255});
+let textureView147 = texture140.createView({arrayLayerCount: 1});
+let texture164 = device0.createTexture({
+  size: [8, 10, 14],
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder101 = commandEncoder132.beginComputePass();
+try {
+computePassEncoder19.setBindGroup(2, bindGroup83);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(1, bindGroup59, new Uint32Array(2729), 359, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(141, 91, 786_788_084, 233_579_471);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(114, 140, 31, 306_665_421, 2_654_790_060);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer61, 12_884);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer18 = buffer31.getMappedRange(0, 24);
+let promise21 = adapter0.requestAdapterInfo();
+let buffer106 = device0.createBuffer({
+  size: 20799,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder133 = device0.createCommandEncoder({label: '\u06ac\u966d\u{1f7f9}\u{1f8fa}\ua914\u36e0\u3df0\u{1f619}\u{1fdff}\u{1fcaf}'});
+let texture165 = device0.createTexture({
+  size: [2, 2, 22],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder22 = commandEncoder133.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 48,
+  clearValue: { r: 976.8, g: -287.4, b: -623.2, a: -39.70, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder64); computePassEncoder64.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline6);
+} catch {}
+let buffer107 = device0.createBuffer({label: '\ubf27\u5c70\u{1fdb2}\u6751\u0686\u7d79\u4fa2', size: 9936, usage: GPUBufferUsage.VERTEX});
+let commandEncoder134 = device0.createCommandEncoder();
+let computePassEncoder102 = commandEncoder134.beginComputePass({});
+let sampler85 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 6.840,
+  lodMaxClamp: 53.36,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup38, new Uint32Array(3008), 302, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(143, 25, 386_213_291, 81_940_696);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer24, 6_700);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer10, 88);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer86, 'uint32', 2_140, 297);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer101, 0, 387);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let buffer108 = device0.createBuffer({
+  size: 13056,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder135 = device0.createCommandEncoder({});
+let computePassEncoder103 = commandEncoder135.beginComputePass({});
+try {
+computePassEncoder100.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup74, new Uint32Array(2320), 294, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(112, 261, 1_034_267_918, 1_321_175_394);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(11, 2, 13, 110_625_436, 1_416_772_827);
+} catch {}
+try {
+renderPassEncoder18.drawIndexedIndirect(buffer0, 44);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({});
+let computePassEncoder104 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup100, new Uint32Array(1053), 95, 0);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle15, renderBundle19, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder14.draw(207, 214, 1_017_229_823, 38_471_117);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u{1fc2d}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 8, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise21;
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let texture166 = device0.createTexture({
+  size: [2, 2, 22],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView148 = texture99.createView({});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup104, new Uint32Array(828), 4, 0);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup58, new Uint32Array(559), 542, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(70, 221, 411_495_969, 66_828_021);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(4, 218, 2, -2_132_934_052, 648_882_721);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer104, 4_720);
+} catch {}
+document.body.prepend(canvas0);
+video1.height = 46;
+let bindGroup108 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 9, resource: textureView147}]});
+let commandEncoder137 = device0.createCommandEncoder({label: '\u70f4\u20e9\u{1fdb8}'});
+let textureView149 = texture140.createView({
+  label: '\ubc4b\u02ee\u66df\u06ff\u8794\u0c30\u0bab\u{1ff66}\u08e1\u3844',
+  dimension: '2d',
+  arrayLayerCount: 1,
+});
+let texture167 = device0.createTexture({size: [256], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder23 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: -861.3, g: 801.3, b: 161.3, a: -695.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder104.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder15.draw(149, 368, 2_723_647_650, 978_377_105);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(4, 8, 7, 869_153_539, 1_882_276_445);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer89, 1_212, 129);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+await gc();
+let textureView150 = texture107.createView({dimension: '2d-array', aspect: 'stencil-only', baseArrayLayer: 0});
+try {
+computePassEncoder102.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle17, renderBundle13, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(76, 209, 26, 188_568_339, 241_944_836);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer104, 3_036);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer1, 'uint16', 1_804, 155);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u02b7');
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 33, resource: sampler83}, {binding: 63, resource: textureView135}],
+});
+let buffer109 = device0.createBuffer({
+  size: 2180,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(226, 75, 106, 194_399_259, 27_474_632);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer14, 1_388);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer55, 1_856, 1_025);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({});
+let computePassEncoder105 = commandEncoder138.beginComputePass({label: '\u660d\ub9b2\u52ae\u0a05\u0490\u5493'});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup57, new Uint32Array(393), 1, 0);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(24, 22, 1, 57_108_944, 1_018_111_639);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer45, 3_612);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer90, 'uint32', 4_596, 5_572);
+} catch {}
+await gc();
+let texture168 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 79},
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer14, 'uint32', 264, 614);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule9,
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', depthFailOp: 'keep', passOp: 'increment-clamp'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 148195677,
+    depthBiasSlopeScale: 77.97239156711635,
+  },
+  vertex: {
+    module: shaderModule9,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 788, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let texture169 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup73, []);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(42, 143, 227, 527_796_104, 667_246_490);
+} catch {}
+try {
+renderPassEncoder18.drawIndexedIndirect(buffer66, 620);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer42, 264);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4_294_967_295, undefined, 496_394_149, 844_341_990);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img3);
+let commandEncoder139 = device0.createCommandEncoder({});
+let textureView151 = texture124.createView({aspect: 'all'});
+let renderPassEncoder24 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: 469.5, g: -71.14, b: 425.7, a: -966.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+});
+let sampler86 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 87.76,
+  lodMaxClamp: 89.33,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle5, renderBundle16, renderBundle2, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 79, 0, -1_887_888_956, 308_145_096);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer72, 876);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer45, 3_188);
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 49496,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup104);
+} catch {}
+try {
+renderPassEncoder2.setViewport(15.750872898677741, 16.085699811230064, 0.13490497830376258, 0.12792263837999515, 0.6459297623526447, 0.8486764649411285);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer88, 2_332);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer55, 'uint32', 1_408, 4);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer62, 0, 463);
+} catch {}
+try {
+  await promise22;
+} catch {}
+let bindGroup110 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 381, resource: textureView23},
+    {binding: 414, resource: textureView97},
+    {binding: 79, resource: textureView41},
+  ],
+});
+let commandEncoder140 = device0.createCommandEncoder({});
+let externalTexture11 = device0.importExternalTexture({label: '\u5cac\u0183\u0e36\u0f2f\u0a96\u9e76\u{1f77e}\ub07f', source: videoFrame13});
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer82, 28);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer82, 36);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer86, 'uint16', 160, 966);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(430).fill(112), /* required buffer size: 430 */
+{offset: 430}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let textureView152 = texture100.createView({});
+let sampler87 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 61.77,
+  lodMaxClamp: 90.42,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder2.draw(68, 33, 741_210_574, 799_134_654);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer45, 352);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 2000, new Int16Array(13777), 1732, 2820);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let imageData12 = new ImageData(12, 36);
+let texture170 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder106 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder106.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.draw(369, 33, 1_197_230_063, 351_592_886);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer54, 388);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline2);
+} catch {}
+let commandEncoder141 = device0.createCommandEncoder({});
+let texture171 = device0.createTexture({
+  label: '\ucdbc\u{1f960}\u{1f7e2}\u68c1\ub247\u{1f8c9}\u{1f9c9}\u3778\u1c2f\u0a59',
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder25 = commandEncoder141.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 50,
+  clearValue: { r: -86.86, g: -569.5, b: -265.7, a: 774.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 405566970,
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup107, new Uint32Array(399), 86, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(100, 188, 320_695_842, 26_180_390);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 216, 0, 1_031_732_631, 802_042_201);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer93, 1_052);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer30, 'uint16', 11_086, 667);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer19 = buffer103.getMappedRange(736);
+document.body.append(img1);
+let bindGroup111 = device0.createBindGroup({
+  label: '\u0187\u0478\ub987\u8678\u00ef\u026f',
+  layout: bindGroupLayout6,
+  entries: [{binding: 201, resource: textureView65}],
+});
+let buffer111 = device0.createBuffer({size: 7614, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup51, new Uint32Array(3308), 83, 0);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(248, 227, 111, 172_241_854, 273_147_298);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder68.insertDebugMarker('\u059e');
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [{binding: 30, resource: {buffer: buffer65, offset: 768, size: 444}}],
+});
+let buffer112 = device0.createBuffer({
+  label: '\uc487\uc5b2\u2d75\ubc05\u0a1f\u94a6\u7134',
+  size: 13120,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView153 = texture154.createView({dimension: '2d'});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder93.setBindGroup(1, bindGroup31, new Uint32Array(3101), 263, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(40);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(0, 5, 0, 366_021_292, 2_185_645_359);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer59, 444);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let bindGroup113 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 79, resource: textureView41},
+    {binding: 414, resource: textureView97},
+    {binding: 381, resource: textureView60},
+  ],
+});
+let buffer113 = device0.createBuffer({size: 47, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let textureView154 = texture9.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder18.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder10.draw(106, 41, 774_451_481, 605_989_440);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer57, 2_332);
+} catch {}
+let buffer114 = device0.createBuffer({size: 6643, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+let externalTexture12 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(5, 65, 1, 39_632_568, 206_876_668);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer104, 356);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer82, 60);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup53, new Uint32Array(1424), 373, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer55, 1_408, 8_983);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.append(video2);
+try {
+computePassEncoder55.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(6, 4, 2, 8);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer20, 2_156);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup12, new Uint32Array(440), 69, 0);
+} catch {}
+try {
+for (let i = 0; i < 4e6; ++i) renderBundleEncoder23.draw(0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup114 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 33, resource: sampler76}, {binding: 63, resource: textureView25}],
+});
+let commandEncoder142 = device0.createCommandEncoder({});
+let texture172 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 45},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder18.drawIndexed(197, 4, 62, -2_016_150_100, 930_352_264);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer30, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder142.copyBufferToBuffer(buffer102, 3252, buffer63, 60, 12);
+} catch {}
+canvas3.height = 65;
+let bindGroup115 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView149}]});
+let buffer115 = device0.createBuffer({
+  size: 8707,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+let textureView155 = texture99.createView({});
+let textureView156 = texture167.createView({
+  label: '\u{1fb60}\ub40a\u0e6f\u{1ff21}\u3c0a\u2f56\u08ad\u{1f9d3}\ueeac',
+  format: 'rgb10a2uint',
+  mipLevelCount: 1,
+});
+let renderPassEncoder26 = commandEncoder143.beginRenderPass({colorAttachments: [{view: textureView88, depthSlice: 44, loadOp: 'clear', storeOp: 'discard'}]});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+renderPassEncoder23.setViewport(1.477506097518243, 0.9072231610196844, 0.30079154638033484, 0.41458903605953423, 0.8700258004275958, 0.9636134370499456);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer28, 608);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder142.insertDebugMarker('\u43fa');
+} catch {}
+let imageBitmap3 = await createImageBitmap(img3);
+let computePassEncoder107 = commandEncoder142.beginComputePass({});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle24 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup23, new Uint32Array(817), 16, 0);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let sampler88 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.48,
+  lodMaxClamp: 93.54,
+  maxAnisotropy: 7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer46, 104); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup48, []);
+} catch {}
+try {
+renderPassEncoder15.draw(83, 17, 615_183_078, 774_030_119);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer102, 1_676);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup116 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView149}]});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle25 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup0, new Uint32Array(942), 369, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup92, new Uint32Array(443), 3, 0);
+} catch {}
+try {
+renderPassEncoder18.draw(232, 182, 700_571_360, 366_268_032);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(14, 117, 4, 6_050_718, 480_087_663);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer22, 1_932);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 20, y: 0 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 1, y: 8, z: 43},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'iec6196624'} });
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 87, resource: {buffer: buffer64, offset: 2304, size: 128}}],
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u1bb9\ufddf\u2364\u99f7\udcc5\ufb50\u0a1b\u0612',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup84, []);
+} catch {}
+try {
+renderPassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder18.draw(133, 71, 487_210_370, 295_483_464);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer89, 476);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer63, 4);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer7, 'uint32', 1_192, 4_061);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer110, 29_184, 6_228);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer63, 'uint16', 92, 23);
+} catch {}
+try {
+computePassEncoder38.insertDebugMarker('\u0a0f');
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let renderPassEncoder27 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: -273.7, g: 8.856, b: 432.6, a: -313.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup96);
+} catch {}
+try {
+renderPassEncoder11.draw(39, 409, 518_657_108, 884_259_209);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder146 = device0.createCommandEncoder({});
+let texture173 = device0.createTexture({
+  size: [2, 2, 56],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder108 = commandEncoder144.beginComputePass({});
+let renderBundle26 = renderBundleEncoder26.finish({});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup6, new Uint32Array(72), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroupsIndirect(buffer104, 1_556); };
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup109);
+} catch {}
+try {
+renderPassEncoder10.draw(266, 320, 1_335_006_892, 1_536_378_009);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer63, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline2);
+} catch {}
+document.body.append(img2);
+let img4 = await imageWithData(159, 48, '#10101010', '#20202020');
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 142, resource: textureView20},
+    {binding: 1, resource: textureView9},
+    {binding: 238, resource: sampler29},
+    {binding: 92, resource: textureView151},
+    {binding: 111, resource: textureView56},
+    {binding: 293, resource: textureView32},
+    {binding: 52, resource: {buffer: buffer83, offset: 1280, size: 34}},
+    {binding: 65, resource: {buffer: buffer75, offset: 1536, size: 388}},
+    {binding: 13, resource: textureView60},
+  ],
+});
+let computePassEncoder109 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder109.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer59, 1_016);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer107, 0, 1_015);
+} catch {}
+try {
+externalTexture6.label = '\u{1f76d}\ud992\u2d07\ua5f2\u{1fec8}\u{1fc7f}\u0602\ue6ed\u{1fa9c}\u5d2c\u0c68';
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder({});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 114});
+let textureView157 = texture7.createView({dimension: 'cube-array', aspect: 'depth-only', arrayLayerCount: 6});
+let renderPassEncoder28 = commandEncoder147.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 121,
+  clearValue: { r: -909.1, g: -0.8108, b: 298.2, a: 888.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup63, new Uint32Array(463), 59, 0);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup74, new Uint32Array(683), 0, 0);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle19, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder14.draw(24, 39, 1_696_009_582, 348_710_047);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(15, 68, 40, 349_547_806, 1_626_681_009);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer14, 1_232);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas2);
+try {
+renderPassEncoder2.drawIndirect(buffer28, 204);
+} catch {}
+try {
+buffer78.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView17}, {binding: 126, resource: textureView70}],
+});
+let buffer116 = device0.createBuffer({size: 17600, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView158 = texture115.createView({mipLevelCount: 1});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8'});
+let renderBundle27 = renderBundleEncoder27.finish({});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup110, new Uint32Array(1869), 318, 0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -797.2, g: -136.0, b: 470.2, a: 934.2, });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 57, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(137).fill(115), /* required buffer size: 137 */
+{offset: 137, bytesPerRow: 208}, {width: 51, height: 69, depthOrArrayLayers: 0});
+} catch {}
+let texture174 = device0.createTexture({
+  size: [16, 20, 76],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView159 = texture1.createView({dimension: '2d-array'});
+let sampler89 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 97.35, compare: 'less-equal'});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup34, new Uint32Array(2666), 324, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(181, 58, 491_605_135, 2_027_500_710);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(2, 92, 2, -2_026_222_145, 207_309_003);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer110, 'uint16', 2_668, 2_879);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let video3 = await videoWithData(52);
+let commandEncoder148 = device0.createCommandEncoder({label: '\ua381\uf1fe\u3ec2\u292e\u7ce8\u0a1a\uf42f\u998a'});
+let renderPassEncoder29 = commandEncoder148.beginRenderPass({
+  label: '\u8d9a\u2c48\u06ac\u0c8d\u0922\u{1fab5}\u89b3\ucb41\u06de\u067d',
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 8,
+  clearValue: { r: -696.5, g: -231.6, b: 380.2, a: 839.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder94.setBindGroup(0, bindGroup102);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(8.970087799283805, 0.5741208435728162, 6.116450214533972, 16.5399852893659, 0.5559245037239343, 0.9579303776733674);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(2, 460, 9, 260_714_037, 697_550_381);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer80, 552);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer90);
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4]});
+let commandEncoder149 = device0.createCommandEncoder();
+let textureView160 = texture165.createView({dimension: '3d', arrayLayerCount: 1});
+let computePassEncoder110 = commandEncoder149.beginComputePass();
+try {
+computePassEncoder88.setBindGroup(0, bindGroup25, new Uint32Array(1296), 121, 0);
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setViewport(3.4720027790338346, 9.441521153832591, 1.0444878399599649, 2.6685711700425427, 0.7123408582063443, 0.8808781036967361);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, undefined, 0, 85_146_160);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture175 = device0.createTexture({
+  label: '\u{1f9de}\u0acf\u766e\u0740\u6349\ue8be\ue6aa\ub018\u{1feba}\u6dd9\u0507',
+  size: [2, 2, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float'],
+});
+let texture176 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder18.drawIndexed(315, 35, 16, 191_287_886, 138_035_336);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer80, 616);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer0, 1_060);
+} catch {}
+let texture177 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 31},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup118);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture161,
+  mipLevel: 0,
+  origin: {x: 37, y: 30, z: 1},
+  aspect: 'all',
+}, new Uint8Array(1_083_812).fill(53), /* required buffer size: 1_083_812 */
+{offset: 310, bytesPerRow: 1039, rowsPerImage: 110}, {width: 54, height: 53, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder({});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder84.setBindGroup(0, bindGroup117, new Uint32Array(1767), 187, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer54, 3_336);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer14, 144);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+let computePassEncoder111 = commandEncoder150.beginComputePass();
+let externalTexture13 = device0.importExternalTexture({source: video1});
+try {
+computePassEncoder111.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup101, new Uint32Array(1105), 52, 0);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline8);
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder();
+let computePassEncoder112 = commandEncoder151.beginComputePass({});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup70, new Uint32Array(306), 3, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(3, 117, 599_625_399, 166_466_780);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(9, 63, 65, -2_020_519_602, 2_926_716_474);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer63, 0, 1);
+} catch {}
+try {
+buffer76.unmap();
+} catch {}
+let buffer117 = device0.createBuffer({size: 17274, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView161 = texture141.createView({label: '\u0e24\u359f\ud472', format: 'r16sint'});
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroupsIndirect(buffer91, 936); };
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 852, new DataView(new ArrayBuffer(4966)), 179, 64);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u0d29\uc16c\ua6bc\uac45',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: vec2h,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: T0,
+}
+@group(0) @binding(285) var<storage, read_write> buffer118: array<array<u32, 1>>;
+struct S6 {
+  @location(10) @interpolate(perspective, center) f0: vec4f
+}
+struct VertexOutput9 {
+  @builtin(position) f35: vec4f,
+  @location(11) @interpolate(flat, center) f36: vec3u
+}
+
+@vertex
+fn vertex0(@location(6) @interpolate(flat) a0: vec3f, a1: S6, @location(8) @interpolate(flat) a2: vec3i, @builtin(instance_index) a3: u32) -> VertexOutput9 {
+  var out: VertexOutput9;
+  _ = a1.f0;
+  return out;
+}
+struct VertexOutput10 {
+  @location(5) f37: vec4f,
+  @builtin(position) f38: vec4f,
+  @location(11) f39: vec4f,
+  @location(2) f40: vec4h
+}
+
+@vertex
+fn vertex1(@location(5) a0: vec2u, @location(2) @interpolate(flat, sample) a1: vec3i) -> VertexOutput10 {
+  var out: VertexOutput10;
+  _ = a1;
+  if bool(a1[1]) {
+    out.f38 %= bitcast<vec4f>(a0.ggrr);
+  }
+  return out;
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec4i) -> @location(200) @interpolate(flat) vec4u {
+  var out: vec4u;
+  if bool(a0[2]) {
+    discard;
+  }
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = buffer118[arrayLength(&buffer118)][0];
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute1() {
+  _ = buffer118[0];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder18.draw(169, 262, 951_835_445, 256_810_322);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(89, 48, 5, 188_730_686, 415_037_700);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer87, 788);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer88, 'uint16', 1_018, 58);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup112, new Uint32Array(4243), 262, 0);
+} catch {}
+try {
+renderPassEncoder15.draw(1_000, 20, 553_790_789, 469_499_459);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(221, 302, 6, -1_447_802_118, 512_568_238);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer61, 56);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+computePassEncoder97.setBindGroup(1, bindGroup42, new Uint32Array(1147), 112, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer45, 8_540); };
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(61, 372, 69, -1_814_314_163, 16_506_895);
+} catch {}
+document.body.append(canvas1);
+let imageBitmap4 = await createImageBitmap(videoFrame14);
+let buffer119 = device0.createBuffer({
+  size: 1807,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+let texture178 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView162 = texture36.createView({dimension: 'cube', aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 6});
+let renderPassEncoder30 = commandEncoder152.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 67,
+  clearValue: { r: -335.8, g: 315.5, b: 872.3, a: -709.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup37, new Uint32Array(76), 5, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 124, 12, 397_845_129, 135_636_114);
+} catch {}
+let bindGroup120 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 173, resource: textureView8}]});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame1});
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'log'} });
+let buffer120 = device0.createBuffer({
+  size: 3508,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder153 = device0.createCommandEncoder({});
+let textureView163 = texture12.createView({dimension: '1d'});
+let computePassEncoder113 = commandEncoder153.beginComputePass();
+let sampler90 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.71,
+  lodMaxClamp: 73.59,
+});
+try {
+computePassEncoder113.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer89, 64);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer119, 'uint32', 52, 684);
+} catch {}
+let externalTexture15 = device0.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup11, new Uint32Array(116), 8, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer88, 12); };
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup87);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer45, 1_152);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer74, 'uint32', 188, 5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer90);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 92},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer109, offset: 256, size: 94}}],
+});
+let textureView164 = texture161.createView({label: '\u{1f73b}\u{1f96e}\u{1fdde}\u{1fe77}\u04c2', dimension: 'cube'});
+let texture179 = device0.createTexture({
+  size: [16, 20, 1],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let textureView165 = texture48.createView({label: '\u{1f741}\u{1faef}\u03c4\uc7b9\uc77c\u9f7d\u02e5\uc63a', aspect: 'depth-only'});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(1, bindGroup110, new Uint32Array(3421), 444, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer59, 24);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 3128, new Float32Array(9757), 3, 324);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder14.draw(207, 290, 910_810_119, 388_428_076);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer54, 1_220);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer119, 'uint32', 84, 74);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+buffer74.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView166 = texture1.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder87.setBindGroup(2, bindGroup38, new Uint32Array(4928), 599, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup61, new Uint32Array(4080), 290, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder11.draw(226, 353, 164_490_157, 33_815_144);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer102, 2_512);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 2_212);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder154.beginComputePass({});
+let sampler91 = device0.createSampler({
+  label: '\ua300\u479a\u08f1\uce7f\u{1f7ee}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.62,
+  lodMaxClamp: 89.66,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup99, new Uint32Array(12), 5, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer120, 1_384);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer1, 180);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer28, 'uint32', 384, 100);
+} catch {}
+try {
+adapter0.label = '\ubc03\u{1fcee}\u6ec7\u026f\u009d';
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 33, resource: sampler52}, {binding: 63, resource: textureView25}],
+});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 1258});
+let textureView167 = texture155.createView({dimension: 'cube-array', aspect: 'depth-only', baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup76, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1, 1, 2); };
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder17.setViewport(9.330380986247931, 1.4095537669885383, 4.400225056497381, 3.605470844695179, 0.9259959967345683, 0.9414710782598971);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 51, 3, -1_814_187_443, 350_147_280);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer66, 'uint32', 140, 3_829);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+buffer101.unmap();
+} catch {}
+document.body.prepend(video1);
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte432', transfer: 'linear'} });
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView168 = texture116.createView({});
+try {
+computePassEncoder114.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.draw(98, 70, 2_256_523_103, 2_524_773_532);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer10, 28);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 4804, new BigUint64Array(2439));
+} catch {}
+let buffer121 = device0.createBuffer({
+  size: 64465,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder155 = device0.createCommandEncoder({});
+let commandBuffer13 = commandEncoder155.finish({});
+try {
+renderPassEncoder15.draw(412, 375, 549_864_171, 1_045_974_728);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer102, 2_588);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 196, new DataView(new ArrayBuffer(13784)), 1013, 324);
+} catch {}
+let video4 = await videoWithData(128);
+let buffer122 = device0.createBuffer({size: 884, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture180 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView169 = texture116.createView({dimension: '3d'});
+try {
+computePassEncoder101.setBindGroup(3, bindGroup43, new Uint32Array(536), 110, 0);
+} catch {}
+try {
+renderPassEncoder15.draw(3, 40, 290_121_169, 350_959_779);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(4, 82, 64, 369_852_587, 833_576_990);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer22, 2_604);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer79, 172);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder85.pushDebugGroup('\u8ddb');
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\u6aa6');
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet26 = device0.createQuerySet({label: '\u39fb\u{1fc20}\u{1fb8c}', type: 'occlusion', count: 584});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup116);
+} catch {}
+try {
+computePassEncoder86.setBindGroup(2, bindGroup91, new Uint32Array(501), 25, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(60, 55, 22_890_664, 27_308_887);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(103, 532, 4, -2_095_344_089, 1_727_852_902);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer104, 1_184);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer93, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let imageData13 = new ImageData(20, 72);
+let commandEncoder156 = device0.createCommandEncoder({});
+let textureView170 = texture33.createView({dimension: '2d-array', aspect: 'depth-only', baseArrayLayer: 1, arrayLayerCount: 2});
+let renderPassEncoder31 = commandEncoder156.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 68,
+  clearValue: { r: 944.8, g: 960.2, b: -217.8, a: -876.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'depth32float-stencil8', sampleCount: 1});
+let renderBundle28 = renderBundleEncoder28.finish({});
+try {
+renderPassEncoder13.draw(19, 154, 351_139_033, 2_975_232_343);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer42, 8_628);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+let commandEncoder157 = device0.createCommandEncoder({});
+let computePassEncoder115 = commandEncoder157.beginComputePass({});
+let sampler92 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.88,
+  lodMaxClamp: 99.99,
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup109, new Uint32Array(739), 242, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(4, 22, 60, 291_554_851, 724_878_747);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer93, 'uint16', 40, 298);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(3_682).fill(99), /* required buffer size: 3_682 */
+{offset: 498, bytesPerRow: 30, rowsPerImage: 106}, {width: 2, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let buffer123 = device0.createBuffer({
+  size: 9926,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder158 = device0.createCommandEncoder({label: '\u1d36\uac1f\u7234'});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer91, 584); };
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup75);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer74, 4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer124 = device0.createBuffer({
+  label: '\u{1fa50}\u5e08\u0869\uaa72\u{1f77a}\u{1fe48}\u{1fb68}\u3556',
+  size: 11059,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture181 = device0.createTexture({
+  label: '\u{1f675}\u02eb\u{1fa4d}\u0930\u8d4b\ubc41\u9baf\ued61\u{1f6c9}',
+  size: [16, 20, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView171 = texture74.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder116 = commandEncoder158.beginComputePass({});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup65, new Uint32Array(2181), 410, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer93, 160);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer58);
+} catch {}
+let buffer125 = device0.createBuffer({size: 1904, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder159 = device0.createCommandEncoder({});
+let computePassEncoder117 = commandEncoder159.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup1, new Uint32Array(329), 85, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup80, new Uint32Array(1063), 154, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle23, renderBundle24, renderBundle23, renderBundle14, renderBundle19, renderBundle26]);
+} catch {}
+document.body.prepend(canvas3);
+let bindGroup123 = device0.createBindGroup({
+  label: '\u99b5\ud77d\uf71a\u4ef9\ub558\u0e75\u7017',
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 270, resource: textureView168},
+    {binding: 30, resource: textureView160},
+    {binding: 54, resource: {buffer: buffer124, offset: 0, size: 1772}},
+    {binding: 116, resource: textureView168},
+    {binding: 404, resource: textureView56},
+    {binding: 6, resource: sampler6},
+  ],
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(2, bindGroup63, new Uint32Array(1430), 756, 0);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle10, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer120, 324);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData11,
+  origin: { x: 6, y: 0 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 8, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 17, resource: {buffer: buffer1, offset: 256, size: 2996}}],
+});
+let commandEncoder160 = device0.createCommandEncoder({});
+let textureView172 = texture152.createView({
+  label: '\u02f8\u{1fef1}\u9a91\u0e46\uecfe\u{1fc01}\u{1fb1a}\uce92\u06d3',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  arrayLayerCount: 7,
+});
+let renderPassEncoder32 = commandEncoder160.beginRenderPass({
+  label: '\uf371\ubce0',
+  colorAttachments: [{view: textureView122, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 265208823,
+});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup101);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(0, bindGroup98, new Uint32Array(1778), 33, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(115);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(3, 495, 1, 339_097_675, 95_423_654);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer88, 1_536);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let sampler93 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.86,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup60, new Uint32Array(373), 185, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup102);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(3, 331, 2, 1_020_514_936, 320_632_766);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer120, 1_128);
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\u9728');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder161 = device0.createCommandEncoder({label: '\u7e3f\ucb6b\u766a\u00e5'});
+let computePassEncoder118 = commandEncoder161.beginComputePass({});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup1, new Uint32Array(2055), 650, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(41, 206, 621_753_137, 654_259_966);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer104, 3_676);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer50, 1_916);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup48);
+} catch {}
+let textureView173 = texture91.createView({dimension: '2d'});
+let renderBundle29 = renderBundleEncoder29.finish({label: '\u{1f660}\u74d8\u3379\u{1ff8c}'});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer104, 892); };
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer83, 1_712);
+} catch {}
+let commandEncoder162 = device0.createCommandEncoder({label: '\uc648\u0aeb'});
+try {
+computePassEncoder108.setBindGroup(0, bindGroup31, new Uint32Array(2579), 186, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup72, new Uint32Array(1255), 142, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder15.draw(146, 384, 490_275_178, 571_797_555);
+} catch {}
+try {
+renderPassEncoder18.drawIndexedIndirect(buffer46, 148);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer5, 'uint16', 1_458, 5_546);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u0863');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 156, new Float32Array(12339), 3028, 0);
+} catch {}
+await gc();
+let buffer126 = device0.createBuffer({
+  label: '\uc6a8\u{1fb16}\u{1f9b6}\ue47b\u18ec\u34ce\u631b\ue727',
+  size: 8518,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView174 = texture9.createView({dimension: '2d', baseMipLevel: 0});
+let computePassEncoder119 = commandEncoder162.beginComputePass();
+let sampler94 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.43,
+  lodMaxClamp: 92.14,
+  compare: 'not-equal',
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder13.draw(829, 459, 247_847_415, 290_458_044);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(24, 136, 0, 497_042_924, 349_828_689);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8Array(245).fill(47), /* required buffer size: 245 */
+{offset: 245, bytesPerRow: 42}, {width: 2, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup125 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView63}]});
+let buffer127 = device0.createBuffer({size: 3046, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder163 = device0.createCommandEncoder({});
+let computePassEncoder120 = commandEncoder163.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(205, 53, 234, 606_713_621, 276_856_963);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer59, 64);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer108, 0, 5_853);
+} catch {}
+let pipeline11 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x4', offset: 1112, shaderLocation: 2},
+          {format: 'float16x4', offset: 824, shaderLocation: 13},
+          {format: 'uint32x3', offset: 168, shaderLocation: 0},
+          {format: 'sint32', offset: 64, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'none', unclippedDepth: true},
+});
+let bindGroup126 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 103, resource: textureView75}]});
+let commandEncoder164 = device0.createCommandEncoder({});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 1076});
+let textureView175 = texture7.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, baseArrayLayer: 2});
+try {
+computePassEncoder114.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer46, 36);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(5, buffer102, 4_228, 8_400);
+} catch {}
+canvas2.height = 740;
+let texture182 = device0.createTexture({size: [16], mipLevelCount: 1, dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView176 = texture149.createView({label: '\u2ead\ud513\ufc06\uf016', dimension: '2d', baseArrayLayer: 16});
+let computePassEncoder121 = commandEncoder164.beginComputePass({});
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer24, 5_804);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer120, 1_968);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer124, 'uint32', 2_208, 2_388);
+} catch {}
+try {
+buffer108.unmap();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+await gc();
+let texture183 = device0.createTexture({
+  size: [16, 20, 11],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup97, new Uint32Array(715), 115, 0);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer88, 172);
+} catch {}
+let imageBitmap5 = await createImageBitmap(video0);
+try {
+device0.label = '\u0d50\ucd74\u061b\u2c54\u4bbf\u2844';
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 269,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer128 = device0.createBuffer({
+  label: '\u4f83\u011b\u0347\u7a23\ued70\u6ce1\uf58d\u813f\u5b3c\uf65f\u1b38',
+  size: 2981,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture184 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 49},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler95 = device0.createSampler({
+  label: '\uf5ea\u0a07',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.66,
+  lodMaxClamp: 99.69,
+});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup116, new Uint32Array(4391), 187, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup114, new Uint32Array(100), 7, 0);
+} catch {}
+try {
+renderPassEncoder18.draw(12, 238, 58_570_327, 306_957_195);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(0, 140, 9, 139_073_870, 411_469_055);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer34, 'uint16', 3_744, 537);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer108, 1488, new DataView(new ArrayBuffer(3455)), 704, 688);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(46, 141, 16, 351_315_051, 83_388_196);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer7, 672);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer89, 412);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder85.popDebugGroup();
+} catch {}
+try {
+  await promise24;
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'pq'} });
+let bindGroup127 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView147}]});
+let texture185 = device0.createTexture({
+  size: [2, 2, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler96 = device0.createSampler({
+  label: '\u59a7\u9a39\u347b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.08,
+  lodMaxClamp: 68.33,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+renderPassEncoder9.draw(59, 107, 156_440_530, 506_844_740);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder165 = device0.createCommandEncoder({});
+let computePassEncoder122 = commandEncoder165.beginComputePass({label: '\u05b7\ud1be\u0375\u3a67\u{1fc3e}\udb19\u535f'});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroups(3, 1); };
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+renderPassEncoder13.draw(224, 1, 1_001_425_268, 38_272_432);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(121_938).fill(185), /* required buffer size: 121_938 */
+{offset: 138, bytesPerRow: 300, rowsPerImage: 29}, {width: 0, height: 1, depthOrArrayLayers: 15});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer129 = device0.createBuffer({
+  label: '\uf83a\u53df\u{1f99a}\uea51\ue6b7\u{1fca0}\u25d9',
+  size: 1092,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder166 = device0.createCommandEncoder();
+let textureView177 = texture88.createView({});
+let computePassEncoder123 = commandEncoder166.beginComputePass({});
+try {
+computePassEncoder120.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle17, renderBundle13, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder11.draw(94, 48, 794_461_694, 523_218_771);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer82, 196);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer14, 1_712);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer95, 176, new BigUint64Array(85));
+} catch {}
+let bindGroup128 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView117}]});
+let buffer130 = device0.createBuffer({
+  size: 29492,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 91});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroupsIndirect(buffer27, 8_648); };
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup46, new Uint32Array(4536), 251, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer123, 352);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer102, 6_300, 1_193);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img4);
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'linear'} });
+let bindGroup129 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 33, resource: sampler26}, {binding: 63, resource: textureView25}],
+});
+let texture186 = device0.createTexture({
+  size: [16, 20, 1],
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder107.setBindGroup(3, bindGroup9, new Uint32Array(2302), 253, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(6, buffer91);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder73.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.draw(7, 202, 1_533_424_809, 6_821_147);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(3, 35, 4, -1_912_209_139, 1_174_515_778);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let bindGroup130 = device0.createBindGroup({
+  label: '\u21f8\u{1fc9f}\u7ecb\uea66\u3ed3\ua4ee\uc36e\uf6b7\u04ef\ucaf7',
+  layout: bindGroupLayout23,
+  entries: [{binding: 269, resource: {buffer: buffer103, offset: 1536}}],
+});
+let buffer131 = device0.createBuffer({size: 7624, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+try {
+renderPassEncoder27.setViewport(4.9515568923267566, 11.415568960965008, 1.742118839374205, 5.154433324055321, 0.5609160283473285, 0.6349540290880491);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(13, 308, 0, 1_013_019_994, 223_044_001);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(5, buffer27, 0, 6_510);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let texture187 = device0.createTexture({size: [2], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let externalTexture16 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup119);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer42, 1_260);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer74, 360, 43);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let textureView178 = texture115.createView({label: '\u096f\ufb32\u03d3\u2617\u{1fb7b}\u0a4a\u{1ff31}\u0188\u326b', mipLevelCount: 2});
+let texture188 = device0.createTexture({
+  size: [2, 2, 220],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView179 = texture125.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder120.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer89, 292);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer124, 'uint16', 934, 1_142);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline11);
+} catch {}
+video0.width = 7;
+let buffer132 = device0.createBuffer({
+  label: '\ua4a4\ua5ca\u{1fb7f}\u{1fffc}\uf13c\u0f43\u0a98\u{1fa53}\ucc2a\u0e54\u{1fc75}',
+  size: 3265,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView180 = texture0.createView({label: '\ua7b6\uf4fa\ubbee', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler97 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.24,
+  lodMaxClamp: 71.30,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder14.draw(485, 146, 213_534_638, 378_119_600);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer112, 'uint16', 1_696, 1_677);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'film', transfer: 'linear'} });
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 952});
+let textureView181 = texture34.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder11.draw(553, 13, 329_603_157, 97_510_743);
+} catch {}
+try {
+renderPassEncoder2.pushDebugGroup('\u006a');
+} catch {}
+try {
+renderPassEncoder2.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer101, 244, new BigUint64Array(4296), 540, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(18_435).fill(180), /* required buffer size: 18_435 */
+{offset: 70, bytesPerRow: 291, rowsPerImage: 55}, {width: 8, height: 36, depthOrArrayLayers: 2});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData14 = new ImageData(128, 68);
+let bindGroup131 = device0.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 269, resource: {buffer: buffer86, offset: 768}}]});
+let buffer133 = device0.createBuffer({
+  size: 19565,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder167 = device0.createCommandEncoder({});
+let sampler98 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.37,
+  lodMaxClamp: 86.89,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder13.draw(49, 0, 422_966_520, 471_081_582);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(77, 54, 44, 499_411_873, 471_021_565);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder167.clearBuffer(buffer25, 4996);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup132 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 9, resource: textureView149}]});
+let buffer134 = device0.createBuffer({
+  size: 10413,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder124 = commandEncoder167.beginComputePass({label: '\uec98\u{1f736}\uc283\u0bba\uce5f\u07c9\u0952\u1297\u{1fd3e}\u78e2\u050d'});
+try {
+computePassEncoder124.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer89);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 19},
+  aspect: 'all',
+}, new Uint8Array(1_353).fill(222), /* required buffer size: 1_353 */
+{offset: 305, bytesPerRow: 29, rowsPerImage: 9}, {width: 4, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({});
+let texture189 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder125 = commandEncoder168.beginComputePass({});
+let sampler99 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.73,
+  lodMaxClamp: 98.13,
+  compare: 'never',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder102.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup113, new Uint32Array(3871), 550, 0);
+} catch {}
+try {
+renderPassEncoder18.draw(46, 45, 1_180_871_709, 104_223_552);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer66, 3_660);
+} catch {}
+try {
+adapter0.label = '\u9358\u{1fee6}\u01c1\u6a61\u1be2\u{1f79d}\ud83d\u{1fbdf}';
+} catch {}
+let buffer135 = device0.createBuffer({
+  size: 8356,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder169 = device0.createCommandEncoder({});
+let texture190 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder33 = commandEncoder169.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 78,
+  clearValue: { r: -136.1, g: 101.1, b: 124.0, a: -935.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 48311422,
+});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle13, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer61, 'uint16', 514, 3_648);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer121, 17_140, 4_915);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'astc-12x12-unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let texture191 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler100 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.88,
+});
+try {
+computePassEncoder87.setBindGroup(1, bindGroup53, new Uint32Array(1416), 455, 0);
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup109);
+} catch {}
+try {
+renderPassEncoder18.drawIndexedIndirect(buffer93, 8);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer80, 3_716);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer63, 'uint32', 28, 16);
+} catch {}
+try {
+buffer73.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer136 = device0.createBuffer({size: 5349, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 31});
+let sampler101 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.99,
+  lodMaxClamp: 97.65,
+});
+try {
+computePassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup43, new Uint32Array(242), 8, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -297.3, g: 555.9, b: 972.6, a: 378.2, });
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+offscreenCanvas0.height = 1081;
+let commandEncoder170 = device0.createCommandEncoder({});
+let texture192 = device0.createTexture({size: [16], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder126 = commandEncoder170.beginComputePass();
+let sampler102 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.57,
+  lodMaxClamp: 65.39,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(3, bindGroup7, new Uint32Array(858), 177, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer63, 60);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint32', 5_124, 578);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer108, 0);
+} catch {}
+let textureView182 = texture48.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup44, new Uint32Array(293), 22, 0);
+} catch {}
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder30.setViewport(11.732884750027988, 5.023851789785985, 1.6315054208531785, 4.905924987663867, 0.04332273915864737, 0.184339969518434);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(119, 4, 13, -1_726_193_966, 504_025_087);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer91, 188);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer30, 'uint32', 1_996, 1_031);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer40, 0);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let promise26 = adapter0.requestAdapterInfo();
+let texture193 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup105, new Uint32Array(2066), 145, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer135, 3_384);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer124, 140, new DataView(new ArrayBuffer(4387)), 677, 1628);
+} catch {}
+let promise27 = adapter0.requestAdapterInfo();
+let texture194 = device0.createTexture({
+  size: [16, 20, 146],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture17 = device0.importExternalTexture({source: video0});
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup25, new Uint32Array(972), 104, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle16, renderBundle14, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 199, 145, 352_231_416, 1_002_883_174);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer50, 0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer17);
+} catch {}
+let bindGroup133 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 87, resource: {buffer: buffer61, offset: 1536}}]});
+let commandEncoder171 = device0.createCommandEncoder({});
+let textureView183 = texture193.createView({mipLevelCount: 1});
+let computePassEncoder127 = commandEncoder171.beginComputePass({});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder65); computePassEncoder65.dispatchWorkgroupsIndirect(buffer14, 524); };
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup128, new Uint32Array(1986), 342, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer27, 6_500);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer120, 380);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+let textureView184 = texture22.createView({});
+try {
+renderPassEncoder12.draw(51, 148, 1_388_908_629, 804_638_662);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer10, 1_364);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 1564, new Int16Array(20994), 1519, 592);
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder();
+let computePassEncoder128 = commandEncoder172.beginComputePass({});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle25, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer50, 128);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer85, 'uint32', 15_224, 91);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise25;
+} catch {}
+let bindGroup134 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView70}, {binding: 267, resource: textureView133}],
+});
+let commandEncoder173 = device0.createCommandEncoder({label: '\u6295\u01dc\u02ff\uab4b\u3ed9\u5229\u{1f894}\u{1ffe8}\uf23e'});
+let querySet31 = device0.createQuerySet({
+  label: '\u1c6b\u{1fa00}\u{1fbb5}\u{1fbd4}\u2afb\u{1fd67}\u1508\u040c\u0bd0',
+  type: 'occlusion',
+  count: 1608,
+});
+let computePassEncoder129 = commandEncoder173.beginComputePass({label: '\u7491\u0f30\ua340\u{1faaa}\u{1fa04}\u0acc\u1eb9\u0827\u064e\u041c'});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup19, new Uint32Array(1192), 223, 0);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup108);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(249, 24, 102, 26_386_565, 1_503_160_672);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas2);
+try {
+computePassEncoder9.label = '\u0816\u9a1d\u4760\u0304\ued0f\u17e1\u{1f893}';
+} catch {}
+let bindGroup135 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 285, resource: {buffer: buffer40, offset: 1024}}]});
+let texture195 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView185 = texture55.createView({dimension: '3d', baseArrayLayer: 0});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup74, new Uint32Array(8208), 1_330, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup57, new Uint32Array(1766), 171, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(128, 57, 2_114_830_572, 90_397_384);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(1, 84, 0, -1_602_128_912, 640_899_708);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer83, 332);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer65, 736);
+} catch {}
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470m', transfer: 'log'} });
+let buffer137 = device0.createBuffer({
+  size: 1117,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder174 = device0.createCommandEncoder({});
+try {
+renderPassEncoder20.executeBundles([renderBundle26, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(21, 225, 71, 107_339_720, 413_994_409);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer106, 2_020);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer108, 'uint16', 1_472, 375);
+} catch {}
+let arrayBuffer20 = buffer38.getMappedRange(696);
+try {
+commandEncoder174.copyBufferToBuffer(buffer121, 1876, buffer78, 952, 172);
+} catch {}
+try {
+computePassEncoder106.pushDebugGroup('\u{1ff96}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 26},
+  aspect: 'all',
+}, new Uint8Array(66_779).fill(158), /* required buffer size: 66_779 */
+{offset: 79, bytesPerRow: 23, rowsPerImage: 145}, {width: 1, height: 0, depthOrArrayLayers: 21});
+} catch {}
+let commandEncoder175 = device0.createCommandEncoder();
+let texture196 = device0.createTexture({
+  label: '\uf77d\u{1fcd8}\u{1ff94}\u0c9b',
+  size: [8, 10, 88],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler103 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.108,
+  lodMaxClamp: 28.55,
+});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup63, new Uint32Array(2122), 719, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, undefined, 1_111_050_655, 278_501_472);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup136 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 59, resource: {buffer: buffer82, offset: 0, size: 40}},
+    {binding: 97, resource: textureView30},
+  ],
+});
+let computePassEncoder130 = commandEncoder175.beginComputePass({label: '\uabce\u0d4a\u5e9f\u56c6\u2047\u0d6d\u9f74\ua2fe\u223c'});
+let renderPassEncoder34 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: 743.1, g: 351.0, b: -933.6, a: 649.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup108, new Uint32Array(4930), 1_969, 0);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(24, 33, 16, 41_096_540, 90_724_826);
+} catch {}
+let bindGroup137 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 121, resource: {buffer: buffer1, offset: 1792, size: 2012}},
+    {binding: 75, resource: textureView91},
+  ],
+});
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout13]});
+let texture197 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 714},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer85, 'uint16', 3_518, 1_845);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 72, new BigUint64Array(2672), 714, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 123, y: 32, z: 4},
+  aspect: 'all',
+}, new Uint8Array(5_921).fill(11), /* required buffer size: 5_921 */
+{offset: 65, bytesPerRow: 48, rowsPerImage: 89}, {width: 0, height: 34, depthOrArrayLayers: 2});
+} catch {}
+let commandEncoder176 = device0.createCommandEncoder({});
+let texture198 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 7},
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder131 = commandEncoder176.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup129, new Uint32Array(311), 17, 0);
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer61, 1_936);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 28, y: 1, z: 23},
+  aspect: 'all',
+}, new Uint8Array(284_616).fill(170), /* required buffer size: 284_616 */
+{offset: 100, bytesPerRow: 241, rowsPerImage: 149}, {width: 34, height: 138, depthOrArrayLayers: 8});
+} catch {}
+let textureView186 = texture163.createView({dimension: '2d', baseArrayLayer: 82, arrayLayerCount: 1});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup116, new Uint32Array(2689), 1_326, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 11 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder177.beginComputePass({label: '\uc4c7\ue956\ueba6\ufe65\u065c\u{1fe27}'});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], stencilReadOnly: true});
+try {
+computePassEncoder132.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.draw(79, 55, 637_299_173, 1_757_003_438);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 270, 3, 1_078_094_879, 762_215_539);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer128, 332);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup84);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer73, 'uint32', 952, 1_666);
+} catch {}
+try {
+buffer135.unmap();
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let pipeline12 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment1',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {
+        arrayStride: 800,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 4, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 328, shaderLocation: 11},
+          {format: 'sint16x2', offset: 56, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let commandEncoder178 = device0.createCommandEncoder({});
+let computePassEncoder133 = commandEncoder178.beginComputePass({label: '\u{1f7bf}\uc55c\u097c\u5cf5\u0ca0\u4141\ufc77'});
+let renderBundle30 = renderBundleEncoder30.finish({});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup53, new Uint32Array(1611), 9, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer50, 4_724);
+} catch {}
+await gc();
+let bindGroup138 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer59, offset: 0, size: 195}}],
+});
+let buffer138 = device0.createBuffer({
+  size: 1707,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture199 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 49},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture200 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder19.setStencilReference(1213);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(6, 11, 1, 155_156_204, 636_247_387);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer61, 824);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline12);
+} catch {}
+try {
+adapter0.label = '\u{1fd22}\u32cc\ua30c\u8450\u04e2\uf155';
+} catch {}
+let buffer139 = device0.createBuffer({
+  size: 12738,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let textureView187 = texture0.createView({label: '\u0ec4\uf384\uc16c\u01ed\u0013\u532c\u0886\u{1f898}\ua409\u76f8\u0cb0', mipLevelCount: 1});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup43, new Uint32Array(72), 23, 0);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(406, 239, 1, -1_759_017_107, 171_285_741);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer121, 1_152);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline11);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+try {
+  await promise26;
+} catch {}
+canvas1.height = 384;
+let videoFrame36 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let bindGroup139 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 103, resource: textureView79}]});
+let sampler104 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.39,
+  lodMaxClamp: 92.52,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup3, new Uint32Array(3631), 466, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer25, 'uint32', 5_204, 3_478);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder106.popDebugGroup();
+} catch {}
+let buffer140 = device0.createBuffer({
+  label: '\u3de5\u{1ff29}\u623b\u0896\u{1f8c8}\ue4a6\ufc90\u0c4e\u0099',
+  size: 32976,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView188 = texture175.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder12.setBlendConstant({ r: -422.4, g: 805.3, b: 355.2, a: -459.1, });
+} catch {}
+try {
+renderPassEncoder10.draw(752_099_089, 241, 237_062_980, 777_956_553);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer54, 8_288);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer129, 316);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer7, 'uint16', 2_572, 3_700);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+  await shaderModule8.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 14},
+  aspect: 'all',
+}, new Uint8Array(21_970).fill(99), /* required buffer size: 21_970 */
+{offset: 46, bytesPerRow: 42, rowsPerImage: 58}, {width: 0, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder({});
+let renderPassEncoder35 = commandEncoder179.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  depthSlice: 94,
+  clearValue: { r: -0.5014, g: 969.7, b: -411.1, a: -647.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler105 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.490,
+  lodMaxClamp: 31.15,
+  maxAnisotropy: 18,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroupsIndirect(buffer16, 204); };
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(298, 4, 29, 368_291_506, 189_732_543);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder180 = device0.createCommandEncoder({});
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 196});
+let computePassEncoder134 = commandEncoder180.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u0eba');
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 841});
+let texture201 = device0.createTexture({
+  label: '\udc3e\uea8c\u5c38\u{1f88f}\u01e2\u{1fc7a}\u01b8\u{1f935}\u4fad',
+  size: {width: 2, height: 2, depthOrArrayLayers: 2},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder135 = commandEncoder181.beginComputePass({label: '\u2a30\u5a25\u201a\u{1fcb6}\u0463\u080c\u{1fb59}\ua598\uda5f\u54d6'});
+let sampler106 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 63.68,
+  lodMaxClamp: 90.45,
+});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 206.7, g: -912.3, b: 71.96, a: 769.9, });
+} catch {}
+try {
+renderPassEncoder2.draw(40, 282, 232_339_785, 525_324_677);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(28, 140, 66, 22_699_170, 304_013_286);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 2_548);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 5, y: 16, z: 6},
+  aspect: 'all',
+}, new Uint8Array(5_517).fill(185), /* required buffer size: 5_517 */
+{offset: 867, bytesPerRow: 6, rowsPerImage: 23}, {width: 0, height: 17, depthOrArrayLayers: 34});
+} catch {}
+let texture202 = device0.createTexture({
+  size: [4, 5, 7],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder25.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.draw(126, 308, 104_203_362, 58_120_107);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer72, 'uint16', 1_686, 330);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(3, buffer70);
+} catch {}
+try {
+querySet17.destroy();
+} catch {}
+document.body.prepend(video0);
+let sampler107 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 71.40,
+  lodMaxClamp: 95.32,
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup69, new Uint32Array(8785), 2_499, 0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 93.55, g: -831.5, b: -329.3, a: -202.6, });
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(0, 2, 3, 5);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer46, 328);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer30, 8_988, 1_613);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise27;
+} catch {}
+try {
+adapter0.label = '\u28c7\ud170\u{1fe1f}\ua545';
+} catch {}
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 126, resource: textureView174}, {binding: 267, resource: textureView17}],
+});
+let commandEncoder182 = device0.createCommandEncoder();
+let querySet34 = device0.createQuerySet({label: '\u0430\u{1fb1f}\u0160\u0b7d', type: 'occlusion', count: 1739});
+let computePassEncoder136 = commandEncoder182.beginComputePass();
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float']});
+let externalTexture18 = device0.importExternalTexture({source: video3, colorSpace: 'display-p3'});
+try {
+computePassEncoder116.setBindGroup(0, bindGroup62, []);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup77, new Uint32Array(149), 84, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder2.draw(4, 36, 90_066_363, 197_735_375);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer112, 'uint16', 386, 430);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup81, new Uint32Array(687), 14, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer85, 'uint32', 184, 1_429);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(2, buffer108, 0, 1_273);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  label: '\u0b2d\ua049\u{1fe34}\u{1f638}\u03a7',
+  layout: 'auto',
+  fragment: {module: shaderModule8, entryPoint: 'fragment0', targets: [{format: 'r16sint'}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 32757517,
+    stencilWriteMask: 518068828,
+    depthBiasSlopeScale: 704.3515851520187,
+    depthBiasClamp: 633.3977921064728,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 140,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 76, shaderLocation: 10},
+          {format: 'float32x2', offset: 16, shaderLocation: 6},
+          {format: 'sint8x2', offset: 0, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder183 = device0.createCommandEncoder({});
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 163});
+let textureView189 = texture197.createView({mipLevelCount: 1});
+let computePassEncoder137 = commandEncoder183.beginComputePass({});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(24);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle15, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(0, 168, 2, 129_261_223, 278_811_190);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer103, 'uint32', 384, 591);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline2);
+} catch {}
+let buffer141 = device0.createBuffer({
+  label: '\u7fbe\u8c1b\u982b\u0fb0\u2261\u{1ffa6}\u06ce\u2177\u0e14\ueac1',
+  size: 1784,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup38, new Uint32Array(5274), 3_089, 0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(15.163963094996848, 1.9046549803219714, 0.5169966221706939, 6.853924110504011, 0.5871218925797095, 0.7779924495078152);
+} catch {}
+try {
+renderPassEncoder12.draw(7, 173, 338_575_737, 333_625_843);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer7, 332);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer91, 556);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'smpteSt4281'} });
+let buffer142 = device0.createBuffer({size: 15254, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView190 = texture59.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer135, 1_824); };
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer10, 120);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer46, 96);
+} catch {}
+let bindGroup141 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 30, resource: {buffer: buffer91, offset: 0}}]});
+let texture203 = device0.createTexture({
+  size: [16, 20, 101],
+  dimension: '2d',
+  format: 'astc-4x4-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture204 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView191 = texture150.createView({});
+try {
+renderPassEncoder10.drawIndexed(2, 69, 1, 514_968_934, 701_720_739);
+} catch {}
+let bindGroup142 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 98, resource: sampler57}]});
+let commandEncoder184 = device0.createCommandEncoder({});
+let texture205 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView192 = texture187.createView({});
+let renderPassEncoder36 = commandEncoder184.beginRenderPass({
+  colorAttachments: [{view: textureView37, depthSlice: 60, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 94841222,
+});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup51, []);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup80, new Uint32Array(3138), 389, 0);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(123);
+} catch {}
+try {
+renderPassEncoder10.draw(238_460_114, 589, 1_317_216_250, 225_130_988);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 222, 1, -1_800_699_703, 507_918_479);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4_294_967_294, undefined, 0, 1_608_535_829);
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  label: '\u{1fa61}\ufdb6\u1001\u04fd\u{1f95a}\uad9f',
+  layout: bindGroupLayout14,
+  entries: [{binding: 30, resource: {buffer: buffer24, offset: 1536, size: 1168}}],
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup113, new Uint32Array(676), 14, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup64, new Uint32Array(1444), 152, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle29, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer54, 20);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer86, 552);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer141, 0, 543);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 49}
+*/
+{
+  source: video1,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder();
+let sampler108 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.71,
+  lodMaxClamp: 77.38,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle10, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder13.draw(77, 144, 156_910_907, 429_178_247);
+} catch {}
+try {
+renderPassEncoder18.drawIndexedIndirect(buffer127, 348);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder185.clearBuffer(buffer108);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let computePassEncoder138 = commandEncoder185.beginComputePass({});
+try {
+computePassEncoder110.setBindGroup(3, bindGroup114, new Uint32Array(344), 48, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup140);
+} catch {}
+try {
+renderPassEncoder11.draw(89, 184, 1_571_759_524, 626_247_659);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer102, 444);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let arrayBuffer21 = buffer131.getMappedRange(1296);
+let texture206 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2uint'],
+});
+let sampler109 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMinClamp: 27.36,
+  lodMaxClamp: 58.71,
+});
+try {
+renderPassEncoder29.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder11.draw(109, 36, 34_687_004, 1_369_726_064);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(119, 32, 30, -2_071_950_296, 203_282_474);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer45, 0);
+} catch {}
+try {
+renderPassEncoder36.insertDebugMarker('\ub378');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer82, 8, new DataView(new ArrayBuffer(41064)), 10483, 20);
+} catch {}
+let textureView193 = texture198.createView({dimension: '2d', baseArrayLayer: 4});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup67, new Uint32Array(451), 315, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup91, new Uint32Array(1358), 175, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(358_440_287, 63, 198_866_898, 443_756_032);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(248, 54, 254, 445_381_848, 2_259_427_232);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let shaderModule14 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 25 max align: 1 */
+struct T0 {
+  @align(1) f0: atomic<u32>,
+  @align(1) @size(8) f1: atomic<u32>,
+  @align(1) @size(13) f2: atomic<i32>,
+}
+/* target size: 25 max align: 1 */
+struct T1 {
+  @align(1) f0: f32,
+  @align(1) f1: array<f16, 1>,
+  @align(1) f2: atomic<u32>,
+  @align(1) @size(15) f3: array<atomic<u32>, 1>,
+}
+@group(0) @binding(33) var<storage, read> buffer143: array<T0>;
+struct S7 {
+  @location(7) @interpolate(flat, center) f0: vec2u
+}
+struct FragmentOutput10 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @location(2) @interpolate(flat, center) f1: vec2i
+}
+
+@fragment
+fn fragment0(a0: S7) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture207 = device0.createTexture({
+  size: {width: 1495, height: 28, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler110 = device0.createSampler({
+  label: '\u{1f9df}\uef23\ufe1d\u8bb9\u9b71\u5a0c\u0e63\u02bb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.34,
+  lodMaxClamp: 96.32,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup127);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle18, renderBundle18, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer133, 2_280);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer139, 36);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer102, 'uint16', 2_188, 1_205);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer80);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 511,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 57, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let bindGroup144 = device0.createBindGroup({
+  label: '\u{1fefe}\u0974\u{1fbe2}\u03ab\u8d41\u7415\u60f2\ue86d',
+  layout: bindGroupLayout22,
+  entries: [{binding: 9, resource: textureView147}],
+});
+let commandEncoder186 = device0.createCommandEncoder();
+let texture208 = device0.createTexture({
+  label: '\u{1fa17}\u05c9\u62cd\u0c24\u0882\ubeb6\u3508\u3b09\u{1fd3b}\uabd6\u523a',
+  size: [16, 20, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture209 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder139 = commandEncoder186.beginComputePass();
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer46, 112);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer37, 60, 132);
+} catch {}
+try {
+renderBundleEncoder17.label = '\uffe5\u{1f9b1}\u732f\u04d1\udf4d\u{1fcd1}\ue17b\u0f1f\u0a88\u000b\u8914';
+} catch {}
+let bindGroup145 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 4, resource: {buffer: buffer137, offset: 0, size: 716}},
+    {binding: 9, resource: {buffer: buffer82, offset: 0, size: 187}},
+  ],
+});
+let texture210 = device0.createTexture({
+  size: [2262, 20, 1],
+  mipLevelCount: 3,
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder33.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder18.draw(26, 0, 417_963_411, 303_311_831);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer138, 184, new BigUint64Array(9500), 649, 140);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture211 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler111 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 25.96,
+  lodMaxClamp: 93.51,
+});
+try {
+computePassEncoder139.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup103);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder10.draw(661_259_661, 35, 541_066_379, 211_324_526);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+document.body.append(video4);
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 578});
+let textureView194 = texture115.createView({aspect: 'all', baseMipLevel: 4, baseArrayLayer: 0});
+try {
+renderPassEncoder34.setStencilReference(573);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(381, 340, 73, 1_076_482_781, 589_221_223);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer133, 9_940);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer45);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let textureView195 = texture71.createView({aspect: 'depth-only'});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup126);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(3, bindGroup13, new Uint32Array(1971), 1_371, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup61, new Uint32Array(1499), 251, 0);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer73, 0, 175);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup146 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [{binding: 121, resource: {buffer: buffer110, offset: 3840}}, {binding: 75, resource: textureView91}],
+});
+let texture212 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView196 = texture131.createView({baseArrayLayer: 3, arrayLayerCount: 3});
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer134, 4_468);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer10, 440);
+} catch {}
+let arrayBuffer22 = buffer129.getMappedRange(0, 12);
+try {
+device0.queue.writeBuffer(buffer33, 2704, new BigUint64Array(50459), 173, 408);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+let shaderModule15 = device0.createShaderModule({
+  label: '\ub91e\u{1ff48}\u{1f68a}\u3d6b',
+  code: `
+enable f16;
+/* target size: 25 max align: 1 */
+struct T0 {
+  @align(1) @size(16) f0: vec2i,
+  @align(1) @size(9) f1: array<atomic<i32>, 1>,
+}
+/* target size: 25 max align: 1 */
+struct T1 {
+  @align(1) f0: array<i32, 1>,
+  @align(1) @size(21) f1: array<vec3i>,
+}
+@group(0) @binding(33) var<storage, read> buffer144: T1;
+struct VertexOutput11 {
+  @location(1) @interpolate(flat, centroid) f41: vec2h,
+  @builtin(position) f42: vec4f
+}
+
+@vertex
+fn vertex0(@location(2) @interpolate(flat) a0: i32, @builtin(vertex_index) a1: u32) -> VertexOutput11 {
+  var out: VertexOutput11;
+  return out;
+}
+struct S8 {
+  @location(5) @interpolate(linear, centroid) f0: vec3h,
+  @location(0) @interpolate(flat) f1: vec4f,
+  @location(7) f2: i32,
+  @location(9) @interpolate(linear, centroid) f3: vec4f
+}
+struct FragmentOutput11 {
+  @location(0) f0: vec4u,
+  @location(6) f1: vec2i
+}
+
+@fragment
+fn fragment0(a0: S8, @location(4) a1: vec3h) -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  out.f0 >>= vec4u(bitcast<u32>(a0.f2));
+  return out;
+}`,
+  hints: {},
+});
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 145,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 155, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 273,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let buffer145 = device0.createBuffer({size: 612, usage: GPUBufferUsage.VERTEX});
+let texture213 = device0.createTexture({
+  size: [4, 5, 55],
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup139);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer24, 504);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer80, 4_120);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer133, 1_808);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 25 max align: 1 */
+struct T0 {
+  @align(1) @size(8) f0: atomic<u32>,
+  @align(1) @size(17) f1: array<array<array<vec3u, 1>, 1>>,
+}
+@group(0) @binding(33) var<storage, read> buffer146: T0;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+});
+let bindGroup147 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 121, resource: {buffer: buffer16, offset: 2048, size: 916}},
+    {binding: 75, resource: textureView91},
+  ],
+});
+let buffer147 = device0.createBuffer({
+  size: 28125,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder187 = device0.createCommandEncoder({});
+let texture214 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture215 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let texture216 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder140 = commandEncoder187.beginComputePass({label: '\u{1f78c}\ud9ca\u{1ff13}\u071a\u{1f727}\u0e6a\ua00a\uccec\u{1f7c8}\u{1fe76}'});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(1, bindGroup30, new Uint32Array(4007), 68, 0);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup75, new Uint32Array(1351), 382, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer27, 4_924);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline12);
+} catch {}
+let bindGroup148 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 97, resource: textureView0},
+    {binding: 59, resource: {buffer: buffer2, offset: 0, size: 852}},
+  ],
+});
+let commandEncoder188 = device0.createCommandEncoder({});
+let textureView197 = texture214.createView({arrayLayerCount: 6});
+let texture217 = device0.createTexture({
+  label: '\u5a47\u{1feaf}\u17d3\u{1ff38}',
+  size: {width: 256},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder141 = commandEncoder188.beginComputePass({label: '\u7668\u0b48\ucbab\udf7f\u17bf\u0310\u0b2d\u08a6'});
+try {
+computePassEncoder96.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer121, 7_224);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(6, buffer70);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(438, 67);
+let commandEncoder189 = device0.createCommandEncoder({});
+let textureView198 = texture213.createView({baseArrayLayer: 11, arrayLayerCount: 11});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup40, new Uint32Array(4534), 1_702, 0);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(86, 96, 112, -1_114_121_534, 736_163_118);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer139, 'uint32', 4_132, 1_203);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer99, 464, new Float32Array(33943), 2143, 72);
+} catch {}
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470bg', transfer: 'bt2020_10bit'} });
+try {
+computePassEncoder141.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup93);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(15, 7, 0, 1);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer87, 188);
+} catch {}
+try {
+commandEncoder189.copyTextureToTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 3, y: 4, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture182,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder190 = device0.createCommandEncoder();
+let renderPassEncoder37 = commandEncoder190.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: -210.9, g: -990.4, b: 483.9, a: 808.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet35,
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle29]);
+} catch {}
+try {
+renderPassEncoder10.draw(434_381_184, 3, 267_982_210, 1_933_822_060);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(119, 33, 36, 412_026_816, 57_075_998);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer45, 832);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer86, 216);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer112, 'uint16', 2_166, 157);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 64 max align: 64 */
+struct T0 {
+  @size(64) f0: array<vec2h, 4>,
+}
+/* target size: 8 max align: 8 */
+struct T1 {
+  f0: vec2f,
+}
+/* target size: 126 max align: 2 */
+struct T2 {
+  @align(2) @size(126) f0: array<atomic<u32>>,
+}
+@group(0) @binding(414) var tex3: texture_2d<u32>;
+@group(0) @binding(381) var tex2: texture_2d<i32>;
+@group(0) @binding(79) var st1: texture_storage_2d<rg32uint, read>;
+struct VertexOutput12 {
+  @location(0) @interpolate(flat, center) f43: vec2i,
+  @builtin(position) f44: vec4f
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec2i, @location(13) @interpolate(perspective) a1: vec2f) -> VertexOutput12 {
+  var out: VertexOutput12;
+  if bool(a1[1]) {
+    out.f43 = bitcast<vec2i>(textureLoad(tex3, vec2i(), 0).wy);
+  }
+  return out;
+}
+struct VertexOutput13 {
+  @builtin(position) f45: vec4f
+}
+
+@vertex
+fn vertex1(@location(9) @interpolate(flat) a0: u32, @location(7) a1: i32, @location(6) @interpolate(flat) a2: vec4h, @location(3) a3: vec2i) -> VertexOutput13 {
+  var out: VertexOutput13;
+  return out;
+}
+struct S9 {
+  @location(15) f0: vec3f
+}
+
+@fragment
+fn fragment0(a0: S9, @location(9) a1: f32, @location(7) @interpolate(flat) a2: vec2u) -> @location(200) vec4u {
+  var out: vec4u;
+  _ = textureLoad(tex2, vec2i(), 0);
+  return out;
+}
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0() {
+  if bool(textureLoad(tex3, vec2i(), 0)[1]) {
+    return;
+  }
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  if bool(textureLoad(tex2, vec2i(), 0)[2]) {
+    return;
+  }
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup112, []);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle15, renderBundle24, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(14, 16, 131, 60_381_015, 1_074_730_556);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer86, 784);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer86, 1_348);
+} catch {}
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 588});
+let textureView199 = texture77.createView({label: '\u0cb7\u02d9\uf6bc\u061f\u0c8a\u0fcf\u66bd\u3a4b\u8fd8'});
+try {
+computePassEncoder119.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup108);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer121, 11_684);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let buffer148 = device0.createBuffer({
+  label: '\u08ae\u0db4\ucf90\u{1fa47}\u147f\u97b1',
+  size: 3238,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder191 = device0.createCommandEncoder({});
+let sampler112 = device0.createSampler({
+  label: '\u{1f9cf}\u1daf\u9649\u0fc1\uce9e\u2ac1\u745b\u{1fa1e}\u0d46\u4080\u8e0b',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.76,
+});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup124);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant({ r: 476.6, g: 675.1, b: 719.3, a: -412.5, });
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder35.setViewport(3.110386826047165, 19.0569268659064, 0.36384435859044356, 0.20240356491048514, 0.3225144845367157, 0.7041681125463617);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer62, 268);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(0, buffer70, 0, 975);
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+let buffer149 = device0.createBuffer({
+  size: 47896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let externalTexture19 = device0.importExternalTexture({source: video2});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(97, 130, 159, 954_836_117, 901_328_191);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer80, 2_652);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer3, 'uint32', 948, 404);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 4, y: 3, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer150 = device0.createBuffer({
+  size: 16755,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture218 = device0.createTexture({
+  size: [16, 20, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder142 = commandEncoder189.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer54, 368); };
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(23, 284, 12, 39_749_143, 926_705_465);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer14, 172);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer44, 2_256);
+} catch {}
+try {
+commandEncoder191.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 836 */
+  offset: 836,
+  bytesPerRow: 512,
+  rowsPerImage: 621,
+  buffer: buffer99,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(1_082).fill(180), /* required buffer size: 1_082 */
+{offset: 4, bytesPerRow: 49, rowsPerImage: 2}, {width: 0, height: 0, depthOrArrayLayers: 12});
+} catch {}
+let texture219 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderPassEncoder38 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView145,
+  depthSlice: 44,
+  clearValue: { r: -639.1, g: -952.5, b: 911.4, a: 511.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup51, new Uint32Array(1646), 144, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer104, 1_944);
+} catch {}
+let buffer151 = device0.createBuffer({size: 61, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture220 = device0.createTexture({
+  label: '\u06aa\u0f86\u47a8\u0b9a\u08de\u0371\ubb3e\u9395',
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler113 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.74,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup62);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle15]);
+} catch {}
+let imageData15 = new ImageData(24, 80);
+let commandEncoder192 = device0.createCommandEncoder({});
+try {
+computePassEncoder17.dispatchWorkgroupsIndirect(buffer128, 188);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(3799);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer85);
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+let promise32 = device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule5, constants: {}}});
+let commandEncoder193 = device0.createCommandEncoder({});
+let querySet38 = device0.createQuerySet({label: '\u0eb5\u3084', type: 'occlusion', count: 1897});
+let computePassEncoder143 = commandEncoder192.beginComputePass({label: '\u3a2c\u8a98\u0473\u6e05\u{1f751}\ua4b4\u0c23\u0487\u4c9d\u08b6\u8827'});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer102, 696); };
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup95);
+} catch {}
+try {
+renderPassEncoder12.draw(58, 22, 74_174_264, 323_487_225);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(209, 108, 18, 992_582_698, 192_355_238);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer10, 848);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer9, 'uint16', 34, 6_517);
+} catch {}
+let bindGroup149 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 554, resource: textureView117}]});
+let textureView200 = texture191.createView({dimension: '1d', baseMipLevel: 0});
+let sampler114 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.50,
+  lodMaxClamp: 55.03,
+});
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(5, 2, 53, 599_736_079, 643_144_571);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer91, 2_752);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData16 = new ImageData(8, 28);
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'unspecified', transfer: 'bt1361ExtendedColourGamut'} });
+let textureView201 = texture51.createView({});
+let computePassEncoder144 = commandEncoder193.beginComputePass({});
+let sampler115 = device0.createSampler({
+  label: '\u75ea\u0670\u086f\u0ea1\u09a3\u71d3',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.52,
+  lodMaxClamp: 81.37,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder130.setBindGroup(3, bindGroup90, new Uint32Array(798), 798, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(57, 0, 296_554_227, 229_846_986);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer1, 4_968);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder194 = device0.createCommandEncoder({});
+let computePassEncoder145 = commandEncoder194.beginComputePass({label: '\u{1fc07}\u8c7f\u{1f65c}\u2f32\u{1feb9}\u5528\ub82b\ued24\u2b42\uf0ec'});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup77);
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.draw(91, 27, 773_989_642, 127_258_619);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(4, 3, 8, 198_738_126, 721_016_295);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer135, 1_052);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(210), /* required buffer size: 19 */
+{offset: 19}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({});
+let computePassEncoder146 = commandEncoder195.beginComputePass({});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup60, new Uint32Array(1972), 376, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline2);
+} catch {}
+let textureView202 = texture152.createView({dimension: '2d', aspect: 'depth-only'});
+try {
+computePassEncoder146.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup11, new Uint32Array(526), 3, 0);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder14.draw(205, 100, 1_300_934_824, 2_060_449_158);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(7, 80, 5, 598_249_915, 59_528_881);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video1);
+video2.height = 35;
+let commandEncoder196 = device0.createCommandEncoder({});
+let renderPassEncoder39 = commandEncoder196.beginRenderPass({
+  label: '\u{1fcd8}\uf18e',
+  colorAttachments: [{view: textureView199, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder144.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup74, new Uint32Array(351), 2, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(87, 154, 1_658_886_073, 674_861_771);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer139, 468);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer89, 688);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer147, 1_980, 3_361);
+} catch {}
+let arrayBuffer23 = buffer109.getMappedRange();
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 8 max align: 8 */
+struct T0 {
+  @align(2) @size(8) f0: u32,
+}
+@group(0) @binding(414) var tex5: texture_1d<i32>;
+@group(0) @binding(381) var tex4: texture_depth_cube;
+@group(0) @binding(79) var st2: texture_storage_2d<rg32uint, read>;
+struct FragmentOutput12 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) @interpolate(flat, center) f1: vec4i,
+  @location(1) f2: vec4u,
+  @location(5) @interpolate(flat, center) f3: i32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  _ = textureLoad(st2, vec2i());
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup150 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 27, resource: {buffer: buffer129, offset: 0}},
+    {binding: 217, resource: {buffer: buffer59, offset: 0, size: 299}},
+    {binding: 176, resource: {buffer: buffer106, offset: 15360, size: 2520}},
+  ],
+});
+let sampler116 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.86,
+  lodMaxClamp: 74.42,
+  compare: 'less',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup137, []);
+} catch {}
+try {
+computePassEncoder107.setBindGroup(3, bindGroup23, new Uint32Array(5477), 154, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(83, 0, 11_155_164);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(34, 106, 13, 205_201_207, 1_370_591);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer120, 108);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer150, 2_412);
+} catch {}
+let bindGroup151 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 238, resource: sampler57},
+    {binding: 142, resource: textureView11},
+    {binding: 13, resource: textureView83},
+    {binding: 111, resource: textureView175},
+    {binding: 1, resource: textureView25},
+    {binding: 293, resource: textureView10},
+    {binding: 52, resource: {buffer: buffer42, offset: 1792, size: 794}},
+    {binding: 92, resource: textureView199},
+    {binding: 65, resource: {buffer: buffer54, offset: 2304, size: 3548}},
+  ],
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup93);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup126);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle29, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer72, 1_428);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer123, 648);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer7, 'uint32', 6_240, 912);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline12);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+canvas1.height = 117;
+let commandEncoder197 = device0.createCommandEncoder({});
+let renderPassEncoder40 = commandEncoder197.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 101,
+  clearValue: { r: 261.6, g: -540.8, b: 771.7, a: -750.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler117 = device0.createSampler({
+  label: '\ub164\u{1faf5}\u84d3\u9574\u1a6c\u6b04\u0b2d\u0c5b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.39,
+  lodMaxClamp: 89.23,
+});
+try {
+computePassEncoder113.setBindGroup(1, bindGroup63, new Uint32Array(2039), 893, 0);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle10, renderBundle10, renderBundle17, renderBundle18, renderBundle17, renderBundle10, renderBundle17, renderBundle13, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer104);
+} catch {}
+let bindGroup152 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 46, resource: {buffer: buffer109, offset: 0, size: 132}}],
+});
+let buffer152 = device0.createBuffer({
+  size: 12344,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView203 = texture35.createView({aspect: 'depth-only', baseArrayLayer: 3});
+try {
+computePassEncoder113.setBindGroup(1, bindGroup140);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup19, new Uint32Array(2224), 201, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(183, 106, 264_099_845, 1_393_877_776);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(35, 19, 15, 387_397_400, 1_194_222_047);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer80, 5_664);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer91, 516);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup132);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(30, 4, 187, 1_521_164, 184_875_656);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer150, 2_236);
+} catch {}
+let buffer153 = device0.createBuffer({size: 6490, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let textureView204 = texture213.createView({
+  label: '\u063c\u61a3\u{1fc9a}\u7f59\ua36a\u9058\u{1fabf}\u0a87\u{1f917}\u0298\u{1f885}',
+  baseArrayLayer: 7,
+  arrayLayerCount: 3,
+});
+let texture221 = device0.createTexture({
+  size: [8, 10, 88],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let texture222 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder83.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup138);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer46, 8);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer120, 320);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer63, 'uint32', 20, 23);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let buffer154 = device0.createBuffer({size: 10587, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder4.dispatchWorkgroups(1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer20, 1_068); };
+} catch {}
+try {
+renderPassEncoder37.setViewport(0.52461629023256, 1.0671559028721918, 0.9824042443888982, 0.6804376548545495, 0.7213612914672082, 0.9967298864478447);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder77.pushDebugGroup('\u9e28');
+} catch {}
+try {
+renderPassEncoder36.insertDebugMarker('\u0168');
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+document.body.prepend(canvas0);
+try {
+externalTexture16.label = '\u0704\u7f99\u{1fde0}\ua98f\u54b1\u{1f6f1}\u11b8\ua164';
+} catch {}
+let texture223 = device0.createTexture({
+  label: '\u40bd\u0174\u01db\u1ea8\u04d5',
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 4,
+  format: 'eac-rg11unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler118 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.06,
+  lodMaxClamp: 96.97,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup67);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer54, 680);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer138, 'uint16', 148, 441);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline2);
+} catch {}
+try {
+buffer151.unmap();
+} catch {}
+let buffer155 = device0.createBuffer({
+  label: '\u2bd4\ua408',
+  size: 2850,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder198 = device0.createCommandEncoder();
+let renderPassEncoder41 = commandEncoder198.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 3,
+  clearValue: { r: -422.0, g: 267.9, b: 903.5, a: -57.16, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup29, new Uint32Array(401), 42, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder14.draw(139, 11, 1_088_378_367, 303_180_759);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(38, 181, 200, 393_013_790, 878_336_175);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer46, 284);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer54, 11_180);
+} catch {}
+let imageData17 = new ImageData(80, 8);
+let commandEncoder199 = device0.createCommandEncoder({});
+let textureView205 = texture54.createView({aspect: 'depth-only', baseMipLevel: 0, arrayLayerCount: 1});
+let sampler119 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 13.05,
+  lodMaxClamp: 81.38,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup107, new Uint32Array(567), 4, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(61);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer153, 248);
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer81, 4916, buffer67, 4944, 80);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: videoFrame34,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 25},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer156 = device0.createBuffer({size: 2280, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT, mappedAtCreation: true});
+let textureView206 = texture24.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 9});
+let renderPassEncoder42 = commandEncoder199.beginRenderPass({
+  colorAttachments: [{
+  view: textureView121,
+  clearValue: { r: 984.7, g: 283.4, b: 556.8, a: 289.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView176,
+    depthClearValue: 2.046712831414405,
+    depthReadOnly: true,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 9247890,
+});
+let sampler120 = device0.createSampler({
+  label: '\ud827\u63c6',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.73,
+  lodMaxClamp: 89.73,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder14.draw(155, 223, 1_593_240_823, 4_294_967_295);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer93, 220);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(1, buffer50, 0);
+} catch {}
+document.body.prepend(img3);
+let imageData18 = new ImageData(40, 100);
+let commandEncoder200 = device0.createCommandEncoder({});
+let textureView207 = texture12.createView({label: '\u329b\u006d\u0a63\u875d\u7de4\u6c6d\uef5e\u{1f862}\u086b\u50aa'});
+let renderPassEncoder43 = commandEncoder200.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: 12.25, g: -558.5, b: -44.62, a: -909.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView140,
+    depthClearValue: -9.34058284898046,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 20183,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  maxDrawCount: 97333709,
+});
+try {
+computePassEncoder133.setBindGroup(1, bindGroup21, new Uint32Array(66), 6, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder63); computePassEncoder63.dispatchWorkgroupsIndirect(buffer82, 80); };
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+renderPassEncoder13.draw(257, 51, 691_659_474, 1_793_753_828);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(200, 142, 275, 40_027_622, 832_481_868);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup12, []);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(3, bindGroup143, new Uint32Array(3634), 351, 0);
+} catch {}
+try {
+renderPassEncoder40.setViewport(12.910578264638092, 18.429819478375652, 2.2634469477126173, 0.9160236294296394, 0.6433671233684705, 0.8588103176240278);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer124, 'uint32', 4_604, 529);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer79.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer101, 232, new BigUint64Array(1888), 429, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise30;
+} catch {}
+try {
+adapter0.label = '\u9d9a\u{1faa7}';
+} catch {}
+let buffer157 = device0.createBuffer({size: 19, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture224 = device0.createTexture({
+  label: '\u{1f94e}\u0ae1\u6c42\u04d6',
+  size: [2, 2, 16],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder121.setBindGroup(3, bindGroup96, new Uint32Array(1224), 31, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup70, new Uint32Array(241), 43, 0);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer54, 184);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, undefined);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 49}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 9 },
+  flipY: true,
+}, {
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let sampler121 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.76,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.draw(238, 56, 301_365_501, 1_022_024_349);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(22, 117, 33, 702_369_212, 917_408_720);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+querySet37.destroy();
+} catch {}
+let arrayBuffer24 = buffer122.getMappedRange(8);
+let img5 = await imageWithData(31, 126, '#10101010', '#20202020');
+let texture225 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroupsIndirect(buffer54, 1_932); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup114, new Uint32Array(3257), 238, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(12, 0, 15, 353_767_817);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer129, 4);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer102, 'uint32', 3_132, 3_061);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(474).fill(103), /* required buffer size: 474 */
+{offset: 474, bytesPerRow: 56}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise31;
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder({});
+let computePassEncoder147 = commandEncoder201.beginComputePass({});
+let sampler122 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 72.97,
+  lodMaxClamp: 72.98,
+  compare: 'greater',
+});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup4, new Uint32Array(1014), 197, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup149);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup102, new Uint32Array(2047), 302, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.draw(67, 586, 735_236_943, 567_805_035);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer155, 268);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(0, buffer101);
+} catch {}
+let videoFrame40 = new VideoFrame(videoFrame39, {timestamp: 0});
+let shaderModule19 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<f32>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: array<i32>,
+}
+/* target size: 4 max align: 4 */
+struct T2 {
+  f0: T0,
+}
+/* target size: 4 max align: 4 */
+struct T3 {
+  f0: array<atomic<u32>, 1>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer158: i32;
+struct VertexOutput14 {
+  @location(3) f46: vec2i,
+  @location(10) f47: i32,
+  @location(8) @interpolate(flat, center) f48: vec2i,
+  @location(1) f49: f32,
+  @location(15) f50: vec4i,
+  @builtin(position) f51: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput14 {
+  var out: VertexOutput14;
+  out.f51 /= vec4f(0.3749, 0.2258, 0.01976, 0.05369);
+  out.f47 = i32(3);
+  return out;
+}
+
+@fragment
+fn fragment0(@location(1) @interpolate(linear) a0: vec4f) -> @location(200) vec4u {
+  var out: vec4u;
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(local_invocation_id) a0: vec3u) {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({label: '\u2cc2\u9e0e', colorFormats: ['rgba16float'], depthReadOnly: true});
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(12, 276, 21, 29_290_138, 441_841_008);
+} catch {}
+let pipeline14 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule3, entryPoint: 'compute0'}});
+let bindGroup153 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView34}, {binding: 126, resource: textureView1}],
+});
+let textureView208 = texture140.createView({aspect: 'stencil-only', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder115); computePassEncoder115.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(26, 104, 29, 123_101_786, 57_703_647);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer74, 116);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer42, 'uint16', 2_272, 321);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup113);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer112, 'uint16', 1_318, 4_770);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer81, 1412, new BigUint64Array(4358), 1770, 48);
+} catch {}
+try {
+externalTexture8.label = '\u10d8\u0a9e\u733a\u{1faf5}\u4100\ua902\u1a8d';
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder({});
+let texture226 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder148 = commandEncoder202.beginComputePass();
+try {
+computePassEncoder140.setBindGroup(3, bindGroup100, new Uint32Array(425), 117, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(110, 164, 184_561_862, 386_629_870);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(23, 7, 45, 705_972_652, 595_050_836);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer156, 2_260);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer81, 'uint32', 4_316, 2_342);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup14, new Uint32Array(1106), 642, 0);
+} catch {}
+let bindGroup154 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView65}]});
+let commandEncoder203 = device0.createCommandEncoder();
+let textureView209 = texture150.createView({format: 'r8unorm'});
+let renderBundle32 = renderBundleEncoder32.finish({});
+let sampler123 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.26,
+  lodMaxClamp: 98.24,
+});
+try {
+computePassEncoder137.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(25, 0, 14, 106_164_993);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer55, 'uint16', 618, 1_365);
+} catch {}
+let imageData19 = new ImageData(52, 40);
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt2020', transfer: 'log'} });
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 1361});
+try {
+renderPassEncoder12.drawIndexed(18, 211, 19, -1_904_703_542, 42_204_652);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer106, 3_848);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder203.copyBufferToBuffer(buffer65, 172, buffer140, 13956, 632);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 100, new DataView(new ArrayBuffer(24928)), 2528, 600);
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+let commandEncoder204 = device0.createCommandEncoder();
+let textureView210 = texture59.createView({dimension: '2d-array', arrayLayerCount: 1});
+let textureView211 = texture8.createView({label: '\u7ff6\uc63e', dimension: 'cube-array', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder149 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder109.setBindGroup(3, bindGroup154, new Uint32Array(503), 60, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer42, 416);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let commandEncoder205 = device0.createCommandEncoder();
+let texture227 = device0.createTexture({
+  label: '\u0428\u09be\u{1f9b3}\u7f64',
+  size: [2, 2, 5],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder44 = commandEncoder205.beginRenderPass({colorAttachments: [{view: textureView177, depthSlice: 30, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle15, renderBundle19, renderBundle24, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder14.draw(100, 79, 177_655_471, 158_741_492);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder203.copyBufferToBuffer(buffer27, 2300, buffer69, 1148, 2660);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline14);
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(652_125_392, 615, 1_426_945_110, 875_471_612);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(30, 53, 51, 76_108_461, 885_057_320);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer140, 4_620);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer10, 44);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer139, 'uint32', 2_276, 2_778);
+} catch {}
+try {
+commandEncoder203.copyBufferToTexture({
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 16 */
+  offset: 16,
+  buffer: buffer59,
+}, {
+  texture: texture182,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture169,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(5_620).fill(115), /* required buffer size: 5_620 */
+{offset: 260, bytesPerRow: 16, rowsPerImage: 67}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 15 },
+  flipY: false,
+}, {
+  texture: texture195,
+  mipLevel: 0,
+  origin: {x: 4, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup92, new Uint32Array(189), 9, 0);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(22, 0, 11, 55_384_924);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer120, 292);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4_294_967_295, undefined, 1_437_843_131, 438_757_222);
+} catch {}
+try {
+buffer135.unmap();
+} catch {}
+try {
+computePassEncoder132.pushDebugGroup('\uac07');
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup155 = device0.createBindGroup({
+  label: '\u{1f9ee}\u085b\u036a\u{1fc4a}\u44ed\u47ec\u68ba\ufc7c\u{1fce7}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 87, resource: {buffer: buffer91, offset: 0, size: 2328}}],
+});
+let commandEncoder206 = device0.createCommandEncoder();
+let texture228 = device0.createTexture({
+  size: [16, 20, 53],
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView212 = texture17.createView({arrayLayerCount: 1});
+let computePassEncoder150 = commandEncoder206.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup92, new Uint32Array(238), 31, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle29, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder13.draw(121, 55, 351_603_274, 1_092_526_369);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(37, 416, 40, -909_258_306, 445_731_135);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer20, 48);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer93, 724);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline12);
+} catch {}
+try {
+computePassEncoder77.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder33.insertDebugMarker('\u5cf3');
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 511, resource: textureView58}, {binding: 57, resource: externalTexture8}],
+});
+let buffer159 = device0.createBuffer({size: 1573, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder207 = device0.createCommandEncoder();
+try {
+computePassEncoder150.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup37, new Uint32Array(1803), 700, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(219, 1, 319_807_461, 1_163_507_075);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(7, 0, 7, 89_891_354);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer129, 224);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer57, 'uint32', 1_320, 559);
+} catch {}
+try {
+commandEncoder207.copyBufferToBuffer(buffer130, 968, buffer159, 0, 836);
+} catch {}
+try {
+commandEncoder207.copyTextureToBuffer({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 3},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 392 */
+  offset: 392,
+  buffer: buffer3,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder203.resolveQuerySet(querySet19, 29, 2, buffer88, 256);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'stencil-only',
+}, new Uint8Array(566).fill(211), /* required buffer size: 566 */
+{offset: 566, bytesPerRow: 268, rowsPerImage: 259}, {width: 256, height: 256, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 838,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {binding: 45, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 999, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 13,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture229 = device0.createTexture({
+  label: '\u6c1d\u5e70\u{1fd06}\u057e\u4371\u240b\u0c2e\u0e8e',
+  size: [4],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture230 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView213 = texture15.createView({dimension: '2d', aspect: 'depth-only'});
+let renderPassEncoder45 = commandEncoder203.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: -213.4, g: 187.3, b: -114.3, a: -600.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 2.615,
+  lodMaxClamp: 33.91,
+  compare: 'equal',
+});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup142);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.draw(142, 8, 768_232_918, 13_159_573);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer149, 14_628);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer151, 4, new BigUint64Array(12461), 1286, 0);
+} catch {}
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'hlg'} });
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 401,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder208 = device0.createCommandEncoder({});
+let texture231 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture232 = device0.createTexture({
+  size: [4, 5, 46],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder151 = commandEncoder207.beginComputePass({});
+let renderPassEncoder46 = commandEncoder208.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: 985.3, g: 882.3, b: 727.1, a: -749.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 286863270,
+});
+let sampler125 = device0.createSampler({
+  label: '\u05f5\u{1fb74}\uf2db\u998a\u{1ff69}\u{1f7ab}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.440,
+  lodMaxClamp: 48.59,
+});
+try {
+computePassEncoder147.setBindGroup(1, bindGroup77, new Uint32Array(643), 5, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(252, 100, 1_143_142_022, 517_625_381);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer119, 'uint32', 180, 142);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(2, buffer37);
+} catch {}
+let commandEncoder209 = device0.createCommandEncoder({});
+let textureView214 = texture231.createView({label: '\u{1f957}\u{1fd83}\u8b8e\u{1fdc6}\u{1fde6}', format: 'rgba32uint'});
+let textureView215 = texture40.createView({label: '\ued2a\u26df\udc82\u3aa0\u45fa\u0c5f\u0482', aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder152 = commandEncoder209.beginComputePass({});
+let sampler126 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.910,
+  lodMaxClamp: 27.29,
+});
+try {
+computePassEncoder151.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup75, new Uint32Array(175), 20, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(25, 427, 165_798_512, 1_550_286_121);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(10, 80, 15, -1_982_291_589, 737_281_037);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer91, 268);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer141, 'uint32', 208, 484);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 5},
+  aspect: 'all',
+}, new Uint8Array(93_352).fill(108), /* required buffer size: 93_352 */
+{offset: 73, bytesPerRow: 51, rowsPerImage: 59}, {width: 0, height: 0, depthOrArrayLayers: 32});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 62 },
+  flipY: false,
+}, {
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup157 = device0.createBindGroup({
+  label: '\u056e\u0401\u17ad\ua46a\u{1feec}\u{1fc68}\u{1fc87}',
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 13, resource: textureView58},
+    {binding: 838, resource: textureView90},
+    {binding: 45, resource: sampler116},
+    {binding: 59, resource: textureView214},
+    {binding: 999, resource: sampler46},
+  ],
+});
+let buffer160 = device0.createBuffer({
+  size: 21117,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture233 = device0.createTexture({
+  size: [2, 2, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder152.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup93, new Uint32Array(3722), 863, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer134, 376);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer151, 'uint32', 16, 31);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer139, 20);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas3);
+await gc();
+let bindGroup158 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 173, resource: textureView30}]});
+let querySet40 = device0.createQuerySet({type: 'occlusion', count: 370});
+let texture234 = device0.createTexture({size: [4, 5, 1], mipLevelCount: 1, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder138.setBindGroup(2, bindGroup16, new Uint32Array(53), 15, 0);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer82, 420);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline12);
+} catch {}
+let bindGroup159 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 30, resource: {buffer: buffer79, offset: 0}}]});
+let commandEncoder210 = device0.createCommandEncoder({});
+let computePassEncoder153 = commandEncoder210.beginComputePass({});
+let sampler127 = device0.createSampler({
+  label: '\u6195\uef05\u{1fe8d}\u03d5\u{1fbdf}',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.60,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder123.setBindGroup(1, bindGroup65, new Uint32Array(4250), 430, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer106, 1_548);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer108, 'uint16', 1_108, 743);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 423});
+try {
+computePassEncoder95.setBindGroup(3, bindGroup136);
+} catch {}
+try {
+computePassEncoder83.setBindGroup(2, bindGroup116, new Uint32Array(2734), 571, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(27, 187, 821_306_459, 1_084_083_614);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 45, 26, 98_398_306, 1_280_825_036);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer119, 'uint32', 464, 142);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  label: '\u0edc\u71f8\u169b\u0e24\ua0ea\u3ee5\u{1fc38}\ua787',
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer126, offset: 2560, size: 542}}],
+});
+try {
+computePassEncoder134.end();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup154);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup43, new Uint32Array(347), 61, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 107, 5, -2_119_309_251, 608_853_508);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer44, 1_856);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer37, 'uint32', 588, 4);
+} catch {}
+try {
+commandEncoder180.copyBufferToBuffer(buffer55, 2576, buffer108, 140, 568);
+} catch {}
+try {
+computePassEncoder132.popDebugGroup();
+} catch {}
+let buffer161 = device0.createBuffer({
+  size: 25135,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let textureView216 = texture184.createView({dimension: 'cube', baseArrayLayer: 13, arrayLayerCount: 6});
+let texture235 = gpuCanvasContext4.getCurrentTexture();
+let textureView217 = texture101.createView({label: '\u89a3\uc6cc\u012f', dimension: '2d-array'});
+let renderPassEncoder47 = commandEncoder211.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 155,
+  clearValue: { r: -770.2, g: 39.95, b: -903.2, a: -201.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler128 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 65.15});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(25, 330, 3, 73_611_656, 228_456_779);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer89, 8);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer81, 'uint16', 808, 1_400);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(6, buffer57, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder180.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1920 */
+  offset: 1920,
+  buffer: buffer134,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder180.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+let textureView218 = texture159.createView({aspect: 'depth-only', baseMipLevel: 0});
+let computePassEncoder154 = commandEncoder180.beginComputePass({});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u04d9\u0d6b',
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder154.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder12.draw(291, 266, 2_608_054_859, 137_850_508);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer93, 1_300);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer3, 'uint32', 108, 203);
+} catch {}
+let bindGroup161 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 87, resource: {buffer: buffer54, offset: 4352, size: 704}}],
+});
+let commandEncoder212 = device0.createCommandEncoder({});
+let textureView219 = texture158.createView({baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder155 = commandEncoder212.beginComputePass({});
+try {
+computePassEncoder116.setBindGroup(0, bindGroup5, new Uint32Array(897), 135, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup134);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup106, new Uint32Array(612), 66, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer20, 300);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer103, 560, 439);
+} catch {}
+try {
+  await promise33;
+} catch {}
+let buffer162 = device0.createBuffer({size: 11010, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder213 = device0.createCommandEncoder({});
+let computePassEncoder156 = commandEncoder213.beginComputePass({label: '\ub488\ue832\u1e8d\u36b2\u087d\ud79e\u{1f75c}\u8c86\u6da4\u0f54'});
+let sampler129 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.32,
+  lodMaxClamp: 47.02,
+});
+try {
+computePassEncoder156.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup76);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup106, new Uint32Array(867), 38, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(1, 6, 19, 20_013_030, 1_265_649_837);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer86, 'uint16', 3_630, 99);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer90, 0, 5_427);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup162 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 267, resource: textureView34}, {binding: 126, resource: textureView1}],
+});
+let commandEncoder214 = device0.createCommandEncoder();
+let textureView220 = texture31.createView({dimension: '2d', aspect: 'stencil-only'});
+try {
+computePassEncoder153.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle5, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder14.draw(97, 176, 1_315_717_603, 179_885_232);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(9, 26, 15, 108_494_492, 927_184_108);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(0, buffer27, 1_316, 236);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup106, new Uint32Array(803), 222, 0);
+} catch {}
+try {
+commandEncoder214.copyBufferToBuffer(buffer104, 76, buffer25, 3736, 8912);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u{1f6ca}');
+} catch {}
+let imageData20 = new ImageData(12, 36);
+let textureView221 = texture93.createView({label: '\u46bf\u612a\u{1f680}'});
+let computePassEncoder157 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(2, bindGroup65, new Uint32Array(2161), 16, 0);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(364);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer90);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup84, new Uint32Array(684), 27, 0);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer34, 'uint32', 660, 72);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let video5 = await videoWithData(105);
+let bindGroup163 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 4, resource: {buffer: buffer147, offset: 14592, size: 4424}},
+    {binding: 9, resource: {buffer: buffer52, offset: 0, size: 161}},
+  ],
+});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder13.draw(54, 112, 323_532_861, 427_903_964);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer161, 672);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer14, 'uint32', 892, 421);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer145);
+} catch {}
+document.body.append(video0);
+let bindGroupLayout28 = pipeline14.getBindGroupLayout(0);
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer88, 768); };
+} catch {}
+try {
+renderPassEncoder12.draw(142, 267, 1_401_990_889, 2_572_388_729);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(13, 256, 3, 595_899_436, 342_942_135);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup149, new Uint32Array(379), 23, 0);
+} catch {}
+try {
+  await promise34;
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 951,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 163,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 403,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 150,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 207,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 313,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 193,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 166,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 498,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 132,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup164 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 201, resource: textureView44}]});
+let buffer163 = device0.createBuffer({
+  size: 1080,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture236 = device0.createTexture({
+  size: [16, 20, 1],
+  mipLevelCount: 1,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle33 = renderBundleEncoder33.finish();
+let sampler130 = device0.createSampler({
+  label: '\u081c\u31e0\ubbbd\u0559\u0958\u0aef\u{1f7d1}\u5f3b\uc384\u0b14',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.89,
+});
+try {
+computePassEncoder157.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup61, new Uint32Array(330), 37, 0);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(14, 389, 63, 1_363_640_219, 1_133_188_054);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer140, 4_368);
+} catch {}
+try {
+buffer154.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+let bindGroup165 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 103, resource: textureView75}]});
+let pipelineLayout17 = device0.createPipelineLayout({label: '\u{1fd25}\u2f5e\u{1ff31}\u449d\ubf78\u04f6\u0716\u{1fe2d}\u{1fb26}', bindGroupLayouts: []});
+let buffer164 = device0.createBuffer({size: 3187, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder215 = device0.createCommandEncoder();
+let texture237 = device0.createTexture({
+  label: '\u4ad3\u{1f74a}\u6dda',
+  size: [4],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float']});
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup65, new Uint32Array(7466), 427, 0);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(379);
+} catch {}
+try {
+renderPassEncoder12.draw(3, 62, 772_668_827, 803_015_155);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer74, 0);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(6, buffer91);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let buffer165 = device0.createBuffer({
+  size: 6818,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder216 = device0.createCommandEncoder({});
+let texture238 = device0.createTexture({
+  size: [4, 5, 1],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture239 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder158 = commandEncoder216.beginComputePass({});
+let renderPassEncoder48 = commandEncoder215.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: 740.6, g: -52.13, b: -788.5, a: -440.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+let renderBundle34 = renderBundleEncoder34.finish({});
+let sampler131 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 4.627,
+  lodMaxClamp: 31.03,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup148);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(4, 174, 190, 860_917_928, 560_375_204);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer156, 496);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer61, 'uint16', 13_862, 2_146);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer40, 768);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup166 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 33, resource: {buffer: buffer89, offset: 1792}}]});
+let commandEncoder217 = device0.createCommandEncoder({});
+let texture240 = device0.createTexture({
+  size: [16, 20, 177],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder159 = commandEncoder217.beginComputePass({});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer133, 3_712); };
+} catch {}
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup96);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer88, 576);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer46, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer86, 'uint32', 600, 1_228);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer89, 200);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup13, new Uint32Array(754), 33, 0);
+} catch {}
+document.body.append(video5);
+let imageData21 = new ImageData(20, 12);
+let textureView222 = texture236.createView({dimension: '2d-array'});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup0, new Uint32Array(2144), 193, 0);
+} catch {}
+try {
+computePassEncoder127.end();
+} catch {}
+try {
+renderPassEncoder9.draw(638_399_643, 25, 368_987_159, 170_434_725);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer152, 'uint32', 7_952, 402);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup144);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer155, 'uint32', 88, 16);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline2);
+} catch {}
+document.body.prepend(img2);
+let commandEncoder218 = device0.createCommandEncoder();
+let texture241 = device0.createTexture({
+  size: [8, 10, 12],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView223 = texture9.createView({aspect: 'all', arrayLayerCount: 1});
+let renderPassEncoder49 = commandEncoder171.beginRenderPass({
+  colorAttachments: [{
+  view: textureView219,
+  clearValue: { r: 173.8, g: -379.9, b: 980.8, a: 257.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer120, 420); };
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup6, new Uint32Array(119), 1, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer139, 160);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer113, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer141, 'uint32', 200, 288);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView224 = texture241.createView({
+  label: '\u002a\u{1f8ab}\u0dc8\u0db3\u0f72\u{1ff1b}\u0f81\ufad9\uac06\ubfca',
+  baseMipLevel: 0,
+  baseArrayLayer: 3,
+  arrayLayerCount: 2,
+});
+let texture242 = device0.createTexture({size: [256, 256, 325], dimension: '3d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView225 = texture111.createView({});
+let computePassEncoder160 = commandEncoder98.beginComputePass({label: '\u{1f8d3}\u{1fec3}\u07ef\u4970\ua9bd\uc05c\u{1f88b}\u7257\u6054\u43c9'});
+let renderPassEncoder50 = commandEncoder218.beginRenderPass({
+  colorAttachments: [{
+  view: textureView145,
+  depthSlice: 155,
+  clearValue: { r: -211.4, g: -603.0, b: 87.93, a: 530.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+});
+let renderBundle35 = renderBundleEncoder35.finish({});
+let externalTexture20 = device0.importExternalTexture({label: '\u1162\u0cdc\uc734\u0fd9\ueaf3', source: videoFrame11});
+try {
+computePassEncoder160.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(229, 268, 3, 199_506_335, 501_306_859);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer87, 784);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(4_294_967_295, undefined, 0, 89_072_409);
+} catch {}
+try {
+buffer136.unmap();
+} catch {}
+let buffer166 = device0.createBuffer({size: 5318, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder219 = device0.createCommandEncoder();
+let texture243 = device0.createTexture({
+  size: [256, 256, 6],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture244 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView226 = texture149.createView({dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 7});
+let computePassEncoder161 = commandEncoder219.beginComputePass();
+try {
+computePassEncoder102.setBindGroup(0, bindGroup3, new Uint32Array(1572), 470, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup30, new Uint32Array(1399), 399, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(10, 4, 761_676_707, 5_329_942);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView227 = texture238.createView({dimension: '2d-array'});
+let texture245 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder74.dispatchWorkgroups(1, 3);
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderPassEncoder10.draw(189, 391, 12_597_446, 1_736_202_104);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(8, 195, 14, -1_918_636_306, 802_572_009);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer46, 56);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer83, 508);
+} catch {}
+let commandEncoder220 = device0.createCommandEncoder({label: '\u{1f7a6}\u2c9c\u{1fa93}\u0a5c\u7170\u0075\u03f6\ufda9\u2dc7\uddde\u9f50'});
+let texture246 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 44},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture247 = gpuCanvasContext2.getCurrentTexture();
+let renderPassEncoder51 = commandEncoder220.beginRenderPass({
+  colorAttachments: [{
+  view: textureView219,
+  clearValue: { r: -327.9, g: -881.6, b: 395.7, a: -947.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 52085336,
+});
+let sampler132 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 41.43,
+  lodMaxClamp: 70.47,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder17.beginOcclusionQuery(35);
+} catch {}
+try {
+renderPassEncoder50.setScissorRect(0, 2, 0, 4);
+} catch {}
+try {
+renderPassEncoder9.draw(661_327_976, 107, 1_342_441_641, 491_135_174);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer82, 8);
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt2020', transfer: 'log'} });
+let buffer167 = device0.createBuffer({
+  size: 18822,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder221 = device0.createCommandEncoder({});
+let textureView228 = texture237.createView({dimension: '1d', aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder162 = commandEncoder221.beginComputePass({label: '\u0898\u3a7d\ud782\u{1ff58}\u6f57\u8a11\ud9f0'});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup101);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer50, 0, 434);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture246,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(8_549).fill(59), /* required buffer size: 8_549 */
+{offset: 349, bytesPerRow: 50, rowsPerImage: 41}, {width: 0, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 576,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 284,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture248 = device0.createTexture({
+  label: '\uf505\ub4cb\u07ac',
+  size: {width: 2, height: 2, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView229 = texture243.createView({mipLevelCount: 1});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 3576, new DataView(new ArrayBuffer(8962)), 508, 5696);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(167).fill(92), /* required buffer size: 167 */
+{offset: 167}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], stencilReadOnly: true});
+let sampler133 = device0.createSampler({
+  label: '\u01ab\ue3f6\u0edf\u0b50\u0939',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.56,
+  lodMaxClamp: 65.28,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup66);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 298, 0, -1_239_955_575, 259_357_837);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer82, 20);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer163, 'uint16', 94, 56);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer65, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame31,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let buffer168 = device0.createBuffer({
+  size: 2375,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder96.setBindGroup(3, bindGroup155);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup162);
+} catch {}
+try {
+renderPassEncoder9.draw(578_169_888, 88, 807_016_261, 1_087_882_925);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(30, 221, 9, 85_892_523, 961_800_471);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer86, 2_500);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer63, 'uint16', 20, 21);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: video3,
+  origin: { x: 7, y: 2 },
+  flipY: false,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let imageData22 = new ImageData(56, 32);
+let bindGroup167 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [{binding: 30, resource: {buffer: buffer28, offset: 0, size: 828}}],
+});
+let commandEncoder222 = device0.createCommandEncoder({});
+let texture249 = device0.createTexture({
+  label: '\u0840\u{1fe46}\u46c6',
+  size: [4],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView230 = texture46.createView({});
+let renderPassEncoder52 = commandEncoder222.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 26,
+  clearValue: { r: 495.3, g: -223.3, b: -357.7, a: -817.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 294415456,
+});
+let renderBundle36 = renderBundleEncoder36.finish();
+let externalTexture21 = device0.importExternalTexture({source: video0});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup142, new Uint32Array(1324), 43, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer50, 2_844);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder223 = device0.createCommandEncoder();
+let computePassEncoder163 = commandEncoder223.beginComputePass({});
+try {
+renderPassEncoder12.drawIndexed(60, 14, 45, 24_190_982, 572_393_688);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer156, 192);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer45, 7_080);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline12);
+} catch {}
+try {
+buffer130.unmap();
+} catch {}
+try {
+adapter0.label = '\u{1ff89}\u0636\u6898\u0cea\ub916\u04fe\u0c4d\u4028';
+} catch {}
+let bindGroup168 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 103, resource: textureView79}]});
+let buffer169 = device0.createBuffer({
+  size: 790,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder224 = device0.createCommandEncoder();
+let textureView231 = texture236.createView({dimension: '2d-array'});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], depthReadOnly: true});
+let sampler134 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.53,
+  lodMaxClamp: 28.20,
+  compare: 'less',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(2, bindGroup43, new Uint32Array(1014), 249, 0);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup80);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer110, 'uint32', 2_532, 5_738);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(0, buffer147);
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'film', transfer: 'hlg'} });
+let texture250 = device0.createTexture({
+  size: [16, 20, 1],
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler135 = device0.createSampler({
+  label: '\u5211\ua537\u29b1\u044e\u3135\u038a\u5302\u9bf6\u{1ffdb}\u0a33\u0513',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.47,
+  lodMaxClamp: 89.55,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup75, []);
+} catch {}
+try {
+renderPassEncoder9.draw(1_350_577_059, 12, 487_588_755, 748_364_520);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer27, 1_844);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(7, buffer3);
+} catch {}
+try {
+renderBundleEncoder37.insertDebugMarker('\ufa81');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame26,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer170 = device0.createBuffer({size: 39032, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let commandEncoder225 = device0.createCommandEncoder({});
+let texture251 = device0.createTexture({size: [4, 5, 1], mipLevelCount: 2, format: 'depth32float-stencil8', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder164 = commandEncoder224.beginComputePass({});
+let renderBundle37 = renderBundleEncoder37.finish({label: '\ucb3f\u1924\ufe72\u{1f6b6}\u39ea\u0456\ub57b\u59c2'});
+let sampler136 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 91.24,
+  lodMaxClamp: 99.14,
+});
+try {
+computePassEncoder164.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(55, 354, 11, 121_845_982, 2_945_762_561);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer54, 5_676);
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder({});
+let computePassEncoder165 = commandEncoder225.beginComputePass({});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup12, new Uint32Array(3546), 702, 0);
+} catch {}
+try {
+computePassEncoder165.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle19, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder13.draw(438, 23, 176_909_467, 1_584_481_337);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(0, 6, 0, 132_207_905, 1_945_832_150);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer134, 408);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer88, 'uint32', 648, 123);
+} catch {}
+try {
+commandEncoder226.copyTextureToBuffer({
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 412 */
+  offset: 412,
+  buffer: buffer18,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder226.insertDebugMarker('\u9d63');
+} catch {}
+let imageData23 = new ImageData(72, 48);
+let texture252 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 4},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder166 = commandEncoder226.beginComputePass({label: '\u{1f76c}\u{1fbf8}\u0c0c\u0156\u0cf8\u00ce\u001c\u8660\u0567'});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup63, new Uint32Array(2454), 353, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroupsIndirect(buffer44, 3_680); };
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(6, 79, 4, 221_569_065, 1_952_304_257);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer34, 'uint16', 3_190, 1_527);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+adapter0.label = '\u0dc8\u7052\uc14e';
+} catch {}
+let querySet42 = device0.createQuerySet({label: '\ued82\u{1fc22}\u0214\u07b8\u{1f6a2}\u0802\u7339\u7c31\udea8', type: 'occlusion', count: 210});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup96, new Uint32Array(193), 13, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup110, new Uint32Array(42), 4, 0);
+} catch {}
+try {
+renderPassEncoder48.setViewport(1.2228223364268063, 0.9764137276502667, 0.04096336147066963, 0.16957830151610634, 0.2736099388980022, 0.9216385066631283);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(158, 161, 51, 11_901_030, 407_861_768);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer46, 208);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(1, buffer123, 2_520, 999);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup169 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 173, resource: textureView19}]});
+let buffer171 = device0.createBuffer({
+  label: '\u0254\u0b81',
+  size: 251,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder227 = device0.createCommandEncoder();
+let textureView232 = texture166.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder96); computePassEncoder96.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(5, 219, 4, 353_227_469, 222_169_379);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer123, 1_360);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer139, 'uint32', 528, 461);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(2, buffer79);
+} catch {}
+try {
+buffer159.unmap();
+} catch {}
+try {
+commandEncoder227.clearBuffer(buffer31);
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder228 = device0.createCommandEncoder({});
+let computePassEncoder167 = commandEncoder228.beginComputePass({});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(1, bindGroup101, new Uint32Array(467), 34, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer28, 424); };
+} catch {}
+try {
+renderPassEncoder12.draw(33, 26, 227_964_927, 2_811_351_045);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(17, 430, 10, -1_531_136_140, 1_024_192_421);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer112, 'uint32', 4_540, 2_513);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline5);
+} catch {}
+let textureView233 = texture158.createView({baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder168 = commandEncoder227.beginComputePass({});
+let sampler137 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.53,
+  lodMaxClamp: 32.74,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder33.setBlendConstant({ r: 491.3, g: -428.3, b: -351.6, a: 611.5, });
+} catch {}
+try {
+renderPassEncoder31.setViewport(4.758927710139309, 1.4545276783177141, 1.1066755796863377, 9.901581124441792, 0.6816108047100703, 0.9590941448275696);
+} catch {}
+try {
+renderPassEncoder11.draw(86, 75, 150_325_625, 987_278_828);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer22, 2_484);
+} catch {}
+try {
+buffer93.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.prepend(video1);
+let commandEncoder229 = device0.createCommandEncoder();
+let computePassEncoder169 = commandEncoder229.beginComputePass({label: '\u{1f91f}\ud218\u0baa\ua81a\u12c3'});
+try {
+computePassEncoder161.setBindGroup(3, bindGroup79, new Uint32Array(2222), 170, 0);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup153, new Uint32Array(13), 6, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(290, 59, 175, -1, 1_171_757_929);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer106, 5_108);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer80, 'uint32', 1_900, 361);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline11);
+} catch {}
+try {
+  await buffer32.mapAsync(GPUMapMode.READ, 0, 224);
+} catch {}
+let texture253 = device0.createTexture({
+  size: [16, 20, 177],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler138 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.38,
+  lodMaxClamp: 60.34,
+  maxAnisotropy: 16,
+});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder135.setBindGroup(0, bindGroup62, new Uint32Array(2503), 289, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(14, 234, 24, -1_755_599_363, 163_946_236);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer22, 1_368);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer155, 'uint32', 304, 239);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup170 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 277, resource: {buffer: buffer0, offset: 256, size: 1104}},
+    {binding: 652, resource: textureView12},
+  ],
+});
+let commandEncoder230 = device0.createCommandEncoder({});
+let texture254 = device0.createTexture({
+  label: '\u{1ff2e}\u{1fd92}\u{1f7a7}\u0686\u{1fe1d}\u0b1a',
+  size: [16, 20, 87],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView234 = texture27.createView({});
+let computePassEncoder170 = commandEncoder230.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup46, new Uint32Array(269), 25, 0);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: 332.2, g: 788.6, b: -120.9, a: 191.0, });
+} catch {}
+try {
+renderPassEncoder9.draw(153_045_034, 76, 886_818_238, 2_992_925_568);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer46, 76);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer124, 'uint32', 80, 757);
+} catch {}
+let promise35 = device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule4, constants: {}}});
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup100, new Uint32Array(1096), 310, 0);
+} catch {}
+try {
+renderPassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder48.setViewport(1.7634608562417713, 0.14379590105785045, 0.21208297733078288, 0.618553706543265, 0.9158939307622841, 0.9235830034443158);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let promise36 = shaderModule9.getCompilationInfo();
+let arrayBuffer25 = buffer40.getMappedRange(1512);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise36;
+} catch {}
+offscreenCanvas0.width = 161;
+let commandEncoder231 = device0.createCommandEncoder({});
+let textureView235 = texture37.createView({
+  label: '\uee2f\u{1fb97}\ud11a\u0913\uaac8\u{1f9c5}\ub727\u09c3\u0256',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+});
+let sampler139 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 26.89,
+  lodMaxClamp: 35.13,
+});
+try {
+computePassEncoder79.setBindGroup(2, bindGroup115, []);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup96, new Uint32Array(1082), 273, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(15, 3, 588_692_819, 525_502_219);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer134, 928);
+} catch {}
+try {
+commandEncoder231.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 31989 */
+  offset: 1269,
+  bytesPerRow: 768,
+  rowsPerImage: 8,
+  buffer: buffer121,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 7},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(138).fill(173), /* required buffer size: 138 */
+{offset: 138}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder232 = device0.createCommandEncoder({});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup31, new Uint32Array(999), 223, 0);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(58);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer93, 276);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let arrayBuffer26 = buffer102.getMappedRange(2632, 4668);
+try {
+commandEncoder231.copyBufferToBuffer(buffer54, 808, buffer91, 160, 328);
+} catch {}
+let commandBuffer14 = commandEncoder231.finish({});
+let computePassEncoder171 = commandEncoder232.beginComputePass({});
+try {
+computePassEncoder87.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(0, bindGroup3, new Uint32Array(907), 237, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(1, 260, 0, 259_716_981, 118_932_944);
+} catch {}
+let arrayBuffer27 = buffer110.getMappedRange(1920, 6504);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let bindGroup171 = device0.createBindGroup({
+  label: '\u3c5e\u{1ffab}\u00db\ub20d\u251d',
+  layout: bindGroupLayout24,
+  entries: [{binding: 57, resource: externalTexture6}, {binding: 511, resource: textureView153}],
+});
+let commandEncoder233 = device0.createCommandEncoder({});
+let textureView236 = texture214.createView({baseArrayLayer: 4, arrayLayerCount: 4});
+let computePassEncoder172 = commandEncoder233.beginComputePass();
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(5, 1, 0, 2);
+} catch {}
+try {
+renderPassEncoder10.draw(211, 6, 206_569_032, 2_672_416_162);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(12, 135, 2, 560_727_643, 994_343_254);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer73, 'uint32', 272, 368);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup172 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [{binding: 30, resource: {buffer: buffer121, offset: 8704, size: 5700}}],
+});
+let textureView237 = texture243.createView({});
+let texture255 = device0.createTexture({size: [2, 2, 8], format: 'depth32float-stencil8', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder87.setPipeline(pipeline14);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle7, renderBundle24, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer57, 3_444);
+} catch {}
+let buffer172 = device0.createBuffer({size: 4158, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder234 = device0.createCommandEncoder({});
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 2616});
+let computePassEncoder173 = commandEncoder234.beginComputePass({});
+try {
+computePassEncoder92.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.draw(15, 8, 1_470_131_727, 114_697_690);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer155, 8);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer82, 64);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let videoFrame45 = new VideoFrame(img0, {timestamp: 0});
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer173 = device0.createBuffer({size: 14461, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder235 = device0.createCommandEncoder({label: '\u0e2d\u1d4e\u4280\u01b9\u2c20\u4868'});
+let texture256 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView238 = texture24.createView({dimension: 'cube', mipLevelCount: 1});
+let computePassEncoder174 = commandEncoder235.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup72, new Uint32Array(2046), 147, 0);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer72, 32);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 43, z: 31},
+  aspect: 'all',
+}, new Uint8Array(124_175).fill(121), /* required buffer size: 124_175 */
+{offset: 257, bytesPerRow: 310, rowsPerImage: 25}, {width: 57, height: 25, depthOrArrayLayers: 16});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: imageData21,
+  origin: { x: 2, y: 3 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(img0);
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup136);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(271);
+} catch {}
+try {
+computePassEncoder103.pushDebugGroup('\u06d4');
+} catch {}
+let bindGroup173 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 33, resource: sampler72}, {binding: 63, resource: textureView25}],
+});
+let externalTexture23 = device0.importExternalTexture({source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder122.setBindGroup(1, bindGroup125, new Uint32Array(1555), 178, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup136);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer139);
+} catch {}
+let textureView239 = texture238.createView({dimension: '2d-array', baseArrayLayer: 0, arrayLayerCount: 1});
+let textureView240 = texture57.createView({});
+let sampler140 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.75,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder172.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer168, 84);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let buffer174 = device0.createBuffer({size: 5283, usage: GPUBufferUsage.VERTEX});
+try {
+computePassEncoder106.setBindGroup(2, bindGroup7, new Uint32Array(2758), 369, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup57, []);
+} catch {}
+try {
+renderPassEncoder12.draw(163, 298, 993_019_602, 33_996_701);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer79, 0);
+} catch {}
+let arrayBuffer28 = buffer42.getMappedRange(2568, 176);
+let imageData24 = new ImageData(60, 48);
+let bindGroup174 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 285, resource: {buffer: buffer91, offset: 256, size: 804}}],
+});
+let buffer175 = device0.createBuffer({size: 2474, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView241 = texture1.createView({label: '\u0426\u047a', dimension: '2d-array', baseArrayLayer: 0});
+let texture257 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder54.setBindGroup(3, bindGroup112, []);
+} catch {}
+try {
+computePassEncoder60.setBindGroup(0, bindGroup7, new Uint32Array(218), 35, 0);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup165);
+} catch {}
+try {
+renderPassEncoder10.draw(1_000, 357, 328_641_155, 1_589_475_775);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 4_200);
+} catch {}
+try {
+buffer92.unmap();
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<u32, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @align(1) f0: atomic<i32>,
+}
+/* target size: 4 max align: 4 */
+struct T2 {
+  @align(1) f0: vec2h,
+}
+@group(0) @binding(285) var<storage, read_write> buffer176: T2;
+struct S10 {
+  @location(13) f0: vec4i
+}
+struct VertexOutput15 {
+  @location(8) f52: vec4h,
+  @location(13) @interpolate(flat, sample) f53: vec4u,
+  @location(3) f54: vec3f,
+  @location(12) f55: vec2h,
+  @location(11) @interpolate(flat, center) f56: vec4i,
+  @builtin(position) f57: vec4f
+}
+
+@vertex
+fn vertex0(@location(3) @interpolate(flat, centroid) a0: vec3i, @location(8) @interpolate(perspective) a1: vec4f, @location(4) a2: vec2u, @location(0) a3: vec3u, @location(15) a4: vec4f, @location(1) a5: vec4i, @location(9) a6: vec3f, a7: S10, @location(5) a8: vec4i) -> VertexOutput15 {
+  var out: VertexOutput15;
+  _ = a2;
+  out.f55 = vec2h(-45512.1);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup175 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [{binding: 172, resource: {buffer: buffer70, offset: 0, size: 391}}],
+});
+let buffer177 = device0.createBuffer({size: 17195, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder236 = device0.createCommandEncoder({});
+try {
+computePassEncoder93.setBindGroup(3, bindGroup136);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.draw(225, 244, 508_572_684, 263_632_960);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(86, 7, 11, 706_398_141, 1_363_993_801);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer87, 1_476);
+} catch {}
+try {
+computePassEncoder103.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 177}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 6 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder237 = device0.createCommandEncoder();
+let textureView242 = texture81.createView({format: 'r16sint', mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder53 = commandEncoder236.beginRenderPass({
+  colorAttachments: [{
+  view: textureView230,
+  clearValue: { r: -269.1, g: -79.29, b: 611.2, a: 4.285, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(0, bindGroup20, new Uint32Array(1092), 135, 0);
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup74, []);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup111, new Uint32Array(2340), 134, 0);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(2, 1, 5, 1);
+} catch {}
+try {
+renderPassEncoder9.draw(414_055_397, 101, 340_683_847, 1_002_994_236);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer27, 7_360);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer134, 1_476);
+} catch {}
+try {
+commandEncoder237.copyBufferToBuffer(buffer17, 172, buffer83, 560, 1100);
+} catch {}
+try {
+commandEncoder237.copyTextureToTexture({
+  texture: texture142,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 52},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder237.resolveQuerySet(querySet32, 36, 6, buffer44, 2304);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let videoFrame46 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpteRp431', transfer: 'pq'} });
+let bindGroup176 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 17, resource: {buffer: buffer112, offset: 0}}]});
+let commandEncoder238 = device0.createCommandEncoder({});
+let textureView243 = texture184.createView({dimension: 'cube', format: 'rgba16float', baseArrayLayer: 7});
+let texture258 = device0.createTexture({
+  size: [256, 256, 18],
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler141 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.48,
+  lodMaxClamp: 90.71,
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderPassEncoder33.setViewport(3.674416363530291, 12.764002120909899, 5.758502314968545, 3.314035665600139, 0.23343132505882125, 0.7112756732303821);
+} catch {}
+try {
+renderPassEncoder11.draw(64, 56, 483_046_468, 482_241_657);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer137, 440);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer22, 1_596);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 1344, new BigUint64Array(23762), 3499, 24);
+} catch {}
+let pipeline15 = await promise32;
+let commandEncoder239 = device0.createCommandEncoder({});
+let texture259 = device0.createTexture({
+  size: [16, 20, 177],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder175 = commandEncoder238.beginComputePass({});
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+renderPassEncoder11.draw(257, 1_000, 1_188_266, 3_600_160);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer102, 1_004);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+buffer167.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer87, 200, new BigUint64Array(17189), 5530, 336);
+} catch {}
+let bindGroup177 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 217, resource: {buffer: buffer61, offset: 5632, size: 2605}},
+    {binding: 27, resource: {buffer: buffer50, offset: 1024, size: 683}},
+    {binding: 176, resource: {buffer: buffer10, offset: 0, size: 265}},
+  ],
+});
+let buffer178 = device0.createBuffer({
+  size: 4187,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer15 = commandEncoder239.finish();
+let computePassEncoder176 = commandEncoder157.beginComputePass({});
+let renderPassEncoder54 = commandEncoder237.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: 779.4, g: -117.4, b: 83.87, a: 802.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer62, 340);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  label: '\u{1f9e6}\u{1f61f}\u447e',
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule8, entryPoint: 'fragment1', targets: [{format: 'rgb10a2uint'}]},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 576,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x4', offset: 248, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+document.body.append(img2);
+let bindGroup178 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 27, resource: {buffer: buffer87, offset: 0, size: 154}},
+    {binding: 217, resource: {buffer: buffer69, offset: 0, size: 2486}},
+    {binding: 176, resource: {buffer: buffer50, offset: 512, size: 111}},
+  ],
+});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer149, 3_284);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer83, 'uint32', 156, 319);
+} catch {}
+let commandEncoder240 = device0.createCommandEncoder({});
+let externalTexture24 = device0.importExternalTexture({source: video0});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup39, new Uint32Array(824), 824, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(100, 9, 447_932_911, 849_508_475);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(144, 46, 40, 254_722_936, 667_646_709);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer121, 'uint16', 2_152, 15_785);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(5, buffer87, 704, 2_374);
+} catch {}
+try {
+commandEncoder240.copyTextureToTexture({
+  texture: texture259,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture218,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  label: '\u{1fc8e}\u1013\u{1ff13}\ue76b\u4c30\u5bce\u4773\u0f40\u092b\u033d\u{1fc4d}',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 40863821,
+    stencilWriteMask: 656726162,
+    depthBias: -1394082657,
+    depthBiasSlopeScale: 444.9586327876982,
+  },
+  vertex: {
+    module: shaderModule8,
+    buffers: [
+      {
+        arrayStride: 492,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 84, shaderLocation: 6}],
+      },
+    ],
+  },
+});
+let bindGroup179 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 57, resource: externalTexture6}, {binding: 511, resource: textureView240}],
+});
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder241 = device0.createCommandEncoder();
+let renderPassEncoder55 = commandEncoder240.beginRenderPass({colorAttachments: [{view: textureView230, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder2.draw(82, 461, 1_131_705_160, 601_463_916);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder241.copyTextureToBuffer({
+  texture: texture253,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 252 */
+  offset: 252,
+  bytesPerRow: 0,
+  rowsPerImage: 226,
+  buffer: buffer165,
+}, {width: 0, height: 2, depthOrArrayLayers: 68});
+} catch {}
+try {
+commandEncoder241.copyTextureToTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture221,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'gamma28curve'} });
+let texture260 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView244 = texture23.createView({});
+let sampler142 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.94,
+  lodMaxClamp: 98.37,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup175);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup15, new Uint32Array(482), 194, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(111, 114, 470_776_221, 43_238_173);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(11, 187, 113, 167_601_742, 438_527_782);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer82, 4);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer34, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 96, new Int16Array(30708), 2597, 28);
+} catch {}
+let buffer179 = device0.createBuffer({
+  size: 27650,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView245 = texture56.createView({});
+let computePassEncoder177 = commandEncoder241.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder126); computePassEncoder126.dispatchWorkgroupsIndirect(buffer137, 604); };
+} catch {}
+try {
+renderPassEncoder13.draw(74, 80, 113_629_349, 333_744_902);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer59, 572);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer80, 900);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer165, 'uint32', 816, 1_087);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer70);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame48 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte240m', transfer: 'gamma28curve'} });
+let commandEncoder242 = device0.createCommandEncoder({});
+let computePassEncoder178 = commandEncoder242.beginComputePass({});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup38, new Uint32Array(1018), 35, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup122, new Uint32Array(176), 70, 0);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer1, 536);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData25 = new ImageData(40, 56);
+let textureView246 = texture241.createView({arrayLayerCount: 1});
+let texture261 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup106);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle36]);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer86, 412);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer63, 28);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4, buffer107);
+} catch {}
+let buffer180 = device0.createBuffer({
+  size: 30752,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView247 = texture191.createView({});
+let texture262 = device0.createTexture({
+  size: [8, 10, 26],
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer147, 564);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(3, buffer27, 3_256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer115, 1744, new Int16Array(3687), 1829, 940);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 20, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let bindGroup180 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 511, resource: textureView234}, {binding: 57, resource: externalTexture15}],
+});
+let textureView248 = texture74.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler143 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 31.83,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder166.setBindGroup(1, bindGroup165);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle19, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder19.draw(168, 299, 634_589_268, 819_208_773);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer62, 4);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer139, 'uint32', 836, 8_403);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer161);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let shaderModule21 = device0.createShaderModule({
+  label: '\udba0\u085f\u{1ff1c}\u1de6\u{1f8c2}\ua559',
+  code: `
+enable f16;
+/* target size: 25 max align: 1 */
+struct T0 {
+  @align(1) @size(25) f0: array<atomic<u32>>,
+}
+/* target size: 25 max align: 1 */
+struct T1 {
+  @align(1) @size(16) f0: array<atomic<i32>, 2>,
+  @align(1) @size(9) f1: array<array<vec3h, 1>>,
+}
+@group(0) @binding(33) var<storage, read> buffer181: T1;
+struct VertexOutput16 {
+  @location(11) @interpolate(flat, centroid) f58: vec3i,
+  @location(7) @interpolate(flat, center) f59: vec3u,
+  @builtin(position) f60: vec4f,
+  @location(14) @interpolate(flat) f61: f16,
+  @location(15) @interpolate(perspective, center) f62: vec3f
+}
+
+@vertex
+fn vertex0() -> VertexOutput16 {
+  var out: VertexOutput16;
+  return out;
+}
+struct VertexOutput17 {
+  @location(15) f63: vec4i,
+  @location(10) @interpolate(perspective, sample) f64: f32,
+  @location(14) @interpolate(linear, centroid) f65: f32,
+  @location(9) f66: f16,
+  @builtin(position) f67: vec4f,
+  @location(3) @interpolate(flat, centroid) f68: vec2h
+}
+
+@vertex
+fn vertex1() -> VertexOutput17 {
+  var out: VertexOutput17;
+  return out;
+}
+struct FragmentOutput13 {
+  @location(1) f0: u32,
+  @location(6) @interpolate(flat, center) f1: u32,
+  @location(0) f2: vec2f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer182 = device0.createBuffer({
+  size: 19324,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u095f\u0851\u{1feb9}\u87e1\u{1fb4e}',
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+});
+let renderBundle38 = renderBundleEncoder38.finish({});
+try {
+computePassEncoder177.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer62, 220);
+} catch {}
+try {
+buffer125.unmap();
+} catch {}
+let textureView249 = texture92.createView({baseMipLevel: 0});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(1, bindGroup99, new Uint32Array(4182), 747, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(211, 87, 107_657_115, 319_395_755);
+} catch {}
+await gc();
+let commandEncoder243 = device0.createCommandEncoder({});
+let textureView250 = texture35.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 0});
+let computePassEncoder179 = commandEncoder243.beginComputePass({});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+renderPassEncoder12.setViewport(10.708251550274243, 19.47687795975892, 2.7737553903334886, 0.45060497927208004, 0.6194372481151723, 0.6505430935823735);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer42, 920);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+buffer112.unmap();
+} catch {}
+document.body.prepend(video3);
+try {
+computePassEncoder42.setBindGroup(3, bindGroup96, new Uint32Array(976), 21, 0);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle25, renderBundle26, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline4);
+} catch {}
+let textureView251 = texture23.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle39 = renderBundleEncoder39.finish({label: '\u9783\uaf1f\u{1fbed}\u06e3\u{1fd1a}\u38ab\u0481\u63a3\u9021'});
+try {
+computePassEncoder165.setBindGroup(0, bindGroup108, new Uint32Array(2288), 265, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup73, new Uint32Array(2150), 300, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(66, 41, 45_316_151, 675_104_565);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(23, 19, 14, 78_661_225, 1_553_928_111);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder244 = device0.createCommandEncoder({});
+let texture263 = device0.createTexture({
+  size: [8, 10, 63],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder180 = commandEncoder244.beginComputePass({});
+try {
+computePassEncoder180.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 96, 208, 88_119_820, 1_911_128_113);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer83, 980);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer108, 'uint16', 1_804, 8_218);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(4, buffer70, 1_728);
+} catch {}
+document.body.prepend(video5);
+let bindGroup181 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 269, resource: {buffer: buffer106, offset: 3840, size: 64}}],
+});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup44, new Uint32Array(2558), 191, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(547, 949, 513_491_450, 274_742_443);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(55, 450, 5, 634_870_974, 1_399_059_153);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer14, 208);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline12);
+} catch {}
+let bindGroup182 = device0.createBindGroup({
+  label: '\ucdec\u4394\u6ec6\u0fa9\u0c47\u06fe\u04f8\u17b2\ua55b\u{1fc9d}\u0d0a',
+  layout: bindGroupLayout24,
+  entries: [{binding: 511, resource: textureView12}, {binding: 57, resource: externalTexture6}],
+});
+let commandEncoder245 = device0.createCommandEncoder({});
+let textureView252 = texture37.createView({
+  label: '\ud73e\u{1f68d}\u08f3\u0481\u016a\u5478\u{1fd41}\u{1ff50}\uec10\u3064',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let sampler144 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.80,
+  maxAnisotropy: 12,
+});
+let shaderModule22 = device0.createShaderModule({
+  label: '\u0ad7\ufb23\ue183',
+  code: `
+enable f16;
+enable f16;
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<atomic<u32>, 1>,
+}
+@group(0) @binding(285) var<storage, read_write> buffer183: f32;
+struct VertexOutput18 {
+  @builtin(position) f69: vec4f
+}
+
+@vertex
+fn vertex0(@location(9) @interpolate(perspective) a0: vec3f, @builtin(instance_index) a1: u32, @location(6) @interpolate(flat) a2: vec3i, @location(1) @interpolate(linear, center) a3: vec3f, @location(13) a4: vec4h, @location(2) a5: vec4i) -> VertexOutput18 {
+  var out: VertexOutput18;
+  _ = a5;
+  if bool(a5[0]) {
+    var v: vec4f;
+  }
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 3)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 347,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 338,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture264 = device0.createTexture({
+  size: [2, 2, 1],
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler145 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 95.17,
+  lodMaxClamp: 97.76,
+});
+try {
+renderPassEncoder39.executeBundles([renderBundle11, renderBundle35, renderBundle11, renderBundle16, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer14, 912);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup35, new Uint32Array(319), 26, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer88, 'uint32', 352, 350);
+} catch {}
+try {
+commandEncoder245.clearBuffer(buffer65);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let video6 = await videoWithData(119);
+let bindGroup183 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 9, resource: {buffer: buffer112, offset: 4352, size: 473}},
+    {binding: 4, resource: {buffer: buffer16, offset: 1792, size: 108}},
+  ],
+});
+let buffer184 = device0.createBuffer({
+  size: 5873,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder246 = device0.createCommandEncoder();
+let texture265 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder181 = commandEncoder246.beginComputePass({label: '\u{1fe55}\u11d3\ud3ae'});
+let renderPassEncoder56 = commandEncoder245.beginRenderPass({
+  colorAttachments: [{
+  view: textureView199,
+  clearValue: { r: -450.4, g: -146.8, b: -875.0, a: -549.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler146 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 29.23,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder34.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup150);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(127, 87, 149, 570_717_340, 493_486_001);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline16);
+} catch {}
+let bindGroup184 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 269, resource: {buffer: buffer92, offset: 512, size: 712}}],
+});
+let commandEncoder247 = device0.createCommandEncoder();
+let computePassEncoder182 = commandEncoder247.beginComputePass({});
+try {
+computePassEncoder182.setBindGroup(3, bindGroup171);
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle23, renderBundle7, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(757, 393, 276, 17_257_108, 200_763_654);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup104, []);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup77, new Uint32Array(4110), 123, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer55, 'uint16', 6_590, 5_955);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let commandEncoder248 = device0.createCommandEncoder({});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 1});
+let renderBundle40 = renderBundleEncoder41.finish();
+let sampler147 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.608,
+  lodMaxClamp: 82.58,
+});
+try {
+computePassEncoder182.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.draw(65, 161, 1_627_350_510, 825_437_782);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer172, 'uint16', 794, 1_393);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer169, 'uint32', 188, 107);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(5, buffer107);
+} catch {}
+let arrayBuffer29 = buffer38.getMappedRange(0, 76);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer108, 3000, new Float32Array(7763), 1120, 376);
+} catch {}
+let buffer185 = device0.createBuffer({
+  size: 21962,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet44 = device0.createQuerySet({type: 'occlusion', count: 1131});
+let texture266 = device0.createTexture({
+  size: [4, 5, 44],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder183 = commandEncoder248.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup79, new Uint32Array(675), 262, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: 79.70, g: -294.1, b: 987.8, a: -802.7, });
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer110, 'uint16', 7_538, 12_769);
+} catch {}
+document.body.append(img5);
+let bindGroup185 = device0.createBindGroup({
+  layout: bindGroupLayout29,
+  entries: [
+    {binding: 166, resource: textureView166},
+    {binding: 403, resource: textureView175},
+    {binding: 116, resource: textureView18},
+    {binding: 207, resource: textureView75},
+    {binding: 313, resource: textureView230},
+    {binding: 150, resource: textureView8},
+    {binding: 498, resource: textureView99},
+    {binding: 163, resource: {buffer: buffer85, offset: 0, size: 5104}},
+    {binding: 193, resource: textureView227},
+    {binding: 137, resource: textureView48},
+    {binding: 71, resource: textureView229},
+    {binding: 75, resource: textureView149},
+    {binding: 951, resource: textureView222},
+    {binding: 132, resource: textureView140},
+    {binding: 58, resource: textureView31},
+    {binding: 18, resource: {buffer: buffer152, offset: 2048}},
+    {binding: 53, resource: textureView228},
+    {binding: 28, resource: textureView193},
+    {binding: 64, resource: textureView224},
+    {binding: 2, resource: sampler84},
+    {binding: 169, resource: textureView60},
+    {binding: 94, resource: textureView213},
+    {binding: 67, resource: {buffer: buffer52, offset: 512, size: 56}},
+    {binding: 3, resource: textureView213},
+  ],
+});
+let commandEncoder249 = device0.createCommandEncoder({});
+let texture267 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder184 = commandEncoder249.beginComputePass({});
+try {
+computePassEncoder175.setBindGroup(2, bindGroup93, new Uint32Array(657), 302, 0);
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(1300);
+} catch {}
+try {
+renderPassEncoder2.draw(0, 630, 0, 964_976_900);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(12, 609, 7, -2_122_762_003, 401_504_448);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+let buffer186 = device0.createBuffer({size: 4817, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder250 = device0.createCommandEncoder({});
+let texture268 = device0.createTexture({
+  size: [2, 2, 75],
+  mipLevelCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView253 = texture254.createView({dimension: '2d', aspect: 'all', format: 'rgb10a2uint', baseArrayLayer: 5});
+try {
+computePassEncoder10.dispatchWorkgroupsIndirect(buffer91, 172);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(28, 482, 9, 89_783_910, 300_491_613);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer81, 'uint32', 76, 5_783);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(0, buffer141, 0);
+} catch {}
+let buffer187 = device0.createBuffer({
+  label: '\u921c\u3a50\u0004',
+  size: 5305,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView254 = texture128.createView({});
+let computePassEncoder185 = commandEncoder250.beginComputePass({});
+let sampler148 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.94,
+  lodMaxClamp: 86.11,
+  compare: 'not-equal',
+  maxAnisotropy: 9,
+});
+try {
+renderBundleEncoder40.setPipeline(pipeline11);
+} catch {}
+let bindGroup186 = device0.createBindGroup({
+  label: '\u0d11\u00b9\u{1fbe4}\u024a',
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 27, resource: {buffer: buffer123, offset: 0, size: 2054}},
+    {binding: 217, resource: {buffer: buffer123, offset: 256, size: 759}},
+    {binding: 176, resource: {buffer: buffer82, offset: 0, size: 43}},
+  ],
+});
+let buffer188 = device0.createBuffer({size: 7505, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 624});
+let texture269 = device0.createTexture({
+  size: {width: 16, height: 20, depthOrArrayLayers: 23},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(1, buffer40, 2_812);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video4);
+await gc();
+let buffer189 = device0.createBuffer({
+  size: 7772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder251 = device0.createCommandEncoder({});
+let computePassEncoder186 = commandEncoder251.beginComputePass({});
+let renderBundle41 = renderBundleEncoder40.finish({label: '\u3f4a\u{1fc90}\ua668\ucede\u051e\u5eaa'});
+try {
+renderPassEncoder53.setViewport(3.3983054544509557, 81.34686538581049, 2.6891868611831122, 4.696039982066284, 0.4702357810646445, 0.8664382365423615);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(15, 79, 125, 1_206_559_212, 62_056_538);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer7, 3_136);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer139, 708);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer101, 'uint16', 192, 61);
+} catch {}
+try {
+buffer163.unmap();
+} catch {}
+let videoFrame49 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'bt2020', transfer: 'hlg'} });
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 159,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let texture270 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView255 = texture65.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup140);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(buffer83, 1_204);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer156, 64);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let texture271 = device0.createTexture({
+  size: [8],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder186.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder9.draw(572_922_869, 43, 81_953_369, 535_610_314);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(218, 4, 156, 405_961_338, 13_488_546);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer42, 2_968);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer27, 5_980);
+} catch {}
+let imageData26 = new ImageData(28, 12);
+let textureView256 = texture270.createView({format: 'r32sint', arrayLayerCount: 1});
+let textureView257 = texture264.createView({
+  label: '\u0107\u6f55\u1f75\ue479\ud128\u3e92\u18f0\u08d6\ue5a8\u0fb3',
+  aspect: 'all',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder14.draw(11, 426, 102_289_600, 213_670_099);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer180, 2_672);
+} catch {}
+let texture272 = device0.createTexture({
+  label: '\uee71\u7733\u046b\u0f7c\u0e1b',
+  size: [8, 10, 72],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder120.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+computePassEncoder148.setBindGroup(0, bindGroup183, new Uint32Array(785), 259, 0);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup62, new Uint32Array(331), 18, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(197, 70, 209, 295_545_287, 582_256_139);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer59, 360);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer113, 'uint16', 2, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder40.setBindGroup(3, bindGroup121);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(2, bindGroup109, new Uint32Array(3117), 318, 0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup93, new Uint32Array(2524), 244, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(9, 2, 31, -2_135_668_743, 172_267_608);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer50, 1_204);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer107, 916, 3_245);
+} catch {}
+let texture273 = device0.createTexture({
+  size: {width: 8, height: 10, depthOrArrayLayers: 13},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView258 = texture187.createView({});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup120);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle41]);
+} catch {}
+try {
+renderPassEncoder13.draw(61, 284, 1_405_900_399, 576_225_471);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(407, 427, 1_295, 1_581_378_099, 20_837_128);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer189, 80);
+} catch {}
+try {
+  await buffer132.mapAsync(GPUMapMode.WRITE, 0, 436);
+} catch {}
+let buffer190 = device0.createBuffer({size: 8706, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView259 = texture270.createView({});
+try {
+renderPassEncoder9.draw(192_278_561, 104, 335_811_058, 833_495_669);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(3_537, 54, 910, 79_725_246, 1_186_549_062);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer150, 552);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer74, 120);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+externalTexture13.label = '\u{1ff34}\u0ff8\ue5a1\ubf5a\ud852\ufcc8\ub55b\u4e42\u4fa4\u{1fff5}';
+} catch {}
+let bindGroup187 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 75, resource: textureView108},
+    {binding: 121, resource: {buffer: buffer180, offset: 2816, size: 972}},
+  ],
+});
+let commandEncoder252 = device0.createCommandEncoder({});
+let commandBuffer16 = commandEncoder252.finish({label: '\u{1f9c0}\u{1f79c}\u18b4\u05db\ua2b2\u{1f8d7}\u34e9\u57be\u8e02'});
+let texture274 = device0.createTexture({size: [4, 5, 1], dimension: '2d', format: 'depth32float-stencil8', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder155.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder95); computePassEncoder95.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup134);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer59, 52);
+} catch {}
+let buffer191 = device0.createBuffer({size: 43578, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let texture275 = device0.createTexture({
+  size: {width: 4, height: 5, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture210.createView({mipLevelCount: 1});
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup52, []);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup6, new Uint32Array(159), 15, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle24, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder9.draw(277_508_219, 230, 903_726_353, 367_095_777);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(19, 83, 0, -2_062_151_519, 125_308_196);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame22.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame48.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1610,6 +1610,9 @@ webkit.org/b/263396 css3/color/text.html [ Skip ]
 
 # WebGPU
 
+# skipped outside of macOS Sequoia due to crash in failed allocation
+[ Ventura Sonoma ] fast/webgpu/nocrash/fuzz-279086.html [ Skip ]
+
 [ Release arm64 ] http/tests/webgpu/webgpu/api [ Pass Failure Timeout ]
 [ Release arm64 ] http/tests/webgpu/webgpu/shader [ Pass Failure Timeout ]
 [ Release arm64 ] http/tests/webgpu/webgpu/web_platform [ Pass Failure Timeout ]

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -874,6 +874,10 @@ void RenderBundleEncoder::endCurrentICB()
 
     if (!m_renderPassEncoder) {
         m_indirectCommandBuffer = [m_device->device() newIndirectCommandBufferWithDescriptor:m_icbDescriptor maxCommandCount:commandCount options:0];
+        if (!m_indirectCommandBuffer) {
+            makeInvalid(@"MTLIndirectCommandBuffer allocation failed, likely tried to encode too many commands");
+            return;
+        }
         m_device->setOwnerWithIdentity(m_indirectCommandBuffer);
     }
 


### PR DESCRIPTION
#### 46279b29a3cc4f8e0a63f2d526f02fae2fbb4fec
<pre>
[WebGPU] RenderBundleEncoder fails to replay commands on invalid encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=279086">https://bugs.webkit.org/show_bug.cgi?id=279086</a>
<a href="https://rdar.apple.com/135198220">rdar://135198220</a>

Reviewed by Dan Glastonbury.

We were not handling OOM situations in the ICB path leading to incorrect
command encoding in OOM situations.

* LayoutTests/fast/webgpu/nocrash/fuzz-279086-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-279086.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::endCurrentICB):

* LayoutTests/TestExpectations
Test appears to crash outside of macOS Sequoia due to failed ICB allocation.
On macOS Sequoia the allocation fails gracefully which allows the test to
pass.

Canonical link: <a href="https://commits.webkit.org/283245@main">https://commits.webkit.org/283245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d91f41b910620e86f63748aead924e26b1c93c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52717 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11283 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15131 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13980 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14474 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1582 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40827 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41903 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->