### PR TITLE
[IFC][SVG text] SVGTextLayoutEngine should not mutate its input

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
@@ -88,6 +88,10 @@ SVGTextBoxIterator svgTextBoxFor(const SVGInlineTextBox* box)
     return { BoxLegacyPath { box } };
 }
 
+SVGTextBox::Key makeKey(const SVGTextBox& textBox)
+{
+    return { &textBox.renderer(), textBox.start() };
+}
 
 }
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
@@ -45,6 +45,8 @@ public:
     const RenderSVGInlineText& renderer() const { return downcast<RenderSVGInlineText>(TextBox::renderer()); }
 
     const SVGInlineTextBox* legacyInlineBox() const;
+
+    using Key = std::pair<const RenderSVGInlineText*, unsigned>;
 };
 
 class SVGTextBoxIterator : public TextBoxIterator {
@@ -79,6 +81,8 @@ private:
 SVGTextBoxIterator firstSVGTextBoxFor(const RenderSVGInlineText&);
 BoxRange<SVGTextBoxIterator> svgTextBoxesFor(const RenderSVGInlineText&);
 SVGTextBoxIterator svgTextBoxFor(const SVGInlineTextBox*);
+
+SVGTextBox::Key makeKey(const SVGTextBox&);
 
 }
 }

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -71,8 +71,7 @@ void SVGInlineTextBox::dirtyOwnLineBoxes()
 {
     LegacyInlineTextBox::dirtyLineBoxes();
 
-    // Clear the now stale text fragments
-    clearTextFragments();
+    m_textFragments = { };
 }
 
 void SVGInlineTextBox::dirtyLineBoxes()

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -52,9 +52,8 @@ public:
 
     FloatRect calculateBoundaries() const;
 
-    void clearTextFragments() { m_textFragments.clear(); }
-    Vector<SVGTextFragment>& textFragments() { return m_textFragments; }
     const Vector<SVGTextFragment>& textFragments() const { return m_textFragments; }
+    void setTextFragments(Vector<SVGTextFragment>&& fragments) { m_textFragments = WTFMove(fragments); }
 
     void dirtyOwnLineBoxes() override;
     void dirtyLineBoxes() override;

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.h
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.h
@@ -53,7 +53,7 @@ private:
     bool isSVGRootInlineBox() const override { return true; }
     void reorderValueListsToLogicalOrder(Vector<SVGTextLayoutAttributes*>&);
     void layoutCharactersInTextBoxes(LegacyInlineFlowBox*, SVGTextLayoutEngine&);
-    void layoutChildBoxes(LegacyInlineFlowBox*, FloatRect* = nullptr);
+    FloatRect layoutChildBoxes(LegacyInlineFlowBox* start, SVGTextFragmentMap&);
     void layoutRootBox(const FloatRect&);
 
     float m_logicalHeight;

--- a/Source/WebCore/rendering/svg/SVGTextChunk.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.h
@@ -29,10 +29,8 @@ namespace WebCore {
 class AffineTransform;
 class SVGInlineTextBox;
 
-using SVGChunkTransformMapKey = std::pair<const RenderSVGInlineText*, unsigned>;
-using SVGChunkTransformMap = HashMap<SVGChunkTransformMapKey, AffineTransform>;
-
-SVGChunkTransformMapKey makeSVGChunkTransformMapKey(InlineIterator::SVGTextBoxIterator);
+using SVGChunkTransformMap = HashMap<InlineIterator::SVGTextBox::Key, AffineTransform>;
+using SVGTextFragmentMap = HashMap<InlineIterator::SVGTextBox::Key, Vector<SVGTextFragment>>;
 
 // A SVGTextChunk describes a range of SVGTextFragments, see the SVG spec definition of a "text chunk".
 class SVGTextChunk {
@@ -47,7 +45,7 @@ public:
         LengthAdjustSpacingAndGlyphs = 1 << 6
     };
 
-    SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>&, unsigned first, unsigned limit);
+    SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>&, unsigned first, unsigned limit, SVGTextFragmentMap&);
 
     unsigned totalCharacters() const;
     float totalLength() const;
@@ -67,11 +65,18 @@ private:
     bool hasLengthAdjustSpacing() const { return m_chunkStyle & LengthAdjustSpacing; }
     bool hasLengthAdjustSpacingAndGlyphs() const { return m_chunkStyle & LengthAdjustSpacingAndGlyphs; }
 
-    bool boxSpacingAndGlyphsTransform(InlineIterator::SVGTextBoxIterator, AffineTransform&) const;
+    bool boxSpacingAndGlyphsTransform(const Vector<SVGTextFragment>&, AffineTransform&) const;
+
+    Vector<SVGTextFragment>& fragments(InlineIterator::SVGTextBoxIterator);
+    const Vector<SVGTextFragment>& fragments(InlineIterator::SVGTextBoxIterator) const;
 
 private:
     // Contains all SVGInlineTextBoxes this chunk spans.
-    Vector<InlineIterator::SVGTextBoxIterator> m_boxes;
+    struct BoxAndFragments {
+        InlineIterator::SVGTextBoxIterator box;
+        Vector<SVGTextFragment>& fragments;
+    };
+    Vector<BoxAndFragments> m_boxes;
 
     unsigned m_chunkStyle { DefaultStyle };
     float m_desiredTextLength { 0 };

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
@@ -58,11 +58,11 @@ float SVGTextChunkBuilder::totalAnchorShift() const
 
 AffineTransform SVGTextChunkBuilder::transformationForTextBox(InlineIterator::SVGTextBoxIterator textBox) const
 {
-    auto it = m_textBoxTransformations.find(makeSVGChunkTransformMapKey(textBox));
+    auto it = m_textBoxTransformations.find(makeKey(*textBox));
     return it == m_textBoxTransformations.end() ? AffineTransform() : it->value;
 }
 
