### PR TITLE
Fix scrollIntoView(...) for SVG elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-svg-shape-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-svg-shape-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL scrollIntoView on an SVG shape element, geometry assert_approx_equals: y after scroll expected 1958 +/- 1 but got 8
-FAIL scrollIntoView on an SVG shape element, translated assert_approx_equals: y after scroll expected 2958 +/- 1 but got 8
-FAIL scrollIntoView on an SVG shape element, rotated assert_approx_equals: x after scroll expected 2745.005859375 +/- 1 but got 0
+PASS scrollIntoView on an SVG shape element, geometry
+PASS scrollIntoView on an SVG shape element, translated
+PASS scrollIntoView on an SVG shape element, rotated
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -4,7 +4,7 @@
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
  * Copyright (C) 2005-2021 Apple Inc. All rights reserved.
- * Copyright (C) 2010, 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2018 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -1834,6 +1834,11 @@ const RenderStyle* RenderElement::targetTextPseudoStyle() const
 
 bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
 {
+    if (isSVGRenderer()) {
+        point = localToAbsoluteQuad(strokeBoundingBox(), UseTransforms).boundingBox().minXMinYCorner();
+        return true;
+    }
+
     if (!isInline() || isReplacedOrInlineBlock()) {
         point = localToAbsolute(FloatPoint(), UseTransforms, &insideFixed);
         return true;
@@ -1890,6 +1895,11 @@ bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
 
 bool RenderElement::getTrailingCorner(FloatPoint& point, bool& insideFixed) const
 {
+    if (isSVGRenderer()) {
+        point = localToAbsoluteQuad(strokeBoundingBox(), UseTransforms).boundingBox().maxXMaxYCorner();
+        return true;
+    }
+
     if (!isInline() || isReplacedOrInlineBlock()) {
         point = localToAbsolute(LayoutPoint(downcast<RenderBox>(*this).size()), UseTransforms, &insideFixed);
         return true;


### PR DESCRIPTION
#### 8a236fd73b8f7fd55de5078993e50bb36015b7e6
<pre>
Fix scrollIntoView(...) for SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=279124">https://bugs.webkit.org/show_bug.cgi?id=279124</a>
<a href="https://rdar.apple.com/135265918">rdar://135265918</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/5d6edb4f084778cf635640c4fafd65418af841f7">https://chromium.googlesource.com/chromium/src.git/+/5d6edb4f084778cf635640c4fafd65418af841f7</a>

This patch enables to compute the bounding rect using the stroke bounding
box to allow &apos;scrollIntoView&apos; work for SVG Shapes.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::getLeadingCorner const):
(WebCore::RenderElement::getTrailingCorner const):
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-svg-shape-expected.txt:

Canonical link: <a href="https://commits.webkit.org/283157@main">https://commits.webkit.org/283157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ee1869b1f4ca4f27eaeb5349082f98ca457245c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52513 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11081 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14881 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71127 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9350 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13777 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59836 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56665 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60112 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14414 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1381 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40578 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->