### PR TITLE
[SVG2] Fix `presentational hints` special cases where supported

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
@@ -59,7 +59,7 @@ PASS text-decoration presentation attribute supported on a relevant element
 FAIL text-overflow presentation attribute supported on a relevant element assert_true: Presentation attribute text-overflow="ellipsis" should be supported on text element expected true got false
 PASS text-rendering presentation attribute supported on a relevant element
 PASS transform-origin presentation attribute supported on a relevant element
-FAIL transform presentation attribute supported on a relevant element assert_true: Presentation attribute transform="scale(2)" should be supported on g element expected true got false
+PASS transform presentation attribute supported on a relevant element
 PASS unicode-bidi presentation attribute supported on a relevant element
 PASS vector-effect presentation attribute supported on a relevant element
 PASS visibility presentation attribute supported on a relevant element

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
@@ -21,10 +21,10 @@ PASS fill presentation attribute not supported on animateMotion
 PASS fill presentation attribute not supported on animateTransform
 FAIL fill presentation attribute not supported on discard assert_false: Presentation attribute fill="blue" should not be supported on discard element expected false got true
 PASS fill presentation attribute not supported on set
-FAIL transform presentation attribute supported on g assert_true: Presentation attribute transform="scale(2)" should be supported on g element expected true got false
-FAIL patternTransform presentation attribute supported on pattern assert_true: Presentation attribute patternTransform="scale(2)" should be supported on pattern element expected true got false
-FAIL patternTransform presentation attribute supported on linearGradient assert_true: Presentation attribute gradientTransform="scale(2)" should be supported on linearGradient element expected true got false
-FAIL patternTransform presentation attribute supported on radialGradient assert_true: Presentation attribute gradientTransform="scale(2)" should be supported on radialGradient element expected true got false
+PASS transform presentation attribute supported on g
+PASS patternTransform presentation attribute supported on pattern
+PASS gradientTransform presentation attribute supported on linearGradient
+PASS gradientTransform presentation attribute supported on radialGradient
 PASS transform presentation attribute not supported on pattern or gradient elements
 PASS patternTransform presentation attribute not supported on g or gradient elements
 PASS gradientTransform presentation attribute not supported on g or pattern elements

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases.html
@@ -121,7 +121,7 @@ if (CSS.supports("transform", "initial")) {
   for (let e of ["linearGradient", "radialGradient"]) {
     test(function() {
       assertPresentationAttributeIsSupported(e, "gradientTransform", "scale(2)", "transform");
-    }, `patternTransform presentation attribute supported on ${e}`);
+    }, `gradientTransform presentation attribute supported on ${e}`);
   }
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes.js
@@ -356,6 +356,10 @@ function presentationAttributeIsSupported(element, attribute, value, property) {
   svg.append(e);
   let propertyValueBefore = getComputedStyle(e).getPropertyValue(property);
   e.setAttribute(attribute, value);
+  // Also set another attribute that is likely to be a presentation attribute,
+  // in order to provoke bugs.
+  const otherAttribute = attribute === 'stroke' ? 'fill' : 'stroke';
+  e.setAttribute(otherAttribute, 'red');
   let propertyValueAfter = getComputedStyle(e).getPropertyValue(property);
   e.remove();
   return propertyValueBefore != propertyValueAfter;

--- a/LayoutTests/platform/glib/svg/batik/text/textProperties-expected.txt
+++ b/LayoutTests/platform/glib/svg/batik/text/textProperties-expected.txt
@@ -78,7 +78,7 @@ layer at (0,0) size 450x500
         RenderSVGInlineText {#text} at (0,0) size 162x16
           chunk 1 (middle anchor) text run 1 at (144.02,280.00) startOffset 0 endOffset 25 width 161.95: "Text Rendering Properties"
       RenderSVGContainer {g} at (24,299) size 152x39 [transform={m=((1.00,0.00)(0.00,1.00)) t=(100.00,305.00)}]
-        RenderSVGContainer {g} at (58,299) size 84x33 [transform={m=((-1.00,0.00)(-0.00,-1.00)) t=(0.00,0.00)}]
+        RenderSVGContainer {g} at (58,299) size 84x33 [transform={m=((-1.00,0.00)(0.00,-1.00)) t=(0.00,0.00)}]
           RenderSVGContainer {use} at (58,299) size 84x33
             RenderSVGText {text} at (-42,-27) size 84x33 contains 1 chunk(s)
               RenderSVGInlineText {#text} at (0,0) size 84x33

--- a/LayoutTests/platform/ios/svg/batik/text/textProperties-expected.txt
+++ b/LayoutTests/platform/ios/svg/batik/text/textProperties-expected.txt
@@ -78,7 +78,7 @@ layer at (0,0) size 450x500
         RenderSVGInlineText {#text} at (0,0) size 159x17
           chunk 1 (middle anchor) text run 1 at (145.85,280.00) startOffset 0 endOffset 25 width 158.29: "Text Rendering Properties"
       RenderSVGContainer {g} at (22,298) size 156x41 [transform={m=((1.00,0.00)(0.00,1.00)) t=(100.00,305.00)}]
-        RenderSVGContainer {g} at (57,298) size 86x34 [transform={m=((-1.00,0.00)(-0.00,-1.00)) t=(0.00,0.00)}]
+        RenderSVGContainer {g} at (57,298) size 86x34 [transform={m=((-1.00,0.00)(0.00,-1.00)) t=(0.00,0.00)}]
           RenderSVGContainer {use} at (57,298) size 86x34
             RenderSVGText {text} at (-43,-27) size 86x34 contains 1 chunk(s)
               RenderSVGInlineText {#text} at (0,0) size 85x34

--- a/LayoutTests/platform/mac/svg/batik/text/textProperties-expected.txt
+++ b/LayoutTests/platform/mac/svg/batik/text/textProperties-expected.txt
@@ -78,7 +78,7 @@ layer at (0,0) size 450x500
         RenderSVGInlineText {#text} at (0,0) size 159x17
           chunk 1 (middle anchor) text run 1 at (145.85,280.00) startOffset 0 endOffset 25 width 158.29: "Text Rendering Properties"
       RenderSVGContainer {g} at (22,297) size 156x42 [transform={m=((1.00,0.00)(0.00,1.00)) t=(100.00,305.00)}]
-        RenderSVGContainer {g} at (57,297) size 86x36 [transform={m=((-1.00,0.00)(-0.00,-1.00)) t=(0.00,0.00)}]
+        RenderSVGContainer {g} at (57,297) size 86x36 [transform={m=((-1.00,0.00)(0.00,-1.00)) t=(0.00,0.00)}]
           RenderSVGContainer {use} at (57,297) size 86x36
             RenderSVGText {text} at (-43,-28) size 86x36 contains 1 chunk(s)
               RenderSVGInlineText {#text} at (0,0) size 85x35

--- a/Source/WebCore/svg/SVGGElement.cpp
+++ b/Source/WebCore/svg/SVGGElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -74,6 +74,15 @@ bool SVGGElement::rendererIsNeeded(const RenderStyle&)
     // Unlike SVGElement::rendererIsNeeded(), we still create renderers, even if
     // display is set to 'none' - which is special to SVG <g> container elements.
     return parentOrShadowHostElement() && parentOrShadowHostElement()->isSVGElement();
+}
+
+void SVGGElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
+{
+    if (name == SVGNames::transformAttr) {
+        addPropertyToPresentationalHintStyle(style, CSSPropertyTransform, value);
+        return;
+    }
+    SVGElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
 }

--- a/Source/WebCore/svg/SVGGElement.h
+++ b/Source/WebCore/svg/SVGGElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -34,6 +34,8 @@ public:
     static Ref<SVGGElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGElement, SVGGraphicsElement>;
+
+    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
 
 private:
     SVGGElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2023 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
@@ -119,6 +119,15 @@ GradientColorStops SVGGradientElement::buildStops()
         stops.addColorStop({ monotonicallyIncreasingOffset, stop.stopColorIncludingOpacity() });
     }
     return stops;
+}
+
+void SVGGradientElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
+{
+    if (name == SVGNames::gradientTransformAttr) {
+        addPropertyToPresentationalHintStyle(style, CSSPropertyTransform, value);
+        return;
+    }
+    SVGElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
 }

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -92,6 +92,8 @@ public:
     SVGAnimatedEnumeration& spreadMethodAnimated() { return m_spreadMethod; }
     SVGAnimatedEnumeration& gradientUnitsAnimated() { return m_gradientUnits; }
     SVGAnimatedTransformList& gradientTransformAnimated() { return m_gradientTransform; }
+
+    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
 
 protected:
     SVGGradientElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -197,6 +197,15 @@ Ref<const SVGTransformList> SVGPatternElement::protectedPatternTransform() const
 AffineTransform SVGPatternElement::localCoordinateSpaceTransform(SVGLocatable::CTMScope) const
 {
     return protectedPatternTransform()->concatenate();
+}
+
+void SVGPatternElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
+{
+    if (name == SVGNames::patternTransformAttr) {
+        addPropertyToPresentationalHintStyle(style, CSSPropertyTransform, value);
+        return;
+    }
+    SVGElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
 }

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -60,6 +60,8 @@ public:
     SVGAnimatedEnumeration& patternContentUnitsAnimated() { return m_patternContentUnits; }
     SVGAnimatedTransformList& patternTransformAnimated() { return m_patternTransform; }
 
+    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
+
 private:
     SVGPatternElement(const QualifiedName&, Document&);
 


### PR DESCRIPTION
#### a4e4545085fa041626131f04be20cc284426e420
<pre>
[SVG2] Fix `presentational hints` special cases where supported

<a href="https://bugs.webkit.org/show_bug.cgi?id=279144">https://bugs.webkit.org/show_bug.cgi?id=279144</a>
<a href="https://rdar.apple.com/135298525">rdar://135298525</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and
Web Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">https://svgwg.org/svg2-draft/styling.html#PresentationAttributes</a>

This patch ensures that `gradientTransform`, `patternTransformAttribute`
and `transform` are mapped to transform property on supported elements.

This patch also sync particular test from WPT upstream as well.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3fed65b68731adff5b419980ad6c02bf83159252">https://github.com/web-platform-tests/wpt/commit/3fed65b68731adff5b419980ad6c02bf83159252</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes.js:
(presentationAttributeIsSupported):
* Source/WebCore/svg/SVGGElement.cpp:
(WebCore::SVGGElement::collectPresentationalHintsForAttribute):
* Source/WebCore/svg/SVGGElement.h:
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::collectPresentationalHintsForAttribute):
* Source/WebCore/svg/SVGGradientElement.h:
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::collectPresentationalHintsForAttribute):
* Source/WebCore/svg/SVGPatternElement.h:
* LayoutTests/platform/glib/svg/batik/text/textProperties-expected.txt:
* LayoutTests/platform/ios/svg/batik/text/textProperties-expected.txt:
* LayoutTests/platform/mac/svg/batik/text/textProperties-expected.txt:

Canonical link: <a href="https://commits.webkit.org/283223@main">https://commits.webkit.org/283223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5266a167372f231d7967f3b4dd81b9529415369

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52647 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14129 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9520 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13915 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59966 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60241 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14463 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1514 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40747 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->