### PR TITLE
Storing loginStatus value in a database

### DIFF
--- a/Source/WebCore/page/LoginStatus.cpp
+++ b/Source/WebCore/page/LoginStatus.cpp
@@ -95,4 +95,12 @@ WallTime LoginStatus::expiry() const
     return WallTime::now() + m_timeToLive;
 }
 
+LoginStatus LoginStatus::isolatedCopy() const & {
+    return LoginStatus { m_domain.isolatedCopy(), m_username.isolatedCopy(), m_tokenType, m_authType, m_loggedInTime, m_timeToLive };
+}
+
+LoginStatus LoginStatus::isolatedCopy() && {
+    return LoginStatus { WTFMove(m_domain).isolatedCopy(), WTFMove(m_username).isolatedCopy(), m_tokenType, m_authType, m_loggedInTime, m_timeToLive };
+}
+
 }

--- a/Source/WebCore/page/LoginStatus.h
+++ b/Source/WebCore/page/LoginStatus.h
@@ -60,6 +60,9 @@ public:
     WallTime loggedInTime() const { return m_loggedInTime; }
     Seconds timeToLive() const { return m_timeToLive; }
 
+    WEBCORE_EXPORT LoginStatus isolatedCopy() const &;
+    WEBCORE_EXPORT LoginStatus isolatedCopy() &&;
+
 private:
     LoginStatus(const RegistrableDomain&, const String& username, CredentialTokenType, AuthenticationType, Seconds timeToLive);
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -39,7 +39,9 @@
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <WebCore/CookieJar.h>
 #include <WebCore/DocumentStorageAccess.h>
+#include <WebCore/IsLoggedIn.h>
 #include <WebCore/KeyedCoding.h>
+#include <WebCore/LoginStatus.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/OrganizationStorageAccessPromptQuirk.h>
 #include <WebCore/ResourceLoadStatistics.h>
@@ -85,6 +87,7 @@ constexpr auto countSubresourceUniqueRedirectsToQuery = "SELECT COUNT(*) FROM Su
 constexpr auto insertObservedDomainQuery = "INSERT INTO ObservedDomains (registrableDomain, lastSeen, hadUserInteraction,"
     "mostRecentUserInteractionTime, grandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, timesAccessedAsFirstPartyDueToUserInteraction,"
     "timesAccessedAsFirstPartyDueToStorageAccessAPI, isScheduledForAllButCookieDataRemoval, mostRecentWebPushInteractionTime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
+constexpr auto insertLoginStatusQuery = "INSERT INTO LoginStatus (registrableDomain, username, tokenType, authenticationType, loggedInTime, timeToLive, status) VALUES (?, ?, ?, ?, ?, ?, ?)"_s;
 constexpr auto storageAccessUnderTopFrameDomainsQuery = "INSERT OR IGNORE INTO StorageAccessUnderTopFrameDomains (domainID, topLevelDomainID) SELECT ?, domainID FROM ObservedDomains WHERE registrableDomain in ( "_s;
 constexpr auto topFrameUniqueRedirectsToQuery = "INSERT OR IGNORE into TopFrameUniqueRedirectsTo (sourceDomainID, toDomainID) SELECT ?, domainID FROM ObservedDomains where registrableDomain in ( "_s;
 constexpr auto topFrameUniqueRedirectsToSinceSameSiteStrictEnforcementQuery = "INSERT OR IGNORE into TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement (sourceDomainID, toDomainID) SELECT ?, domainID FROM ObservedDomains where registrableDomain in ( "_s;
@@ -106,6 +109,7 @@ constexpr auto subresourceUnderTopFrameDomainExistsQuery = "SELECT EXISTS (SELEC
 constexpr auto subresourceUniqueRedirectsToExistsQuery = "SELECT EXISTS (SELECT 1 FROM SubresourceUniqueRedirectsTo WHERE subresourceDomainID = ? "
     "AND toDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
 constexpr auto storageAccessExistsQuery = "SELECT EXISTS (SELECT 1 FROM StorageAccessUnderTopFrameDomains WHERE domainID = ? AND topLevelDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
