### PR TITLE
Fix ptrauth build error in Source/WTF/wtf/BlockPtr.h

### DIFF
--- a/Source/WTF/wtf/BlockPtr.h
+++ b/Source/WTF/wtf/BlockPtr.h
@@ -32,19 +32,38 @@
 
 #if __has_include(<ptrauth.h>)
 #include <ptrauth.h>
+
+#ifdef __ptrauth_block_copy_helper
 #define WTF_COPY_FUNCTION_POINTER_QUALIFIER __ptrauth_block_copy_helper
+#else
+#define WTF_COPY_FUNCTION_POINTER_QUALIFIER
+#endif
+
+#ifdef __ptrauth_block_destroy_helper
 #define WTF_DISPOSE_FUNCTION_POINTER_QUALIFIER __ptrauth_block_destroy_helper
+#else
+#define WTF_DISPOSE_FUNCTION_POINTER_QUALIFIER
+#endif
+
+#ifdef __ptrauth_block_invocation_pointer
 #define WTF_INVOKE_FUNCTION_POINTER_QUALIFIER __ptrauth_block_invocation_pointer
+#else
+#define WTF_INVOKE_FUNCTION_POINTER_QUALIFIER
+#endif
+
 #ifdef __ptrauth_objc_isa_pointer
 #define WTF_ISA_POINTER_QUALIFIER __ptrauth_objc_isa_pointer
 #else
 #define WTF_ISA_POINTER_QUALIFIER
 #endif
+
 #else
+
 #define WTF_COPY_FUNCTION_POINTER_QUALIFIER
 #define WTF_DISPOSE_FUNCTION_POINTER_QUALIFIER
 #define WTF_INVOKE_FUNCTION_POINTER_QUALIFIER
 #define WTF_ISA_POINTER_QUALIFIER
+
 #endif
 
 // Because ARC enablement is a compile-time choice, and we compile this header


### PR DESCRIPTION
#### 1e5e1e166abc3992b960a8b7c5c70fe78bebb187
<pre>
Fix ptrauth build error in Source/WTF/wtf/BlockPtr.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=279119">https://bugs.webkit.org/show_bug.cgi?id=279119</a>

Reviewed by Justin Michaud.

When I run `Tools/Scripts/build-and-analyze` on macOS with the public
SDK, I&apos;m getting build errors in expansions of
WTF_COPY/DISPOSE/INVOKE_FUNCTION_POINTER_QUALIFIER macros.
ptrauth.h exists but __ptrauth_block_copy/dipose/invoke_helper functions
are undefined. Do something like <a href="https://commits.webkit.org/222290@main">https://commits.webkit.org/222290@main</a>
and explicitly check whether the functions are defined.

* Source/WTF/wtf/BlockPtr.h:

Canonical link: <a href="https://commits.webkit.org/283210@main">https://commits.webkit.org/283210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21002cfa044a202d453fe3f112d6e8759456fb1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52501 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13963 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14865 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58495 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71111 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64626 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59824 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60099 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1366 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40562 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15217 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->