### PR TITLE
[macOS] Send playEffect() twice to Gamepad.actuator and it cannot stop with reset()

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -33,13 +33,15 @@
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
+OBJC_CLASS CHHapticEngine;
+
 namespace WebCore {
 
 class GameControllerHapticEngines;
 struct GamepadEffectParameters;
 enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEffect : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEffect> {
+class GameControllerHapticEffect final : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEffect> {
     WTF_MAKE_TZONE_ALLOCATED(GameControllerHapticEffect);
 public:
     static RefPtr<GameControllerHapticEffect> create(GameControllerHapticEngines&, GamepadHapticEffectType, const GamepadEffectParameters&);
@@ -48,14 +50,19 @@ public:
     void start(CompletionHandler<void(bool)>&&);
     void stop();
 
-    void leftEffectFinishedPlaying();
-    void rightEffectFinishedPlaying();
-
 private:
-    GameControllerHapticEffect(RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer);
+    GameControllerHapticEffect(RetainPtr<CHHapticEngine>&& leftEngine, RetainPtr<CHHapticEngine>&& rightEngine, RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer);
 
+    void ensureStarted(Function<void(bool)>&&);
+    void startEngine(CHHapticEngine *, Function<void(bool)>&&);
+    void registerNotification(CHHapticEngine *, Function<void(bool)>&&);
+
+    RetainPtr<CHHapticEngine> m_leftEngine;
+    RetainPtr<CHHapticEngine> m_rightEngine;
     RetainPtr<id> m_leftPlayer;
     RetainPtr<id> m_rightPlayer;
+    unsigned m_engineStarted { 0 };
+    unsigned m_playerFinished { 0 };
     CompletionHandler<void(bool)> m_completionHandler;
 };
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -42,7 +42,7 @@ class GameControllerHapticEffect;
 struct GamepadEffectParameters;
 enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEngines : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEngines> {
+class GameControllerHapticEngines final : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEngines> {
     WTF_MAKE_TZONE_ALLOCATED(GameControllerHapticEngines);
 public:
     static Ref<GameControllerHapticEngines> create(GCController *);
@@ -61,17 +61,12 @@ public:
 private:
     explicit GameControllerHapticEngines(GCController *);
 
-    void ensureStarted(GamepadHapticEffectType, CompletionHandler<void(bool)>&&);
     RefPtr<GameControllerHapticEffect>& currentEffectForType(GamepadHapticEffectType);
 
     RetainPtr<CHHapticEngine> m_leftHandleEngine;
     RetainPtr<CHHapticEngine> m_rightHandleEngine;
     RetainPtr<CHHapticEngine> m_leftTriggerEngine;
     RetainPtr<CHHapticEngine> m_rightTriggerEngine;
-    bool m_failedToStartLeftHandleEngine { false };
-    bool m_failedToStartRightHandleEngine { false };
-    bool m_failedToStartLeftTriggerEngine { false };
-    bool m_failedToStartRightTriggerEngine { false };
     RefPtr<GameControllerHapticEffect> m_currentDualRumbleEffect;
     RefPtr<GameControllerHapticEffect> m_currentTriggerRumbleEffect;
 };

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
@@ -35,7 +35,6 @@
 #import <GameController/GameController.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
-#import <wtf/CompletionHandler.h>
 #import <wtf/TZoneMallocInlines.h>
 
 #import "GameControllerSoftLink.h"
@@ -47,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(GameControllerHapticEngines);
 
 Ref<GameControllerHapticEngines> GameControllerHapticEngines::create(GCController *gamepad)
 {
-    return *adoptRef(new GameControllerHapticEngines(gamepad));
+    return adoptRef(*new GameControllerHapticEngines(gamepad));
 }
 
 GameControllerHapticEngines::GameControllerHapticEngines(GCController *gamepad)
@@ -79,7 +78,7 @@ void GameControllerHapticEngines::playEffect(GamepadHapticEffectType type, const
     // Trying to create pattern players with a 0 duration will fail. However, Games on XBox seem to use such
     // requests to stop vibrating.
     if (!parameters.duration) {
-        if (auto effect = std::exchange(currentEffect, nullptr))
+        if (RefPtr effect = std::exchange(currentEffect, nullptr))
             effect->stop();
         return completionHandler(true);
     }
@@ -88,33 +87,22 @@ void GameControllerHapticEngines::playEffect(GamepadHapticEffectType type, const
     if (!newEffect)
         return completionHandler(false);
 
-    if (currentEffect)
-        currentEffect->stop();
+    if (RefPtr effect = currentEffect)
+        effect->stop();
 
     currentEffect = WTFMove(newEffect);
-    ensureStarted(type, [weakThis = WeakPtr { *this }, type, effect = WeakPtr { *currentEffect }, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+    currentEffect->start([weakThis = WeakPtr { *this }, effect = WeakPtr { *currentEffect }, type, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+        ASSERT(isMainThread());
+
+        completionHandler(success);
+
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
-            return completionHandler(false);
+            return;
 
         auto& currentEffect = protectedThis->currentEffectForType(type);
-        if (!currentEffect || currentEffect.get() != effect.get())
-            return completionHandler(false);
-
-        if (!success) {
+        if (currentEffect.get() == effect.get())
             currentEffect = nullptr;
-            return completionHandler(false);
-        }
-
-        currentEffect->start([weakThis = WTFMove(weakThis), effect = WTFMove(effect), type, completionHandler = WTFMove(completionHandler)](bool success) mutable {
-            completionHandler(success);
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            auto& currentEffect = protectedThis->currentEffectForType(type);
-            if (currentEffect.get() == effect.get())
-                currentEffect = nullptr;
-        });
     });
 }
 
@@ -124,71 +112,6 @@ void GameControllerHapticEngines::stopEffects()
         currentEffect->stop();
     if (auto currentEffect = std::exchange(m_currentTriggerRumbleEffect, nullptr))
         currentEffect->stop();
-}
-
-void GameControllerHapticEngines::ensureStarted(GamepadHapticEffectType effectType, CompletionHandler<void(bool)>&& completionHandler)
-{
-    auto callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }, effectType, completionHandler = WTFMove(completionHandler)]() mutable {
-        bool success = false;
-        switch (effectType) {
-        case GamepadHapticEffectType::DualRumble:
-            success = weakThis && !weakThis->m_failedToStartLeftHandleEngine && !weakThis->m_failedToStartRightHandleEngine;
-            break;
-        case GamepadHapticEffectType::TriggerRumble:
-            success = weakThis && !weakThis->m_failedToStartLeftTriggerEngine && !weakThis->m_failedToStartRightTriggerEngine;
-            break;
-        }
-        completionHandler(success);
-    });
-    auto startEngine = [weakThis = WeakPtr { *this }](CHHapticEngine *engine, CompletionHandler<void(bool)>&& completionHandler, std::function<void()>&& playersFinished) mutable {
-        [engine startWithCompletionHandler:makeBlockPtr([engine, completionHandler = WTFMove(completionHandler), playersFinished](NSError* error) mutable {
-            ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), success = !error]() mutable {
-                completionHandler(success);
-            });
-            if (error)
-                RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::ensureStarted: Failed to start haptic engine");
-            [engine notifyWhenPlayersFinished:makeBlockPtr([playersFinished](NSError *) mutable -> CHHapticEngineFinishedAction {
-                ensureOnMainRunLoop([playersFinished] {
-                    playersFinished();
-                });
-                return CHHapticEngineFinishedActionLeaveEngineRunning;
-            }).get()];
-        }).get()];
-    };
-    switch (effectType) {
-    case GamepadHapticEffectType::DualRumble:
-        startEngine(m_leftHandleEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartLeftHandleEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentDualRumbleEffect)
-                Ref { *weakThis->m_currentDualRumbleEffect }->leftEffectFinishedPlaying();
-        });
-        startEngine(m_rightHandleEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartRightHandleEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentDualRumbleEffect)
-                Ref { *weakThis->m_currentDualRumbleEffect }->rightEffectFinishedPlaying();
-        });
-        break;
-    case GamepadHapticEffectType::TriggerRumble:
-        startEngine(m_leftTriggerEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartLeftTriggerEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentTriggerRumbleEffect)
-                Ref { *weakThis->m_currentTriggerRumbleEffect }->leftEffectFinishedPlaying();
-        });
-        startEngine(m_rightTriggerEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartRightTriggerEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentTriggerRumbleEffect)
-                Ref { *weakThis->m_currentTriggerRumbleEffect }->rightEffectFinishedPlaying();
-        });
-        break;
-    }
 }
 
 void GameControllerHapticEngines::stop(CompletionHandler<void()>&& completionHandler)


