### PR TITLE
Make TestWebKitAPI::WebTransportServer more robust

### DIFF
--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "CoroutineUtilities.h"
+#import <Network/Network.h>
+#import <wtf/CompletionHandler.h>
+
+namespace TestWebKitAPI {
+
+class ReceiveHTTPRequestOperation;
+class ReceiveBytesOperation;
+class SendOperation;
+
+class Connection {
+public:
+    void send(String&&, CompletionHandler<void()>&& = nullptr) const;
+    void send(Vector<uint8_t>&&, CompletionHandler<void()>&& = nullptr) const;
+    void send(RetainPtr<dispatch_data_t>&&, CompletionHandler<void(bool)>&& = nullptr) const;
+    SendOperation awaitableSend(Vector<uint8_t>&&);
+    SendOperation awaitableSend(String&&);
+    SendOperation awaitableSend(RetainPtr<dispatch_data_t>&&);
+    void sendAndReportError(Vector<uint8_t>&&, CompletionHandler<void(bool)>&&) const;
+    void receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&&, size_t minimumSize = 1) const;
+    ReceiveBytesOperation awaitableReceiveBytes() const;
+    void receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&&, Vector<char>&& buffer = { }) const;
+    ReceiveHTTPRequestOperation awaitableReceiveHTTPRequest() const;
+    void webSocketHandshake(CompletionHandler<void()>&& = { });
+    void terminate(CompletionHandler<void()>&& = { });
+    void cancel();
+
+private:
+    friend class HTTPServer;
+    friend class WebTransportServer;
+    Connection(nw_connection_t connection)
+        : m_connection(connection) { }
+
+    RetainPtr<nw_connection_t> m_connection;
+};
+
+class ReceiveHTTPRequestOperation {
+public:
+    ReceiveHTTPRequestOperation(const Connection& connection)
+        : m_connection(connection) { }
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<>);
+    Vector<char> await_resume() { return WTFMove(m_result); }
+private:
+    Connection m_connection;
+    Vector<char> m_result;
+};
+
+class ReceiveBytesOperation {
+public:
+    ReceiveBytesOperation(const Connection& connection)
+        : m_connection(connection) { }
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<>);
+    Vector<uint8_t> await_resume() { return WTFMove(m_result); }
+private:
+    Connection m_connection;
+    Vector<uint8_t> m_result;
+};
+
+class SendOperation {
+public:
+    SendOperation(RetainPtr<dispatch_data_t>&& data, const Connection& connection)
+        : m_data(WTFMove(data))
+        , m_connection(connection) { }
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<>);
+    void await_resume() { }
+private:
+    RetainPtr<dispatch_data_t> m_data;
+    Connection m_connection;
+};
+
+RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&&);
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "NetworkConnection.h"
+
+#import "HTTPServer.h"
+#import <wtf/BlockPtr.h>
+#import <wtf/SHA1.h>
+#import <wtf/text/Base64.h>
+
+namespace TestWebKitAPI {
+
+RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&& v)
+{
+    auto bufferSize = v.size();
+    auto rawPointer = v.releaseBuffer().leakPtr();
+    return adoptNS(dispatch_data_create(rawPointer, bufferSize, dispatch_get_main_queue(), ^{
+        fastFree(rawPointer);
+    }));
+}
+
+static Vector<uint8_t> vectorFromData(dispatch_data_t content)
+{
+    ASSERT(content);
+    __block Vector<uint8_t> request;
+    dispatch_data_apply(content, ^bool(dispatch_data_t, size_t, const void* buffer, size_t size) {
+        request.append(std::span { static_cast<const uint8_t*>(buffer), size });
+        return true;
+    });
+    return request;
+}
+
+static RetainPtr<dispatch_data_t> dataFromString(String&& s)
+{
+    auto impl = s.releaseImpl();
+    ASSERT(impl->is8Bit());
+    auto characters = impl->span8();
+    return adoptNS(dispatch_data_create(characters.data(), characters.size(), dispatch_get_main_queue(), ^{
+        (void)impl;
+    }));
+}
+
+void Connection::receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler, size_t minimumSize) const
+{
+    nw_connection_receive(m_connection.get(), minimumSize, std::numeric_limits<uint32_t>::max(), makeBlockPtr([connection = *this, completionHandler = WTFMove(completionHandler)](dispatch_data_t content, nw_content_context_t, bool, nw_error_t error) mutable {
+        if (error || !content)
+            return completionHandler({ });
+        completionHandler(vectorFromData(content));
+    }).get());
+}
+
+void Connection::receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&& completionHandler, Vector<char>&& buffer) const
+{
+    receiveBytes([connection = *this, completionHandler = WTFMove(completionHandler), buffer = WTFMove(buffer)](Vector<uint8_t>&& bytes) mutable {
+        buffer.appendVector(WTFMove(bytes));
+        if (auto* doubleNewline = strnstr(buffer.data(), "\r\n\r\n", buffer.size())) {
+            if (auto* contentLengthBegin = strnstr(buffer.data(), "Content-Length", buffer.size())) {
+                size_t contentLength = atoi(contentLengthBegin + strlen("Content-Length: "));
+                size_t headerLength = doubleNewline - buffer.data() + strlen("\r\n\r\n");
+                if (buffer.size() - headerLength < contentLength)
+                    return connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));
+            }
+            completionHandler(WTFMove(buffer));
+        } else
+            connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));
+    });
+}
+
+ReceiveHTTPRequestOperation Connection::awaitableReceiveHTTPRequest() const
+{
+    return { *this };
+}
+
+void ReceiveHTTPRequestOperation::await_suspend(std::coroutine_handle<> handle)
+{
+    m_connection.receiveHTTPRequest([this, handle](Vector<char>&& result) mutable {
+        m_result = WTFMove(result);
+        handle();
+    });
+}
+
+ReceiveBytesOperation Connection::awaitableReceiveBytes() const
+{
+    return { *this };
+}
+
+void ReceiveBytesOperation::await_suspend(std::coroutine_handle<> handle)
+{
+    m_connection.receiveBytes([this, handle](Vector<uint8_t>&& result) mutable {
+        m_result = WTFMove(result);
+        handle();
+    });
+}
+
+void SendOperation::await_suspend(std::coroutine_handle<> handle)
+{
+    m_connection.send(WTFMove(m_data), [handle] (bool) mutable {
+        handle();
+    });
+}
+
+SendOperation Connection::awaitableSend(Vector<uint8_t>&& message)
+{
+    return { dataFromVector(WTFMove(message)), *this };
+}
+
+SendOperation Connection::awaitableSend(String&& message)
+{
+    return { dataFromString(WTFMove(message)), *this };
+}
+
+SendOperation Connection::awaitableSend(RetainPtr<dispatch_data_t>&& data)
+{
+    return { WTFMove(data), *this };
+}
+
+void Connection::send(String&& message, CompletionHandler<void()>&& completionHandler) const
+{
+    send(dataFromString(WTFMove(message)), [completionHandler = WTFMove(completionHandler)] (bool) mutable {
+        if (completionHandler)
+            completionHandler();
+    });
+}
+
+void Connection::send(Vector<uint8_t>&& message, CompletionHandler<void()>&& completionHandler) const
+{
+    send(dataFromVector(WTFMove(message)), [completionHandler = WTFMove(completionHandler)] (bool) mutable {
+        if (completionHandler)
+            completionHandler();
+    });
+}
+
+void Connection::sendAndReportError(Vector<uint8_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    send(dataFromVector(WTFMove(message)), WTFMove(completionHandler));
+}
+
+void Connection::send(RetainPtr<dispatch_data_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    nw_connection_send(m_connection.get(), message.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTFMove(completionHandler)](nw_error_t error) mutable {
+        if (completionHandler)
+            completionHandler(!!error);
+    }).get());
+}
+
+void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandler)
+{
+    receiveHTTPRequest([connection = Connection(*this), connectionHandler = WTFMove(connectionHandler)] (Vector<char>&& request) mutable {
+
+        auto webSocketAcceptValue = [] (const Vector<char>& request) {
+            constexpr auto* keyHeaderField = "Sec-WebSocket-Key: ";
+            const char* keyBegin = strnstr(request.data(), keyHeaderField, request.size()) + strlen(keyHeaderField);
+            ASSERT(keyBegin);
+            const char* keyEnd = strnstr(keyBegin, "\r\n", request.size() + (keyBegin - request.data()));
+            ASSERT(keyEnd);
+
+            const auto webSocketKeyGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_span;
+            SHA1 sha1;
+            sha1.addBytes(byteCast<uint8_t>(std::span { keyBegin, keyEnd }));
+            sha1.addBytes(webSocketKeyGUID);
+            SHA1::Digest hash;
+            sha1.computeHash(hash);
+            return base64EncodeToString(hash);
+        };
+
+        connection.send(HTTPResponse(101, {
+            { "Upgrade"_s, "websocket"_s },
+            { "Connection"_s, "Upgrade"_s },
+            { "Sec-WebSocket-Accept"_s, webSocketAcceptValue(request) }
+        }).serialize(HTTPResponse::IncludeContentLength::No), WTFMove(connectionHandler));
+    });
+}
+
+void Connection::terminate(CompletionHandler<void()>&& completionHandler)
+{
+    nw_connection_set_state_changed_handler(m_connection.get(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_connection_state_t state, nw_error_t error) mutable {
+        ASSERT_UNUSED(error, !error);
+        if (state == nw_connection_state_cancelled && completionHandler)
+            completionHandler();
+    }).get());
+    nw_connection_cancel(m_connection.get());
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -23,6 +23,7 @@
 
 DeprecatedGlobalValues.mm
 EditingTestHarness.mm
