### PR TITLE
[GStreamer] Use GstMappedFrame in CoordinatedPlatformLayerBufferVideo

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -664,6 +664,8 @@ GstMappedFrame::GstMappedFrame(const GRefPtr<GstSample>& sample, GstMapFlags fla
     gst_video_frame_map(&m_frame, &info, gst_sample_get_buffer(sample.get()), flags);
 }
 
+GstMappedFrame::GstMappedFrame() = default;
+
 GstMappedFrame::~GstMappedFrame()
 {
     // FIXME: Make this un-conditional when the minimum GStreamer dependency version is >= 1.22.

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -206,11 +206,11 @@ private:
 
 class GstMappedFrame {
     WTF_MAKE_TZONE_ALLOCATED(GstMappedFrame);
-    WTF_MAKE_NONCOPYABLE(GstMappedFrame);
+
 public:
     GstMappedFrame(GstBuffer*, GstVideoInfo*, GstMapFlags);
     GstMappedFrame(const GRefPtr<GstSample>&, GstMapFlags);
-
+    GstMappedFrame();
     ~GstMappedFrame();
 
     GstVideoFrame* get();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -46,9 +46,8 @@ private:
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromGLMemory(GstVideoInfo*);
 
     GRefPtr<GstBuffer> m_gstBuffer;
-    GstVideoFrame m_videoFrame;
+    GstMappedFrame m_videoFrame;
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
-    bool m_isMapped { false };
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
 };
 


### PR DESCRIPTION
#### 16fff459efee5fc8d31d0afcc682f0a91d19c183
<pre>
[GStreamer] Use GstMappedFrame in CoordinatedPlatformLayerBufferVideo
<a href="https://bugs.webkit.org/show_bug.cgi?id=279121">https://bugs.webkit.org/show_bug.cgi?id=279121</a>

Reviewed by NOBODY (OOPS!).

By using GstMappedFrame we no longer need manual tracking of the frame map state.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromGLMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::paintToTextureMapper):
(WebCore::CoordinatedPlatformLayerBufferVideo::~CoordinatedPlatformLayerBufferVideo): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16fff459efee5fc8d31d0afcc682f0a91d19c183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16277 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52507 "Failure limit exceed. At least found 185 new test failures: compositing/geometry/clipped-video-controller.html compositing/self-painting-layers.html compositing/shared-backing/clipping-and-shared-backing.html compositing/video/video-border-radius.html compositing/video/video-clip-change-src.html compositing/video/video-reflection.html compositing/video/video-update-rendering.html compositing/visibility/visibility-simple-video-layer.html fast/mediastream/MediaStream-video-element-change-audio-route.html fast/mediastream/MediaStream-video-element-video-tracks-disabled.html ... (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11067 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68455 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41345 "14 new passes 1 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56590 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33131 "Found 2 new API test failures: /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14872 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13767 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59829 "Failure limit exceed. At least found 185 new test failures: compositing/geometry/clipped-video-controller.html compositing/geometry/video-fixed-scrolling.html compositing/layers-inside-overflow-scroll.html compositing/overflow/scroll-ancestor-update.html compositing/self-painting-layers.html compositing/shared-backing/clipping-and-shared-backing.html compositing/video/video-update-rendering.html compositing/visibility/visibility-simple-video-layer.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56652 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60104 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1369 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->