### PR TITLE
Add support for icon_variants and variants in menus and action APIs for Web Extensions.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionMenuItem.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMenuItem.serialization.in
@@ -31,7 +31,7 @@ struct WebKit::WebExtensionMenuItemParameters {
     String title;
     String command;
 
-    String iconDictionaryJSON;
+    String iconsJSON;
 
     std::optional<bool> checked;
     std::optional<bool> enabled;

--- a/Source/WebKit/Shared/Extensions/WebExtensionMenuItemParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMenuItemParameters.h
@@ -44,7 +44,7 @@ struct WebExtensionMenuItemParameters {
     String title;
     String command;
 
-    String iconDictionaryJSON;
+    String iconsJSON;
 
     std::optional<bool> checked;
     std::optional<bool> enabled;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -87,7 +87,10 @@ public:
     void propertiesDidChange();
 
     CocoaImage *icon(CGSize);
-    void setIconsDictionary(NSDictionary *);
+    void setIcons(NSDictionary *);
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+    void setIconVariants(NSArray *);
+#endif
 
     String label(FallbackWhenEmpty = FallbackWhenEmpty::Yes) const;
     void setLabel(String);
@@ -144,6 +147,8 @@ public:
 private:
     WebExtensionAction* fallbackAction() const;
 
+    void clearIconCache();
+
 #if PLATFORM(MAC)
     void detectPopoverColorScheme();
 #endif
@@ -166,7 +171,14 @@ private:
     String m_customPopupPath;
     String m_popupWebViewInspectionName;
 
+    RetainPtr<CocoaImage> m_cachedIcon;
+    RetainPtr<NSSet> m_cachedIconScales;
+    CGSize m_cachedIconIdealSize { CGSizeZero };
+
     RetainPtr<NSDictionary> m_customIcons;
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+    RetainPtr<NSArray> m_customIconVariants;
+#endif
     String m_customLabel;
     String m_customBadgeText;
     ssize_t m_blockedResourceCount { 0 };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -702,7 +702,7 @@ private:
     bool isActionMessageAllowed();
     void actionGetTitle(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
     void actionSetTitle(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, const String& title, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void actionSetIcon(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, const String& iconDictionaryJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void actionSetIcon(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, const String& iconsJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void actionGetPopup(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
     void actionSetPopup(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, const String& popupPath, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void actionOpenPopup(WebPageProxyIdentifier, std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -29,7 +29,7 @@ messages -> WebExtensionContext {
     // Action APIs
     [EnabledIf='isActionMessageAllowed()'] ActionGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
     [EnabledIf='isActionMessageAllowed()'] ActionSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String title) -> (Expected<void, WebKit::WebExtensionError> result)
-    [EnabledIf='isActionMessageAllowed()'] ActionSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconDictionaryJSON) -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isActionMessageAllowed()'] ActionSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconsJSON) -> (Expected<void, WebKit::WebExtensionError> result)
     [EnabledIf='isActionMessageAllowed()'] ActionGetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
     [EnabledIf='isActionMessageAllowed()'] ActionSetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String popupPath) -> (Expected<void, WebKit::WebExtensionError> result)
     [EnabledIf='isActionMessageAllowed()'] ActionOpenPopup(WebKit::WebPageProxyIdentifier identifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
@@ -126,7 +126,7 @@ messages -> WebExtensionContext {
     [EnabledIf='isSidebarMessageAllowed()'] SidebarSetOptions(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<String> panelSourcePath, std::optional<bool> enabled) -> (Expected<void, WebKit::WebExtensionError> result)
     [EnabledIf='isSidebarMessageAllowed()'] SidebarGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
     [EnabledIf='isSidebarMessageAllowed()'] SidebarSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<String> title) -> (Expected<void, WebKit::WebExtensionError> result)
-    [EnabledIf='isSidebarMessageAllowed()'] SidebarSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconDictionaryJSON) -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconsJSON) -> (Expected<void, WebKit::WebExtensionError> result)
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     // Storage APIs

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -122,6 +122,8 @@ private:
 
     static String removeAmpersands(const String&);
 
+    void clearIconCache() const;
+
     enum class ForceUnchecked : bool { No, Yes };
     CocoaMenuItem *platformMenuItem(const WebExtensionMenuItemContextParameters&, ForceUnchecked = ForceUnchecked::No) const;
 
@@ -132,7 +134,15 @@ private:
     String m_title;
 
     RefPtr<WebExtensionCommand> m_command;
+
+    mutable RetainPtr<CocoaImage> m_cachedIcon;
+    mutable RetainPtr<NSSet> m_cachedIconScales;
+    mutable CGSize m_cachedIconIdealSize { CGSizeZero };
+
     RetainPtr<NSDictionary> m_icons;
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+    RetainPtr<NSArray> m_iconVariants;
+#endif
 
     bool m_checked : 1 { false };
     bool m_enabled : 1 { true };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -56,6 +56,14 @@ static NSString * const popupKey = @"popup";
 static NSString * const textKey = @"text";
 static NSString * const titleKey = @"title";
 
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+static NSString * const variantsKey = @"variants";
+static NSString * const colorSchemesKey = @"color_schemes";
+static NSString * const lightKey = @"light";
+static NSString * const darkKey = @"dark";
+static NSString * const anyKey = @"any";
+#endif
+
 namespace WebKit {
 
 bool WebExtensionAPIAction::parseActionDetails(NSDictionary *details, std::optional<WebExtensionWindowIdentifier>& windowIdentifier, std::optional<WebExtensionTabIdentifier>& tabIdentifier, NSString **outExceptionString)
@@ -363,6 +371,11 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 
 bool WebExtensionAPIAction::isValidDimensionKey(NSString *dimension)
 {
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+    if ([dimension isEqualToString:anyKey])
+        return true;
+#endif
+
     double value = dimension.doubleValue;
     if (!value)
         return false;
@@ -379,9 +392,129 @@ bool WebExtensionAPIAction::isValidDimensionKey(NSString *dimension)
     return true;
 }
 
+NSString *WebExtensionAPIAction::parseIconPath(NSString *path, const URL& baseURL)
+{
+    // Resolve paths as relative against the base URL, unless it is a data URL.
+    if ([path hasPrefix:@"data:"])
+        return path
+    return URL { baseURL, path }.path().toString();
+}
+
+NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionary *input, const URL& baseURL, bool forVariants, NSString *inputKey, NSString **outExceptionString)
+{
+    auto *result = [NSMutableDictionary dictionaryWithCapacity:input.count];
+
+    for (NSString *key in input) {
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+        if (forVariants && [key isEqualToString:colorSchemesKey])
+            continue;
+#endif
+
+        if (!isValidDimensionKey(key)) {
+            if (outExceptionString)
+                *outExceptionString = toErrorString(nullptr, inputKey, @"'%@' is not a valid dimension", key);
+            return nil;
+        }
+
+        NSString *path = input[key];
+        if (!validateObject(path, [NSString stringWithFormat:@"%@[%@]", inputKey, key], NSString.class, outExceptionString))
+            return nil;
+
+        result[key] = parseIconPath(path, baseURL);
+    }
+
+    return result;
+}
+
+NSMutableDictionary *WebExtensionAPIAction::parseIconImageDataDictionary(NSDictionary *input, bool forVariants, NSString *inputKey, NSString **outExceptionString)
+{
+    auto *result = [NSMutableDictionary dictionaryWithCapacity:input.count];
+
+    for (NSString *key in input) {
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+        if (forVariants && [key isEqualToString:colorSchemesKey])
+            continue;
+#endif
+
+        if (!isValidDimensionKey(key)) {
+            if (outExceptionString)
+                *outExceptionString = toErrorString(nullptr, inputKey, @"'%@' is not a valid dimension", key);
+            return nil;
+        }
+
+        id value = input[key];
+        if (!validateObject(value, [NSString stringWithFormat:@"%@[%@]", inputKey, key], JSValue.class, outExceptionString))
+            return nil;
+
+        auto *dataURLString = dataURLFromImageData(value, nullptr, key, outExceptionString);
+        if (!dataURLString)
+            return nil;
+
+        result[key] = dataURLString;
+    }
+
+    return result;
+}
+
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& baseURL, NSString *inputKey, NSString **outExceptionString)
+{
+    auto *result = [NSMutableArray arrayWithCapacity:input.count];
+
+    NSString *firstExceptionString;
+    for (NSUInteger index = 0; index < input.count; ++index) {
+        NSDictionary *dictionary = input[index];
+        auto *compositeKey = [NSString stringWithFormat:@"%@[%lu]", inputKey, index];
+
+        // Try parsing the variant as image data first.
+        auto *parsedDictionary = parseIconImageDataDictionary(dictionary, true, compositeKey, !firstExceptionString ? &firstExceptionString : nullptr);
+
+        // If image data failed, try parsing as paths.
+        if (!parsedDictionary)
+            parsedDictionary = parseIconPathsDictionary(dictionary, baseURL, true, compositeKey, !firstExceptionString ? &firstExceptionString : nullptr);
+
+        // If all types failed, continue.
+        if (!parsedDictionary) {
+            ASSERT(firstExceptionString);
+            continue;
+        }
+
+        if (NSArray *colorSchemes = dictionary[colorSchemesKey]) {
+            auto *colorSchemesCompositeKey = [NSString stringWithFormat:@"%@['%@']", compositeKey, colorSchemesKey];
+            if (!validateObject(colorSchemes, colorSchemesCompositeKey, @[ NSString.class ], !firstExceptionString ? &firstExceptionString : nullptr))
+                continue;
+
+            if (![colorSchemes containsObject:lightKey] && ![colorSchemes containsObject:darkKey]) {
+                if (!firstExceptionString)
+                    firstExceptionString = toErrorString(nil, colorSchemesCompositeKey, @"it must specify either 'light' or 'dark'");
+                continue;
+            }
+
+            parsedDictionary[colorSchemesKey] = colorSchemes;
+        }
+
+        ASSERT(parsedDictionary);
+        [result addObject:parsedDictionary];
+    }
+
+    if (input.count && !result.count) {
+        // An exception is only set if no valid icon variants were found,
+        // maintaining flexibility for future support of different inputs.
+        if (!firstExceptionString)
+            firstExceptionString = toErrorString(nil, inputKey, @"it didn't contain any valid icon variants");
+        if (outExceptionString)
+            *outExceptionString = firstExceptionString;
+        return nil;
+    }
+
+    return [result copy];
+}
+#endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+
 void WebExtensionAPIAction::setIcon(WebFrame& frame, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setIcon
+    // Icon Variants: https://github.com/w3c/webextensions/blob/main/proposals/dark_mode_extension_icons.md
 
     std::optional<WebExtensionWindowIdentifier> windowIdentifier;
     std::optional<WebExtensionTabIdentifier> tabIdentifier;
@@ -391,6 +524,9 @@ void WebExtensionAPIAction::setIcon(WebFrame& frame, NSDictionary *details, Ref<
     static NSDictionary<NSString *, id> *types = @{
         pathKey: [NSOrderedSet orderedSetWithObjects:NSString.class, NSDictionary.class, NSNull.class, nil],
         imageDataKey: [NSOrderedSet orderedSetWithObjects:JSValue.class, NSDictionary.class, NSNull.class, nil],
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+        variantsKey: [NSOrderedSet orderedSetWithObjects:@[ NSDictionary.class ], NSNull.class, nil],
+#endif
     };
 
     if (!validateDictionary(details, @"details", nil, types, outExceptionString))
@@ -413,59 +549,37 @@ void WebExtensionAPIAction::setIcon(WebFrame& frame, NSDictionary *details, Ref<
     }
 
     if (auto *images = objectForKey<NSDictionary>(details, imageDataKey)) {
-        auto *mutableIconDictionary = [NSMutableDictionary dictionaryWithCapacity:images.count];
-
-        for (NSString *key in images) {
-            if (!isValidDimensionKey(key)) {
-                *outExceptionString = toErrorString(nil, imageDataKey, @"'%@' in not a valid dimension", key);
-                return;
-            }
-
-            if (!validateObject(images[key], [NSString stringWithFormat:@"%@[%@]", imageDataKey, key], JSValue.class, outExceptionString))
-                return;
-
-            JSValue *imageData = images[key];
-            auto *dataURLString = dataURLFromImageData(imageData, nullptr, key, outExceptionString);
-            if (!dataURLString)
-                return;
-
-            mutableIconDictionary[key] = dataURLString;
-        }
-
-        iconDictionary = [mutableIconDictionary copy];
+        iconDictionary = parseIconImageDataDictionary(images, false, imageDataKey, outExceptionString);
+        if (!iconDictionary)
+            return;
     }
 
     if (auto *path = objectForKey<NSString>(details, pathKey)) {
         // Chrome documentation states that 'details.path = foo' is equivalent to 'details.path = { '16': foo }'.
         // Documentation: https://developer.chrome.com/docs/extensions/reference/action/#method-setIcon
-        iconDictionary = @{ @"16": path };
+        iconDictionary = @{ @"16": parseIconPath(path, frame.url()) };
     }
 
     if (auto *paths = objectForKey<NSDictionary>(details, pathKey)) {
-        for (NSString *key in paths) {
-            if (!isValidDimensionKey(key)) {
-                *outExceptionString = toErrorString(nil, pathKey, @"'%@' in not a valid dimension", key);
-                return;
-            }
-
-            if (!validateObject(paths[key], [NSString stringWithFormat:@"%@[%@]", pathKey, key], NSString.class, outExceptionString))
-                return;
-        }
-
-        iconDictionary = paths;
+        iconDictionary = parseIconPathsDictionary(paths, frame.url(), false, pathKey, outExceptionString);
+        if (!iconDictionary)
+            return;
     }
 
-    // Resolve paths as relative against the frame's URL, unless it is a data URL.
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setIcon#path
-    iconDictionary = mapObjects(iconDictionary, ^(id key, NSString *path) {
-        if (![path hasPrefix:@"data:"])
-            path = URL { frame.url(), path }.path().toString();
-        return path;
-    });
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+    NSArray *iconVariants;
+    if (auto *variants = objectForKey<NSArray>(details, variantsKey)) {
+        iconVariants = parseIconVariants(variants, frame.url(), variantsKey, outExceptionString);
+        if (!iconVariants)
+            return;
+    }
 
-    auto *iconDictionaryJSON = encodeJSONString(iconDictionary);
+    auto *iconsJSON = encodeJSONString(iconVariants ?: iconDictionary, JSONOptions::FragmentsAllowed);
+#else
+    auto *iconsJSON = encodeJSONString(iconDictionary);
+#endif
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetIcon(windowIdentifier, tabIdentifier, iconDictionaryJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetIcon(windowIdentifier, tabIdentifier, iconsJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -66,6 +66,14 @@ private:
     friend class WebExtensionAPIMenus;
 
     static bool isValidDimensionKey(NSString *);
+    static NSString *parseIconPath(NSString *path, const URL& baseURL);
+    static NSMutableDictionary *parseIconPathsDictionary(NSDictionary *, const URL& baseURL, bool forVariants, NSString *inputKey, NSString **outExceptionString);
+    static NSMutableDictionary *parseIconImageDataDictionary(NSDictionary *, bool forVariants, NSString *inputKey, NSString **outExceptionString);
+
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+    static NSArray *parseIconVariants(NSArray *, const URL& baseURL, NSString *inputKey, NSString **outExceptionString);
+#endif
+
     static bool parseActionDetails(NSDictionary *, std::optional<WebExtensionWindowIdentifier>&, std::optional<WebExtensionTabIdentifier>&, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onClicked;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
@@ -44,8 +44,8 @@ public:
 #if PLATFORM(COCOA)
     using ClickHandlerMap = HashMap<String, Ref<WebExtensionCallbackHandler>>;
 
-    id createMenu(WebPage&, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void update(WebPage&, id identifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    id createMenu(WebPage&, WebFrame&, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void update(WebPage&, WebFrame&, id identifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void remove(id identifier, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void removeAll(Ref<WebExtensionCallbackHandler>&&);
@@ -58,7 +58,7 @@ public:
 
 private:
     enum class ForUpdate : bool { No, Yes };
-    bool parseCreateAndUpdateProperties(ForUpdate, NSDictionary *, std::optional<WebExtensionMenuItemParameters>&, RefPtr<WebExtensionCallbackHandler>&, NSString **outExceptionString);
+    bool parseCreateAndUpdateProperties(ForUpdate, NSDictionary *, const URL& baseURL, std::optional<WebExtensionMenuItemParameters>&, RefPtr<WebExtensionCallbackHandler>&, NSString **outExceptionString);
 
     WebPageProxyIdentifier m_pageProxyIdentifier;
     RefPtr<WebExtensionAPIEvent> m_onClicked;

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -678,11 +678,11 @@ EOF
             unshift(@methodSignatureNames, "context") if $needsScriptContext;
             unshift(@parameters, "context") if $needsScriptContext;
 
-            unshift(@methodSignatureNames, "page") if $needsPage;
-            unshift(@parameters, "*page") if $needsPage;
-
             unshift(@methodSignatureNames, "frame") if $needsFrame;
             unshift(@parameters, "*frame") if $needsFrame;
+
+            unshift(@methodSignatureNames, "page") if $needsPage;
+            unshift(@parameters, "*page") if $needsPage;
 
             push(@methodSignatureNames, "outExceptionString") if $needsExceptionString;
             push(@parameters, "&exceptionString") if $needsExceptionString;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIMenus.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIMenus.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIMenus {
 
-    [RaisesException, ImplementedAs=createMenu, NeedsPage] any create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
-    [RaisesException, ReturnsPromiseWhenCallbackIsOmitted, NeedsPage] void update([NSObject] any identifier, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, ImplementedAs=createMenu, NeedsPage, NeedsFrame] any create([NSDictionary=NullAllowed] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, ReturnsPromiseWhenCallbackIsOmitted, NeedsPage, NeedsFrame] void update([NSObject] any identifier, [NSDictionary=NullAllowed] any properties, [Optional, CallbackHandler] function callback);
 
     [RaisesException, ReturnsPromiseWhenCallbackIsOmitted] void remove([NSObject] any identifier, [Optional, CallbackHandler] function callback);
     [ReturnsPromiseWhenCallbackIsOmitted] void removeAll([Optional, CallbackHandler] function callback);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -100,10 +100,10 @@ TEST(WKWebExtensionAPIMenus, Errors)
         @"browser.test.assertThrows(() => browser.menus.create({ visible: 'bad', title: 'Test' }), /'visible' is expected to be a boolean, but a string was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ enabled: 'bad', title: 'Test' }), /'enabled' is expected to be a boolean, but a string was provided/i)",
 
-        @"browser.test.assertThrows(() => browser.menus.create({ icons: 123, title: 'Test' }), /'icons' is expected to be a string or an object, but a number was provided/i)",
+        @"browser.test.assertThrows(() => browser.menus.create({ icons: 123, title: 'Test' }), /'icons' is expected to be a string or an object or null, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ icons: { 16: 123 }, title: 'Test' }), /'icons\\[16]' value is invalid, because a string is expected, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ icons: { '16': 123 }, title: 'Test' }), /'icons\\[16]' value is invalid, because a string is expected, but a number was provided/i)",
-        @"browser.test.assertThrows(() => browser.menus.create({ icons: { '1.2': 'test.png' }, title: 'Test' }), /'icons' value is invalid, because '1.2' in not a valid dimension/i)",
+        @"browser.test.assertThrows(() => browser.menus.create({ icons: { '1.2': 'test.png' }, title: 'Test' }), /'icons' value is invalid, because '1.2' is not a valid dimension/i)",
 
         @"browser.test.assertThrows(() => browser.menus.create({ onclick: 'bad', title: 'Test' }), /'onclick' is expected to be a value, but a string was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ onclick: { }, title: 'Test' }), /'onclick' is expected to be a value, but an object was provided/i)",
@@ -751,6 +751,552 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
 
     [manager run];
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
+TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-with-icon-variants',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item with Icon Variants',",
+        @"  icon_variants: [",
+        @"    { 16: 'icon-dark-16.png', 'color_schemes': [ 'dark' ] },",
+        @"    { 16: 'icon-light-16.png', 'color_schemes': [ 'light' ] }",
+        @"  ],",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"icon-dark-16.png": darkIcon16,
+        @"icon-light-16.png": lightIcon16,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with Icon Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with Icon Variants");
+#endif
+
+    Util::performWithAppearance(Util::Appearance::Dark, ^{
+        EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor whiteColor]));
+    });
+
+    Util::performWithAppearance(Util::Appearance::Light, ^{
+        EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor blackColor]));
+    });
+}
+
+TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const createImageData = (size, color) => {",
+        @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
+        @"  context.fillStyle = color",
+        @"  context.fillRect(0, 0, size, size)",
+
+        @"  return context.getImageData(0, 0, size, size)",
+        @"}",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"const darkImageData = createImageData(16, 'white')",
+        @"const lightImageData = createImageData(16, 'black')",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-with-icon-variants',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item with ImageData Variants',",
+        @"  icon_variants: [",
+        @"    { 16: darkImageData, 'color_schemes': [ 'dark' ] },",
+        @"    { 16: lightImageData, 'color_schemes': [ 'light' ] }",
+        @"  ],",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with ImageData Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with ImageData Variants");
+#endif
+
+    Util::performWithAppearance(Util::Appearance::Dark, ^{
+        EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor whiteColor]));
+    });
+
+    Util::performWithAppearance(Util::Appearance::Light, ^{
+        EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor blackColor]));
+    });
+}
+
+TEST(WKWebExtensionAPIMenus, MenuItemWithWithNoValidVariants)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const createImageData = (size, color) => {",
+        @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
+        @"  context.fillStyle = color",
+        @"  context.fillRect(0, 0, size, size)",
+
+        @"  return context.getImageData(0, 0, size, size)",
+        @"}",
+
+        @"const validImageData = createImageData(16, 'white')",
+
+        @"await browser.test.assertThrows(() => browser.menus.create({",
+        @"    id: 'submenu-item-invalid-dimension',",
+        @"    parentId: 'top-level-item',",
+        @"    title: 'Submenu with Invalid Dimension Key',",
+        @"    icon_variants: [",
+        @"      { 'sixteen': validImageData, 'color_schemes': [ 'light' ] }",
+        @"    ],",
+        @"    contexts: [ 'action' ]",
+        @"}), /'icon_variants\\[0\\]' value is invalid, because 'sixteen' is not a valid dimension/)",
+
+        @"await browser.test.assertThrows(() => browser.menus.create({",
+        @"    id: 'submenu-item-invalid-color-scheme',",
+        @"    parentId: 'top-level-item',",
+        @"    title: 'Submenu with Invalid Color Scheme',",
+        @"    icon_variants: [",
+        @"      { '16': validImageData, 'color_schemes': [ 'bad' ] }",
+        @"    ],",
+        @"    contexts: [ 'action' ]",
+        @"}), /'icon_variants\\[0\\]\\['color_schemes'\\]' value is invalid, because it must specify either 'light' or 'dark'/)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+    };
+
+    Util::loadAndRunExtension(menusManifest, resources);
+}
+
+TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const createImageData = (size, color) => {",
+        @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
+        @"  context.fillStyle = color",
+        @"  context.fillRect(0, 0, size, size)",
+
+        @"  return context.getImageData(0, 0, size, size)",
+        @"}",
+
+        @"const validImageData = createImageData(16, 'black')",
+        @"const invalidImageData = createImageData(16, 'white')",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-mixed',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item with Mixed Variants',",
+        @"  icon_variants: [",
+        @"    { 'sixteen': invalidImageData, 'color_schemes': [ 'dark' ] },",
+        @"    { '16': validImageData, 'color_schemes': [ 'light' ] }",
+        @"  ],",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with Mixed Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with Mixed Variants");
+#endif
+
+    EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+
+    Util::performWithAppearance(Util::Appearance::Light, ^{
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor blackColor]));
+    });
+
+    Util::performWithAppearance(Util::Appearance::Dark, ^{
+        // Should still be black, as light variant is used.
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor blackColor]));
+    });
+}
+
+TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const whiteSVGData = 'data:image/svg+xml;base64,' + btoa(`",
+        @"  <svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">",
+        @"    <rect width=\"100\" height=\"100\" fill=\"white\" />",
+        @"  </svg>`)",
+
+        @"const blackSVGData = 'data:image/svg+xml;base64,' + btoa(`",
+        @"  <svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">",
+        @"    <rect width=\"100\" height=\"100\" fill=\"black\" />",
+        @"  </svg>`)",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'all' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-with-icon-variants',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item with SVG Icon Variants',",
+        @"  icon_variants: [",
+        @"    { any: whiteSVGData, 'color_schemes': [ 'dark' ] },",
+        @"    { any: blackSVGData, 'color_schemes': [ 'light' ] }",
+        @"  ],",
+        @"  contexts: [ 'all' ]",
+        @"}))",
+
+        @"browser.test.yield('Menus Created')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with SVG Icon Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with SVG Icon Variants");
+#endif
+
+    EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+
+    Util::performWithAppearance(Util::Appearance::Dark, ^{
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor whiteColor]));
+    });
+
+    Util::performWithAppearance(Util::Appearance::Light, ^{
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor blackColor]));
+    });
+}
+
+TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-without-icon-variants',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item without Icon Variants',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.update('submenu-item-without-icon-variants', {",
+        @"  title: 'Submenu Item with Icon Variants',",
+        @"  icon_variants: [",
+        @"    { 16: 'icon-dark-16.png', 'color_schemes': [ 'dark' ] },",
+        @"    { 16: 'icon-light-16.png', 'color_schemes': [ 'light' ] }",
+        @"  ]",
+        @"}))",
+
+        @"browser.test.yield('Menus Updated')",
+    ]);
+
+    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"icon-dark-16.png": darkIcon16,
+        @"icon-light-16.png": lightIcon16,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Updated");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with Icon Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item with Icon Variants");
+#endif
+
+    EXPECT_TRUE(CGSizeEqualToSize(submenuItem.image.size, CGSizeMake(16, 16)));
+
+    Util::performWithAppearance(Util::Appearance::Dark, ^{
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor whiteColor]));
+    });
+
+    Util::performWithAppearance(Util::Appearance::Light, ^{
+        EXPECT_TRUE(Util::compareColors(Util::pixelColor(submenuItem.image), [CocoaColor blackColor]));
+    });
+}
+
+TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-with-icon-variants',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item with Icon Variants',",
+        @"  icon_variants: [",
+        @"    { 16: 'icon-dark-16.png', 'color_schemes': [ 'dark' ] },",
+        @"    { 16: 'icon-light-16.png', 'color_schemes': [ 'light' ] }",
+        @"  ],",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.update('submenu-item-with-icon-variants', {",
+        @"  icon_variants: null,",
+        @"  title: 'Submenu Item without Icon Variants'",
+        @"}))",
+
+        @"browser.test.yield('Menus Updated')",
+    ]);
+
+    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"icon-dark-16.png": darkIcon16,
+        @"icon-light-16.png": lightIcon16,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Updated");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item without Icon Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item without Icon Variants");
+#endif
+
+    // Icon should be null after clearing.
+    EXPECT_NULL(submenuItem.image);
+}
+
+TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'top-level-item',",
+        @"  title: 'Top Level Menu',",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.create({",
+        @"  id: 'submenu-item-with-icon-variants',",
+        @"  parentId: 'top-level-item',",
+        @"  title: 'Submenu Item with Icon Variants',",
+        @"  icon_variants: [",
+        @"    { 16: 'icon-dark-16.png', 'color_schemes': [ 'dark' ] },",
+        @"    { 16: 'icon-light-16.png', 'color_schemes': [ 'light' ] }",
+        @"  ],",
+        @"  contexts: [ 'action' ]",
+        @"}))",
+
+        @"browser.test.assertSafe(() => browser.menus.update('submenu-item-with-icon-variants', {",
+        @"  icon_variants: [ ],",
+        @"  title: 'Submenu Item without Icon Variants'",
+        @"}))",
+
+        @"browser.test.yield('Menus Updated')",
+    ]);
+
+    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"icon-dark-16.png": darkIcon16,
+        @"icon-light-16.png": lightIcon16,
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Updated");
+
+    auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
+    auto *menuItems = action.menuItems;
+
+    EXPECT_EQ(menuItems.count, 1lu);
+
+    auto *topLevelMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    EXPECT_TRUE([topLevelMenuItem isKindOfClass:[CocoaMenuItem class]]);
+    EXPECT_NS_EQUAL(topLevelMenuItem.title, @"Top Level Menu");
+
+#if USE(APPKIT)
+    EXPECT_EQ(topLevelMenuItem.submenu.itemArray.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuItem>(topLevelMenuItem.submenu.itemArray.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item without Icon Variants");
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    EXPECT_EQ(parentMenu.children.count, 1lu);
+
+    auto *submenuItem = dynamic_objc_cast<CocoaMenuAction>(parentMenu.children.firstObject);
+    EXPECT_NS_EQUAL(submenuItem.title, @"Submenu Item without Icon Variants");
+#endif
+
+    // Icon should be null after clearing.
+    EXPECT_NULL(submenuItem.image);
+}
+#endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 
 TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
 {


### PR DESCRIPTION
#### ad1823e801dac7db59725880ff4d4ec17bd3e51f
<pre>
Add support for icon_variants and variants in menus and action APIs for Web Extensions.
<a href="https://webkit.org/b/279135">https://webkit.org/b/279135</a>
<a href="https://rdar.apple.com/problem/134885372">rdar://problem/134885372</a>

Reviewed by Brian Weinstein.

Add support for the `icons_variants` key in `menus.create()` and `menus.update()`.
Also add support for `variants` key in `action.setIcon()`.

Proposal: <a href="https://github.com/w3c/webextensions/blob/main/proposals/dark_mode_extension_icons.md">https://github.com/w3c/webextensions/blob/main/proposals/dark_mode_extension_icons.md</a>
WECG issue: <a href="https://github.com/w3c/webextensions/issues/229">https://github.com/w3c/webextensions/issues/229</a>

* Source/WebKit/Shared/Extensions/WebExtensionMenuItem.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionMenuItemParameters.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::actionSetIcon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::clearCustomizations):
(WebKit::WebExtensionAction::icon):
(WebKit::WebExtensionAction::setIcons):
(WebKit::WebExtensionAction::setIconVariants):
(WebKit::WebExtensionAction::clearIconCache):
(WebKit::WebExtensionAction::setIconsDictionary): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::WebExtensionMenuItem):
(WebKit::WebExtensionMenuItem::minimalParameters const):
(WebKit::WebExtensionMenuItem::update):
(WebKit::WebExtensionMenuItem::icon const):
(WebKit::WebExtensionMenuItem::clearIconCache const):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::isValidDimensionKey):
(WebKit::WebExtensionAPIAction::parseIconPath):
(WebKit::WebExtensionAPIAction::parseIconPathsDictionary):
(WebKit::WebExtensionAPIAction::parseIconImageDataDictionary):
(WebKit::WebExtensionAPIAction::parseIconVariants):
(WebKit::WebExtensionAPIAction::setIcon):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
(WebKit::WebExtensionAPIMenus::createMenu):
(WebKit::WebExtensionAPIMenus::update):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIMenus.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithDataURL)): Renamed.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconThrowsWithNoValidVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithSVGDataURL)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, Errors)): Fixed expectations.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithWithNoValidVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)): Added.

Canonical link: <a href="https://commits.webkit.org/283219@main">https://commits.webkit.org/283219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95477d9a38db2521ab88253e5a927025a8de6e57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65613 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/44984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/18231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67731 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/52785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/16502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/69639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/52785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/18231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/52785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/18231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15098 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/52785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/18231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/71345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/9567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/16502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/71345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/9599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/18231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/71345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/18231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9938 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/41614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->