### PR TITLE
IPC stream sync message send hangs sometimes when using NotStreamEncodableReply

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -221,9 +221,11 @@ bool StreamServerConnection::dispatchStreamMessage(Decoder&& decoder, StreamMess
         return false;
     }
     WakeUpClient result = WakeUpClient::No;
-    if (decoder.isSyncMessage())
+    if (decoder.isSyncMessage()) {
         result = m_buffer.releaseAll();
-    else
+        if (m_syncReplyToDispatch)
+            m_connection->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTFMove(m_syncReplyToDispatch)));
+    } else
         result = m_buffer.release(decoder.currentBufferOffset());
     if (result == WakeUpClient::Yes)
         m_clientWaitSemaphore.signal();

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -135,6 +135,7 @@ private:
     Deque<UniqueRef<Decoder>> m_outOfStreamMessages WTF_GUARDED_BY_LOCK(m_outOfStreamMessagesLock);
 
     bool m_isDispatchingStreamMessage { false };
+    std::unique_ptr<IPC::Encoder> m_syncReplyToDispatch;
     Lock m_receiversLock;
     using ReceiversMap = HashMap<std::pair<uint8_t, uint64_t>, Ref<StreamMessageReceiver>>;
     ReceiversMap m_receivers WTF_GUARDED_BY_LOCK(m_receiversLock);
@@ -165,9 +166,16 @@ void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequest
         }
     }
     auto encoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());
-
     (encoder.get() << ... << std::forward<Arguments>(arguments));
-    m_connection->sendSyncReply(WTFMove(encoder));
+    if (m_isDispatchingStreamMessage) {
+        // Send sync reply only after releasing the buffer. Otherwise client might receive the message before server
+        // releases the buffer. Client would the send a new message, and release would happen only after.
+        m_syncReplyToDispatch = encoder.moveToUniquePtr();
+    } else {
+        // Asynchronously replying from the current thread is supported. Note: This is not thread safe,
+        // as any other thread might execute before the buffer release.
+        m_connection->sendSyncReply(WTFMove(encoder));
+    }
 }
 
 template<typename T, typename... Arguments>

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -98,6 +98,16 @@ void IPCStreamTester::syncMessageEmptyReply(uint32_t, CompletionHandler<void()>&
     completionHandler();
 }
 
+void IPCStreamTester::syncMessage(uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
+{
+    completionHandler(value);
+}
+
+void IPCStreamTester::syncMessageNotStreamEncodableReply(uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
+{
+    completionHandler(value);
+}
+
 void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int32_t)>&& completionHandler)
 {
     if (!value) {
@@ -110,6 +120,10 @@ void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int3
 void IPCStreamTester::asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
     completionHandler(value + 1);
+}
+
+void IPCStreamTester::emptyMessage()
+{
 }
 
 #if USE(FOUNDATION)

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -58,11 +58,14 @@ private:
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
 
     // Messages.
+    void syncMessage(uint32_t value, CompletionHandler<void(uint32_t)>&&);
+    void syncMessageNotStreamEncodableReply(uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(std::optional<WebCore::SharedMemory::Handle>&&)>&&);
     void syncMessageEmptyReply(uint32_t, CompletionHandler<void()>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);
     void checkAutoreleasePool(CompletionHandler<void(int32_t)>&&);
     void asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&&);
+    void emptyMessage();
 
     const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     const Ref<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -23,12 +23,15 @@
 #if ENABLE(IPC_TESTING_API)
 
 messages -> IPCStreamTester NotRefCounted Stream {
+    SyncMessage(uint32_t value) -> (uint32_t sameValue) Synchronous
+    SyncMessageNotStreamEncodableReply(uint32_t value) -> (uint32_t sameValue) Synchronous NotStreamEncodableReply
     SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (std::optional<WebCore::SharedMemory::Handle> handle) Synchronous NotStreamEncodableReply
     SyncMessageEmptyReply(uint32_t value) -> () Synchronous
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous
 
     CheckAutoreleasePool() -> (int32_t previousUseCount) Synchronous
     AsyncPing(uint32_t value) -> (uint32_t nextValue)
+    EmptyMessage()
 }
 
 #endif


### PR DESCRIPTION
#### efa2afee8f4a050d542c6ab8a881f5f0714f2165
<pre>
IPC stream sync message send hangs sometimes when using NotStreamEncodableReply
<a href="https://bugs.webkit.org/show_bug.cgi?id=279188">https://bugs.webkit.org/show_bug.cgi?id=279188</a>
<a href="https://rdar.apple.com/133004320">rdar://133004320</a>

Reviewed by Simon Fraser.

Normal stream IPC sync message reply protocol is that the reply would be
written to the beginning of the message buffer and the whole buffer
would be released to the client.

In case of NotStreamEncodableReply, the buffer would be released to the
client but the out of stream (OOS) message would be sent via
IPC::Connection. This would be done to support replying with
kernel-transferred objects.

There was be a race condition with the implementation, where the OOS
message would be sent by the server and received by the client before
the server would continue. This would cause the client to write the
subsequent messages to the unexpected index of the message buffer. Once
the server would continue, it would release the message buffer to the
client, overwriting the clients index values.

Fix by first releasing the buffer to the client and then sending the OOS
message.

* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessage):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendSyncReply):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncMessage):
(WebKit::IPCStreamTester::syncMessageNotStreamEncodableReply):
(WebKit::IPCStreamTester::emptyMessage):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/283237@main">https://commits.webkit.org/283237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77ec0c654bbbdfbc93d27f641885fe5f983d46e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52658 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14141 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9531 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13927 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59976 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1527 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41834 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->