### PR TITLE
Video is sometimes mispositioned in element fullscreen window

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1072,18 +1072,10 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         // apply the default web view state (which sets both parameters anyways)?
         [webView _setMinimumEffectiveDeviceWidth:0];
         [webView _setViewScale:1.f];
-        WebKit::WKWebViewState().applyTo(webView.get());
         [webView _overrideZoomScaleParametersWithMinimumZoomScale:WebKit::baseScale maximumZoomScale:WebKit::baseScale allowUserScaling:NO];
         [webView _resetContentOffset];
         [_window insertSubview:webView.get() atIndex:0];
-
-        // _obscuredInsets and _unobscuredSafeAreaInsets were already reset by
-        // WKWebViewState::applyTo(), but inserting webView into _window may change its
-        // safeAreaInsets, which may cause the client to set new (un)obscured insets.
-        // Therefore we need to reset them again.
-        [webView _resetObscuredInsets];
-        [webView _resetUnobscuredSafeAreaInsets];
-
+        WebKit::WKWebViewState().applyTo(webView.get());
         [webView setNeedsLayout];
         [webView layoutIfNeeded];
 
@@ -1108,6 +1100,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
             [self._webView _doAfterNextVisibleContentRectAndPresentationUpdate:makeBlockPtr([self, protectedSelf, logIdentifier] {
                 if (auto* manager = [protectedSelf _manager]) {
                     OBJC_ALWAYS_LOG(logIdentifier, "presentation updated");
+                    WebKit::WKWebViewState().applyTo(self._webView);
                     manager->willEnterFullScreen();
                     return;
                 }


### PR DESCRIPTION
#### 63cdf52be469766f2c633447803aa4ea1645af1d
<pre>
Video is sometimes mispositioned in element fullscreen window
<a href="https://bugs.webkit.org/show_bug.cgi?id=279102">https://bugs.webkit.org/show_bug.cgi?id=279102</a>
<a href="https://rdar.apple.com/135224530">rdar://135224530</a>

Reviewed by Wenson Hsieh.

In webkit.org/b/278842 we found that the client may sometimes synchronously modify WKWebView&apos;s
_obscuredInsets when the web view is inserted in the element fullscreen window. 282915@main
attempted to fix this but it was incomplete because, in addition to _obscuredInsets, the client may
also modify the scroll view&apos;s contentInset and contentOffset. The result is similar to the issue
seen in bug 278842: the video is mispositioned in the fullscreen window (and sometimes can be
scrolled).

This change follows up 282915@main with a more complete fix. Instead of resetting just
_obscuredInsets and _unobscuredSafeAreaInsets after inserting the web view, we now just defer
resetting all WKWebView and WKScrollView properties until after -insertSubview:atIndex: is called.
Additionally, we reset all properties again right before changing fullscreenState to
WKFullscreenStateEnteringFullscreen since the client may modify properties while we wait for a
presentation update. At the point where fullscreenState changes to
WKFullscreenStateEnteringFullscreen we expect the client to avoid modifying WKWebView and
WKScrollView properties for the duration of the element fullscreen presentation.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:]):

Canonical link: <a href="https://commits.webkit.org/283160@main">https://commits.webkit.org/283160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0f54ef9823245896341a85b946a9f867cc7c726

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16029 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16309 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11108 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68487 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38054 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14905 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9374 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14416 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1401 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40601 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41677 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->