+constexpr auto loginStatusExistsQuery = "SELECT EXISTS (SELECT 1 FROM LoginStatus WHERE domainID = ?)"_s;
 
 // UPDATE Queries
 constexpr auto mostRecentUserInteractionQuery = "UPDATE ObservedDomains SET hadUserInteraction = ?, mostRecentUserInteractionTime = ? "_s
@@ -121,6 +125,7 @@ constexpr auto updateMostRecentWebPushInteractionTimeQuery = "UPDATE ObservedDom
 
 // SELECT Queries
 constexpr auto domainIDFromStringQuery = "SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?"_s;
+constexpr auto loginStatusDomainIDFromStringQuery = "SELECT domainID FROM LoginStatus WHERE registrableDomain = ?"_s;
 constexpr auto domainStringFromDomainIDQuery = "SELECT registrableDomain FROM ObservedDomains WHERE domainID = ?"_s;
 constexpr auto isPrevalentResourceQuery = "SELECT isPrevalent FROM ObservedDomains WHERE registrableDomain = ?"_s;
 constexpr auto isVeryPrevalentResourceQuery = "SELECT isVeryPrevalent FROM ObservedDomains WHERE registrableDomain = ?"_s;
@@ -147,6 +152,7 @@ constexpr auto observedDomainsExistsQuery = "SELECT EXISTS (SELECT * FROM Observ
 
 // DELETE Queries
 constexpr auto removeAllDataQuery = "DELETE FROM ObservedDomains WHERE domainID = ?"_s;
+constexpr auto removeLoginStatusQuery = "DELETE FROM LoginStatus WHERE domainID = ?"_s;
 
 constexpr auto createObservedDomain = "CREATE TABLE ObservedDomains ("
     "domainID INTEGER PRIMARY KEY, registrableDomain TEXT NOT NULL UNIQUE ON CONFLICT FAIL, lastSeen REAL NOT NULL, "
@@ -228,6 +234,11 @@ constexpr auto createSubresourceUniqueRedirectsFrom = "CREATE TABLE SubresourceU
 
 constexpr auto createOperatingDates = "CREATE TABLE OperatingDates ("
     "year INTEGER NOT NULL, month INTEGER NOT NULL, monthDay INTEGER NOT NULL)"_s;
+
+constexpr auto createLoginStatus = "CREATE TABLE LoginStatus ("
+    "domainID INTEGER PRIMARY KEY, registrableDomain TEXT NOT NULL UNIQUE ON CONFLICT FAIL, username TEXT, "
+    "tokenType INTEGER, authenticationType INTEGER, loggedInTime REAL, "
+    "timeToLive REAL, status INTEGER NOT NULL)"_s;
 
 // CREATE UNIQUE INDEX Queries.
 constexpr auto createUniqueIndexStorageAccessUnderTopFrameDomains = "CREATE UNIQUE INDEX IF NOT EXISTS StorageAccessUnderTopFrameDomains_domainID_topLevelDomainID on StorageAccessUnderTopFrameDomains ( domainID, topLevelDomainID )"_s;
@@ -801,6 +812,7 @@ const MemoryCompactLookupOnlyRobinHoodHashMap<String, TableAndIndexPair>& Resour
         { "SubresourceUniqueRedirectsTo"_s, std::make_pair<String, std::optional<String>>(createSubresourceUniqueRedirectsTo, stripIndexQueryToMatchStoredValue(createUniqueIndexSubresourceUniqueRedirectsTo)) },
         { "SubresourceUniqueRedirectsFrom"_s, std::make_pair<String, std::optional<String>>(createSubresourceUniqueRedirectsFrom, stripIndexQueryToMatchStoredValue(createUniqueIndexSubresourceUniqueRedirectsFrom)) },
         { "OperatingDates"_s, std::make_pair<String, std::optional<String>>(createOperatingDates, stripIndexQueryToMatchStoredValue(createUniqueIndexOperatingDates)) },
