### PR TITLE
Add first visual layout timestamp to _WKPageLoadTiming

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPageLoadTiming.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPageLoadTiming.h
@@ -32,6 +32,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKPageLoadTiming : NSObject
 
 @property (nonatomic, readonly) NSDate *navigationStart;
+@property (nonatomic, readonly) NSDate *firstVisualLayout;
 @property (nonatomic, readonly) NSDate *firstMeaningfulPaint;
 @property (nonatomic, readonly) NSDate *documentFinishedLoading;
 @property (nonatomic, readonly) NSDate *allSubresourcesFinishedLoading;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPageLoadTiming.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPageLoadTiming.mm
@@ -38,6 +38,7 @@ static NSDate *nsDateFromMonotonicTime(WallTime time)
 
 @implementation _WKPageLoadTiming {
     WallTime _navigationStart;
+    WallTime _firstVisualLayout;
     WallTime _firstMeaningfulPaint;
     WallTime _documentFinishedLoading;
     WallTime _allSubresourcesFinishedLoading;
@@ -49,6 +50,7 @@ static NSDate *nsDateFromMonotonicTime(WallTime time)
         return nil;
 
     _navigationStart = timing.navigationStart();
+    _firstVisualLayout = timing.firstVisualLayout();
     _firstMeaningfulPaint = timing.firstMeaningfulPaint();
     _documentFinishedLoading = timing.documentFinishedLoading();
     _allSubresourcesFinishedLoading = timing.allSubresourcesFinishedLoading();
@@ -59,6 +61,11 @@ static NSDate *nsDateFromMonotonicTime(WallTime time)
 - (NSDate *)navigationStart
 {
     return nsDateFromMonotonicTime(_navigationStart);
+}
+
+- (NSDate *)firstVisualLayout
+{
+    return nsDateFromMonotonicTime(_firstVisualLayout);
 }
 
 - (NSDate *)firstMeaningfulPaint

--- a/Source/WebKit/UIProcess/WebPageLoadTiming.h
+++ b/Source/WebKit/UIProcess/WebPageLoadTiming.h
@@ -41,6 +41,9 @@ public:
 
     WallTime navigationStart() const { return m_navigationStart; }
 
+    WallTime firstVisualLayout() const { return m_firstVisualLayout; }
+    void setFirstVisualLayout(WallTime timestamp) { m_firstVisualLayout = timestamp; }
+
     WallTime firstMeaningfulPaint() const { return m_firstMeaningfulPaint; }
     void setFirstMeaningfulPaint(WallTime timestamp) { m_firstMeaningfulPaint = timestamp; }
 
@@ -56,6 +59,7 @@ public:
 
 private:
     WallTime m_navigationStart;
+    WallTime m_firstVisualLayout;
     WallTime m_firstMeaningfulPaint;
     WallTime m_documentFinishedLoading;
     WallTime m_allSubresourcesFinishedLoading;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6131,6 +6131,8 @@ void WebPageProxy::generatePageLoadingTimingSoon()
         return;
     if (m_framesWithSubresourceLoadingForPageLoadTiming.size())
         return;
+    if (!m_pageLoadTiming->firstVisualLayout())
+        return;
     if (!m_pageLoadTiming->firstMeaningfulPaint())
         return;
     if (!m_pageLoadTiming->documentFinishedLoading())
@@ -7083,7 +7085,7 @@ void WebPageProxy::didFirstLayoutForFrame(FrameIdentifier, const UserData& userD
 {
 }
 
-void WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection& connection, FrameIdentifier frameID, const UserData& userData)
+void WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection& connection, FrameIdentifier frameID, const UserData& userData, WallTime timestamp)
 {
     Ref protectedPageClient { pageClient() };
 
@@ -7095,6 +7097,11 @@ void WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection& conne
 
     if (frame->isMainFrame())
         protectedPageClient->didFirstVisuallyNonEmptyLayoutForMainFrame();
+
+    if (m_pageLoadTiming && !m_pageLoadTiming->firstVisualLayout()) {
+        m_pageLoadTiming->setFirstVisualLayout(timestamp);
+        generatePageLoadingTimingSoon();
+    }
 }
 
 void WebPageProxy::didLayoutForCustomContentProvider()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2574,7 +2574,7 @@ private:
 
     void didReceiveTitleForFrame(IPC::Connection&, WebCore::FrameIdentifier, const String&, const UserData&);
     void didFirstLayoutForFrame(WebCore::FrameIdentifier, const UserData&);
