### PR TITLE
[SVG] zoom applied twice to font size in foreignObject

### DIFF
--- a/LayoutTests/svg/zoom/page/zoom-foreignObject-2-expected.html
+++ b/LayoutTests/svg/zoom/page/zoom-foreignObject-2-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    :root {
+        zoom: 4;
+        font-size: 16px;
+    }
+  </style>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div>TEST</div>
+    </foreignObject>
+  </svg>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div>TEST</div>
+    </foreignObject>
+  </svg>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div>TEST</div>
+    </foreignObject>
+  </svg>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div>TEST</div>
+    </foreignObject>
+  </svg>
+</html>

--- a/LayoutTests/svg/zoom/page/zoom-foreignObject-2.html
+++ b/LayoutTests/svg/zoom/page/zoom-foreignObject-2.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    :root {
+        zoom: 4;
+        font-size: 16px;
+    }
+  </style>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div>TEST</div>
+    </foreignObject>
+  </svg>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div style="font-size:16px">TEST</div>
+    </foreignObject>
+  </svg>
+  <svg width="50" height="25">
+    <foreignObject width="50" height="25">
+      <div style="font-size:inherit">TEST</div>
+    </foreignObject>
+  </svg>
+  <svg width="50" height="25" style="font-size:inherit">
+    <foreignObject width="50" height="25">
+      <div>TEST</div>
+    </foreignObject>
+  </svg>
+</html>

--- a/Source/WebCore/css/svg.css
+++ b/Source/WebCore/css/svg.css
@@ -94,3 +94,9 @@ text, tspan, tref {
 a:any-link {
     cursor: pointer;
 }
+
+/* SVG handles zooming in a different way. font-size has to be resolved at document boundaries. */
+
+*|*:not(*) > svg, foreignObject > *|*:not(*) {
+    font-size: inherit;
+}


### PR DESCRIPTION
#### cfc54d246e12d5b86b33aeb832e093677e17a4c8
<pre>
[SVG] zoom applied twice to font size in foreignObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=279041">https://bugs.webkit.org/show_bug.cgi?id=279041</a>

Reviewed by NOBODY (OOPS!).

WebKit handles zoom factor (zoom property and page zoom) differently
for SVG. WebKit multiplies computed CSS length values by a zoom factor
for HTML elements, but for SVG elements. WebKit scales SVG
differently. Thus, font-size property is zoomed for HTML elements, but
unzoomed for a SVG elements.

If a compound HTML document included a SVG document that included
another HTML document, and font-size property was specified to a HTML
element of the outer HTML document, and a zoom factor was applied, the
computed font-size was zoomed. If it was inherited to elements of the
inner HTML document. WebKit scaled SVG. Eventually, the font size of
the inner HTML was zoomed twice.

font-size property should be resolved at root elements of included
documents.

* LayoutTests/svg/zoom/page/zoom-foreignObject-2-expected.html: Added.
* LayoutTests/svg/zoom/page/zoom-foreignObject-2.html: Added.
* Source/WebCore/css/svg.css:
(*|*:not(*) &gt; svg, foreignObject &gt; *|*:not(*)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfc54d246e12d5b86b33aeb832e093677e17a4c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16407 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52608 "Found 3 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68585 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41466 "Found 3 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38144 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14081 "Found 4 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html svg/custom/foreign-object-skew.svg svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15003 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59978 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14423 "Found 4 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html svg/custom/foreign-object-skew.svg svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9472 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13875 "Found 5 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html svg/custom/foreign-object-skew.svg svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59925 "Found 3 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60198 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7829 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1473 "Found 4 new test failures: imported/blink/svg/zoom/text/zoom-em-units.html svg/custom/foreign-object-skew.svg svg/zoom/text/zoom-hixie-mixed-008.xml svg/zoom/text/zoom-hixie-mixed-009.xml (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->