### PR TITLE
[view-transitions] `m_shouldCallUpdateCallback` is unused

### DIFF
--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,7 +62,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewTransition);
 ViewTransition::ViewTransition(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback, Vector<AtomString>&& initialActiveTypes)
     : ActiveDOMObject(document)
     , m_updateCallback(WTFMove(updateCallback))
-    , m_shouldCallUpdateCallback(true)
     , m_ready(createPromiseAndWrapper(document))
     , m_updateCallbackDone(createPromiseAndWrapper(document))
     , m_finished(createPromiseAndWrapper(document))
@@ -220,9 +219,6 @@ void ViewTransition::callUpdateCallback()
 
     if (m_phase != ViewTransitionPhase::Done)
         m_phase = ViewTransitionPhase::UpdateCallbackCalled;
-
-    if (!m_shouldCallUpdateCallback)
-        return;
 
     Ref document = *this->document();
     RefPtr<DOMPromise> callbackPromise;

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -222,8 +222,7 @@ private:
     FloatSize m_initialLargeViewportSize;
     float m_initialPageZoom;
 
-    RefPtr<ViewTransitionUpdateCallback>  m_updateCallback;
-    bool m_shouldCallUpdateCallback { false };
+    RefPtr<ViewTransitionUpdateCallback> m_updateCallback;
 
     using PromiseAndWrapper = std::pair<Ref<DOMPromise>, Ref<DeferredPromise>>;
     PromiseAndWrapper m_ready;


### PR DESCRIPTION
#### 21ae17075503e3c93bf2828c3d4c308a688746d5
<pre>
[view-transitions] `m_shouldCallUpdateCallback` is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=279134">https://bugs.webkit.org/show_bug.cgi?id=279134</a>
<a href="https://rdar.apple.com/135286738">rdar://135286738</a>

Reviewed by NOBODY (OOPS!).

`resolveInboundCrossDocumentViewTransition()` sets the phase to `ViewTransitionPhase::UpdateCallbackCalled` which means `callUpdateCallback()` is never reached.

This makes `m_shouldCallUpdateCallback` no longer useful.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::ViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
* Source/WebCore/dom/ViewTransition.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21ae17075503e3c93bf2828c3d4c308a688746d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69477 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16340 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52562 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11134 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33185 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38096 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59932 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14367 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71182 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9405 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13830 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59884 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56712 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60157 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7774 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1425 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40632 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->