### PR TITLE
Add more signposts to JetStream2 to extract important regions

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/JetStream2.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/JetStream2.patch
@@ -1,76 +1,172 @@
 diff --git a/PerformanceTests/JetStream2/JetStreamDriver.js b/PerformanceTests/JetStream2/JetStreamDriver.js
-index 9079f300cd95..2de6fad99aaa 100644
+index 42a9848dec0d..7e75662d1326 100644
 --- a/JetStreamDriver.js
 +++ b/JetStreamDriver.js
-@@ -544,6 +544,7 @@ get runnerCode() {
+@@ -542,16 +542,22 @@ get runnerCode() {
          return `
              let __benchmark = new Benchmark(${this.iterations});
              let results = [];
-+            __signpostStart(${JSON.stringify(this.name)});
++            let testName = ${JSON.stringify(this.name)};
++            __signpostStart(testName);
              for (let i = 0; i < ${this.iterations}; i++) {
                  if (__benchmark.prepareForNextIteration)
                      __benchmark.prepareForNextIteration();
-@@ -554,6 +555,7 @@ get runnerCode() {
+ 
++                let iterationName = testName + "-" + i;
+                 let start = Date.now();
++                __signpostStart(iterationName);
+                 __benchmark.runIteration();
++                __signpostStop(iterationName);
+                 let end = Date.now();
  
                  results.push(Math.max(1, end - start));
              }
-+            __signpostStop(${JSON.stringify(this.name)});
++            __signpostStop(testName);
              if (__benchmark.validate)
                  __benchmark.validate();
              top.currentResolve(results);`;
-@@ -956,6 +958,7 @@ get runnerCode() {
+@@ -950,13 +956,19 @@ get runnerCode() {
          return `
          async function doRun() {
              let __benchmark = new Benchmark();
-+            __signpostStart(${JSON.stringify(this.name)});
++            let testName = ${JSON.stringify(this.name)};
++            __signpostStart(testName);
              let results = [];
              for (let i = 0; i < ${this.iterations}; i++) {
++                let iterationName = testName + "-" + i;
                  let start = Date.now();
-@@ -963,6 +966,7 @@ async function doRun() {
++                __signpostStart(iterationName);
+                 await __benchmark.runIteration();
++                __signpostStop(iterationName);
                  let end = Date.now();
                  results.push(Math.max(1, end - start));
              }
-+            __signpostStop(${JSON.stringify(this.name)});
++            __signpostStop(testName);
              if (__benchmark.validate)
                  __benchmark.validate();
              top.currentResolve(results);
-@@ -992,6 +996,7 @@ get runnerCode() {
+@@ -986,17 +998,26 @@ get runnerCode() {
          return `
              let benchmark = new Benchmark();
              let results = [];
-+            __signpostStart(${JSON.stringify(this.name)});
++            let testName = ${JSON.stringify(this.name)};
++            __signpostStart(testName);
              {
++                let subtestName = testName + "-Stdlib";
                  let start = Date.now();
++                __signpostStart(subtestName);
                  benchmark.buildStdlib();
-@@ -1003,6 +1008,7 @@ get runnerCode() {
-                 benchmark.run();
++                __signpostStop(subtestName);
                  results.push(Date.now() - start);
              }
-+            __signpostStop(${JSON.stringify(this.name)});
+ 
+             {
++                let subtestName = testName + "-Main";
+                 let start = Date.now();
++                __signpostStart(subtestName);
+                 benchmark.run();
++                __signpostStop(subtestName);
+                 results.push(Date.now() - start);
+             }
++            __signpostStop(testName);
  
              top.currentResolve(results);
              `;
-@@ -1089,6 +1095,7 @@ get prerunCode() {
+@@ -1074,12 +1095,19 @@ get prerunCode() {
+                 if (compileTime !== null)
+                     throw new Error("called report compile time twice");
+                 compileTime = t;
++                __signpostStop(${JSON.stringify(this.name)} + "-Compile");
++            };
++
++            globalObject.startRunTime = (t) => {
++                __signpostStart(${JSON.stringify(this.name)} + "-Run");
+             };
+ 
+             globalObject.reportRunTime = (t) => {
                  if (runTime !== null)
                      throw new Error("called report run time twice")
                  runTime = t;
++                __signpostStop(${JSON.stringify(this.name)} + "-Run");
 +                __signpostStop(${JSON.stringify(this.name)});
                  top.currentResolve([compileTime, runTime]);
              };
  
-@@ -1130,6 +1137,7 @@ get runnerCode() {
+@@ -1121,6 +1149,8 @@ get runnerCode() {
                  xhr.responseType = 'arraybuffer';
                  xhr.onload = function() {
                      Module.wasmBinary = xhr.response;
 +                    __signpostStart(${JSON.stringify(this.name)});
++                    __signpostStart(${JSON.stringify(this.name)} + "-Compile");
                      doRun();
                  };
                  xhr.send(null);
-@@ -1146,6 +1154,7 @@ get runnerCode() {
+@@ -1137,6 +1167,8 @@ get runnerCode() {
              Module.monitorRunDependencies = null;
  
              Promise.resolve(42).then(() => {
 +                __signpostStart(${JSON.stringify(this.name)});
++                __signpostStart(${JSON.stringify(this.name)} + "-Compile");
                  try {
                      doRun();
                  } catch(e) {
+diff --git a/PerformanceTests/JetStream2/wasm/HashSet.js b/PerformanceTests/JetStream2/wasm/HashSet.js
+index 9507abd12320..ca0cba97497c 100644
+--- a/wasm/HashSet.js
++++ b/wasm/HashSet.js
+@@ -1006,6 +1006,7 @@ function ___setErrNo(value) {
+ });
+ var _main = Module["_main"] = (function() {
+  let start = benchmarkTime();
++ startRunTime(start);
+  let ret = Module["asm"]["_main"].apply(null, arguments);
+  reportRunTime(benchmarkTime() - start);
+  return ret;
+diff --git a/PerformanceTests/JetStream2/wasm/gcc-loops.js b/PerformanceTests/JetStream2/wasm/gcc-loops.js
+index 7ae84663b4fc..287fcc9b13cf 100644
+--- a/wasm/gcc-loops.js
++++ b/wasm/gcc-loops.js
+@@ -5204,6 +5204,7 @@ function invoke_viijii(index, a1, a2, a3, a4, a5, a6) {
+ });
+ var _main = Module["_main"] = (function() {
+  let start = benchmarkTime();
++ startRunTime(start);
+  let ret = Module["asm"]["_main"].apply(null, arguments);
+  reportRunTime(benchmarkTime() - start);
+  return ret;
+diff --git a/PerformanceTests/JetStream2/wasm/quicksort.js b/PerformanceTests/JetStream2/wasm/quicksort.js
+index 23bbb485e676..a650ef4c0e07 100644
+--- a/wasm/quicksort.js
++++ b/wasm/quicksort.js
+@@ -1028,6 +1028,7 @@ function invoke_iiii(index, a1, a2, a3) {
+ });
+ var _main = Module["_main"] = (function() {
+  let start = benchmarkTime();
++ startRunTime(start);
+  let result = Module["asm"]["_main"].apply(null, arguments);
+  reportRunTime(benchmarkTime() - start);
+  return result;
+diff --git a/PerformanceTests/JetStream2/wasm/richards.js b/PerformanceTests/JetStream2/wasm/richards.js
+index a04c0b795166..bb66e96b165d 100644
+--- a/wasm/richards.js
++++ b/wasm/richards.js
+@@ -930,6 +930,7 @@ function invoke_ii(index, a1) {
+ });
+ var _main = Module["_main"] = (function() {
+  let start = benchmarkTime();
++ startRunTime(start);
+  let ret = Module["asm"]["_main"].apply(null, arguments);
+  reportRunTime(benchmarkTime() - start);
+  return ret;
+diff --git a/PerformanceTests/JetStream2/wasm/tsf.js b/PerformanceTests/JetStream2/wasm/tsf.js
+index 4ff2ab80ede6..0148299c80eb 100644
+--- a/wasm/tsf.js
++++ b/wasm/tsf.js
+@@ -4747,6 +4747,7 @@ function invoke_viii(index, a1, a2, a3) {
+ });
+ var _main = Module["_main"] = (function() {
+  let start = benchmarkTime();
++ startRunTime(start);
+  let ret = Module["asm"]["_main"].apply(null, arguments);
+  reportRunTime(benchmarkTime() - start);
+  return ret;


### PR DESCRIPTION
#### eee983e7df7c4a2c70ed21a506ced7cf7bc4d7af
<pre>
Add more signposts to JetStream2 to extract important regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=279112">https://bugs.webkit.org/show_bug.cgi?id=279112</a>
<a href="https://rdar.apple.com/135254046">rdar://135254046</a>

Reviewed by Mark Lam.

This patch adds more signposts to JetStream2 so that we can extract important period like startup time / compile time specifically.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/JetStream2.patch:

Canonical link: <a href="https://commits.webkit.org/283141@main">https://commits.webkit.org/283141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b6171cc468418b29dce3275d4206f35e300c205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17989 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16263 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/69399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68441 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/64887 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14858 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71104 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9327 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9359 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/7704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9911 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40555 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->