-    void didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection&, WebCore::FrameIdentifier, const UserData&);
+    void didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection&, WebCore::FrameIdentifier, const UserData&, WallTime);
     void didDisplayInsecureContentForFrame(IPC::Connection&, WebCore::FrameIdentifier, const UserData&);
     void didRunInsecureContentForFrame(IPC::Connection&, WebCore::FrameIdentifier, const UserData&);
     void mainFramePluginHandlesPageScaleGestureDidChange(bool, double minScale, double maxScale);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -131,7 +131,7 @@ messages -> WebPageProxy {
     DidFinishDocumentLoadForFrame(WebCore::FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, WebKit::UserData userData, WallTime timestamp)
     DidFinishLoadForFrame(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::ResourceRequest request, std::optional<WebCore::NavigationIdentifier> navigationID, WebKit::UserData userData)
     DidFirstLayoutForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)
-    DidFirstVisuallyNonEmptyLayoutForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)
+    DidFirstVisuallyNonEmptyLayoutForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData, WallTime timestamp)
     DidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> layoutMilestones, WallTime timestamp)
     DidReceiveTitleForFrame(WebCore::FrameIdentifier frameID, String title, WebKit::UserData userData)
     DidDisplayInsecureContentForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -833,7 +833,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCor
         // FIXME: We should consider removing the old didFirstVisuallyNonEmptyLayoutForFrame API since this is doing double duty with the new didLayout API.
         WebLocalFrameLoaderClient_RELEASE_LOG(Layout, "dispatchDidReachLayoutMilestone: dispatching DidFirstVisuallyNonEmptyLayoutForFrame");
         webPage->injectedBundleLoaderClient().didFirstVisuallyNonEmptyLayoutForFrame(*webPage, m_frame, userData);
-        webPage->send(Messages::WebPageProxy::DidFirstVisuallyNonEmptyLayoutForFrame(m_frame->frameID(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+        webPage->send(Messages::WebPageProxy::DidFirstVisuallyNonEmptyLayoutForFrame(m_frame->frameID(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get()), WallTime::now()));
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -2549,6 +2549,8 @@ TEST(WKNavigation, GeneratePageLoadTiming)
         NSDate *afterEnd = [NSDate now];
         EXPECT_EQ([beforeStart compare:timing.navigationStart], NSOrderedAscending);
         EXPECT_EQ([timing.navigationStart compare:afterEnd], NSOrderedAscending);
+        EXPECT_EQ([timing.navigationStart compare:timing.firstVisualLayout], NSOrderedAscending);
+        EXPECT_EQ([timing.firstVisualLayout compare:afterEnd], NSOrderedAscending);
         EXPECT_EQ([timing.navigationStart compare:timing.firstMeaningfulPaint], NSOrderedAscending);
         EXPECT_EQ([timing.firstMeaningfulPaint compare:afterEnd], NSOrderedAscending);
         EXPECT_EQ([timing.navigationStart compare:timing.documentFinishedLoading], NSOrderedAscending);


### PR DESCRIPTION
#### 0469eebb7581fc17ede9e131440c305324e93b50
<pre>
Add first visual layout timestamp to _WKPageLoadTiming
<a href="https://bugs.webkit.org/show_bug.cgi?id=279152">https://bugs.webkit.org/show_bug.cgi?id=279152</a>

Reviewed by Chris Dumez.

Add the first visual layout timestamp to _WKPageLoadTiming as it will be used on iOS PLT.

* Source/WebKit/UIProcess/API/Cocoa/_WKPageLoadTiming.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKPageLoadTiming.mm:
(-[_WKPageLoadTiming _initWithTiming:]):
(-[_WKPageLoadTiming firstVisualLayout]):
* Source/WebKit/UIProcess/WebPageLoadTiming.h:
(WebKit::WebPageLoadTiming::firstVisualLayout const):
(WebKit::WebPageLoadTiming::setFirstVisualLayout):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::generatePageLoadingTimingSoon):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, GeneratePageLoadTiming)):

Canonical link: <a href="https://commits.webkit.org/283185@main">https://commits.webkit.org/283185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42527f43696b43e4d3746473a922dece30384ad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16098 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52591 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68556 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41453 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14974 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71220 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60181 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1455 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41746 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->