### PR TITLE
[WebGPU] Instance being retained longer than its corresponding RemoteGPU

### DIFF
--- a/Source/WebGPU/WebGPU/Adapter.h
+++ b/Source/WebGPU/WebGPU/Adapter.h
@@ -31,6 +31,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/WeakPtr.h>
 
 struct WGPUAdapterImpl {
 };
@@ -65,7 +66,7 @@ public:
     void makeInvalid() { m_device = nil; }
     bool isXRCompatible() const;
 
-    Instance& instance() const { return m_instance; }
+    RefPtr<Instance> instance() const { return m_instance.get(); }
 
 
 private:
@@ -73,7 +74,7 @@ private:
     Adapter(Instance&);
 
     id<MTLDevice> m_device { nil };
-    const Ref<Instance> m_instance;
+    const ThreadSafeWeakPtr<Instance> m_instance;
 
     const HardwareCapabilities m_capabilities { };
     bool m_deviceRequested { false };

--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -39,14 +39,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Adapter);
 
 Adapter::Adapter(id<MTLDevice> device, Instance& instance, bool xrCompatible, HardwareCapabilities&& capabilities)
     : m_device(device)
-    , m_instance(instance)
+    , m_instance(&instance)
     , m_capabilities(WTFMove(capabilities))
     , m_xrCompatible(xrCompatible)
 {
 }
 
 Adapter::Adapter(Instance& instance)
-    : m_instance(instance)
+    : m_instance(&instance)
 {
 }
 

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -498,7 +498,7 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
         return { mtlTextures[0], mtlTextures[1], simd::float3x2(1.f), colorSpaceConversionMatrix };
     }
 
-    if (auto optionalWebProcessID = instance().webProcessID()) {
+    if (auto optionalWebProcessID = webProcessID()) {
         if (auto webProcessID = optionalWebProcessID->sendRight())
             IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
     }

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -127,7 +127,7 @@ public:
     void generateAnOutOfMemoryError(String&& message);
     void generateAnInternalError(String&& message);
 
-    Instance& instance() const { return m_adapter->instance(); }
+    RefPtr<Instance> instance() const { return m_adapter->instance(); }
     bool hasUnifiedMemory() const { return m_device.hasUnifiedMemory; }
 
     uint32_t maxBuffersPlusVertexBuffersForVertexStage() const;
@@ -165,6 +165,7 @@ public:
     };
     ExternalTextureData createExternalTextureFromPixelBuffer(CVPixelBufferRef, WGPUColorSpace) const;
     RefPtr<XRSubImage> getXRViewSubImage(WGPUXREye);
+    const std::optional<const MachSendRight> webProcessID() const;
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -98,7 +98,7 @@ void ExternalTexture::update(CVPixelBufferRef pixelBuffer)
 {
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
     if (IOSurfaceRef ioSurface = CVPixelBufferGetIOSurface(pixelBuffer)) {
-        if (auto optionalWebProcessID = m_device->instance().webProcessID()) {
+        if (auto optionalWebProcessID = m_device->webProcessID()) {
             if (auto webProcessID = optionalWebProcessID->sendRight())
                 IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
         }

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -33,6 +33,7 @@
 #import <wtf/Ref.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/WeakPtr.h>
 
 struct WGPUInstanceImpl {
 };
@@ -47,7 +48,7 @@ class Adapter;
 class PresentationContext;
 
 // https://gpuweb.github.io/gpuweb/#gpu
-class Instance : public WGPUInstanceImpl, public ThreadSafeRefCounted<Instance> {
+class Instance : public WGPUInstanceImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Instance> {
     WTF_MAKE_TZONE_ALLOCATED(Instance);
 public:
     static Ref<Instance> create(const WGPUInstanceDescriptor&);
@@ -56,7 +57,7 @@ public:
         return adoptRef(*new Instance());
     }
 
-    ~Instance();
+    virtual ~Instance();
 
     Ref<PresentationContext> createSurface(const WGPUSurfaceDescriptor&);
     void processEvents();

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -905,7 +905,8 @@ void Queue::scheduleWork(Instance::WorkItem&& workItem)
     if (!device)
         return;
 
-    device->instance().scheduleWork(WTFMove(workItem));
+    if (auto inst = device->instance(); inst.get())
+        inst->scheduleWork(WTFMove(workItem));
 }
 
 void Queue::clearTextureViewIfNeeded(TextureView& textureView)


### PR DESCRIPTION
#### 1b1f0299a6918f7ab386fee8d5f442913385cc85
<pre>
[WebGPU] Instance being retained longer than its corresponding RemoteGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=279138">https://bugs.webkit.org/show_bug.cgi?id=279138</a>
<a href="https://rdar.apple.com/135292412">rdar://135292412</a>

Reviewed by Dan Glastonbury.

Chance Instance from Ref&lt;&gt; to a ThreadSafeWeakPtr&lt;&gt; to break a retain
cycle causing Instance to outlive it&apos;s corresponding RemoteGPU instance.

* Source/WebGPU/WebGPU/Adapter.h:
(WebGPU::Adapter::instance const):
* Source/WebGPU/WebGPU/Adapter.mm:
(WebGPU::Adapter::Adapter):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createExternalTextureFromPixelBuffer const):
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::instance const):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::setOwnerWithIdentity const):
(WebGPU::Device::popErrorScope):
(WebGPU::Device::webProcessID const):
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::update):
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::scheduleWork):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipelineAsync):

Canonical link: <a href="https://commits.webkit.org/283190@main">https://commits.webkit.org/283190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92f08d5c51e88bd7146b69fbda7cb06fff4872f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16065 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52565 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11140 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38100 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71187 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59885 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60158 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14439 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1429 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->