### PR TITLE
Provide _browsingWarning SPI for testing WarningViews

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -445,6 +445,12 @@ struct PerWebProcessState {
 - (void)_clearWarningViewIfForMainFrameNavigation;
 - (void)_clearBrowsingWarningIfForMainFrameNavigation;
 
+#if !TARGET_OS_IPHONE
+@property (nonatomic, readonly) NSView *_browsingWarning;
+#else
+@property (nonatomic, readonly) UIView *_browsingWarning;
+#endif
+
 - (std::optional<BOOL>)_resolutionForShareSheetImmediateCompletionForTesting;
 
 - (void)_didAccessBackForwardList NS_DIRECT;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4091,6 +4091,11 @@ static bool isLockdownModeWarningNeeded()
 
 - (UIView *)_safeBrowsingWarning
 {
+    return self._warningView;
+}
+
+- (UIView *)_browsingWarning
+{
     return _warningView.get();
 }
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1376,6 +1376,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSView *)_safeBrowsingWarning
 {
+    return self._browsingWarning;
+}
+
+- (NSView *)_browsingWarning
+{
     return _impl->warningView();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -58,6 +58,14 @@ static NSTimeInterval redirectDelay;
 static bool didCancelRedirect;
 static bool didReceiveAllowPrivateToken;
 
+@interface WKWebView ()
+#if !TARGET_OS_IPHONE
+@property (nonatomic, readonly) NSView *_browsingWarning;
+#else
+@property (nonatomic, readonly) UIView *_browsingWarning;
+#endif
+@end
+
 @interface NavigationDelegate : NSObject <WKNavigationDelegate, _WKWebsiteDataStoreDelegate>
 @end
 
@@ -1822,17 +1830,17 @@ TEST(WKNavigation, HTTPSOnlyHTTPFallbackGoBack)
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure"]]];
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
-    while (![webView _safeBrowsingWarning])
+    EXPECT_NULL([webView _browsingWarning]);
+    while (![webView _browsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
-    EXPECT_NOT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NOT_NULL([webView _browsingWarning]);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(finishedSuccessfully);
     EXPECT_FALSE(failedNavigation);
 
     EXPECT_WK_STREQ([webView title], "This Connection Is Not Secure");
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
+    checkTitleAndClick([webView _browsingWarning].subviews.firstObject.subviews[3], "Go Back");
     Util::run(&failedNavigation);
 
     EXPECT_EQ(errorCode, NSURLErrorServerCertificateUntrusted);
@@ -1896,17 +1904,17 @@ TEST(WKNavigation, HTTPSOnlyHTTPFallbackContinue)
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure"]]];
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
-    while (![webView _safeBrowsingWarning])
+    EXPECT_NULL([webView _browsingWarning]);
+    while (![webView _browsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
-    EXPECT_NOT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NOT_NULL([webView _browsingWarning]);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(finishedSuccessfully);
     EXPECT_FALSE(failedNavigation);
 
     EXPECT_WK_STREQ([webView title], "This Connection Is Not Secure");
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[4], "Continue");
+    checkTitleAndClick([webView _browsingWarning].subviews.firstObject.subviews[4], "Continue");
     Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
@@ -2035,12 +2043,12 @@ TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure"]]];
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
-    while (![webView _safeBrowsingWarning])
+    EXPECT_NULL([webView _browsingWarning]);
+    while (![webView _browsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
-    EXPECT_NOT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NOT_NULL([webView _browsingWarning]);
 
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
+    checkTitleAndClick([webView _browsingWarning].subviews.firstObject.subviews[3], "Go Back");
     TestWebKitAPI::Util::run(&didFailNavigation);
 
     EXPECT_EQ(errorCode, NSURLErrorServerCertificateUntrusted);
@@ -2133,12 +2141,12 @@ TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)
     }];
     TestWebKitAPI::Util::run(&doneEvaluatingJavaScript);
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
-    while (![webView _safeBrowsingWarning])
+    EXPECT_NULL([webView _browsingWarning]);
+    while (![webView _browsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
-    EXPECT_NOT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NOT_NULL([webView _browsingWarning]);
 
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
+    checkTitleAndClick([webView _browsingWarning].subviews.firstObject.subviews[3], "Go Back");
     TestWebKitAPI::Util::run(&didFailNavigation);
 
     EXPECT_EQ(errorCode, NSURLErrorServerCertificateUntrusted);
@@ -2211,12 +2219,12 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure"]]];
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
-    while (![webView _safeBrowsingWarning])
+    EXPECT_NULL([webView _browsingWarning]);
+    while (![webView _browsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
-    EXPECT_NOT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NOT_NULL([webView _browsingWarning]);
 
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
+    checkTitleAndClick([webView _browsingWarning].subviews.firstObject.subviews[3], "Go Back");
     TestWebKitAPI::Util::run(&didFailNavigation);
 
     EXPECT_EQ(errorCode, _WKErrorCodeHTTPSUpgradeRedirectLoop);
@@ -2237,12 +2245,12 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
     loadCount = 0;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
-    while (![webView _safeBrowsingWarning])
+    EXPECT_NULL([webView _browsingWarning]);
+    while (![webView _browsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
-    EXPECT_NOT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NOT_NULL([webView _browsingWarning]);
 
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
+    checkTitleAndClick([webView _browsingWarning].subviews.firstObject.subviews[3], "Go Back");
     TestWebKitAPI::Util::run(&didFailNavigation);
 
     EXPECT_EQ(errorCode, kCFURLErrorHTTPTooManyRedirects);
@@ -2331,9 +2339,9 @@ TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure"]]];
 
-    EXPECT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NULL([webView _browsingWarning]);
     TestWebKitAPI::Util::run(&finishedSuccessfully);
-    EXPECT_NULL([webView _safeBrowsingWarning]);
+    EXPECT_NULL([webView _browsingWarning]);
     EXPECT_FALSE(didFailNavigation);
     EXPECT_EQ(loadCount, 3);
 


### PR DESCRIPTION
#### 8795a1c69731f3e91d8016e22c30ed1003fffe94
<pre>
Provide _browsingWarning SPI for testing WarningViews
<a href="https://bugs.webkit.org/show_bug.cgi?id=279133">https://bugs.webkit.org/show_bug.cgi?id=279133</a>
<a href="https://rdar.apple.com/135285894">rdar://135285894</a>

Reviewed by NOBODY (OOPS!).

Expose a new interface on WKWebView as _browsingWarning for accessing a
WarningView that is being shown. This replaces most existing usage of
_safeBrowsingWarning.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _safeBrowsingWarning]):
(-[WKWebView _browsingWarning]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _safeBrowsingWarning]):
(-[WKWebView _browsingWarning]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSOnlyHTTPFallbackGoBack)):
(TEST(WKNavigation, HTTPSOnlyHTTPFallbackContinue)):
(TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)):
(TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)):
(TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8795a1c69731f3e91d8016e22c30ed1003fffe94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65436 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44807 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67554 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52590 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52548 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11126 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68503 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/52590 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56639 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33169 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/52590 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14014 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14921 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/52590 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71167 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9390 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59871 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9422 "Hash 8795a1c6 for PR 33127 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60144 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1415 "Passed tests") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40617 "Hash 8795a1c6 for PR 33127 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41693 "Hash 8795a1c6 for PR 33127 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42876 "Hash 8795a1c6 for PR 33127 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41437 "Hash 8795a1c6 for PR 33127 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->