+NetworkConnection.mm
 WKWebViewConfigurationExtras.mm
 
 cocoa/CGImagePixelReader.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3774,6 +3774,9 @@
 		F6FDDDD214241AD4004F1729 /* PrivateBrowsingPushStateNoHistoryCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateBrowsingPushStateNoHistoryCallback.cpp; sourceTree = "<group>"; };
 		F6FDDDD514241C48004F1729 /* push-state.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "push-state.html"; sourceTree = "<group>"; };
 		FA049D0F2BCF22210099C221 /* LoadAndDecodeImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadAndDecodeImage.mm; sourceTree = "<group>"; };
+		FA65EFFC2C87F43C00A0A123 /* CoroutineUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoroutineUtilities.h; sourceTree = "<group>"; };
+		FA65F0042C87F4CF00A0A123 /* NetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkConnection.h; sourceTree = "<group>"; };
+		FA65F0052C87F4CF00A0A123 /* NetworkConnection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkConnection.mm; sourceTree = "<group>"; };
 		FA8650312C7D01CA00117287 /* WebTransportServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportServer.h; sourceTree = "<group>"; };
 		FA8650322C7D01CA00117287 /* WebTransportServer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebTransportServer.mm; sourceTree = "<group>"; };
 		FA8650332C7D047B00117287 /* WebTransport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebTransport.mm; sourceTree = "<group>"; };
@@ -3914,6 +3917,7 @@
 				BCA61C3A11700B9400460D1E /* mac */,
 				A17A5A3122A887610065C5F0 /* TestRunnerShared */,
 				BC131A9E1171317C00B69727 /* config.h */,
