### PR TITLE
Weak-link BrowserEngineCore library on macOS

### DIFF
--- a/Source/JavaScriptCore/Configurations/Base.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Base.xcconfig
@@ -159,6 +159,12 @@ WK_USE_RESTRICTED_ENTITLEMENTS = $(USE_INTERNAL_SDK);
 // Shared variables used for dynamic or static linking of JavaScriptCore and jsc.
 
 JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework BrowserEngineCore;
+JSC_SEC_LD_FLAGS[sdk=macosx*] = -weak_framework BrowserEngineCore;
+JSC_SEC_LD_FLAGS[sdk=macosx13*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.0*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.1*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.2*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.3*] = ;
 JSC_SEC_LD_FLAGS[sdk=appletv*] = ;
 JSC_SEC_LD_FLAGS[sdk=watch*] = ;
 JSC_SEC_LD_FLAGS[sdk=xr*] = ;

--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -165,6 +165,12 @@ WK_APPLEJPEGXL_LDFLAGS = $(WK_APPLEJPEGXL_LDFLAGS_$(WK_USE_APPLEJPEGXL));
 WK_APPLEJPEGXL_LDFLAGS_YES = -weak_framework AppleJPEGXL;
 
 JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework BrowserEngineCore;
+JSC_SEC_LD_FLAGS[sdk=macosx*] = -weak_framework BrowserEngineCore;
+JSC_SEC_LD_FLAGS[sdk=macosx13*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.0*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.1*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.2*] = ;
+JSC_SEC_LD_FLAGS[sdk=macosx14.3*] = ;
 JSC_SEC_LD_FLAGS[sdk=appletv*] = ;
 JSC_SEC_LD_FLAGS[sdk=watch*] = ;
 JSC_SEC_LD_FLAGS[sdk=xr*] = ;


### PR DESCRIPTION
#### ff07392359cf9e86c51ffd391b1b0915a619bf67
<pre>
Weak-link BrowserEngineCore library on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=278066">https://bugs.webkit.org/show_bug.cgi?id=278066</a>
<a href="https://rdar.apple.com/133777782">rdar://133777782</a>

Reviewed by Per Arne Vollan.

Currently we only link this on iOS due to some historical issues with
linking it more widely. Now, however, we should be able to use it on
macOS as well: doing so will allow us to de-duplicate some code that
currently needs to stay around for the sake of macOS.

I previously tried to strong-link this based on a hypothesis
(282930@main) but it broke some obscure builds so we need to fall back
to weak-linking like we do on iOS.

* Source/JavaScriptCore/Configurations/Base.xcconfig:
* Source/WebCore/Configurations/WebCore.xcconfig:

Canonical link: <a href="https://commits.webkit.org/283511@main">https://commits.webkit.org/283511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e67fe938aa6e8605b0b7aae5e7f127e4982d2a42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52547 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14009 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14917 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58546 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71163 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64676 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59868 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60141 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14683 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1410 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86443 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40613 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15226 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->