+        { "LoginStatus"_s, std::make_pair<String, std::optional<String>>(createLoginStatus, std::nullopt) },
     };
     return expectedTableAndIndexQueries;
 }
@@ -820,7 +832,8 @@ std::span<const ASCIILiteral> ResourceLoadStatisticsStore::sortedTables()
         "SubresourceUnderTopFrameDomains"_s,
         "SubresourceUniqueRedirectsTo"_s,
         "SubresourceUniqueRedirectsFrom"_s,
-        "OperatingDates"_s
+        "OperatingDates"_s,
+        "LoginStatus"_s
     };
 
     return sortedTables;
@@ -1144,6 +1157,11 @@ bool ResourceLoadStatisticsStore::createSchema()
         return false;
     }
 
+    if (!m_database.executeCommand(createLoginStatus)) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("createSchema: failed to execute statement createLoginStatus");
+        return false;
+    }
+
     if (!createUniqueIndices())
         return false;
 
@@ -1193,6 +1211,9 @@ void ResourceLoadStatisticsStore::destroyStatements()
     m_removeAllDataStatement = nullptr;
     m_checkIfTableExistsStatement = nullptr;
     m_updateMostRecentWebPushInteractionTimeStatement = nullptr;
+    m_insertObservedDomainStatement = nullptr;
+    m_removeLoginStatusStatement = nullptr;
+    m_loginStatusExistsStatement = nullptr;
 }
 
 bool ResourceLoadStatisticsStore::insertObservedDomain(const ResourceLoadStatistics& loadStatistics)
@@ -1228,6 +1249,105 @@ bool ResourceLoadStatisticsStore::insertObservedDomain(const ResourceLoadStatist
     return true;
 }
 
