### PR TITLE
Don't return early from populateCommandsIfNeeded if the dictionary is empty

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1996,9 +1996,10 @@ void WebExtension::populateCommandsIfNeeded()
 
     auto *commandsDictionary = objectForKey<NSDictionary>(m_manifest, commandsManifestKey, false, NSDictionary.class);
     if (!commandsDictionary) {
-        if (id value = [m_manifest objectForKey:commandsManifestKey]; value && ![value isKindOfClass:NSDictionary.class])
+        if (id value = [m_manifest objectForKey:commandsManifestKey]; value && ![value isKindOfClass:NSDictionary.class]) {
             recordError(createError(Error::InvalidCommands));
-        return;
+            return;
+        }
     }
 
     if (id value = [m_manifest objectForKey:commandsManifestKey]; commandsDictionary.count != dynamic_objc_cast<NSDictionary>(value).count) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -114,9 +114,13 @@ bool WebExtensionCommand::setActivationKey(String activationKey)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         auto *allowedCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
+        // F1-F12.
         [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF704, 12)];
+        // Insert, Delete, Home.
         [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF727, 3)];
+        // End, Page Up, Page Down.
         [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF72B, 3)];
+        // Up, Down, Left, Right.
         [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF700, 4)];
         [allowedCharacterSet addCharactersInString:@",. "];
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -47,7 +47,7 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
         return extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"action", false);
 
     if (name == "commands"_s)
-        return objectForKey<NSDictionary>(extensionContext().manifest(), @"commands");
+        return objectForKey<NSDictionary>(extensionContext().manifest(), @"commands", false);
 
     if (name == "declarativeNetRequest"_s)
         return extensionContext().hasPermission(name) || extensionContext().hasPermission("declarativeNetRequestWithHostAccess"_s);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -1651,7 +1651,7 @@ TEST(WKWebExtension, CommandsParsing)
     };
 
     testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_FALSE(testExtension.hasCommands);
+    EXPECT_TRUE(testExtension.hasCommands);
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary = @{
@@ -1665,7 +1665,7 @@ TEST(WKWebExtension, CommandsParsing)
     };
 
     testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_FALSE(testExtension.hasCommands);
+    EXPECT_TRUE(testExtension.hasCommands);
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary = @{
@@ -1679,7 +1679,7 @@ TEST(WKWebExtension, CommandsParsing)
     };
 
     testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_FALSE(testExtension.hasCommands);
+    EXPECT_TRUE(testExtension.hasCommands);
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary = @{

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -72,6 +72,29 @@ static auto *commandsManifest = @{
     }
 };
 
+static auto *emptyCommandsManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Test Commands",
+    @"description": @"Test Commands",
+    @"version": @"1.0",
+
+    @"permissions": @[ @"webNavigation" ],
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"action": @{
+        @"default_title": @"Test Action"
+    },
+
+    @"commands": @{
+    }
+};
+
 TEST(WKWebExtensionAPICommands, GetAllCommands)
 {
     auto *backgroundScript = Util::constructScript(@[
@@ -93,6 +116,23 @@ TEST(WKWebExtensionAPICommands, GetAllCommands)
     ]);
 
     Util::loadAndRunExtension(commandsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifest)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"let commands = await browser.commands.getAll()",
+        @"browser.test.assertEq(commands.length, 1, 'Should be one command.')",
+
+        @"let executeActionCommand = commands.find(command => command.name === '_execute_action')",
+
+        @"browser.test.assertTrue(!!executeActionCommand, '_execute_action command should exist')",
+        @"browser.test.assertEq(executeActionCommand.description, 'Test Action', 'The description should be')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(emptyCommandsManifest, @{ @"background.js": backgroundScript });
 }
 
 TEST(WKWebExtensionAPICommands, CommandEvent)


### PR DESCRIPTION
#### 9a753fd3e08746a0158839beeb86738c51e3d5f8
<pre>
Don&apos;t return early from populateCommandsIfNeeded if the dictionary is empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=279164">https://bugs.webkit.org/show_bug.cgi?id=279164</a>
<a href="https://rdar.apple.com/135279505">rdar://135279505</a>

Reviewed by Timothy Hatcher.

If an extension specifies an empty &quot;commands&quot; manifest entry (or no entry at all), we still want to give it an `_execute_*_action` command. This PR
makes that change and adds a test.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::populateCommandsIfNeeded): Only return early if the commands entry is malformed, not just if it&apos;s empty.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::setActivationKey): Add comments for what these values represent.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Consider an empty dictionary entry non-nil.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifest)):

Canonical link: <a href="https://commits.webkit.org/283189@main">https://commits.webkit.org/283189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9d9991f78101d4453a44ab561a1b0cf8377ecbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16417 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68595 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14091 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15013 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71259 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9482 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56778 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7834 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41785 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->