### PR TITLE
[JSC] Use FixedVector / span directly instead of unlinkedValueProfile etc.

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2796,6 +2796,7 @@ void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(const Co
     unsigned index = 0;
     UnlinkedCodeBlock* unlinkedCodeBlock = this->unlinkedCodeBlock();
     bool isBuiltinFunction = unlinkedCodeBlock->isBuiltinFunction();
+    auto unlinkedValueProfiles = unlinkedCodeBlock->unlinkedValueProfiles().mutableSpan();
     forEachValueProfile([&](auto& profile, bool isArgument) {
         unsigned numSamples = profile.totalNumberOfSamples();
         using Profile = std::remove_reference_t<decltype(profile)>;
@@ -2806,7 +2807,7 @@ void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(const Co
         if (isArgument) {
             profile.computeUpdatedPrediction(locker);
             if (!isBuiltinFunction)
-                unlinkedCodeBlock->unlinkedValueProfile(index).update(profile);
+                unlinkedValueProfiles[index].update(profile);
             ++index;
             return;
         }
@@ -2814,7 +2815,7 @@ void CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness(const Co
             numberOfLiveNonArgumentValueProfiles++;
         profile.computeUpdatedPrediction(locker);
         if (!isBuiltinFunction)
-            unlinkedCodeBlock->unlinkedValueProfile(index).update(profile);
+            unlinkedValueProfiles[index].update(profile);
         ++index;
     });
 
@@ -2856,10 +2857,11 @@ void CodeBlock::updateAllArrayProfilePredictions()
     unsigned index = 0;
     UnlinkedCodeBlock* unlinkedCodeBlock = this->unlinkedCodeBlock();
     bool isBuiltinFunction = unlinkedCodeBlock->isBuiltinFunction();
+    auto unlinkedArrayProfiles = unlinkedCodeBlock->unlinkedArrayProfiles().mutableSpan();
     auto process = [&] (ArrayProfile& profile) {
         profile.computeUpdatedPrediction(this);
         if (!isBuiltinFunction)
-            unlinkedCodeBlock->unlinkedArrayProfile(index).update(profile);
+            unlinkedArrayProfiles[index].update(profile);
         ++index;
     };
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -406,6 +406,8 @@ public:
         return m_argumentValueProfiles[argumentIndex];
     }
 
+    FixedVector<ArgumentValueProfile>& argumentValueProfiles() { return m_argumentValueProfiles; }
+
     ValueProfile& valueProfileForOffset(unsigned profileOffset) { return m_metadata->valueProfileForOffset(profileOffset); }
 
     ValueProfile* tryGetValueProfileForBytecodeIndex(BytecodeIndex);

--- a/Source/JavaScriptCore/bytecode/CodeBlockInlines.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockInlines.h
@@ -36,8 +36,8 @@ namespace JSC {
 template<typename Functor>
 void CodeBlock::forEachValueProfile(const Functor& func)
 {
-    for (unsigned i = 0; i < numberOfArgumentValueProfiles(); ++i)
-        func(valueProfileForArgument(i), true);
+    for (auto& profile : argumentValueProfiles())
+        func(profile, true);
 
     if (m_metadata) {
         auto wrapper = [&] (ValueProfile& profile) {

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -352,8 +352,8 @@ public:
         return !isBuiltinFunction();
     }
     void allocateSharedProfiles(unsigned numBinaryArithProfiles, unsigned numUnaryArithProfiles);
-    UnlinkedValueProfile& unlinkedValueProfile(unsigned index) { return m_valueProfiles[index]; }
-    UnlinkedArrayProfile& unlinkedArrayProfile(unsigned index) { return m_arrayProfiles[index]; }
+    FixedVector<UnlinkedValueProfile>& unlinkedValueProfiles() { return m_valueProfiles; }
+    FixedVector<UnlinkedArrayProfile>& unlinkedArrayProfiles() { return m_arrayProfiles; }
     unsigned numberOfValueProfiles() const { return m_valueProfiles.size(); }
     unsigned numberOfArrayProfiles() const { return m_arrayProfiles.size(); }
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
@@ -36,15 +36,18 @@ namespace JSC { namespace Profiler {
 BytecodeSequence::BytecodeSequence(CodeBlock* codeBlock)
 {
     StringPrintStream out;
-    
-    for (unsigned i = 0; i < codeBlock->numberOfArgumentValueProfiles(); ++i) {
+
+    {
+        unsigned index = 0;
         ConcurrentJSLocker locker(codeBlock->valueProfileLock());
-        CString description = codeBlock->valueProfileForArgument(i).briefDescription(locker);
-        if (!description.length())
-            continue;
-        out.reset();
-        out.print("arg", i, ": ", description);
-        m_header.append(out.toCString());
+        for (auto& profile : codeBlock->argumentValueProfiles()) {
+            CString description = profile.briefDescription(locker);
+            if (!description.length())
+                continue;
+            out.reset();
+            out.print("arg", index++, ": ", description);
+            m_header.append(out.toCString());
+        }
     }
     
     ICStatusMap statusMap;


### PR DESCRIPTION
#### 87225a402a926fd24015eeb9ab68b083496073a0
<pre>
[JSC] Use FixedVector / span directly instead of unlinkedValueProfile etc.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279118">https://bugs.webkit.org/show_bug.cgi?id=279118</a>
<a href="https://rdar.apple.com/135259552">rdar://135259552</a>

Reviewed by Yijia Huang.

Let&apos;s just directly use FixedVector / span instead of unlinkedValueProfile etc. function.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness):
(JSC::CodeBlock::updateAllArrayProfilePredictions):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::argumentValueProfiles):
* Source/JavaScriptCore/bytecode/CodeBlockInlines.h:
(JSC::CodeBlock::forEachValueProfile):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::unlinkedValueProfiles):
(JSC::UnlinkedCodeBlock::unlinkedArrayProfiles):
(JSC::UnlinkedCodeBlock::unlinkedValueProfile): Deleted.
(JSC::UnlinkedCodeBlock::unlinkedArrayProfile): Deleted.
* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp:
(JSC::Profiler::BytecodeSequence::BytecodeSequence):

Canonical link: <a href="https://commits.webkit.org/283165@main">https://commits.webkit.org/283165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933eb97c0b9f0c2c56ed92dead4ad9056a546c47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52499 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11058 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14859 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58489 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71105 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64620 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59823 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56644 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60098 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1361 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86387 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9920 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40556 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15215 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/f32-tuple-jsapi-exported.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42813 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->