### PR TITLE
Make WKLockdownModeEnabledKey a CFString literal

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
@@ -39,8 +39,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
 
 + (BOOL)isCaptivePortalModeEnabled
 {
-    auto key = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, WKLockdownModeEnabledKey.characters(), kCFStringEncodingUTF8, kCFAllocatorNull));
-    auto preferenceValue = adoptCF(CFPreferencesCopyValue(key.get(), kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost));
+    auto preferenceValue = adoptCF(CFPreferencesCopyValue(WKLockdownModeEnabledKeyCFString, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost));
     if (preferenceValue.get() == kCFBooleanTrue)
         return true;
 
@@ -54,8 +53,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
 
 + (void)setCaptivePortalModeEnabled:(BOOL)enabled
 {
-    auto key = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, WKLockdownModeEnabledKey.characters(), kCFStringEncodingUTF8, kCFAllocatorNull));
-    CFPreferencesSetValue(key.get(), enabled ? kCFBooleanTrue : kCFBooleanFalse, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
+    CFPreferencesSetValue(WKLockdownModeEnabledKeyCFString, enabled ? kCFBooleanTrue : kCFBooleanFalse, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFPreferencesSynchronize(kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
@@ -27,6 +27,12 @@
 #import <wtf/text/ASCIILiteral.h>
 
 const auto LDMEnabledKey = CFSTR("LDMGlobalEnabled");
-constexpr auto WKLockdownModeEnabledKey = "WKLockdownModeEnabled"_s;
+
+#define WK_LOCKDOWN_MODE_ENABLED_KEY_MACRO WKLockdownModeEnabled
+// "WKLockdownModeEnabled"_s
+constexpr auto WKLockdownModeEnabledKey = WTF_CONCAT(STRINGIZE_VALUE_OF(WK_LOCKDOWN_MODE_ENABLED_KEY_MACRO), _s);
+// CFSTR("WKLockdownModeEnabled")
+const auto WKLockdownModeEnabledKeyCFString = CFSTR(STRINGIZE_VALUE_OF(WK_LOCKDOWN_MODE_ENABLED_KEY_MACRO));
+
 // This string must remain consistent with the lockdown mode notification name in privacy settings.
 constexpr auto WKLockdownModeContainerConfigurationChangedNotification = @"WKCaptivePortalModeContainerConfigurationChanged";


### PR DESCRIPTION
#### 827e0b9c258027000f3b22605cf909db787bf991
<pre>
Make WKLockdownModeEnabledKey a CFString literal
<a href="https://bugs.webkit.org/show_bug.cgi?id=279163">https://bugs.webkit.org/show_bug.cgi?id=279163</a>

Reviewed by Abrar Rahman Protyasha.

Having two variables of the same string is better
than manual conversion at runtime.

* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm:
  (+[_WKSystemPreferences isCaptivePortalModeEnabled]): Use new constant
  WKLockdownModeEnabledKeyCFString.
  (+[_WKSystemPreferences setCaptivePortalModeEnabled:]): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h:
  Define new constant WKLockdownModeEnabledKeyCFString.

Canonical link: <a href="https://commits.webkit.org/284059@main">https://commits.webkit.org/284059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62d545a4332e5485061854840c725f9c605ab81e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19502 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54577 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12982 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35041 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40336 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74116 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62030 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62050 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3590 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->