+				FA65EFFC2C87F43C00A0A123 /* CoroutineUtilities.h */,
 				7C6BBD8B19CEA63000C1F5E0 /* Counters.cpp */,
 				7C6BBD8A19CEA54300C1F5E0 /* Counters.h */,
 				5CABDBEC2735CB4D00B88BCB /* DeprecatedGlobalValues.cpp */,
@@ -3972,6 +3976,8 @@
 				F42F081627449FFD007E0D90 /* ImageAnalysisTestingUtilities.mm */,
 				F44A530D21B8976900DBB99C /* InstanceMethodSwizzler.h */,
 				F44A531021B8976900DBB99C /* InstanceMethodSwizzler.mm */,
+				FA65F0042C87F4CF00A0A123 /* NetworkConnection.h */,
+				FA65F0052C87F4CF00A0A123 /* NetworkConnection.mm */,
 				0F139E721A423A2B00F590F5 /* PlatformUtilitiesCocoa.mm */,
 				F4010B8224DA267F00A876E2 /* PoseAsClass.h */,
 				F4010B8124DA267F00A876E2 /* PoseAsClass.mm */,

--- a/Tools/TestWebKitAPI/WebTransportServer.mm
+++ b/Tools/TestWebKitAPI/WebTransportServer.mm
@@ -29,10 +29,24 @@
 #import "HTTPServer.h"
 #import "Utilities.h"
 #import <pal/spi/cf/CFNetworkSPI.h>
