### PR TITLE
CSS view timeline needs conversion data to properly resolve insets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-computed-expected.txt
@@ -40,4 +40,7 @@ PASS Property animation-timeline value 'view(y 1px auto)'
 PASS Property animation-timeline value 'view(1px y)'
 PASS Property animation-timeline value 'view(y auto)'
 PASS Property animation-timeline value 'view(y auto auto)'
+PASS Property animation-timeline value 'view(10% 10px)'
+PASS Property animation-timeline value 'view(auto calc(1% + 1px))'
+PASS Property animation-timeline value 'view(2em calc(1% + 1em))'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-computed.html
@@ -69,5 +69,8 @@ test_computed_value('animation-timeline', 'view(y 1px auto)');
 test_computed_value('animation-timeline', 'view(1px y)', 'view(y 1px)');
 test_computed_value('animation-timeline', 'view(y auto)', 'view(y)');
 test_computed_value('animation-timeline', 'view(y auto auto)', 'view(y)');
+test_computed_value('animation-timeline', 'view(10% 10px)', 'view(10% 10px)');
+test_computed_value('animation-timeline', 'view(auto calc(1% + 1px))');
+test_computed_value('animation-timeline', 'view(2em calc(1% + 1em))', 'view(32px calc(1% + 16px))');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-parsing-expected.txt
@@ -58,6 +58,7 @@ PASS e.style['animation-timeline'] = "view(1px)" should set the property value
 PASS e.style['animation-timeline'] = "view(1px 1px)" should set the property value
 PASS e.style['animation-timeline'] = "view(1px auto)" should set the property value
 PASS e.style['animation-timeline'] = "view(auto calc(1% + 1px))" should set the property value
+PASS e.style['animation-timeline'] = "view(2em calc(1% + 1em))" should set the property value
 PASS e.style['animation-timeline'] = "view(auto)" should set the property value
 PASS e.style['animation-timeline'] = "view(auto auto)" should set the property value
 PASS e.style['animation-timeline'] = "view(y 1px 2px 3px)" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-parsing.html
@@ -75,6 +75,7 @@ test_valid_value('animation-timeline', 'view(1px)');
 test_valid_value('animation-timeline', 'view(1px 1px)', 'view(1px)');
 test_valid_value('animation-timeline', 'view(1px auto)');
 test_valid_value('animation-timeline', 'view(auto calc(1% + 1px))');
+test_valid_value('animation-timeline', 'view(2em calc(1% + 1em))');
 test_valid_value('animation-timeline', 'view(auto)', 'view()');
 test_valid_value('animation-timeline', 'view(auto auto)', 'view()');
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -601,6 +601,7 @@ animation/FrameRateAligner.cpp
 animation/KeyframeEffect.cpp
 animation/KeyframeEffectStack.cpp
 animation/KeyframeInterpolation.cpp
+animation/ScrollAxis.cpp
 animation/ScrollTimeline.cpp
 animation/StyleOriginatedAnimation.cpp
 animation/StyleOriginatedAnimationEvent.cpp
@@ -1034,6 +1035,7 @@ css/parser/CSSPropertyParserConsumer+Resolution.cpp
 css/parser/CSSPropertyParserConsumer+String.cpp
 css/parser/CSSPropertyParserConsumer+Symbol.cpp
 css/parser/CSSPropertyParserConsumer+Time.cpp
+css/parser/CSSPropertyParserConsumer+Timeline.cpp
 css/parser/CSSPropertyParserConsumer+TimingFunction.cpp
 css/parser/CSSPropertyParserConsumer+Transform.cpp
 css/parser/CSSPropertyParserConsumer+URL.cpp