+void ResourceLoadStatisticsStore::insertLoginStatus(const RegistrableDomain& domain, IsLoggedIn loggedInStatus, const std::optional<LoginStatus>& lastAuthentication)
+{
+    ASSERT(!RunLoop::isMain());
+
+    if (loginStatusDomainID(domain)) {
+        ITP_RELEASE_LOG_ERROR("insertLoginStatus: failed to find domain");
+        return;
+    }
+
+    enum {
+        DomainIDIndex,
+        RegistrableDomainIndex,
+        UsernameIndex,
+        TokenTypeIndex,
+        AuthenticationTypeIndex,
+        LoggedInTimeIndex,
+        TimeToLiveIndex,
+        StatusIndex
+    };
+
+    auto scopedStatement = this->scopedStatement(m_insertLoginstatusStatement, insertLoginStatusQuery, "insertLoginstatus"_s);
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertLoginStatus: failed to create scoped statement");
+        return;
+    }
+
+    if (scopedStatement->bindText(RegistrableDomainIndex, domain.string()) != SQLITE_OK) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertLoginStatus: failed to bind registrableDomain");
+        return;
+    }
+
+    if (lastAuthentication) {
+        if (scopedStatement->bindText(UsernameIndex, lastAuthentication->username()) != SQLITE_OK
+            || scopedStatement->bindInt(TokenTypeIndex, static_cast<int>(lastAuthentication->tokenType())) != SQLITE_OK
+            || scopedStatement->bindInt(AuthenticationTypeIndex, static_cast<int>(lastAuthentication->authType())) != SQLITE_OK
+            || scopedStatement->bindDouble(LoggedInTimeIndex, lastAuthentication->loggedInTime().secondsSinceEpoch().value()) != SQLITE_OK
+            || scopedStatement->bindDouble(TimeToLiveIndex, lastAuthentication->timeToLive().seconds()) != SQLITE_OK) {
+            ITP_RELEASE_LOG_DATABASE_ERROR("insertLoginStatus: failed to bind lastAuthentication values");
+            return;
+        }
+    } else {
+        if (scopedStatement->bindNull(UsernameIndex) != SQLITE_OK
+            || scopedStatement->bindNull(TokenTypeIndex) != SQLITE_OK
+            || scopedStatement->bindNull(AuthenticationTypeIndex) != SQLITE_OK
+            || scopedStatement->bindNull(LoggedInTimeIndex) != SQLITE_OK
+            || scopedStatement->bindNull(TimeToLiveIndex) != SQLITE_OK) {
+            ITP_RELEASE_LOG_DATABASE_ERROR("insertLoginStatus: failed to bind NULL values for lastAuthentication");
+            return;
+        }
+    }
+
+    if (scopedStatement->bindInt(StatusIndex, static_cast<int>(loggedInStatus)) != SQLITE_OK) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertLoginStatus: failed to bind status");
+        return;
+    }
+
+    if (scopedStatement->step() != SQLITE_DONE) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertLoginStatus: failed to step statement");
+        return;
+    }
+    return;
+}
+
+void ResourceLoadStatisticsStore::removeLoginStatus(const RegistrableDomain& domain)
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto domainIDToRemove = loginStatusDomainID(domain);
+    if (!domainIDToRemove) {
+        ITP_RELEASE_LOG_ERROR("removeLoginStatus: failed to find domain");
+        return;
+    }
+
+    auto scopedStatement = this->scopedStatement(m_removeLoginStatusStatement, removeLoginStatusQuery, "removeLoginStatus"_s);
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, *domainIDToRemove) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_DONE) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("removeLoginstatus: failed to step statement");
+        }
+}
+
+bool ResourceLoadStatisticsStore::loginStatusExists(const RegistrableDomain& domain)
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto domainID = loginStatusDomainID(domain);
+    if (!domainID)
+        return false;
+
+    auto scopedStatement = this->scopedStatement(m_loginStatusExistsStatement, loginStatusExistsQuery, "loginStatusExists"_s);
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, *domainID) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_ROW) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("loginStatusExists: failed to step statement");
+        return false;
+    }
+    return true;
+}
+
 bool ResourceLoadStatisticsStore::relationshipExists(SQLiteStatementAutoResetScope& statement, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const
 {
     if (!firstDomainID)
@@ -1249,7 +1369,21 @@ std::optional<unsigned> ResourceLoadStatisticsStore::domainID(const RegistrableD
 {
     ASSERT(!RunLoop::isMain());
 
-    auto scopedStatement = this->scopedStatement(m_domainIDFromStringStatement, domainIDFromStringQuery, "domainID"_s);
+    return domainIDWithTable(domain, m_domainIDFromStringStatement, domainIDFromStringQuery);
+}
+
+std::optional<unsigned> ResourceLoadStatisticsStore::loginStatusDomainID(const RegistrableDomain& domain) const
+{
+    ASSERT(!RunLoop::isMain());
+
+    return domainIDWithTable(domain, m_loginStatusDomainIDFromStringStatement, loginStatusDomainIDFromStringQuery);
+}
+
+std::optional<unsigned> ResourceLoadStatisticsStore::domainIDWithTable(const RegistrableDomain& domain, std::unique_ptr<WebCore::SQLiteStatement>& statement, ASCIILiteral query) const
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto scopedStatement = this->scopedStatement(statement, query, "domainID"_s);
     if (!scopedStatement || scopedStatement->bindText(1, domain.string()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("domainID: failed to bind parameter");
         return std::nullopt;
@@ -1751,6 +1885,27 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
     grantStorageAccessInternal(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, userWasPromptedEarlier, scope, canRequestStorageAccessWithoutUserInteraction, [completionHandler = WTFMove(completionHandler)] (StorageAccessWasGranted wasGranted) mutable {
         completionHandler(wasGranted == StorageAccessWasGranted::Yes ? StorageAccessStatus::HasAccess : StorageAccessStatus::CannotRequestAccess);
     });
+}
+
+void ResourceLoadStatisticsStore::setLoginStatus(const RegistrableDomain& domain, IsLoggedIn loggedInStatus, std::optional<LoginStatus>&& lastAuthentication)
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto loginStatusToSet = lastAuthentication && lastAuthentication->hasExpired() ? std::nullopt : std::optional(WTFMove(lastAuthentication));
+    if (loginStatusToSet)
+        loginStatusToSet->setTimeToLive(WebCore::LoginStatus::TimeToLiveLong);
+
+    if (loggedInStatus == IsLoggedIn::LoggedIn)
+        insertLoginStatus(domain, loggedInStatus, lastAuthentication);
+    else if (loggedInStatus == IsLoggedIn::LoggedOut)
+        removeLoginStatus(domain);
+}
+
+bool ResourceLoadStatisticsStore::isLoggedIn(const RegistrableDomain& domain)
+{
+    ASSERT(!RunLoop::isMain());
+
+    return loginStatusExists(domain);
 }
 
 void ResourceLoadStatisticsStore::requestStorageAccessUnderOpener(DomainInNeedOfStorageAccess&& domainInNeedOfStorageAccess, PageIdentifier openerPageID, OpenerDomain&& openerDomain, CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction)

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -33,7 +33,6 @@
 #include "WebsiteDataType.h"
 #include <WebCore/DocumentStorageAccess.h>
 #include <WebCore/FrameIdentifier.h>
-#include <WebCore/IsLoggedIn.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ResourceLoadObserver.h>
@@ -262,7 +261,6 @@ private:
 
     HashSet<RegistrableDomain> m_domainsWithUserInteractionQuirk;
     HashMap<TopFrameDomain, Vector<SubResourceDomain>> m_domainsWithCrossPageStorageAccessQuirk;
-    HashMap<RegistrableDomain, std::pair<IsLoggedIn, std::optional<WebCore::LoginStatus>>> m_loginStatus;
 
     bool m_hasScheduledProcessStats { false };
     bool m_firstNetworkProcessCreated { false };


### PR DESCRIPTION
#### 96606df018fb75b2e6f5b643438712c2f642eafb
<pre>
Storing loginStatus value in a database
<a href="https://bugs.webkit.org/show_bug.cgi?id=279162">https://bugs.webkit.org/show_bug.cgi?id=279162</a>
<a href="https://rdar.apple.com/135310202">rdar://135310202</a>

Reviewed by Chris Dumez and Alex Christensen.

In the initial implementation, the loginStatus was stored in a temporary hashmap, and the status was cleared once the session ended. In this patch, we update the implementation to store the status persistently in the LoginStatus table within the observations.db database.
This functionality is covered by the layout test http/tests/login-status/login-status-api-getter-setter-functions.html.

* Source/WebCore/page/LoginStatus.cpp:
(WebCore::LoginStatus::isolatedCopy const):
(WebCore::LoginStatus::isolatedCopy):
* Source/WebCore/page/LoginStatus.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::expectedTableAndIndexQueries):
(WebKit::ResourceLoadStatisticsStore::sortedTables):
(WebKit::ResourceLoadStatisticsStore::createSchema):
(WebKit::ResourceLoadStatisticsStore::destroyStatements):
(WebKit::ResourceLoadStatisticsStore::insertLoginStatus):
(WebKit::ResourceLoadStatisticsStore::removeLoginStatus):
(WebKit::ResourceLoadStatisticsStore::loginStatusExists):
(WebKit::ResourceLoadStatisticsStore::domainID const):
(WebKit::ResourceLoadStatisticsStore::loginStatusDomainID const):
(WebKit::ResourceLoadStatisticsStore::domainIDWithTable const):
(WebKit::ResourceLoadStatisticsStore::setLoginStatus):
(WebKit::ResourceLoadStatisticsStore::isLoggedIn):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setLoginStatus):
(WebKit::WebResourceLoadStatisticsStore::isLoggedIn):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:

Canonical link: <a href="https://commits.webkit.org/283505@main">https://commits.webkit.org/283505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc39479d1c8e12ab7f67cc5a5188ac302bdd28a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53295 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11892 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60629 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60943 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2201 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10076 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41631 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->