-void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes)
+void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap& fragmentMap)
 {
     if (lineLayoutBoxes.isEmpty())
         return;
@@ -71,25 +71,25 @@ void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBo
     unsigned first = limit;
 
     for (unsigned i = 0; i < limit; ++i) {
-        if (!lineLayoutBoxes[i]->legacyInlineBox()->startsNewTextChunk())
+        if (!chunkStarts.contains(makeKey(*lineLayoutBoxes[i])))
             continue;
 
         if (first == limit)
             first = i;
         else {
             ASSERT_WITH_SECURITY_IMPLICATION(first != i);
-            m_textChunks.append(SVGTextChunk(lineLayoutBoxes, first, i));
+            m_textChunks.append(SVGTextChunk(lineLayoutBoxes, first, i, fragmentMap));
             first = i;
         }
     }
 
     if (first != limit)
-        m_textChunks.append(SVGTextChunk(lineLayoutBoxes, first, limit));
+        m_textChunks.append(SVGTextChunk(lineLayoutBoxes, first, limit, fragmentMap));
 }
 
-void SVGTextChunkBuilder::layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes)
+void SVGTextChunkBuilder::layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap& fragmentMap)
 {
-    buildTextChunks(lineLayoutBoxes);
+    buildTextChunks(lineLayoutBoxes, chunkStarts, fragmentMap);
     if (m_textChunks.isEmpty())
         return;
 

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -46,8 +46,8 @@ public:
     float totalAnchorShift() const;
     AffineTransform transformationForTextBox(InlineIterator::SVGTextBoxIterator) const;
 
-    void buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes);
-    void layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes);
+    void buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
+    void layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
 
 private:
     Vector<SVGTextChunk> m_textChunks;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -54,7 +54,8 @@ public:
     void endTextPathLayout();
 
     void layoutInlineTextBox(InlineIterator::SVGTextBoxIterator);
-    void finishLayout();
+
+    SVGTextFragmentMap finishLayout();
 
 private:
     void updateCharacterPositionIfNeeded(float& x, float& y);
@@ -79,7 +80,12 @@ private:
 
     Vector<InlineIterator::SVGTextBoxIterator> m_lineLayoutBoxes;
     Vector<InlineIterator::SVGTextBoxIterator> m_pathLayoutBoxes;
+
+    // Output.
+    HashMap<InlineIterator::SVGTextBox::Key, Vector<SVGTextFragment>> m_fragmentMap;
+
     SVGTextChunkBuilder m_chunkLayoutBuilder;
+    HashSet<InlineIterator::SVGTextBox::Key> m_lineLayoutChunkStarts;
 
     SVGTextFragment m_currentTextFragment;
     unsigned m_layoutAttributesPosition { 0 };


### PR DESCRIPTION
#### b5c89ea40f95e6668af6af0e7999b3fdb665960e
<pre>
[IFC][SVG text] SVGTextLayoutEngine should not mutate its input
<a href="https://bugs.webkit.org/show_bug.cgi?id=279187">https://bugs.webkit.org/show_bug.cgi?id=279187</a>
<a href="https://rdar.apple.com/problem/135341497">rdar://problem/135341497</a>

Reviewed by Alan Baradlay.

Separate input and output.

* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp:
(WebCore::InlineIterator::makeKey):
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h:
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::dirtyOwnLineBoxes):
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGRootInlineBox.cpp:
(WebCore::SVGRootInlineBox::computePerCharacterLayoutInformation):
(WebCore::SVGRootInlineBox::layoutChildBoxes):
* Source/WebCore/rendering/svg/SVGRootInlineBox.h:
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
(WebCore::SVGTextChunk::SVGTextChunk):
(WebCore::SVGTextChunk::totalCharacters const):
(WebCore::SVGTextChunk::totalLength const):
(WebCore::SVGTextChunk::processTextLengthSpacingCorrection const):
(WebCore::SVGTextChunk::buildBoxTransformations const):
(WebCore::SVGTextChunk::boxSpacingAndGlyphsTransform const):
(WebCore::SVGTextChunk::processTextAnchorCorrection const):
(WebCore::makeSVGChunkTransformMapKey): Deleted.
* Source/WebCore/rendering/svg/SVGTextChunk.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp:
(WebCore::SVGTextChunkBuilder::transformationForTextBox const):
(WebCore::SVGTextChunkBuilder::buildTextChunks):
(WebCore::SVGTextChunkBuilder::layoutTextChunks):
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::recordTextFragment):
(WebCore::SVGTextLayoutEngine::beginTextPathLayout):
(WebCore::SVGTextLayoutEngine::layoutInlineTextBox):
(WebCore::SVGTextLayoutEngine::finalizeTransformMatrices):
(WebCore::SVGTextLayoutEngine::finishLayout):

Return output text fragments as a map.

(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:

Canonical link: <a href="https://commits.webkit.org/283211@main">https://commits.webkit.org/283211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34e66adb196641e41644f51d35321c191be3dfda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11240 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68653 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14146 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71318 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13935 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7886 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40767 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->