--- a/Source/WebCore/animation/ScrollAxis.cpp
+++ b/Source/WebCore/animation/ScrollAxis.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollAxis.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, ScrollAxis axis)
+{
+    switch (axis) {
+    case ScrollAxis::Block: ts << "block"; break;
+    case ScrollAxis::Inline: ts << "inline"; break;
+    case ScrollAxis::X: ts << "x"; break;
+    case ScrollAxis::Y: ts << "y"; break;
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/ScrollAxis.h
+++ b/Source/WebCore/animation/ScrollAxis.h
@@ -25,8 +25,12 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
 namespace WebCore {
 
 enum class ScrollAxis : uint8_t { Block, Inline, X, Y };
+
+TextStream& operator<<(TextStream&, ScrollAxis);
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -87,7 +87,22 @@ ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
 {
 }
 
-Ref<CSSValue> ScrollTimeline::toCSSValue() const
+void ScrollTimeline::dump(TextStream& ts) const
+{
+    auto hasScroller = m_scroller != Scroller::Nearest;
+    auto hasAxis = m_axis != ScrollAxis::Block;
+
+    ts << "scroll(";
+    if (hasScroller)
+        ts << (m_scroller == Scroller::Root ? "root" : "self");
+    if (hasScroller && hasAxis)
+        ts << " ";
+    if (hasAxis)
+        ts << m_axis;
+    ts << ")";
+}
+
+Ref<CSSValue> ScrollTimeline::toCSSValue(const RenderStyle&) const
 {
     auto scroller = [&]() {
         switch (m_scroller) {

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class CSSScrollValue;
 class Element;
+class RenderStyle;
 
 class ScrollTimeline : public AnimationTimeline {
 public:
@@ -50,7 +51,8 @@ public:
     const AtomString& name() const { return m_name; }
     void setName(const AtomString& name) { m_name = name; }
 
-    virtual Ref<CSSValue> toCSSValue() const;
+    virtual void dump(TextStream&) const;
+    virtual Ref<CSSValue> toCSSValue(const RenderStyle&) const;
 
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -33,20 +33,24 @@
 
 namespace WebCore {
 
+namespace Style {
+class BuilderState;
+}
+
 class CSSViewValue;
 class Element;
 
 struct ViewTimelineInsets {
     std::optional<Length> start;
     std::optional<Length> end;
-    bool operator==(const auto& other) const { return start == other.start && end == other.end; }
+    bool operator==(const ViewTimelineInsets&) const = default;
 };
 
 class ViewTimeline final : public ScrollTimeline {
 public:
     static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
-    static Ref<ViewTimeline> createFromCSSValue(const CSSViewValue&);
+    static Ref<ViewTimeline> createFromCSSValue(Style::BuilderState&, const CSSViewValue&);
 
     Element* subject() const { return m_subject.get(); }
     const CSSNumericValue& startOffset() const { return m_startOffset.get(); }
@@ -57,7 +61,8 @@ private:
     explicit ViewTimeline(ViewTimelineOptions&& = { });
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 
-    Ref<CSSValue> toCSSValue() const final;
+    void dump(TextStream&) const final;
+    Ref<CSSValue> toCSSValue(const RenderStyle&) const final;
     bool isViewTimeline() const final { return true; }
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -452,7 +452,7 @@ void CSSToStyleMap::mapAnimationTimeline(Animation& animation, const CSSValue& v
     if (treatAsInitialValue(value, CSSPropertyAnimationTimeline))
         animation.setTimeline(Animation::initialTimeline());
     else if (auto* viewValue = dynamicDowncast<CSSViewValue>(value))
-        animation.setTimeline(ViewTimeline::createFromCSSValue(*viewValue));
+        animation.setTimeline(ViewTimeline::createFromCSSValue(m_builderState, *viewValue));
     else if (auto* scrollValue = dynamicDowncast<CSSScrollValue>(value))
         animation.setTimeline(ScrollTimeline::createFromCSSValue(*scrollValue));
     else if (value.isCustomIdent())

--- a/Source/WebCore/css/CSSToStyleMap.h
+++ b/Source/WebCore/css/CSSToStyleMap.h
@@ -68,7 +68,7 @@ public:
     void mapAnimationName(Animation&, const CSSValue&);
     static void mapAnimationPlayState(Animation&, const CSSValue&);
     static void mapAnimationProperty(Animation&, const CSSValue&);
-    static void mapAnimationTimeline(Animation&, const CSSValue&);
+    void mapAnimationTimeline(Animation&, const CSSValue&);
     void mapAnimationTimingFunction(Animation&, const CSSValue&);
     static void mapAnimationCompositeOperation(Animation&, const CSSValue&);
     static void mapAnimationAllowsDiscreteTransitions(Animation&, const CSSValue&);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -61,6 +61,7 @@
 #include "CSSPropertyParserConsumer+Resolution.h"
 #include "CSSPropertyParserConsumer+String.h"
 #include "CSSPropertyParserConsumer+Time.h"
+#include "CSSPropertyParserConsumer+Timeline.h"
 #include "CSSPropertyParserConsumer+TimingFunction.h"
 #include "CSSPropertyParserConsumer+Transform.h"
 #include "CSSPropertyParserConsumer+URL.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+Timeline.h"
+
+#include "CSSParserContext.h"
+#include "CSSParserTokenRange.h"
+#include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSPropertyParserConsumer+List.h"
+#include "CSSPropertyParsing.h"
+#include "CSSScrollValue.h"
+#include "CSSValuePair.h"
+#include "CSSViewValue.h"
+
+namespace WebCore {
+namespace CSSPropertyParserHelpers {
+
+static RefPtr<CSSValue> consumeAnimationTimelineScroll(CSSParserTokenRange& range, const CSSParserContext&)
+{
+    // <scroll()> = scroll( [ <scroller> || <axis> ]? )
+    // <scroller> = root | nearest | self
+    // <axis> = block | inline | x | y
+    // https://drafts.csswg.org/scroll-animations-1/#scroll-notation
+
+    if (range.peek().type() != FunctionToken || range.peek().functionId() != CSSValueScroll)
+        return nullptr;
+
+    auto args = consumeFunction(range);
+
+    if (!args.size())
+        return CSSScrollValue::create(nullptr, nullptr);
+
+    auto scroller = CSSPropertyParsing::consumeScroller(args);
+    auto axis = CSSPropertyParsing::consumeAxis(args);
+
+    // Try <scroller> again since the order of <scroller> and <axis> is not guaranteed.
+    if (!scroller)
+        scroller = CSSPropertyParsing::consumeScroller(args);
+
+    // If there are values left to consume, these are not valid <scroller> or <axis> and the function is invalid.
+    if (args.size())
+        return nullptr;
+
+    return CSSScrollValue::create(WTFMove(scroller), WTFMove(axis));
+}
+
+static RefPtr<CSSValue> consumeAnimationTimelineView(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    // <view()> = view( [ <axis> || <'view-timeline-inset'> ]? )
+    // <axis> = block | inline | x | y
+    // <'view-timeline-inset'> = [ [ auto | <length-percentage> ]{1,2} ]#
+    // https://drafts.csswg.org/scroll-animations-1/#view-notation
+
+    if (range.peek().type() != FunctionToken || range.peek().functionId() != CSSValueView)
+        return nullptr;
+
+    auto args = consumeFunction(range);
+
+    if (!args.size())
+        return CSSViewValue::create();
+
+    auto axis = CSSPropertyParsing::consumeAxis(args);
+    auto startInset = CSSPropertyParsing::consumeSingleViewTimelineInset(args, context);
+    auto endInset = CSSPropertyParsing::consumeSingleViewTimelineInset(args, context);
+
+    // Try <axis> again since the order of <axis> and <'view-timeline-inset'> is not guaranteed.
+    if (!axis)
+        axis = CSSPropertyParsing::consumeAxis(args);
+
+    // If there are values left to consume, these are not valid <axis> or <'view-timeline-inset'> and the function is invalid.
+    if (args.size())
+        return nullptr;
+
+    return CSSViewValue::create(WTFMove(axis), WTFMove(startInset), WTFMove(endInset));
+}
+
+static RefPtr<CSSValue> consumeSingleAnimationTimeline(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    // <single-animation-timeline> = auto | none | <dashed-ident> | <scroll()> | <view()>
+    // https://drafts.csswg.org/css-animations-2/#typedef-single-animation-timeline
+
+    auto id = range.peek().id();
+    if (id == CSSValueAuto || id == CSSValueNone)
+        return consumeIdent(range);
+    if (auto name = consumeDashedIdent(range))
+        return name;
+    if (auto scroll = consumeAnimationTimelineScroll(range, context))
+        return scroll;
+    return consumeAnimationTimelineView(range, context);
+}
+
+RefPtr<CSSValue> consumeAnimationTimeline(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    // <animation-timeline> = <single-animation-timeline>#
+    // https://drafts.csswg.org/css-animations-2/#animation-timeline
+
+    return consumeCommaSeparatedListWithSingleValueOptimization(range, [context](CSSParserTokenRange& range) -> RefPtr<CSSValue> {
+        return consumeSingleAnimationTimeline(range, context);
+    });
+}
+
+RefPtr<CSSValue> consumeViewTimelineInsetListItem(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    // <view-timeline-inset-item> = <single-view-timeline-inset>{1,2}
+    // <single-view-timeline-inset> = auto | <length-percentage>
+    // https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset
+
+    auto startInset = CSSPropertyParsing::consumeSingleViewTimelineInset(range, context);
+    if (!startInset)
+        return nullptr;
+
+    if (auto endInset = CSSPropertyParsing::consumeSingleViewTimelineInset(range, context)) {
+        if (endInset != startInset)
+            return CSSValuePair::createNoncoalescing(startInset.releaseNonNull(), endInset.releaseNonNull());
+    }
+
+    return startInset;
+}
+
+RefPtr<CSSValue> consumeViewTimelineInset(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    // <view-timeline-inset> = <view-timeline-inset-item>#
+    // https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset
+
+    return consumeCommaSeparatedListWithoutSingleValueOptimization(range, [context](CSSParserTokenRange& range) {
+        return consumeViewTimelineInsetListItem(range, context);
+    });
+}
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+class CSSValue;
+struct CSSParserContext;
+
+namespace CSSPropertyParserHelpers {
+
+// MARK: - Consumer functions
+
+RefPtr<CSSValue> consumeAnimationTimeline(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeViewTimelineInsetListItem(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeViewTimelineInset(CSSParserTokenRange&, const CSSParserContext&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -160,12 +160,6 @@ RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextUnderlinePosition(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeAnimationTimeline(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeSingleAnimationTimeline(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeAnimationTimelineScroll(CSSParserTokenRange&);
-RefPtr<CSSValue> consumeAnimationTimelineView(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeViewTimelineInsetListItem(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeViewTimelineInset(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSPrimitiveValue> consumeAnchor(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange&);
 

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3951,6 +3951,7 @@ class GenerateCSSPropertyParsing:
                     "CSSPropertyParserConsumer+Resolution.h",
                     "CSSPropertyParserConsumer+String.h",
                     "CSSPropertyParserConsumer+Time.h",
+                    "CSSPropertyParserConsumer+Timeline.h",
                     "CSSPropertyParserConsumer+TimingFunction.h",
                     "CSSPropertyParserConsumer+Transform.h",
                     "CSSPropertyParserConsumer+URL.h",

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -171,18 +171,26 @@ TextStream& operator<<(TextStream& ts, Animation::Direction direction)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, Animation::TimelineKeyword keyword)
+{
+    switch (keyword) {
+    case Animation::TimelineKeyword::Auto: ts << "auto"; break;
+    case Animation::TimelineKeyword::None: ts << "none"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, const Animation::Timeline& timeline)
 {
     WTF::switchOn(timeline,
-        [&] (Animation::TimelineKeyword keyword) {
-            switch (keyword) {
-            case Animation::TimelineKeyword::Auto: ts << "auto"; break;
-            case Animation::TimelineKeyword::None: ts << "none"; break;
-            }
-        }, [&] (const AtomString& customIdent) {
+        [&](Animation::TimelineKeyword keyword) {
+            ts << keyword;
+        },
+        [&](const AtomString& customIdent) {
             ts << customIdent;
-        }, [&] (const Ref<ScrollTimeline>& scrollTimeline) {
-            ts << scrollTimeline->toCSSValue()->cssText();
+        },
+        [&](const Ref<ScrollTimeline>& scrollTimeline) {
+            scrollTimeline->dump(ts);
         }
     );
     return ts;

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -271,6 +271,7 @@ public:
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);
 WTF::TextStream& operator<<(WTF::TextStream&, Animation::TransitionProperty);
 WTF::TextStream& operator<<(WTF::TextStream&, Animation::Direction);
+WTF::TextStream& operator<<(WTF::TextStream&, Animation::TimelineKeyword);
 WTF::TextStream& operator<<(WTF::TextStream&, const Animation::Timeline&);
 WTF::TextStream& operator<<(WTF::TextStream&, const Animation&);
 


### PR DESCRIPTION
#### c58919c8dc38fa050a4a1e4396c203a264881e52
<pre>
CSS view timeline needs conversion data to properly resolve insets
<a href="https://bugs.webkit.org/show_bug.cgi?id=279097">https://bugs.webkit.org/show_bug.cgi?id=279097</a>

Reviewed by Tim Nguyen.

Removes use of deprecated primitive value resolvers by passing in
conversion data for resolution.

With resolution now potentially creating Calculation::Values, computed
value support needs to pipe the RenderStyle in so that the primitive
value can be correctly constructed.

Takes opportunity to split timeline specific parsing into its own
set of files.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-parsing.html:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/ScrollAxis.cpp: Added.
* Source/WebCore/animation/ScrollAxis.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/css/CSSToStyleMap.cpp:
* Source/WebCore/css/CSSToStyleMap.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h: Added.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/process-css-properties.py:
* Source/WebCore/platform/animation/Animation.cpp:
* Source/WebCore/platform/animation/Animation.h:

Canonical link: <a href="https://commits.webkit.org/283155@main">https://commits.webkit.org/283155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25590e5a224ad0cdca9e4d5ff2334a1b4bf9b4b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52464 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13926 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71066 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9289 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13720 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1329 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40516 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->