### PR TITLE
dladukedev.com shows white for 5 seconds.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039-expected.txt
@@ -1,0 +1,3 @@
+
+PASS link rel=expect: render blocking stops waiting when the document finishes loading
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/utils.js"></script>
+<title>link rel=expect: render blocking stops waiting when the document finishes loading</title>
+
+<link rel=expect href="#invalid" blocking="render">
+<script>
+var timeoutHit = false;
+setTimeout(() => { timeoutHit = true; }, 3000);
+
+async_test((t) => {
+  requestAnimationFrame(() => {
+    t.step(() => assert_false(timeoutHit, "requestAnimationFrame should not have been delayed by the link that didn't find its target"));
+    t.done();
+  });
+}, "");
+</script>
+</head>
+<body>
+  <div id="first"></div>
+  <div id="last"></div>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8352,12 +8352,12 @@ void Document::unblockRenderingOn(Element& element)
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#process-internal-resource-links
-void Document::processInternalResourceLinks(HTMLAnchorElement& anchor)
+void Document::processInternalResourceLinks(HTMLAnchorElement* anchor)
 {
     auto copy = copyToVector(m_renderBlockingElements);
     for (auto& element : copy) {
         if (RefPtr link = dynamicDowncast<HTMLLinkElement>(element.get()))
-            link->processInternalResourceLink(&anchor);
+            link->processInternalResourceLink(anchor);
     }
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1833,7 +1833,7 @@ public:
     enum class ImplicitRenderBlocking : bool { Yes, No };
     void blockRenderingOn(Element&, ImplicitRenderBlocking = ImplicitRenderBlocking::No);
     void unblockRenderingOn(Element&);
-    void processInternalResourceLinks(HTMLAnchorElement&);
+    void processInternalResourceLinks(HTMLAnchorElement* = nullptr);
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -261,7 +261,7 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
         if (m_relList)
             m_relList->associatedAttributeValueChanged();
     } else if (name == nameAttr)
-        document().processInternalResourceLinks(*this);
+        document().processInternalResourceLinks(this);
 }
 
 bool HTMLAnchorElement::isURLAttribute(const Attribute& attribute) const
@@ -750,7 +750,7 @@ ReferrerPolicy HTMLAnchorElement::referrerPolicy() const
 Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    document().processInternalResourceLinks(*this);
+    document().processInternalResourceLinks(this);
     return result;
 }
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -448,7 +448,7 @@ void HTMLLinkElement::processInternalResourceLink(HTMLAnchorElement* anchor)
     } else
         indicatedElement = document().findAnchor(m_url.fragmentIdentifier());
 
-    // FIXME: "is on a stack of open elements of an HTML parser whose associated Document is doc"
+    // FIXME: Bug 279167 - Don't match if indicatedElement "is on a stack of open elements of an HTML parser whose associated Document is doc"
     if (document().readyState() == Document::ReadyState::Loading && isConnected() && mediaAttributeMatches() && !indicatedElement) {
         potentiallyBlockRendering();
         if (!m_expectIdTargetObserver)

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -139,8 +139,14 @@ void HTMLDocumentParser::prepareToStopParsing()
     DocumentParser::prepareToStopParsing();
 
     // We will not have a scriptRunner when parsing a DocumentFragment.
-    if (m_scriptRunner)
+    if (m_scriptRunner) {
         document()->setReadyState(Document::ReadyState::Interactive);
+
+        // FIXME: Bug 279167 - This should be called after every element is popped
+        // from the stack of open elements, not just the last.
+        if (!isDetached())
+            document()->processInternalResourceLinks();
+    }
 
     // Setting the ready state above can fire mutation event and detach us
     // from underneath. In that case, just bail out.


### PR DESCRIPTION
#### 64c4d3857e78e1f367b712db9d3f93ce59d9ab8f
<pre>
dladukedev.com shows white for 5 seconds.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279165">https://bugs.webkit.org/show_bug.cgi?id=279165</a>
&lt;<a href="https://rdar.apple.com/135315499">rdar://135315499</a>&gt;

Reviewed by Tim Nguyen.

Render blocking prevents the page from being displayed until the timeout.

The page has a &lt;link rel=expect&gt; render blocking link that never gets resolved.

Render blocking for &lt;link&gt; should only be in place while the Document&apos;s ready state is &apos;loading&apos;, and should be removed once the page is fully loaded.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processInternalResourceLinks):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::processInternalResourceLink):
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::prepareToStopParsing):

Canonical link: <a href="https://commits.webkit.org/283246@main">https://commits.webkit.org/283246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/287e95131e33ecc9ed94bc5a564f86e436e69a79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52719 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11292 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14212 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13991 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60314 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14475 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1592 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41919 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->