### PR TITLE
AX: misspelling-range.html is pass crash flaky.

### DIFF
--- a/LayoutTests/accessibility/misspelling-range.html
+++ b/LayoutTests/accessibility/misspelling-range.html
@@ -34,7 +34,6 @@ if (window.accessibilityController && window.internals) {
 
     setTimeout(async () => {
         misspellingRange = null;
-        startMarker = null;
         await waitFor(() => {
             misspellingRange = text.misspellingTextMarkerRange(startRange, true);
             return text.stringForTextMarkerRange(misspellingRange) == "wrods";

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -119,10 +119,10 @@ RetainPtr<NSArray> AXTextMarkerRange::platformData() const
     auto* cache = object->axObjectCache();
     if (!cache)
         return nil;
-    return adoptNS(@[
-        adoptNS([[WebAccessibilityTextMarker alloc] initWithTextMarker:&m_start.m_data cache:cache]).autorelease(),
-        adoptNS([[WebAccessibilityTextMarker alloc] initWithTextMarker:&m_end.m_data cache:cache]).autorelease()
-    ]);
+
+    auto start = adoptNS([[WebAccessibilityTextMarker alloc] initWithTextMarker:&m_start.m_data cache:cache]);
+    auto end = adoptNS([[WebAccessibilityTextMarker alloc] initWithTextMarker:&m_end.m_data cache:cache]);
+    return adoptNS([[NSArray alloc] initWithObjects:start.get(), end.get(), nil]);
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 1d817283101f0fff904f893bc3ea38afab64c8bf
<pre>
AX: misspelling-range.html is pass crash flaky.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279145">https://bugs.webkit.org/show_bug.cgi?id=279145</a>
&lt;<a href="https://rdar.apple.com/problem/135298645">rdar://problem/135298645</a>&gt;

Reviewed by David Kilzer and Alexey Proskuryakov.

The random crash is caused by AXTextMarkerRange::platformData() returning adoptNS(@[...]). @[] creates an autoreleased object, and adoptNS will take ownership of the object, thus doubly releasing it when the variable goes out of scope. The fix is to return adoptNS([[NSArray alloc] initWithObjects:...]) instead of adoptNS(@[...]). [NSArray alloc] creates a retained object, not autoreleased, that can be adopted.

In addition, the elements in the array are now added without calling autorelease() on them, which is slightly more efficient (thanks to David Kilzer for the suggestion and explanation).

* LayoutTests/accessibility/misspelling-range.html: Removed unnecessary line, not related to crash.
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::platformData const):

Canonical link: <a href="https://commits.webkit.org/283206@main">https://commits.webkit.org/283206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b0eec832f1ab0b63452f34e14cc943308ff2e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69542 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52606 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11181 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41463 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14078 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71247 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59924 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60197 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7822 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40697 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41773 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->