### PR TITLE
Speedometer 3: getBoundingClientRect spends time updating layer positions that it doesn't use.

### DIFF
--- a/LayoutTests/fast/css/aspect-ratio-no-relayout.html
+++ b/LayoutTests/fast/css/aspect-ratio-no-relayout.html
@@ -5,9 +5,9 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     document.body.offsetTop;
-    const layoutCountBefore = internals.layoutCount;
+    internals.startTrackingLayoutUpdates();
     target.style.color = "blue";
     document.body.offsetTop;
-    log.textContent = `Layout count: ${internals.layoutCount - layoutCountBefore}`;
+    log.textContent = `Layout count: ${internals.layoutUpdateCount()}`;
 }
 </script>

--- a/LayoutTests/fast/css/font-size-adjust-none-no-relayout.html
+++ b/LayoutTests/fast/css/font-size-adjust-none-no-relayout.html
@@ -4,9 +4,9 @@
     if (window.testRunner && window.internals) {
         testRunner.dumpAsText();
         document.body.offsetTop;
-        const layoutCountBefore = internals.layoutCount;
+        internals.startTrackingLayoutUpdates();
         document.documentElement.style.fontSizeAdjust = 'none';
         document.body.offsetTop;
-        log.textContent = `Layout count: ${internals.layoutCount - layoutCountBefore}`;
+        log.textContent = `Layout count: ${internals.layoutUpdateCount()}`;
     }
 </script>

--- a/LayoutTests/fast/images/animated-gif-no-layout.html
+++ b/LayoutTests/fast/images/animated-gif-no-layout.html
@@ -3,14 +3,11 @@
     // no layout. If the test passes, there are two green squares. If it fails, then one
     // or both of the squares is red instead.
 
