### PR TITLE
Fix the iOS build after rdar://115866097

### DIFF
--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -186,7 +186,7 @@ bool DragDropInteractionState::anyActiveDragSourceContainsSelection() const
     return false;
 }
 
-void DragDropInteractionState::prepareForDragSession(id <UIDragSession> session, dispatch_block_t completionHandler)
+void DragDropInteractionState::prepareForDragSession(id<UIDragSession> session, DragPreparationBlock completionHandler)
 {
     m_dragSession = session;
     m_dragStartCompletionBlock = completionHandler;
@@ -332,7 +332,7 @@ bool DragDropInteractionState::shouldRequestAdditionalItemForDragSession(id <UID
     return m_dragSession == session && !m_addDragItemCompletionBlock && !m_dragStartCompletionBlock;
 }
 
-void DragDropInteractionState::dragSessionWillRequestAdditionalItem(void (^completion)(NSArray <UIDragItem *> *))
+void DragDropInteractionState::dragSessionWillRequestAdditionalItem(AddDragItemBlock completion)
 {
     clearStagedDragSource();
     m_addDragItemCompletionBlock = completion;

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -141,12 +141,6 @@ WTF_EXTERN_C_END
 @interface UITextInputTraits : NSObject <UITextInputTraits, UITextInputTraits_Private, NSCopying>
 @end
 
-@protocol UIDragInteractionDelegate_ForWebKitOnly <UIDragInteractionDelegate>
-@optional
-- (void)_dragInteraction:(UIDragInteraction *)interaction prepareForSession:(id<UIDragSession>)session completion:(void(^)(void))completion;
-- (void)_dragInteraction:(UIDragInteraction *)interaction itemsForAddingToSession:(id <UIDragSession>)session withTouchAtPoint:(CGPoint)point completion:(void(^)(NSArray<UIDragItem *> *))completion;
-@end
-
 @class WebEvent;
 
 @protocol UITextInputPrivate <UITextInput, UITextInputTraits_Private>

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -35,6 +35,7 @@
 #import "TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <BrowserEngineKit/BrowserEngineKit.h>
 #import <Contacts/Contacts.h>
 #import <MapKit/MapKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -1578,7 +1579,9 @@ TEST(DragAndDropTests, UnresponsivePageDoesNotHangUI)
 
     // The test passes if we can prepare for a drag session without timing out.
     auto dragSession = adoptNS([[MockDragSession alloc] init]);
-    [(id <UIDragInteractionDelegate_ForWebKitOnly>)[webView dragInteractionDelegate] _dragInteraction:[webView dragInteraction] prepareForSession:dragSession.get() completion:^() { }];
+    [[webView dragInteractionDelegate] dragInteraction:[webView dragInteraction] prepareDragSession:dragSession.get() completion:^{
+        return NO;
+    }];
 }
 
 TEST(DragAndDropTests, WebItemProviderPasteboardLoading)

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -35,6 +35,9 @@
 #import <UIKit/NSItemProvider+UIKitAdditions.h>
 #endif
 
+@class BEDragInteraction;
+@protocol BEDragInteractionDelegate;
+
 #if PLATFORM(IOS_FAMILY)
 
 typedef NS_ENUM(NSInteger, DragAndDropPhase) {
@@ -68,10 +71,10 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 @end
 
 @interface WKWebView (DragAndDropTesting)
-- (id <UIDropInteractionDelegate>)dropInteractionDelegate;
-- (id <UIDragInteractionDelegate>)dragInteractionDelegate;
+- (id<UIDropInteractionDelegate>)dropInteractionDelegate;
+- (id<BEDragInteractionDelegate>)dragInteractionDelegate;
 - (UIDropInteraction *)dropInteraction;
-- (UIDragInteraction *)dragInteraction;
+- (BEDragInteraction *)dragInteraction;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### d53ab7c16664e076925dd62f6a03e5074067d63e
<pre>
Fix the iOS build after <a href="https://rdar.apple.com/115866097">rdar://115866097</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279090">https://bugs.webkit.org/show_bug.cgi?id=279090</a>
<a href="https://rdar.apple.com/135224537">rdar://135224537</a>

Reviewed by Abrar Rahman Protyasha.

Fix the iOS build, after the removal of the `UIDragInteractionDelegate_ForWebKitOnly` SPI protocol.

This was used to implement asynchronously-triggered drag interactions prior to iOS 17.4; however, on
iOS 17.4 and later, WebKit now uses public API from BrowserEngineKit&apos;s `BEDragInteractionDelegate`,
which offers parity with the SPI protocol.

The implementations of `BEDragInteractionDelegate` protocol methods currently wrap  implementations
of their SPI counterparts. This was only done to make it possible to easily switch between using the
API and SPI with a runtime flag, while maintining binary and source compatibility with both. This is
no longer necessary since the oldest maintained version of WebKit is now iOS 17.5 (currently in EWS)
which uses the newer BrowserEngineKit APIs, so we can switch entirely to this new API.

* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
(WebKit::DragDropInteractionState::BlockPtr&lt;BOOL):
(WebKit::DragDropInteractionState::BlockPtr&lt;void): Deleted.
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::prepareForDragSession):
(WebKit::DragDropInteractionState::dragSessionWillRequestAdditionalItem):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _didHandleDragStartRequest:]):
(-[WKContentView dragInteraction:prepareDragSession:completion:]):
(-[WKContentView dragInteraction:itemsForAddingToSession:forTouchAtPoint:completion:]):
(-[WKContentView _dragInteraction:itemsForAddingToSession:withTouchAtPoint:completion:]): Deleted.
(-[WKContentView _dragInteraction:prepareForSession:completion:]): Deleted.
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::TEST(DragAndDropTests, UnresponsivePageDoesNotHangUI)):
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[WKWebView dropInteractionDelegate]):
(-[WKWebView dragInteractionDelegate]):
(-[DragAndDropSimulator runFrom:to:additionalItemRequestLocations:]):
(-[DragAndDropSimulator _sendQueuedAdditionalItemRequest]):

Teach the drag and drop test harness to start simulated drag sessions by calling into
`BEDragInteractionDelegate` APIs, rather than the legacy UIKit SPI.

Canonical link: <a href="https://commits.webkit.org/283132@main">https://commits.webkit.org/283132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41d8b6a1cb2012890aec0414270e9a0a9b61abbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52452 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11020 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14810 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71056 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59780 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56602 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1321 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40506 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->