### PR TITLE
Async XMLHttpRequest should not clear the send flag when ThreadableLoader calls back sync

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XMLHttpRequest: abort() still works when error thrown internally
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.js
@@ -1,0 +1,16 @@
+// META: title=XMLHttpRequest: abort() still works when error thrown internally
+"use strict";
+
+const test_runner = async_test();
+
+test_runner.step(() => {
+  const client = new XMLHttpRequest();
+
+  client.open("GET", "invalid-protocol://example.com", true);
+  client.onabort = test_runner.step_func(() => {
+    test_runner.done();
+  });
+
+  client.send(null);
+  client.abort();
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XMLHttpRequest: abort() still works when error thrown internally
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->


### PR DESCRIPTION
#### 50196a8672218ccaa9557a64b958bb2317987997
<pre>
Async XMLHttpRequest should not clear the send flag when ThreadableLoader calls back sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=279189">https://bugs.webkit.org/show_bug.cgi?id=279189</a>

Reviewed by NOBODY (OOPS!).

With asynchronous XMLHttpRequest the loader could call back
synchronously in a failure scenario and that would then immediately
unset the send flag, but schedule a task for other error handling.

Unsetting the send flag there however means that calling abort()
immediately after no longer works. So unsetting that needs to happen
from the same task (it already happens). Given that abort() can now
unset the send flag we also need to account for that in the error
handling steps, similar to how the specification deals with it.

* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.js: Added.
(test_runner.step):
* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-with-error.any.worker.html: Added.
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):
(WebCore::XMLHttpRequest::abort):
(WebCore::XMLHttpRequest::networkError):
(WebCore::XMLHttpRequest::abortError):
(WebCore::XMLHttpRequest::didFail):
(WebCore::XMLHttpRequest::didReachTimeout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50196a8672218ccaa9557a64b958bb2317987997

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16465 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52656 "Found 5 new test failures: http/tests/contentextensions/async-xhr-onerror.html imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11230 "Found 1 new test failure: http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68643 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41518 "Found 4 new test failures: http/tests/security/contentSecurityPolicy/connect-src-xmlhttprequest-blocked.html http/tests/security/contentSecurityPolicy/worker-connect-src-blocked.html http/tests/security/contentSecurityPolicy/worker-multiple-csp-headers.html http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33284 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38198 "Found 3 new test failures: imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14138 "Found 8 new test failures: http/tests/security/contentSecurityPolicy/connect-src-xmlhttprequest-blocked.html http/tests/security/contentSecurityPolicy/worker-connect-src-blocked.html http/tests/security/contentSecurityPolicy/worker-multiple-csp-headers.html http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html http/tests/websocket/tests/hybi/client-close-2.html imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60031 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14479 "Found 8 new test failures: http/tests/security/contentSecurityPolicy/connect-src-xmlhttprequest-blocked.html http/tests/security/contentSecurityPolicy/worker-connect-src-blocked.html http/tests/security/contentSecurityPolicy/worker-multiple-csp-headers.html http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9530 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13925 "Found 8 new test failures: http/tests/security/contentSecurityPolicy/connect-src-xmlhttprequest-blocked.html http/tests/security/contentSecurityPolicy/worker-connect-src-blocked.html http/tests/security/contentSecurityPolicy/worker-multiple-csp-headers.html http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59975 "Found 9 new test failures: http/tests/contentextensions/async-xhr-onerror.html http/tests/security/contentSecurityPolicy/connect-src-xmlhttprequest-blocked.html http/tests/security/contentSecurityPolicy/worker-connect-src-blocked.html http/tests/security/contentSecurityPolicy/worker-multiple-csp-headers.html http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60250 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7877 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1524 "Found 8 new test failures: http/tests/security/contentSecurityPolicy/connect-src-xmlhttprequest-blocked.html http/tests/security/contentSecurityPolicy/worker-connect-src-blocked.html http/tests/security/contentSecurityPolicy/worker-multiple-csp-headers.html http/tests/security/isolatedWorld/bypass-main-world-csp-for-xhr.html imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-connect-src-blocked.sub.html imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->