### PR TITLE
Fire load event for more navigation error cases

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -172,6 +172,8 @@ enum class ColorSchemePreference : uint8_t {
     Dark
 };
 
+enum class InvokedFromNotifyFinished : bool { Yes, No };
+
 enum class ContentExtensionDefaultEnablement : bool { Disabled, Enabled };
 using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, HashSet<String>>;
 
@@ -549,7 +551,7 @@ private:
 
     void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     void finishedLoading();
-    void mainReceivedError(const ResourceError&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
+    void mainReceivedError(const ResourceError&, LoadWillContinueInAnotherProcess, InvokedFromNotifyFinished = InvokedFromNotifyFinished::No);
     WEBCORE_EXPORT void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
     WEBCORE_EXPORT void responseReceived(CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
     WEBCORE_EXPORT void dataReceived(CachedResource&, const SharedBuffer&) override;


### PR DESCRIPTION
#### 4bdd17247046dbf5ebdf9d39754faeda19ff5ae7
<pre>
Fire load event for more navigation error cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=279185">https://bugs.webkit.org/show_bug.cgi?id=279185</a>

Reviewed by NOBODY (OOPS!).

We currently only replace the document with an error document in a
select number of cases. Instead we should replace the document in the
majority of cases. This better matches Chrome and generally makes our
handling of errors more consistent.

Follow-up patches can then treat more scenarios as a network error,
which should then automatically be handled by this code path.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::mainReceivedError):
(WebCore::DocumentLoader::stopLoading):
(WebCore::DocumentLoader::notifyFinished):
(WebCore::DocumentLoader::continueAfterContentPolicy):
(WebCore::DocumentLoader::cancelMainResourceLoad):
* Source/WebCore/loader/DocumentLoader.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdd17247046dbf5ebdf9d39754faeda19ff5ae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16458 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52648 "Found 35 new test failures: fast/css/acid2-pixel.html fast/css/acid2.html fast/dom/crash-with-bad-url.html fast/events/media-focus-in-standalone-media-document.html fast/innerHTML/innerHTML-iframe.html fast/multicol/continuation-inside-multicol-crash.html fast/overflow/overflow-height-float-not-removed-crash3.html fast/table/giantCellspacing.html http/tests/contentextensions/main-resource-redirect-error.html http/tests/loading/bad-server-subframe.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11224 "Found 6 new test failures: editing/execCommand/apply-style-text-decoration-crash.html editing/style/apply-style-iframe-crash.html fast/dom/crash-with-bad-url.html http/tests/loading/bad-server-subframe.html http/tests/security/http-0.9/iframe-blocked.html imported/w3c/web-platform-tests/trusted-types/DOMParser-parseFromString-regression.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68636 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41511 "Found 47 new test failures: contentfiltering/allow-media-document.html contentfiltering/block-after-add-data-then-allow-unblock.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-add-data.html contentfiltering/block-after-finished-adding-data-then-allow-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data.html contentfiltering/block-after-response-then-allow-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-response.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56752 "Found 42 new API test failures: TestWebKitAPI.WKNavigation.DidFailProvisionalNavigation, TestWebKitAPI.WKNavigation.HTTPSOnlyWithSameSiteBypass, TestWebKitAPI.WebKit.ErrorSecureCoding, TestWebKitAPI.ContentFiltering.LoadAlternateAfterAddDataWK1, TestWebKitAPI.WKNavigation.HTTPSFirstHTTPDowngrade, TestWebKitAPI.WKBrowsingContextLoadDelegateTest.SimpleLoadFail, TestWebKitAPI.ContentFiltering.BlockDownloadAfterResponse, TestWebKitAPI.WKWebView.FTPMainResource, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.WebSocket.LoadRequestWSS ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33276 "Found 10 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-error, /TestWebKit:WebKit.FailedLoad, /WPE/TestSSL:/webkit/WebKitWebView/tls-errors-policy, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors, /WPE/TestAuthentication:/webkit/Authentication/authentication-cancel, /WPE/TestSSL:/webkit/WebKitWebView/tls-http-auth, /WPE/TestLoaderClient:/webkit/WebKitWebView/is-loading, /WPE/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors, /WPE/TestSSL:/webkit/WebKitWebView/tls-errors-redirect-to-http (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38192 "Found 8 new test failures: imported/w3c/web-platform-tests/fetch/h1-parsing/resources-with-0x00-in-header.window.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/pageload-video.html imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken-weird.html imported/w3c/web-platform-tests/navigation-timing/dom_interactive_media_document.html imported/w3c/web-platform-tests/service-workers/service-worker/fetch-frame-resource.https.html imported/w3c/web-platform-tests/service-workers/service-worker/update-recovery.https.html imported/w3c/web-platform-tests/trusted-types/DOMParser-parseFromString-regression.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14131 "Found 60 new test failures: contentfiltering/block-after-add-data-then-allow-unblock.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-add-data.html contentfiltering/block-after-response-then-allow-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-response.html dom/xhtml/level2/html/HTMLIFrameElement11.xhtml editing/execCommand/apply-style-command-crash.html editing/style/apply-style-crash.html fast/css/acid2-pixel.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15054 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60024 "Found 34 new API test failures: TestWebKitAPI.WKNavigation.DidFailProvisionalNavigation, TestWebKitAPI.WKNavigation.HTTPSOnlyWithSameSiteBypass, TestWebKitAPI.WebKit.ErrorSecureCoding, TestWebKitAPI.WKNavigation.HTTPSFirstHTTPDowngrade, TestWebKitAPI.ContentFiltering.BlockDownloadAfterResponse, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.WebSocket.LoadRequestWSS, TestWebKitAPI.ContentFiltering.LoadAlternateAfterAddDataWK2, TestWebKitAPI.WKNavigation.HTTPSFirstHTTPDowngradeRedirect, TestWebKitAPI.WKWebExtensionAPIWebNavigation.ErrorOccurred ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14472 "Found 60 new test failures: animations/timing-functions.html contentfiltering/allow-media-document.html contentfiltering/block-after-add-data-then-allow-unblock.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-add-data.html contentfiltering/block-after-finished-adding-data-then-allow-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data.html contentfiltering/block-after-response-then-allow-unblock.html contentfiltering/block-after-response-then-deny-unblock.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9523 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13918 "Found 60 new test failures: contentfiltering/allow-media-document.html contentfiltering/block-after-add-data-then-allow-unblock.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-add-data.html contentfiltering/block-after-finished-adding-data-then-allow-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data.html contentfiltering/block-after-response-then-allow-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-response.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59967 "Found 36 new test failures: fast/css/acid2-pixel.html fast/css/acid2.html fast/dom/crash-with-bad-url.html fast/events/media-focus-in-standalone-media-document.html fast/innerHTML/innerHTML-iframe.html fast/multicol/continuation-inside-multicol-crash.html fast/overflow/overflow-height-float-not-removed-crash3.html fast/table/giantCellspacing.html http/tests/contentextensions/main-resource-redirect-error.html http/tests/loading/bad-server-subframe.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56817 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60242 "Found 11 new API test failures: /TestWebKit:WebKit.FailedLoad, /WebKitGTK/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/is-loading, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-storage, /WebKitGTK/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-cancel, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-policy, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-redirect-to-http, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-http-auth ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7870 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1517 "Found 60 new test failures: contentfiltering/allow-media-document.html contentfiltering/block-after-add-data-then-allow-unblock.html contentfiltering/block-after-add-data-then-deny-unblock.html contentfiltering/block-after-add-data.html contentfiltering/block-after-finished-adding-data-then-allow-unblock.html contentfiltering/block-after-finished-adding-data-then-deny-unblock.html contentfiltering/block-after-finished-adding-data.html contentfiltering/block-after-response-then-allow-unblock.html contentfiltering/block-after-response-then-deny-unblock.html contentfiltering/block-after-response.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->