### PR TITLE
Begin integrating password autofill with LoginStatus API

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -355,7 +355,7 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
 
         if (auto response = AuthenticatorResponse::tryCreate(WTFMove(data), attachment)) {
             if (RefPtr page = weakPage.get())
-                page->setLastAuthentication(LoginStatus::AuthenticationType::WebAuthn);
+                page->setLastAuthentication(LoginStatusAuthenticationType::WebAuthn, emptyString());
             promise.resolve(PublicKeyCredential::create(response.releaseNonNull()).ptr());
             return;
         }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5464,9 +5464,9 @@ void Page::activeNowPlayingSessionUpdateTimerFired()
     chrome().client().hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
 }
 
-void Page::setLastAuthentication(LoginStatus::AuthenticationType authType)
+void Page::setLastAuthentication(LoginStatus::AuthenticationType authType, const String& username)
 {
-    auto loginStatus = LoginStatus::create(RegistrableDomain(mainFrameURL()), emptyString(), LoginStatus::CredentialTokenType::HTTPStateToken, authType, LoginStatus::TimeToLiveAuthentication);
+    auto loginStatus = LoginStatus::create(RegistrableDomain(mainFrameURL()), username, LoginStatus::CredentialTokenType::HTTPStateToken, authType, LoginStatus::TimeToLiveAuthentication);
     if (loginStatus.hasException())
         return;
     m_lastAuthentication = loginStatus.releaseReturnValue().moveToUniquePtr();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1274,7 +1274,7 @@ public:
     bool canShowWhileLocked() const { return m_canShowWhileLocked; }
 #endif
 
-    void setLastAuthentication(LoginStatusAuthenticationType);
+    WEBCORE_EXPORT void setLastAuthentication(LoginStatusAuthenticationType, const String& username);
     const LoginStatus* lastAuthentication() const { return m_lastAuthentication.get(); }
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1283,16 +1283,22 @@ void NetworkConnectionToWebProcess::requestStorageAccess(RegistrableDomain&& sub
 
 void NetworkConnectionToWebProcess::setLoginStatus(RegistrableDomain&& domain, IsLoggedIn loggedInStatus, std::optional<WebCore::LoginStatus>&& lastAuthentication, CompletionHandler<void()>&& completionHandler)
 {
-    if (isLoginStatusAPIRequiresWebAuthnEnabled() && !lastAuthentication) {
-        auto umanagedAuthentication = LoginStatus::create(domain, emptyString(), WebCore::LoginStatus::CredentialTokenType::HTTPStateToken, WebCore::LoginStatus::AuthenticationType::Unmanaged, WebCore::LoginStatus::TimeToLiveAuthentication);
-        if (umanagedAuthentication.hasException())
-            return completionHandler();
-        lastAuthentication = umanagedAuthentication.releaseReturnValue();
+    std::optional<WebCore::LoginStatus> trustworthySignal;
+
+    if (isLoginStatusAPIRequiresWebAuthnEnabled()) {
+        if (lastAuthentication)
+            trustworthySignal = WTFMove(lastAuthentication);
+        else {
+            auto unmanagedAuthentication = LoginStatus::create(domain, emptyString(), WebCore::LoginStatus::CredentialTokenType::HTTPStateToken, WebCore::LoginStatus::AuthenticationType::Unmanaged, WebCore::LoginStatus::TimeToLiveAuthentication);
+            if (unmanagedAuthentication.hasException())
+                return completionHandler();
+            trustworthySignal = unmanagedAuthentication.releaseReturnValue();
+        }
     }
 
     if (auto* networkSession = this->networkSession()) {
         if (auto* resourceLoadStatistics = networkSession->resourceLoadStatistics()) {
-            resourceLoadStatistics->setLoginStatus(WTFMove(domain), loggedInStatus, WTFMove(lastAuthentication), WTFMove(completionHandler));
+            resourceLoadStatistics->setLoginStatus(WTFMove(domain), loggedInStatus, WTFMove(trustworthySignal), WTFMove(completionHandler));
             return;
         }
     }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -395,7 +395,7 @@ private:
     void storageAccessQuirkForTopFrameDomain(URL&& topFrameURL, CompletionHandler<void(Vector<RegistrableDomain>)>&&);
     void requestStorageAccessUnderOpener(WebCore::RegistrableDomain&& domainInNeedOfStorageAccess, WebCore::PageIdentifier openerPageID, WebCore::RegistrableDomain&& openerDomain);
 
-    void setLoginStatus(RegistrableDomain&&, WebCore::IsLoggedIn, std::optional<WebCore::LoginStatus>&&, CompletionHandler<void()>&&);
+    void setLoginStatus(RegistrableDomain&&, WebCore::IsLoggedIn, std::optional<WebCore::LoginStatus>&& lastAuthentication, CompletionHandler<void()>&&);
     void isLoggedIn(RegistrableDomain&&, CompletionHandler<void(bool)>&&);
     bool isLoginStatusAPIRequiresWebAuthnEnabled() const { return m_sharedPreferencesForWebProcess.loginStatusAPIRequiresWebAuthnEnabled; }
     void addOriginAccessAllowListEntry(const String& sourceOrigin, const String& destinationProtocol, const String& destinationHost, bool allowDestinationSubdomains);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3242,6 +3242,11 @@ WEBCORE_PRIVATE_COMMAND(pasteAndMatchStyle)
 
 #endif // PLATFORM(MAC)
 
+- (void)_didFillPasswordForUsername:(NSString *)username
+{
+    _page->didFillPasswordForUsername(username);
+}
+
 #pragma mark - iOS WKPrivate
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -315,6 +315,8 @@ for this property.
 - (void)_isJITEnabled:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (void)_removeDataDetectedLinks:(dispatch_block_t)completion WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 
+- (void)_didFillPasswordForUsername:(NSString *)username WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 - (IBAction)_alignCenter:(id)sender WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (IBAction)_alignJustified:(id)sender WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (IBAction)_alignLeft:(id)sender WK_API_AVAILABLE(macos(10.14.4), ios(12.2));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -979,6 +979,11 @@ Ref<WebPageProxy> WebPageProxy::Internals::protectedPage() const
     return page.get();
 }
 
+void WebPageProxy::didFillPasswordForUsername(const String& username)
+{
+    send(Messages::WebPage::DidFillPasswordForUsername(username));
+}
+
 void WebPageProxy::addAllMessageReceivers()
 {
     Ref process = m_legacyMainFrameProcess;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2723,6 +2723,7 @@ public:
 
     Ref<AboutSchemeHandler> protectedAboutSchemeHandler();
 
+    void didFillPasswordForUsername(const String& username);
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8644,6 +8644,14 @@ void WebPage::isLoggedIn(RegistrableDomain&& domain, CompletionHandler<void(bool
     WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::IsLoggedIn(WTFMove(domain)), WTFMove(completionHandler));
 }
 
+void WebPage::didFillPasswordForUsername(const String& username)
+{
+    RefPtr page = corePage();
+    if (!page)
+        return;
+    page->setLastAuthentication(LoginStatusAuthenticationType::PasswordManager, username);
+}
+
 void WebPage::addDomainWithPageLevelStorageAccess(const RegistrableDomain& topLevelDomain, const RegistrableDomain& resourceDomain)
 {
     m_internals->domainsWithPageLevelStorageAccess.add(topLevelDomain, HashSet<RegistrableDomain> { }).iterator->value.add(resourceDomain);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1605,6 +1605,7 @@ public:
     void requestStorageAccess(WebCore::RegistrableDomain&& subFrameDomain, WebCore::RegistrableDomain&& topFrameDomain, WebFrame&, WebCore::StorageAccessScope, CompletionHandler<void(WebCore::RequestStorageAccessResult)>&&);
     void setLoginStatus(WebCore::RegistrableDomain&&, WebCore::IsLoggedIn, CompletionHandler<void()>&&);
     void isLoggedIn(WebCore::RegistrableDomain&&, CompletionHandler<void(bool)>&&);
+    void didFillPasswordForUsername(const String& username);
     bool hasPageLevelStorageAccess(const WebCore::RegistrableDomain& topLevelDomain, const WebCore::RegistrableDomain& resourceDomain) const;
     void addDomainWithPageLevelStorageAccess(const WebCore::RegistrableDomain& topLevelDomain, const WebCore::RegistrableDomain& resourceDomain);
     void clearPageLevelStorageAccess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -882,4 +882,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     WillBeginContextMenuInteraction()
     DidEndContextMenuInteraction()
 #endif
+
+    DidFillPasswordForUsername(String username)
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -42,6 +42,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebsiteDataRecordPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/BlockPtr.h>
@@ -2200,4 +2201,40 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
     EXPECT_WK_STREQ([uiDelegate waitForAlert], @"true");
     EXPECT_FALSE(didSendSite2CookieHeader);
     didSendSite2CookieHeader = false;
+}
+
+TEST(ResourceLoadStatistics, LoginStatusRequiresPasswordAutoFill)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/index"_s, { @"" } }
+    });
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    for (_WKFeature *feature in WKPreferences._features) {
+        if ([feature.key isEqualToString:@"LoginStatusAPIEnabled"] || [feature.key isEqualToString:@"LoginStatusAPIRequiresWebAuthnEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+
+    [webView loadRequest:server.request("/index"_s)];
+    [webView _test_waitForDidFinishNavigation];
+    [webView _didFillPasswordForUsername:@"example"];
+
+    __block bool done { false };
+    [webView evaluateJavaScript:@"navigator.setStatus('logged-in');" completionHandler:^(id, NSError *) {
+        [webView evaluateJavaScript:@"navigator.isLoggedIn()" completionHandler:^(id result, NSError *) {
+            EXPECT_TRUE([result boolValue]);
+            done = true;
+        }];
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    [webView evaluateJavaScript:@"navigator.setStatus('logged-out');" completionHandler:^(id, NSError *) {
+        [webView evaluateJavaScript:@"navigator.isLoggedIn()" completionHandler:^(id result, NSError *) {
+            EXPECT_FALSE([result boolValue]);
+            done = true;
+        }];
+    }];
+    TestWebKitAPI::Util::run(&done);
 }


### PR DESCRIPTION
#### 68291cef7f3bf33d44e16f0a6bfc2770988bc65e
<pre>
Begin integrating password autofill with LoginStatus API
<a href="https://bugs.webkit.org/show_bug.cgi?id=279084">https://bugs.webkit.org/show_bug.cgi?id=279084</a>
<a href="https://rdar.apple.com/135221840">rdar://135221840</a>

Reviewed by NOBODY (OOPS!).

We integrate Password Autofill with LoginStatus API. So setting a status is now conditional to logging in getting a signal from password Autofill in 30s. We receive this signal from Safari indicating whether the user has clicked the password autofill option.

Originally written by pooneh-nb &lt;pnikkhahbahrami@ucdavis.edu&gt;

* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setLastAuthentication):
* Source/WebCore/page/Page.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::setLoginStatus):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _didFillPasswordForUsername:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFillPasswordForUsername):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setLoginStatus):
(WebKit::WebPage::didFillPasswordForUsername):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, LoginStatusRequiresPasswordAutoFill)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68291cef7f3bf33d44e16f0a6bfc2770988bc65e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73728 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99746 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12539 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87546 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.LoginStatusRequiresPasswordAutoFill (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46591 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82396 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.LoginStatusRequiresPasswordAutoFill (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17368 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82776 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83616 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82163 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26821 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17289 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28928 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->