### PR TITLE
Scrubbing and skipping back/forward should be disabled in modern media controls when the host does not support seeking

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -58,6 +58,7 @@ class TimeControl extends LayoutItem
         this._duration = 0;
         this._currentTime = 0;
         this._loading = false;
+        this._supportsSeeking = true;
 
         if (this._shouldShowDurationTimeLabel) {
             this.durationTimeLabel.element.addEventListener("click", this);
@@ -96,7 +97,22 @@ class TimeControl extends LayoutItem
             return;
 
         this._loading = flag;
-        this.scrubber.disabled = flag;
+        this.scrubber.disabled = this._loading || !this._supportsSeeking;
+        this.needsLayout = true;
+    }
+
+    get supportsSeeking()
+    {
+        return this._supportsSeeking;
+    }
+    
+    set supportsSeeking(flag)
+    {
+        if (this._supportsSeeking === flag)
+            return;
+
+        this._supportsSeeking = flag;
+        this.scrubber.disabled = this._loading || !this._supportsSeeking;
         this.needsLayout = true;
     }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -74,3 +74,7 @@
     right: var(--tvos-controls-horizontal-margin);
     bottom: calc(var(--tvos-controls-vertical-margin) + var(--tvos-controls-bar-height) + var(--tvos-metadata-container-bottom-margin));
 }
+
+.media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > :is(.primary, .secondary) {
+    display: initial;
+}

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -366,9 +366,6 @@ class MediaController
 
         if (this.host && this.host.inWindowFullscreen) {
             this._stopPropagationOnClickEvents();
-            if (!this.host.supportsSeeking)
-                this.controls.timeControl.scrubber.disabled = true;
-
             if (!this.host.supportsRewind)
                 this.controls.rewindButton.dropped = true;
         }

--- a/Source/WebCore/Modules/modern-media-controls/media/skip-back-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/skip-back-support.js
@@ -46,7 +46,8 @@ class SkipBackSupport extends MediaControllerSupport
 
     syncControl()
     {
-        this.control.enabled = this.mediaController.media.duration <= maxNonLiveDuration;
+        const supportsSeeking = !this.mediaController.host || this.mediaController.host.supportsSeeking;
+        this.control.enabled = supportsSeeking && this.mediaController.media.duration <= maxNonLiveDuration;
     }
 
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/skip-forward-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/skip-forward-support.js
@@ -46,7 +46,8 @@ class SkipForwardSupport extends MediaControllerSupport
 
     syncControl()
     {
-        this.control.enabled = this.mediaController.media.duration <= maxNonLiveDuration;
+        const supportsSeeking = !this.mediaController.host || this.mediaController.host.supportsSeeking;
+        this.control.enabled = supportsSeeking && this.mediaController.media.duration <= maxNonLiveDuration;
     }
 
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/time-control-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/time-control-support.js
@@ -28,6 +28,13 @@ class TimeControlSupport extends MediaControllerSupport
 
     // Protected
 
+    enable()
+    {
+        super.enable();
+
+        this.control.supportsSeeking = !this.mediaController.host || this.mediaController.host.supportsSeeking;
+    }
+
     get control()
     {
         return this.mediaController.controls.timeControl;


### PR DESCRIPTION
#### 13ff8bb8fd293373a964e479b04e4120b690c5af
<pre>
Scrubbing and skipping back/forward should be disabled in modern media controls when the host does not support seeking
<a href="https://bugs.webkit.org/show_bug.cgi?id=279095">https://bugs.webkit.org/show_bug.cgi?id=279095</a>
<a href="https://rdar.apple.com/134959242">rdar://134959242</a>

Reviewed by Eric Carlson.

When MediaControlsHost does not support seeking, scrubbing and skip back/forward buttons should not
be available in modern media controls. Scrubbing was already disabled when in in-window fullscreen,
but this change makes scrubbing disabled elsewhere. This change also tweaks the appearance of a
disabled scrubber in tvOS media controls.

* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.):
(TimeControl.prototype.set loading):
(TimeControl.prototype.get supportsSeeking):
(TimeControl.prototype.set supportsSeeking):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css:
(.media-controls.fullscreen.tvos .slider.default.disabled &gt; .appearance &gt; .fill &gt; :is(.primary, .secondary)):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):
* Source/WebCore/Modules/modern-media-controls/media/skip-back-support.js:
(SkipBackSupport.prototype.syncControl):
(SkipBackSupport):
* Source/WebCore/Modules/modern-media-controls/media/skip-forward-support.js:
(SkipForwardSupport.prototype.syncControl):
(SkipForwardSupport):
* Source/WebCore/Modules/modern-media-controls/media/time-control-support.js:
(TimeControlSupport.prototype.enable):

Canonical link: <a href="https://commits.webkit.org/283402@main">https://commits.webkit.org/283402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e055f4a4bb1aa09e430c1eb8a921aaaa68fdff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70184 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53084 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14650 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71886 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14399 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8344 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1982 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41333 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->