### PR TITLE
Adopt more smart pointers in html

### DIFF
--- a/Source/WebCore/html/BaseCheckableInputType.cpp
+++ b/Source/WebCore/html/BaseCheckableInputType.cpp
@@ -95,7 +95,7 @@ bool BaseCheckableInputType::canSetStringValue() const
 bool BaseCheckableInputType::accessKeyAction(bool sendMouseEvents)
 {
     ASSERT(element());
-    return InputType::accessKeyAction(sendMouseEvents) || element()->dispatchSimulatedClick(0, sendMouseEvents ? SendMouseUpDownEvents : SendNoEvents);
+    return InputType::accessKeyAction(sendMouseEvents) || protectedElement()->dispatchSimulatedClick(0, sendMouseEvents ? SendMouseUpDownEvents : SendNoEvents);
 }
 
 String BaseCheckableInputType::fallbackValue() const

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -160,7 +160,7 @@ static void appendServerMapMousePosition(StringBuilder& url, Event& event)
     if (!mouseEvent)
         return;
 
-    auto* imageElement = dynamicDowncast<HTMLImageElement>(mouseEvent->target());
+    RefPtr imageElement = dynamicDowncast<HTMLImageElement>(mouseEvent->target());
     if (!imageElement)
         return;
 

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -151,7 +151,7 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
             // the Form or button relationships.
             protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-            if (auto currentForm = form()) {
+            if (RefPtr currentForm = form()) {
                 if (m_type == SUBMIT)
                     currentForm->submitIfPossible(&event, this);
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -602,7 +602,7 @@ void HTMLCanvasElement::reset()
     setSurfaceSize(newSize);
 
     if (m_context) {
-        if (auto* context = dynamicDowncast<GPUBasedCanvasRenderingContext>(*m_context))
+        if (RefPtr context = dynamicDowncast<GPUBasedCanvasRenderingContext>(*m_context))
             context->reshape();
     }
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -189,7 +189,7 @@ void HTMLFormElement::submitImplicitly(Event& event, bool fromImplicitSubmission
 {
     unsigned submissionTriggerCount = 0;
     for (auto& listedElement : m_listedElements) {
-        auto* formElement = dynamicDowncast<HTMLFormControlElement>(*listedElement);
+        RefPtr formElement = dynamicDowncast<HTMLFormControlElement>(*listedElement);
         if (!formElement)
             continue;
         if (formElement->isSuccessfulSubmitButton()) {

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -99,7 +99,7 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
     // the Form or button relationships.
     protectedElement->protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-    if (auto currentForm = protectedElement->form())
+    if (RefPtr currentForm = protectedElement->form())
         currentForm->submitIfPossible(&event, element()); // Event handlers can run.
 
     event.setDefaultHandled();

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -319,7 +319,7 @@ String RangeInputType::serialize(const Decimal& value) const
 // FIXME: Could share this with BaseClickableWithKeyInputType and BaseCheckableInputType if we had a common base class.
 bool RangeInputType::accessKeyAction(bool sendMouseEvents)
 {
-    auto* element = this->element();
+    RefPtr element = this->element();
     return InputType::accessKeyAction(sendMouseEvents) || (element && element->dispatchSimulatedClick(0, sendMouseEvents ? SendMouseUpDownEvents : SendNoEvents));
 }
 


### PR DESCRIPTION
#### 2e45091d497708080542c6cf52efc344329309c1
<pre>
Adopt more smart pointers in html
<a href="https://bugs.webkit.org/show_bug.cgi?id=279120">https://bugs.webkit.org/show_bug.cgi?id=279120</a>

Reviewed by Chris Dumez.

Adopt smart pointers in html based
on [alpha.webkit.UncountedCallArgsChecker] and
[alpha.webkit.NoUncountedMemberChecker] warnings.

* Source/WebCore/html/BaseCheckableInputType.cpp:
(WebCore::BaseCheckableInputType::accessKeyAction):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::appendServerMapMousePosition):
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::reset):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitImplicitly):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::handleDOMActivateEvent):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::accessKeyAction):

Canonical link: <a href="https://commits.webkit.org/283166@main">https://commits.webkit.org/283166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8915571f48b119ac8f0f9a99aecdd91d0261dca8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52502 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13964 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14866 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59825 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56650 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60100 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/hit-test, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1367 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40563 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->