### PR TITLE
dom/intersection-observer-document-leak.html is a flaky text failure

### DIFF
--- a/LayoutTests/fast/dom/intersection-observer-document-leak-expected.txt
+++ b/LayoutTests/fast/dom/intersection-observer-document-leak-expected.txt
@@ -1,11 +1,15 @@
 main frame - has 1 onunload handler(s)
+main frame - has 1 onunload handler(s)
+main frame - has 1 onunload handler(s)
 Tests that IntersectionObserver doesn't cause Document leaks.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS internals.isDocumentAlive(frameDocumentID) is true
-PASS The iframe document didn't leak.
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS At least 1 iframe document was destroyed.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/intersection-observer-document-leak.html
+++ b/LayoutTests/fast/dom/intersection-observer-document-leak.html
@@ -6,11 +6,29 @@
 description("Tests that IntersectionObserver doesn't cause Document leaks.");
 jsTestIsAsync = true;
 
-frameDocumentID = 0;
-checkCount = 0;
+didCreate = null;
 
-onload = () => {
-    window.open("resources/intersection-observer-document-leak-popup.html");
+onload = async () => {
+    const frameDocumentIDs = [];
+    for (var i = 0; i < 3; i++) {
+        frameDocumentIDs.push(await new Promise(resolve => {
+            didCreate = resolve;
+            window.open("resources/intersection-observer-document-leak-popup.html");
+        }));
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    for (var i = 0; i < 3; i++) {
+        gc();
+        if (frameDocumentIDs.some((id) => !internals.isDocumentAlive(id))) {
+            testPassed("At least 1 iframe document was destroyed.");
+            finishJSTest();
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    testFailed("All iframe documents leaked.");
+    finishJSTest();
 };
 
 function popupDocumentWasCreated(frameDocument)
@@ -20,20 +38,7 @@ function popupDocumentWasCreated(frameDocument)
 
     frameDocumentID = internals.documentIdentifier(frameDocument);
     shouldBeTrue("internals.isDocumentAlive(frameDocumentID)");
-    handle = setInterval(() => {
-        gc();
-        if (!internals.isDocumentAlive(frameDocumentID)) {
-            clearInterval(handle);
-            testPassed("The iframe document didn't leak.");
-            finishJSTest();
-        }
-        checkCount++;
-        if (checkCount > 500) {
-            clearInterval(handle);
-            testFailed("The iframe document leaked.");
-            finishJSTest();
-        }
-    }, 10);
+    didCreate(frameDocumentID);
 }
 </script>
 </body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3635,8 +3635,6 @@ pointerevents/mouse/pointer-event-basic-properties.html [ Timeout ]
 imported/w3c/web-platform-tests/workers/semantics/multiple-workers/004.html [ Failure Pass ]
 [ Release ] perf/nested-combined-selectors.html [ Failure ]
 
-webkit.org/b/238227 fast/dom/intersection-observer-document-leak.html [ Pass Failure ]
-
 webkit.org/b/238519 animations/shadow-host-child-change.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/236930 accessibility/ios-simulator/aria-details.html [ Crash Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2421,9 +2421,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-ze
 imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-mixed-srl-016.xht [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-upright-srl-018.xht [ Pass ImageOnlyFailure ]
 
-# webkit.org/b/278952 [ Ventura ] fast/dom/intersection-observer-document-leak.html is a flaky failure.
-fast/dom/intersection-observer-document-leak.html [ Pass Failure ]
-
 # webkit.org/b/279213 REGRESSION (Sonoma): [ macOS Sonoma ] 3x http/tests/media/video-* is a constant failure.
 [ Sonoma+ ] http/tests/media/video-error-abort.html [ Failure ]
 [ Sonoma+ ] http/tests/media/video-served-as-text.html [ Failure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1231,8 +1231,6 @@ webkit.org/b/182128 fast/dom/navigator-detached-no-crash.html [ Pass Failure ]
 
 webkit.org/b/257624 fast/dom/SelectorAPI/caseID.html [ Failure Pass ]
 
-webkit.org/b/238227 fast/dom/intersection-observer-document-leak.html [ Pass Failure ]
-
 webkit.org/b/265213 fast/dom/Range/detach-range-during-deletecontents.html [ Skip ] # Timeout
 
 webkit.org/b/227753 [ Debug ] fast/dom/Window/post-message-large-array-buffer-should-not-crash.html [ Pass Failure ]


### PR DESCRIPTION
#### 50e1cf7938dbfc5fcb6e47d0af94a3ef3fb3693b
<pre>
dom/intersection-observer-document-leak.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=238227">https://bugs.webkit.org/show_bug.cgi?id=238227</a>

Reviewed by Chris Dumez.

Due to conservative GC&apos;s property, document leak tests should create
some documents to test. Open 3 windows, and pass the test if at least
a single document is reclaimed.

* LayoutTests/fast/dom/intersection-observer-document-leak-expected.txt:
* LayoutTests/fast/dom/intersection-observer-document-leak.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/283244@main">https://commits.webkit.org/283244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f4b19da0bafef87fb119a1bf6d32ab9bdc6590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18295 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/16285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16567 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/69702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/16285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68743 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56844 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14223 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/15161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14565 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/71408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9631 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/71408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56909 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/71408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/7951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9953 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/41677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->