### PR DESCRIPTION
#### 467d7dd6f1ea3e0b36eb4e3c01869663b066831a
<pre>
[macOS] Send playEffect() twice to Gamepad.actuator and it cannot stop with reset()
<a href="https://bugs.webkit.org/show_bug.cgi?id=279094">https://bugs.webkit.org/show_bug.cgi?id=279094</a>
<a href="https://rdar.apple.com/126589062">rdar://126589062</a>

Reviewed by Chris Dumez.

When sending playEffect() to Gamepad.actuator more than once, the reset() cannot stop the gamepad from vibrating.

The root cause of the issue is requesting a completionHandler invocation to wrong effect object.
Say two sequential playEffect requests is coming.

1. The effect object of request 1 is stored in m_currentDualRumbleEffect and referenced by currentEffect in playEffect() method.
2. In second playEffect(), currentEffect is stopped  before start playing second one. This is in main thread.
3. Notification for stopPlaying is called for first request {*) in CoreHaptics thread.
4. currentEffect is replaced with new effect.
5. Notification arrived in main thread and try to invoke completionHandler targeting to second request. This is wrong because the notification is for first request.

Move the play logic from GameControllerHapticEngines to GameControllerHapticEffect to avoid this confusion.

* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):
(WebCore::GameControllerHapticEffect::GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::~GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::start):
(WebCore::GameControllerHapticEffect::ensureStarted):
(WebCore::GameControllerHapticEffect::startEngine):
(WebCore::GameControllerHapticEffect::registerNotification):
(WebCore::GameControllerHapticEffect::stop):
(WebCore::GameControllerHapticEffect::leftEffectFinishedPlaying): Deleted.
(WebCore::GameControllerHapticEffect::rightEffectFinishedPlaying): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:
(WebCore::GameControllerHapticEngines::create):
(WebCore::GameControllerHapticEngines::playEffect):
(WebCore::GameControllerHapticEngines::ensureStarted): Deleted.

Canonical link: <a href="https://commits.webkit.org/286251@main">https://commits.webkit.org/286251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a436b64eff4b78881ba7c2145346bf99b536c97e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75325 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28165 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2549 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/79796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78392 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64709 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22202 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22541 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/2655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/81282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/2816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64705 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16581 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/2622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->