-    var layoutCountBeforeTimer;
-
     function animationComplete()
     {
         if (window.internals && window.testRunner) {
             internals.updateLayoutAndStyleForAllFrames();
-            var count = internals.layoutCount - layoutCountBeforeTimer;
-            if (count == 0) {
+            if (internals.layoutUpdateCount() == 0) {
                 var indicator = document.getElementById("indicator");
                 indicator.addEventListener("load", function() { testRunner.notifyDone(); })
                 indicator.src = "resources/rgb-jpeg-green.jpg";
@@ -25,7 +22,7 @@
         if (window.internals && window.testRunner) {
             testRunner.waitUntilDone();
             internals.updateLayoutAndStyleForAllFrames();
-            layoutCountBeforeTimer = internals.layoutCount;
+            internals.startTrackingLayoutUpdates();
         }
 
         // The 200ms value here is longer than the time it takes for gif-loop-count.gif

--- a/LayoutTests/fast/layout/bounding-client-rect-no-layer-updates-expected.txt
+++ b/LayoutTests/fast/layout/bounding-client-rect-no-layer-updates-expected.txt
@@ -1,0 +1,19 @@
+Test that layout and render layer updates do not happen for style changes that do not need them.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result.actualLayoutCount is result.expectedLayoutCount
+PASS result.actualLayerUpdateCount is result.expectedLayerUpdateCount
+PASS result.actualLayoutCount is result.expectedLayoutCount
+PASS result.actualLayerUpdateCount is result.expectedLayerUpdateCount
+PASS result.actualLayoutCount is result.expectedLayoutCount
+PASS result.actualLayerUpdateCount is result.expectedLayerUpdateCount
+PASS result.actualLayoutCount is result.expectedLayoutCount
+PASS result.actualLayerUpdateCount is result.expectedLayerUpdateCount
+PASS result.actualLayoutCount is result.expectedLayoutCount
+PASS result.actualLayerUpdateCount is result.expectedLayerUpdateCount
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/layout/bounding-client-rect-no-layer-updates.html
+++ b/LayoutTests/fast/layout/bounding-client-rect-no-layer-updates.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        .container > div {
+            margin: 20px;
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        description('Test that layout and render layer updates do not happen for style changes that do not need them.');
+        window.jsTestIsAsync = true;
+
+        var results = [];
+        var result;
+
+	// Stash the results during the test, so that we don't mutate layout inserting the output into the document.
+        function expectLayoutAndLayerUpdateCounts(layoutCount, layerUpdateCount)
+        {
+            results.push({
+                expectedLayoutCount: layoutCount,
+                actualLayoutCount: internals.layoutUpdateCount(),
+                expectedLayerUpdateCount: layerUpdateCount,
+                actualLayerUpdateCount: internals.renderLayerPositionUpdateCount()
+            });
+        }
+
+        function runTest()
+        {
+            internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
+            internals.startTrackingLayoutUpdates();
+            internals.startTrackingRenderLayerPositionUpdates();
+
+            const boxes = document.querySelectorAll('.box');
+
+            // Check that interleaved mutations and getBoundingClientRect don't trigger layer updates.
+            boxes[0].style.width = "101px";
+            boxes[0].getBoundingClientRect();
+
+            expectLayoutAndLayerUpdateCounts(1, 0);
+
+	    boxes[1].style.width = "101px";
+            boxes[1].getBoundingClientRect();
+
+            expectLayoutAndLayerUpdateCounts(2, 0);
+
+            boxes[2].style.width = "101px";
+            boxes[2].getBoundingClientRect();
+
+            expectLayoutAndLayerUpdateCounts(3, 0);
+
+            // Check that getBoundingClientRect without mutations doesn't do any extra work.
+            for (let box of boxes) {
+                box.getBoundingClientRect();
+            }
+
+            expectLayoutAndLayerUpdateCounts(3, 0);
+
+            // Check that flushing layout via another property results in the layer update happening.
+            boxes[1].offsetTop;
+
+            expectLayoutAndLayerUpdateCounts(4, 1);
+
+            for (let i = 0; i < results.length; i++) {
+              result =  results[i];
+              shouldBe('result.actualLayoutCount', 'result.expectedLayoutCount');
+              shouldBe('result.actualLayerUpdateCount', 'result.expectedLayerUpdateCount');
+            }
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', function() {
+            window.setTimeout(runTest, 200);
+        }, false);
+    </script>
+</head>
+<body>
+  <div class="container">
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+    <div id="box" class="box"></div>
+  </div>
+
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/list-item-equal-style-change-no-repaint.html
+++ b/LayoutTests/fast/repaint/list-item-equal-style-change-no-repaint.html
@@ -29,15 +29,15 @@ if (window.testRunner)
 
 if (window.internals) {
   document.body.offsetHeight;
-  let layoutCountBefore = internals.layoutCount;
+  internals.startTrackingLayoutUpdates();
   // This should not trigger layout.
   document.body.classList.add('animated');
   document.body.offsetHeight;
-  let layoutCountAfter = internals.layoutCount;
+  let layoutCount = internals.layoutUpdateCount();
 
   let pre = document.createElement('pre');
   document.body.appendChild(pre);
-  pre.innerHTML = "Number of layouts triggered: " + (layoutCountAfter - layoutCountBefore);
+  pre.innerHTML = "Number of layouts triggered: " + layoutCount;
 }
 </script>
 </html>

--- a/LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts.html
+++ b/LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts.html
@@ -49,10 +49,9 @@
             debug('');
             debug("Test that scrolling doesn't trigger a layout per scroll");
 
-            const initialLayoutCount = internals.layoutCount;
+            internals.startTrackingLayoutUpdates();
             await doMouseWheelScroll();
-            const finalLayoutCount = internals.layoutCount;
-            layoutCount = finalLayoutCount - initialLayoutCount;
+            layoutCount = internals.layoutUpdateCount();
             shouldBeTrue('layoutCount <= 4');
             if (layoutCount > 4)
                 debug('saw ' + layoutCount + ' layouts')

--- a/LayoutTests/http/tests/contentextensions/font-display-none-repeated-layout-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/font-display-none-repeated-layout-expected.txt
@@ -6,7 +6,7 @@ Make sure that a content-blocker rule which is triggered by a webfont and causes
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS endLayoutCount - startLayoutCount < 5 is true
+PASS layoutCount < 5 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/contentextensions/font-display-none-repeated-layout.html
+++ b/LayoutTests/http/tests/contentextensions/font-display-none-repeated-layout.html
@@ -19,17 +19,16 @@ description("Make sure that a content-blocker rule which is triggered by a webfo
 
 window.jsTestIsAsync = true;
 
-var startLayoutCount = -1;
-var endLayoutCount = -1;
+var layoutCount = -1;
 
 if (window.internals)
-    startLayoutCount = window.internals.layoutCount;
+    internals.startTrackingLayoutUpdates();
 
 window.setTimeout(function() {
     if (window.internals) {
-        endLayoutCount = window.internals.layoutCount;
+        layoutCount = internals.layoutUpdateCount();
     }
-    shouldBeTrue("endLayoutCount - startLayoutCount < 5");
+    shouldBeTrue("layoutCount < 5");
     finishJSTest();
 }, 500);
 </script>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1381,7 +1381,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
 int AccessibilityRenderObject::layoutCount() const
 {
     auto* view = dynamicDowncast<RenderView>(m_renderer.get());
-    return view ? view->frameView().layoutContext().layoutCount() : 0;
+    return view ? view->frameView().layoutUpdateCount() : 0;
 }
 
 CharacterRange AccessibilityRenderObject::documentBasedSelectedTextRange() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2765,9 +2765,9 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
                 } else
                     context = nullptr;
             }
-            if (frameView->layoutContext().isLayoutPending() || renderView()->needsLayout()) {
+            if (frameView->layoutContext().needsLayout(layoutOptions)) {
                 ContentVisibilityForceLayoutScope scope(*renderView(), context);
-                frameView->layoutContext().layout();
+                frameView->layoutContext().layout(layoutOptions.contains(LayoutOptions::CanDeferUpdateLayerPositions));
                 result = UpdateLayoutResult::ChangesDone;
             }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -379,6 +379,11 @@ enum class LayoutOptions : uint8_t {
     ContentVisibilityForceLayout = 1 << 2,
     UpdateCompositingLayers = 1 << 3,
     DoNotLayoutAncestorDocuments = 1 << 4,
+    // Doesn't call RenderLayer::recursiveUpdateLayerPositionsAfterLayout if
+    // possible. The caller should use a LocalFrameView::AutoPreventLayerAccess
+    // for the scope that layout is expected to be flushed to stop any access to
+    // the stale RenderLayers.
+    CanDeferUpdateLayerPositions = 1 << 5
 };
 
 enum class HttpEquivPolicy : uint8_t {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1925,7 +1925,8 @@ std::optional<std::pair<CheckedPtr<RenderObject>, FloatRect>> Element::boundingA
 FloatRect Element::boundingClientRect()
 {
     Ref document = this->document();
-    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout, LayoutOptions::CanDeferUpdateLayerPositions }, this);
+    LocalFrameView::AutoPreventLayerAccess preventAccess(document->view());
     auto pair = boundingAbsoluteRectWithoutLayout();
     if (!pair)
         return { };

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -31,6 +31,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "RenderLayer.h"
+#include "RenderLayerInlines.h"
 #include "RenderObject.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -48,6 +48,7 @@
 #include "Page.h"
 #include "PageGroup.h"
 #include "RenderLayer.h"
+#include "RenderLayerInlines.h"
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "Settings.h"

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -67,8 +67,8 @@ public:
     LocalFrameViewLayoutContext(LocalFrameView&);
     ~LocalFrameViewLayoutContext();
 
-    WEBCORE_EXPORT void layout();
-    bool needsLayout() const;
+    WEBCORE_EXPORT void layout(bool canDeferUpdateLayerPositions = false);
+    bool needsLayout(OptionSet<LayoutOptions> layoutOptions = { }) const;
 
     // We rely on the side-effects of layout, like compositing updates, to update state in various subsystems
     // whose dependencies are poorly defined. This call triggers such updates.
@@ -97,8 +97,6 @@ public:
 
     bool needsSkippedContentLayout() const { return m_needsSkippedContentLayout; }
     void setNeedsSkippedContentLayout(bool needsSkippedContentLayout) { m_needsSkippedContentLayout = needsSkippedContentLayout; }
-
-    unsigned layoutCount() const { return m_layoutCount; }
 
     RenderElement* subtreeLayoutRoot() const;
     void clearSubtreeLayoutRoot() { m_subtreeLayoutRoot.clear(); }
@@ -144,13 +142,15 @@ private:
     friend class LayoutStateDisabler;
     friend class SubtreeLayoutStateMaintainer;
 
-    void performLayout();
+    bool needsLayoutInternal() const;
+
+    void performLayout(bool canDeferUpdateLayerPositions);
     bool canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
     void layoutTimerFired();
     void runPostLayoutTasks();
-    void runOrScheduleAsynchronousTasks();
+    void runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions);
     bool inAsynchronousTasks() const { return m_inAsynchronousTasks; }
 
     void setSubtreeLayoutRoot(RenderElement&);
@@ -197,7 +197,6 @@ private:
     LayoutPhase m_layoutPhase { LayoutPhase::OutsideLayout };
     enum class LayoutNestedState : uint8_t  { NotInLayout, NotNested, Nested };
     LayoutNestedState m_layoutNestedState { LayoutNestedState::NotInLayout };
-    unsigned m_layoutCount { 0 };
     unsigned m_disableSetNeedsLayoutCount { 0 };
     unsigned m_paintOffsetCacheDisableCount { 0 };
     LayoutStateStack m_layoutStateStack;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1099,9 +1099,9 @@ void RenderElement::willBeRemovedFromTree()
     RenderObject::willBeRemovedFromTree();
 }
 
-bool RenderElement::didVisitDuringLastLayout() const
+bool RenderElement::didVisitSinceLayout(LayoutIdentifier identifier) const
 {
-    return layoutIdentifier() == view().frameView().layoutContext().layoutIdentifier();
+    return layoutIdentifier() >= identifier;
 }
 
 inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -304,7 +304,7 @@ public:
     using LayoutIdentifier = unsigned;
     void setLayoutIdentifier(LayoutIdentifier layoutIdentifier) { m_layoutIdentifier = layoutIdentifier; }
     LayoutIdentifier layoutIdentifier() const { return m_layoutIdentifier; }
-    bool didVisitDuringLastLayout() const;
+    bool didVisitSinceLayout(LayoutIdentifier) const;
 
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1003,10 +1003,10 @@ void RenderLayer::willUpdateLayerPositions()
 void RenderLayer::updateLayerPositionsAfterStyleChange()
 {
     willUpdateLayerPositions();
-    recursiveUpdateLayerPositions(flagsForUpdateLayerPositions(*this));
+    recursiveUpdateLayerPositions(0, flagsForUpdateLayerPositions(*this));
 }
 
-void RenderLayer::updateLayerPositionsAfterLayout(bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass canUseSimplifiedRepaintPass)
+void RenderLayer::updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifier layoutIdentifier, bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass canUseSimplifiedRepaintPass)
 {
     auto updateLayerPositionFlags = [&](bool isRelayoutingSubtree, bool didFullRepaint) {
         auto flags = flagsForUpdateLayerPositions(*this);
@@ -1022,10 +1022,10 @@ void RenderLayer::updateLayerPositionsAfterLayout(bool isRelayoutingSubtree, boo
     LOG(Compositing, "RenderLayer %p updateLayerPositionsAfterLayout", this);
     willUpdateLayerPositions();
 
-    recursiveUpdateLayerPositions(updateLayerPositionFlags(isRelayoutingSubtree, didFullRepaint), canUseSimplifiedRepaintPass);
+    recursiveUpdateLayerPositions(layoutIdentifier, updateLayerPositionFlags(isRelayoutingSubtree, didFullRepaint), canUseSimplifiedRepaintPass);
 }
 
-void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFlag> flags, CanUseSimplifiedRepaintPass canUseSimplifiedRepaintPass)
+void RenderLayer::recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier layoutIdentifier, OptionSet<UpdateLayerPositionsFlag> flags, CanUseSimplifiedRepaintPass canUseSimplifiedRepaintPass)
 {
     updateLayerPosition(&flags);
     if (m_scrollableArea)
@@ -1067,7 +1067,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
         auto mayNeedRepaintRectUpdate = [&] {
             if (canUseSimplifiedRepaintPass == CanUseSimplifiedRepaintPass::No)
                 return true;
-            if (!renderer().didVisitDuringLastLayout())
+            if (!renderer().didVisitSinceLayout(layoutIdentifier))
                 return false;
             if (auto* renderBox = this->renderBox(); renderBox && renderBox->hasRenderOverflow()) {
                 // Disable optimization for subtree when dealing with overflow as RenderLayer is not sized to enclose overflow.
@@ -1135,7 +1135,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
         flags.add(SeenCompositedScrollingLayer);
 
     for (RenderLayer* child = firstChild(); child; child = child->nextSibling())
-        child->recursiveUpdateLayerPositions(flags, canUseSimplifiedRepaintPass);
+        child->recursiveUpdateLayerPositions(layoutIdentifier, flags, canUseSimplifiedRepaintPass);
 
     if (m_scrollableArea)
         m_scrollableArea->updateMarqueePosition();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -445,13 +445,13 @@ public:
     RenderLayer* reflectionLayer() const;
     bool isReflectionLayer(const RenderLayer&) const;
 
-    const LayoutPoint& location() const { return m_topLeft; }
+    inline const LayoutPoint& location() const;
     void setLocation(const LayoutPoint& p) { m_topLeft = p; }
 
-    const IntSize& size() const { return m_layerSize; }
+    inline const IntSize& size() const;
     void setSize(const IntSize& size) { m_layerSize = size; } // Only public for RenderTreeAsText.
 
-    LayoutRect rect() const { return LayoutRect(location(), size()); }
+    inline LayoutRect rect() const;
 
     IntSize visibleSize() const;
 
@@ -500,7 +500,7 @@ public:
 
     void updateLayerPositionsAfterStyleChange();
     enum class CanUseSimplifiedRepaintPass : uint8_t { No, Yes };
-    void updateLayerPositionsAfterLayout(bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass);
+    void updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifier, bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass);
     void updateLayerPositionsAfterOverflowScroll();
     void updateLayerPositionsAfterDocumentScroll();
 
@@ -1005,7 +1005,7 @@ private:
     // Returns true if the position changed.
     bool updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* = nullptr);
 
-    void recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFlag>, CanUseSimplifiedRepaintPass = CanUseSimplifiedRepaintPass::No);
+    void recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier, OptionSet<UpdateLayerPositionsFlag>, CanUseSimplifiedRepaintPass = CanUseSimplifiedRepaintPass::No);
 
     enum UpdateLayerPositionsAfterScrollFlag {
         IsOverflowScroll                        = 1 << 0,

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -23,6 +23,8 @@
 #include "RenderLayer.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGResourceClipper.h"
+#include "RenderView.h"
+#include "SVGGraphicsElement.h"
 
 namespace WebCore {
 
@@ -72,6 +74,23 @@ inline bool RenderLayer::hasNonOpacityTransparency() const
 inline RenderSVGHiddenContainer* RenderLayer::enclosingSVGHiddenOrResourceContainer() const
 {
     return m_enclosingSVGHiddenOrResourceContainer.get();
+}
+
+inline const LayoutPoint& RenderLayer::location() const
+{
+    ASSERT(!renderer().view().frameView().layerAccessPrevented());
+    return m_topLeft;
+}
+
+inline const IntSize& RenderLayer::size() const
+{
+    ASSERT(!renderer().view().frameView().layerAccessPrevented());
+    return m_layerSize;
+}
+
+inline LayoutRect RenderLayer::rect() const
+{
+    return LayoutRect(location(), size());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -364,9 +364,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     // We don't update compositing layers, because we need to do a deep update from the compositing ancestor.
     if (!view.frameView().layoutContext().isInRenderTreeLayout()) {
         // If we're in the middle of layout, we'll just update layers once layout has finished.
-        m_layer.updateLayerPositionsAfterOverflowScroll();
-
-        view.frameView().scheduleUpdateWidgetPositions();
+        view.frameView().updateLayerPositionsAfterOverflowScroll(m_layer);
 
         if (!m_updatingMarqueePosition) {
             // Avoid updating compositing layers if, higher on the stack, we're already updating layer

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4028,6 +4028,44 @@ unsigned Internals::lastStyleUpdateSize() const
     return document->lastStyleUpdateSizeForTesting();
 }
 
+ExceptionOr<void> Internals::startTrackingLayoutUpdates()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    document->view()->startTrackingLayoutUpdates();
+    return { };
+}
+
+ExceptionOr<unsigned> Internals::layoutUpdateCount()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    return document->view()->layoutUpdateCount();
+}
+
+ExceptionOr<void> Internals::startTrackingRenderLayerPositionUpdates()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    document->view()->startTrackingRenderLayerPositionUpdates();
+    return { };
+}
+
+ExceptionOr<unsigned> Internals::renderLayerPositionUpdateCount()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    return document->view()->renderLayerPositionUpdateCount();
+}
+
 ExceptionOr<void> Internals::startTrackingCompositingUpdates()
 {
     Document* document = contextDocument();
@@ -4133,14 +4171,6 @@ ExceptionOr<void> Internals::updateLayoutIgnorePendingStylesheetsAndRunPostLayou
     document->flushDeferredAXObjectCacheUpdate();
 
     return { };
-}
-
-unsigned Internals::layoutCount() const
-{
-    Document* document = contextDocument();
-    if (!document || !document->view())
-        return 0;
-    return document->view()->layoutContext().layoutCount();
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -669,6 +669,12 @@ public:
     ExceptionOr<unsigned> styleRecalcCount();
     unsigned lastStyleUpdateSize() const;
 
+    ExceptionOr<void> startTrackingLayoutUpdates();
+    ExceptionOr<unsigned> layoutUpdateCount();
+
+    ExceptionOr<void> startTrackingRenderLayerPositionUpdates();
+    ExceptionOr<unsigned> renderLayerPositionUpdateCount();
+
     ExceptionOr<void> startTrackingCompositingUpdates();
     ExceptionOr<unsigned> compositingUpdateCount();
 
@@ -683,7 +689,6 @@ public:
 
     void updateLayoutAndStyleForAllFrames() const;
     ExceptionOr<void> updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks(Node*);
-    unsigned layoutCount() const;
 
     Ref<ArrayBuffer> serializeObject(const RefPtr<SerializedScriptValue>&) const;
     Ref<SerializedScriptValue> deserializeBuffer(ArrayBuffer&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -889,6 +889,12 @@ enum RenderingMode {
     unsigned long styleRecalcCount();
     readonly attribute unsigned long lastStyleUpdateSize;
 
+    undefined startTrackingLayoutUpdates();
+    unsigned long layoutUpdateCount();
+
+    undefined startTrackingRenderLayerPositionUpdates();
+    unsigned long renderLayerPositionUpdateCount();
+
     undefined startTrackingCompositingUpdates();
     unsigned long compositingUpdateCount();
 
@@ -903,8 +909,6 @@ enum RenderingMode {
     // If |node| is an HTMLIFrameElement, it assumes node.contentDocument is
     // specified without security checks. Unspecified or null means this document.
     undefined updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks(optional Node? node = null);
-
-    readonly attribute unsigned long layoutCount;
 
     // Returns a string with information about the mouse cursor used at the specified client location.
     DOMString getCurrentCursorInfo();

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1408,7 +1408,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     WebCore::LocalFrame *frame = core(self);
     if (!frame || !frame->view())
         return 0;
-    return frame->view()->layoutContext().layoutCount();
+    return frame->view()->layoutUpdateCount();
 }
 
 - (BOOL)isTelephoneNumberParsingAllowed


### PR DESCRIPTION
#### 36471855c3cb59685b184d7632904cb9ad87468f
<pre>
Speedometer 3: getBoundingClientRect spends time updating layer positions that it doesn&apos;t use.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279150">https://bugs.webkit.org/show_bug.cgi?id=279150</a>
&lt;<a href="https://rdar.apple.com/133492305">rdar://133492305</a>&gt;

Reviewed by Simon Fraser.

Adds a new option to Document::updateLayout for callers to request that updateLayerPositions
be deferred, and uses it for getBoundingClientRect.

Adds an assertion to RenderLayer::position/size() to make sure no code tries to access
layers positions while in this new state.
The assert only covers the scope of getBoundingClientRect, since arbtirary other code
can run next and might try to access the unflushed layer. This shouldn&apos;t be a new concern
though, since `needsLayout` will be true, and the other code should already be flushing layout
if it needs to access layer positions.

LocalFrameView::needsLayout now returns true if there&apos;s actual layout, or a pending layer
flush, so that we flush the layers next time to we try to layout.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::boundingClientRect):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::topContentInsetDidChange):
(WebCore::LocalFrameView::hasPendingUpdateLayerPositions const):
(WebCore::LocalFrameView::flushUpdateLayerPositions):
(WebCore::LocalFrameView::didLayout):
(WebCore::LocalFrameView::updateLayerPositionsAfterScrolling):
(WebCore::LocalFrameView::updateLayerPositionsAfterOverflowScroll):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks):
(WebCore::LocalFrameViewLayoutContext::needsLayout const):
(WebCore::LocalFrameViewLayoutContext::needsLayoutInternal const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::didVisitSinceLayout const):
(WebCore::RenderElement::didVisitDuringLastLayout const): Deleted.
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPositionsAfterStyleChange):
(WebCore::RenderLayer::updateLayerPositionsAfterLayout):
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::location const):
(WebCore::RenderLayer::size const):
(WebCore::RenderLayer::rect const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):

Canonical link: <a href="https://commits.webkit.org/283252@main">https://commits.webkit.org/283252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5718a4c74659eac9a3165a7b9e434fbd754f6d7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52740 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11317 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14241 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15185 "Hash 5718a4c7 for PR 33145 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9655 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14015 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60332 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1618 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40881 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->