### PR TITLE
[WebDriver] pointerevents/mouse-pointer-boundary-events-for-shadowdom.html WPT is failing through WebDriver, but not through WKTR

### DIFF
--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -283,7 +283,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
 #if !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
         RELEASE_ASSERT_NOT_REACHED();
 #else
-        resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Viewport), b.nodeHandle, [this, &a, &b, inputSource = inputSource.type, eventDispatchFinished = WTFMove(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
+        resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Pointer), b.nodeHandle, [this, &a, &b, inputSource = inputSource.type, eventDispatchFinished = WTFMove(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
             if (error) {
                 eventDispatchFinished(error);
                 return;


### PR DESCRIPTION
#### 086f6c0f2d059ee5c649f79a4c8d1ccf5c3e02cf
<pre>
[WebDriver] pointerevents/mouse-pointer-boundary-events-for-shadowdom.html WPT is failing through WebDriver, but not through WKTR
<a href="https://bugs.webkit.org/show_bug.cgi?id=274639">https://bugs.webkit.org/show_bug.cgi?id=274639</a>
<a href="https://rdar.apple.com/128668986">rdar://128668986</a>

Reviewed by Wenson Hsieh.

The test in question fails because it dispatches a couple of pointer
move actions through the testdriver.js Actions() interface. The failure
mode indicates that the mouse cursor jumps back and forth to the origin
between subsequent pointer moves, which causes unexpected event dispatch
on the body.

Our automation state management interleaves the &quot;Pause&quot; state with the
&quot;PointerMove&quot; state in the simulated input source states we transition
our input source across. The pause is required as part of a pointer move
action, as specified in the WebDriver spec.

A &quot;Pause&quot; state has an (invalid) {0,0} location value associated with it,
so whenever we transition between pointer move actions, we transition
first to an intermediate &quot;Pause&quot; state, and the state location resolution
logic in SimulatedInputDispatcher::transitionInputSourceToState() treats
the “origin” location of a “Pause” state relative to the viewport. This
has the effect of our cursor jumping back and forth - during a pointer
move sequence - between the last pointer move location and the origin,
which is where the extra pointer events emitted on the body come from.

This patch addresses the issue by instead defaulting to a pointer origin
(not viewport origin) for state location resolution. For states where the
location matters, WebDriver _should_ be plumbing us the appropriate origin
to resolve against. When this origin is not provided, we can safely assume
that the location is not meaningful either, and resolve against a pointer
origin. This gets rid of the unexpected displacements for states with
meaningless locations.

* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::SimulatedInputDispatcher::transitionInputSourceToState):

Canonical link: <a href="https://commits.webkit.org/283186@main">https://commits.webkit.org/283186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c19a2516ee085092ce13afef2de2cc3501822740

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16111 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52596 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11169 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38129 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71233 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13860 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60186 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1457 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9930 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40683 "Failed to checkout and rebase branch from PR 33154") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41759 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->