+#import <wtf/BlockPtr.h>
 
 namespace TestWebKitAPI {
 
-WebTransportServer::WebTransportServer()
+struct WebTransportServer::Data : public RefCounted<WebTransportServer::Data> {
+    static Ref<Data> create(Function<Task(Connection)>&& connectionHandler) { return adoptRef(*new Data(WTFMove(connectionHandler))); }
+    Data(Function<Task(Connection)>&& connectionHandler)
+        : connectionHandler(WTFMove(connectionHandler)) { }
+
+    Function<Task(Connection)> connectionHandler;
+    RetainPtr<nw_listener_t> listener;
+    Vector<RetainPtr<nw_connection_group_t>> connectionGroups;
+    Vector<RetainPtr<nw_connection_t>> connections;
+    Vector<CoroutineHandle<Task::promise_type>> coroutineHandles;
+};
+
+WebTransportServer::WebTransportServer(Function<Task(Connection)>&& connectionHandler)
+    : m_data(Data::create(WTFMove(connectionHandler)))
 {
     auto configureTLS = [](nw_protocol_options_t options) {
         RetainPtr securityOptions = adoptNS(nw_quic_connection_copy_sec_protocol_options(options));
@@ -42,55 +56,45 @@ WebTransportServer::WebTransportServer()
 
     RetainPtr parameters = adoptNS(nw_parameters_create_quic_stream(NW_PARAMETERS_DEFAULT_CONFIGURATION, configureTLS));
 
-    m_listener = adoptNS(nw_listener_create(parameters.get()));
+    RetainPtr listener = adoptNS(nw_listener_create(parameters.get()));
 
-    // FIXME: This block unsafely captures this.
-    nw_listener_set_new_connection_group_handler(m_listener.get(), ^(nw_connection_group_t connectionGroup) {
+    nw_listener_set_new_connection_group_handler(listener.get(), [data = m_data] (nw_connection_group_t connectionGroup) {
         constexpr uint32_t maximumMessageSize { std::numeric_limits<uint32_t>::max() };
         constexpr bool rejectOversizedMessages { false };
-        nw_connection_group_set_receive_handler(connectionGroup, maximumMessageSize, rejectOversizedMessages, ^(dispatch_data_t data, nw_content_context_t, bool) {
+        nw_connection_group_set_receive_handler(connectionGroup, maximumMessageSize, rejectOversizedMessages, ^(dispatch_data_t, nw_content_context_t, bool) {
             // FIXME: Implement and test datagrams with WebTransport.
         });
 
-        // FIXME: This block unsafely captures this.
-        nw_connection_group_set_new_connection_handler(connectionGroup, ^(nw_connection_t connection) {
+        nw_connection_group_set_new_connection_handler(connectionGroup, [data] (nw_connection_t connection) {
+            data->connections.append(connection);
             nw_connection_set_queue(connection, dispatch_get_main_queue());
-            nw_connection_set_state_changed_handler(connection, ^(nw_connection_state_t state, nw_error_t error) {
-                if (error) {
-                    ASSERT_NOT_REACHED();
-                    return;
-                }
-                if (state != nw_connection_state_ready)
-                    return;
-                nw_connection_receive(connection, 1, std::numeric_limits<uint32_t>::max(), ^(dispatch_data_t content, nw_content_context_t context, bool is_complete, nw_error_t error) {
-                    nw_connection_send(connection, content, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
-                        ASSERT_UNUSED(error, !error);
-                    });
-                });
-            });
             nw_connection_start(connection);
-            m_connections.append(connection);
+            data->coroutineHandles.append(data->connectionHandler(connection).handle);
         });
 
         nw_connection_group_set_queue(connectionGroup, dispatch_get_main_queue());
         nw_connection_group_start(connectionGroup);
-        m_connectionGroups.append(connectionGroup);
+        data->connectionGroups.append(connectionGroup);
     });
-    nw_listener_set_queue(m_listener.get(), dispatch_get_main_queue());
+    nw_listener_set_queue(listener.get(), dispatch_get_main_queue());
 
     __block bool ready = false;
-    nw_listener_set_state_changed_handler(m_listener.get(), ^(nw_listener_state_t state, nw_error_t error) {
+    nw_listener_set_state_changed_handler(listener.get(), ^(nw_listener_state_t state, nw_error_t error) {
         ASSERT_UNUSED(error, !error);
         if (state == nw_listener_state_ready)
             ready = true;
     });
-    nw_listener_start(m_listener.get());
+    nw_listener_start(listener.get());
     Util::run(&ready);
+
+    m_data->listener = WTFMove(listener);
 }
+
+WebTransportServer::~WebTransportServer() = default;
 
 uint16_t WebTransportServer::port() const
 {
-    return nw_listener_get_port(m_listener.get());
+    return nw_listener_get_port(m_data->listener.get());
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -33,7 +33,6 @@
 #import <wtf/CallbackAggregator.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
-#import <wtf/SHA1.h>
 #import <wtf/ThreadSafeRefCounted.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/MakeString.h>
@@ -326,36 +325,6 @@ static ASCIILiteral statusText(unsigned statusCode)
     return "Unknown Status Code"_s;
 }
 
-static RetainPtr<dispatch_data_t> dataFromString(String&& s)
-{
-    auto impl = s.releaseImpl();
-    ASSERT(impl->is8Bit());
-    auto characters = impl->span8();
-    return adoptNS(dispatch_data_create(characters.data(), characters.size(), dispatch_get_main_queue(), ^{
-        (void)impl;
-    }));
-}
-
-RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&& v)
-{
-    auto bufferSize = v.size();
-    auto rawPointer = v.releaseBuffer().leakPtr();
-    return adoptNS(dispatch_data_create(rawPointer, bufferSize, dispatch_get_main_queue(), ^{
-        fastFree(rawPointer);
-    }));
-}
-
-static Vector<uint8_t> vectorFromData(dispatch_data_t content)
-{
-    ASSERT(content);
-    __block Vector<uint8_t> request;
-    dispatch_data_apply(content, ^bool(dispatch_data_t, size_t, const void* buffer, size_t size) {
-        request.append(std::span { static_cast<const uint8_t*>(buffer), size });
-        return true;
-    });
-    return request;
-}
-
 static void appendUTF8ToVector(Vector<uint8_t>& vector, const String& string)
 {
     vector.append(string.utf8().span());
@@ -458,134 +427,6 @@ WKWebViewConfiguration *HTTPServer::httpsProxyConfiguration() const
     auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     return viewConfiguration.autorelease();
-}
-
-void Connection::receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler, size_t minimumSize) const
-{
-    nw_connection_receive(m_connection.get(), minimumSize, std::numeric_limits<uint32_t>::max(), makeBlockPtr([connection = *this, completionHandler = WTFMove(completionHandler)](dispatch_data_t content, nw_content_context_t, bool, nw_error_t error) mutable {
-        if (error || !content)
-            return completionHandler({ });
-        completionHandler(vectorFromData(content));
-    }).get());
-}
-
-void Connection::receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&& completionHandler, Vector<char>&& buffer) const
-{
-    receiveBytes([connection = *this, completionHandler = WTFMove(completionHandler), buffer = WTFMove(buffer)](Vector<uint8_t>&& bytes) mutable {
-        buffer.appendVector(WTFMove(bytes));
-        if (auto* doubleNewline = strnstr(buffer.data(), "\r\n\r\n", buffer.size())) {
-            if (auto* contentLengthBegin = strnstr(buffer.data(), "Content-Length", buffer.size())) {
-                size_t contentLength = atoi(contentLengthBegin + strlen("Content-Length: "));
-                size_t headerLength = doubleNewline - buffer.data() + strlen("\r\n\r\n");
-                if (buffer.size() - headerLength < contentLength)
-                    return connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));
-            }
-            completionHandler(WTFMove(buffer));
-        } else
-            connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));
-    });
-}
-
-ReceiveOperation Connection::awaitableReceiveHTTPRequest() const
-{
-    return { *this };
-}
-
-void ReceiveOperation::await_suspend(std::coroutine_handle<> handle)
-{
-    m_connection.receiveHTTPRequest([this, handle](Vector<char>&& result) mutable {
-        m_result = WTFMove(result);
-        handle();
-    });
-}
-
-void SendOperation::await_suspend(std::coroutine_handle<> handle)
-{
-    m_connection.send(WTFMove(m_data), [handle] (bool) mutable {
-        handle();
-    });
-}
-
-SendOperation Connection::awaitableSend(Vector<uint8_t>&& message)
-{
-    return { dataFromVector(WTFMove(message)), *this };
-}
-
-SendOperation Connection::awaitableSend(String&& message)
-{
-    return { dataFromString(WTFMove(message)), *this };
-}
-
-SendOperation Connection::awaitableSend(RetainPtr<dispatch_data_t>&& data)
-{
-    return { WTFMove(data), *this };
-}
-
-void Connection::send(String&& message, CompletionHandler<void()>&& completionHandler) const
-{
-    send(dataFromString(WTFMove(message)), [completionHandler = WTFMove(completionHandler)] (bool) mutable {
-        if (completionHandler)
-            completionHandler();
-    });
-}
-
-void Connection::send(Vector<uint8_t>&& message, CompletionHandler<void()>&& completionHandler) const
-{
-    send(dataFromVector(WTFMove(message)), [completionHandler = WTFMove(completionHandler)] (bool) mutable {
-        if (completionHandler)
-            completionHandler();
-    });
-}
-
-void Connection::sendAndReportError(Vector<uint8_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
-{
-    send(dataFromVector(WTFMove(message)), WTFMove(completionHandler));
-}
-
-void Connection::send(RetainPtr<dispatch_data_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
-{
-    nw_connection_send(m_connection.get(), message.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTFMove(completionHandler)](nw_error_t error) mutable {
-        if (completionHandler)
-            completionHandler(!!error);
-    }).get());
-}
-
-void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandler)
-{
-    receiveHTTPRequest([connection = Connection(*this), connectionHandler = WTFMove(connectionHandler)] (Vector<char>&& request) mutable {
-
-        auto webSocketAcceptValue = [] (const Vector<char>& request) {
-            constexpr auto* keyHeaderField = "Sec-WebSocket-Key: ";
-            const char* keyBegin = strnstr(request.data(), keyHeaderField, request.size()) + strlen(keyHeaderField);
-            ASSERT(keyBegin);
-            const char* keyEnd = strnstr(keyBegin, "\r\n", request.size() + (keyBegin - request.data()));
-            ASSERT(keyEnd);
-
-            const auto webSocketKeyGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_span;
-            SHA1 sha1;
-            sha1.addBytes(byteCast<uint8_t>(std::span { keyBegin, keyEnd }));
-            sha1.addBytes(webSocketKeyGUID);
-            SHA1::Digest hash;
-            sha1.computeHash(hash);
-            return base64EncodeToString(hash);
-        };
-
-        connection.send(HTTPResponse(101, {
-            { "Upgrade"_s, "websocket"_s },
-            { "Connection"_s, "Upgrade"_s },
-            { "Sec-WebSocket-Accept"_s, webSocketAcceptValue(request) }
-        }).serialize(HTTPResponse::IncludeContentLength::No), WTFMove(connectionHandler));
-    });
-}
-
-void Connection::terminate(CompletionHandler<void()>&& completionHandler)
-{
-    nw_connection_set_state_changed_handler(m_connection.get(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_connection_state_t state, nw_error_t error) mutable {
-        ASSERT_UNUSED(error, !error);
-        if (state == nw_connection_state_cancelled && completionHandler)
-            completionHandler();
-    }).get());
-    nw_connection_cancel(m_connection.get());
 }
 
 Vector<uint8_t> HTTPResponse::bodyFromString(const String& string)


