### PR TITLE
[WebDriver][WPE] Segfault in MiniBrowser in some tests when the first window is closed and a new one is created

### DIFF
--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -332,7 +332,19 @@ static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationActi
 static WebKitWebView* createWebViewForAutomationCallback(WebKitAutomationSession*, WebKitWebView* view)
 {
 #if ENABLE_WPE_PLATFORM
-    // Creating new views in the old API is not supported by WPE's MiniBrowser, so we just return the same view as before
+
+    // The original view might have been closed, so we need to find a valid view to clone
+    if (!g_hash_table_lookup(openViews, view)) {
+        GHashTableIter iter;
+        gpointer key, value;
+        g_hash_table_iter_init(&iter, openViews);
+        if (!g_hash_table_iter_next(&iter, &key, &value))
+            return nullptr;
+        view = WEBKIT_WEB_VIEW(value);
+    }
+
+    // Creating new views in the old API through automation is not supported by WPE's MiniBrowser,
+    // so we just return the same view as before
     if (!useWPEPlatformAPI)
         return view;
 


### PR DESCRIPTION
#### b9f177ccdf00a6ea7e5983939ec470063dd6d3e2
<pre>
[WebDriver][WPE] Segfault in MiniBrowser in some tests when the first window is closed and a new one is created
<a href="https://bugs.webkit.org/show_bug.cgi?id=279101">https://bugs.webkit.org/show_bug.cgi?id=279101</a>

Reviewed by Carlos Garcia Campos.

Ensure we&apos;re using a live view as the base for new automated views. And
in the case of the old WPE API, ensure we&apos;re returning a live view.

This fixes the case where the original view might have been closed and
the application is kept alive through younger views.

In a future commit, we might avoid hardcoding the original view as the
createWebViewForAutomationCallback user data, using another scheme to
track a live view.

* Tools/MiniBrowser/wpe/main.cpp:
(createWebViewForAutomationCallback):

Canonical link: <a href="https://commits.webkit.org/283170@main">https://commits.webkit.org/283170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9502b408cdedf76d959d7a0caab5ba3f3554faf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52536 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11103 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68482 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33166 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14901 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9370 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13800 "Found 2 new test failures: imported/w3c/web-platform-tests/media-source/URL-createObjectURL.html imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7742 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1400 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40597 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->