### PR DESCRIPTION
#### 72de008ffc2a35922d34a064338028ea694ff7b6
<pre>
Make TestWebKitAPI::WebTransportServer more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=279107">https://bugs.webkit.org/show_bug.cgi?id=279107</a>
<a href="https://rdar.apple.com/135249015">rdar://135249015</a>

Reviewed by Matthew Finkel.

WebTransportServer was barely enough to do one echo.
This makes it more robust.  It now receives a connection
handler in its constructor and shares the TestWebKitAPI::Connection
code with HTTPServer.  This will allow us to write more interesting
tests.

* Tools/TestWebKitAPI/CoroutineUtilities.h: Copied from Tools/TestWebKitAPI/WebTransportServer.h.
(TestWebKitAPI::CoroutineHandle::CoroutineHandle):
(TestWebKitAPI::CoroutineHandle::~CoroutineHandle):
(TestWebKitAPI::Task::promise_type::get_return_object):
(TestWebKitAPI::Task::promise_type::initial_suspend):
(TestWebKitAPI::Task::promise_type::unhandled_exception):
(TestWebKitAPI::Task::promise_type::return_void):
* Tools/TestWebKitAPI/NetworkConnection.h: Added.
(TestWebKitAPI::Connection::receiveHTTPRequest):
(TestWebKitAPI::Connection::webSocketHandshake):
(TestWebKitAPI::Connection::terminate):
(TestWebKitAPI::Connection::Connection):
(TestWebKitAPI::ReceiveHTTPRequestOperation::ReceiveHTTPRequestOperation):
(TestWebKitAPI::ReceiveHTTPRequestOperation::await_ready):
(TestWebKitAPI::ReceiveHTTPRequestOperation::await_resume):
(TestWebKitAPI::ReceiveBytesOperation::ReceiveBytesOperation):
(TestWebKitAPI::ReceiveBytesOperation::await_ready):
(TestWebKitAPI::ReceiveBytesOperation::await_resume):
(TestWebKitAPI::SendOperation::SendOperation):
(TestWebKitAPI::SendOperation::await_ready):
(TestWebKitAPI::SendOperation::await_resume):
* Tools/TestWebKitAPI/NetworkConnection.mm: Added.
(TestWebKitAPI::dataFromVector):
(TestWebKitAPI::vectorFromData):
(TestWebKitAPI::dataFromString):
(TestWebKitAPI::Connection::receiveBytes const):
(TestWebKitAPI::Connection::receiveHTTPRequest const):
(TestWebKitAPI::Connection::awaitableReceiveHTTPRequest const):
(TestWebKitAPI::ReceiveHTTPRequestOperation::await_suspend):
(TestWebKitAPI::Connection::awaitableReceiveBytes const):
(TestWebKitAPI::ReceiveBytesOperation::await_suspend):
(TestWebKitAPI::SendOperation::await_suspend):
(TestWebKitAPI::Connection::awaitableSend):
(TestWebKitAPI::Connection::send const):
(TestWebKitAPI::Connection::sendAndReportError const):
(TestWebKitAPI::Connection::webSocketHandshake):
(TestWebKitAPI::Connection::terminate):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, Basic)):
* Tools/TestWebKitAPI/WebTransportServer.h:
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::Data::create):
(TestWebKitAPI::WebTransportServer::Data::Data):
(TestWebKitAPI::WebTransportServer::WebTransportServer):
(TestWebKitAPI::WebTransportServer::port const):
* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
(TestWebKitAPI::CoroutineHandle::CoroutineHandle): Deleted.
(TestWebKitAPI::CoroutineHandle::~CoroutineHandle): Deleted.
(TestWebKitAPI::Task::promise_type::get_return_object): Deleted.
(TestWebKitAPI::Task::promise_type::initial_suspend): Deleted.
(TestWebKitAPI::Task::promise_type::unhandled_exception): Deleted.
(TestWebKitAPI::Task::promise_type::return_void): Deleted.
(TestWebKitAPI::Connection::receiveHTTPRequest): Deleted.
(TestWebKitAPI::Connection::webSocketHandshake): Deleted.
(TestWebKitAPI::Connection::terminate): Deleted.
(TestWebKitAPI::Connection::Connection): Deleted.
(TestWebKitAPI::ReceiveOperation::ReceiveOperation): Deleted.
(TestWebKitAPI::ReceiveOperation::await_ready): Deleted.
(TestWebKitAPI::ReceiveOperation::await_resume): Deleted.
(TestWebKitAPI::SendOperation::SendOperation): Deleted.
(TestWebKitAPI::SendOperation::await_ready): Deleted.
(TestWebKitAPI::SendOperation::await_resume): Deleted.
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::dataFromString): Deleted.
(TestWebKitAPI::dataFromVector): Deleted.
(TestWebKitAPI::vectorFromData): Deleted.
(TestWebKitAPI::Connection::receiveBytes const): Deleted.
(TestWebKitAPI::Connection::receiveHTTPRequest const): Deleted.
(TestWebKitAPI::Connection::awaitableReceiveHTTPRequest const): Deleted.
(TestWebKitAPI::ReceiveOperation::await_suspend): Deleted.
(TestWebKitAPI::SendOperation::await_suspend): Deleted.
(TestWebKitAPI::Connection::awaitableSend): Deleted.
(TestWebKitAPI::Connection::send const): Deleted.
(TestWebKitAPI::Connection::sendAndReportError const): Deleted.
(TestWebKitAPI::Connection::webSocketHandshake): Deleted.
(TestWebKitAPI::Connection::terminate): Deleted.

Canonical link: <a href="https://commits.webkit.org/283177@main">https://commits.webkit.org/283177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67308581d106f53d413f555efd55b034417df838

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16089 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16369 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68547 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33207 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14965 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9434 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9466 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7797 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9927 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->