### PR TITLE
Use smart pointers when accessing Page

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -254,7 +254,7 @@ void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPro
         return;
     }
 
-    if (auto* page = frame->page())
+    if (RefPtr page = frame->page())
         resultAsString = page->applyLinkDecorationFiltering(resultAsString, LinkDecorationFilteringTrigger::Paste);
 
     promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(frame->document(), resultAsString, type));

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -72,7 +72,7 @@ ThreadableWebSocketChannel::ThreadableWebSocketChannel() = default;
 std::optional<ThreadableWebSocketChannel::ValidatedURL> ThreadableWebSocketChannel::validateURL(Document& document, const URL& requestedURL)
 {
     ValidatedURL validatedURL { requestedURL, true };
-    if (auto* page = document.page()) {
+    if (RefPtr page = document.page()) {
         if (!page->allowsLoadFromURL(requestedURL, MainFrameMainResource::No))
             return { };
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -553,7 +553,7 @@ void WebXRSession::minimalUpdateRendering()
     if (!sessionDocument)
         return;
 
-    if (auto* page = sessionDocument->page()) {
+    if (RefPtr page = sessionDocument->page()) {
         page->forEachDocument([&] (Document& document) {
             document.serviceRequestVideoFrameCallbacks();
         });

--- a/Source/WebCore/animation/DocumentTimelinesController.cpp
+++ b/Source/WebCore/animation/DocumentTimelinesController.cpp
@@ -85,7 +85,7 @@ void DocumentTimelinesController::updateAnimationsAndSendEvents(ReducedResolutio
     std::optional<FramesPerSecond> defaultTimelineFrameRate;
     // This will hold the frame rate used for this timeline until now.
     std::optional<FramesPerSecond> previousTimelineFrameRate;
-    if (auto* page = m_document.page()) {
+    if (RefPtr page = m_document.page()) {
         defaultTimelineFrameRate = page->preferredRenderingUpdateFramesPerSecond({ Page::PreferredRenderingUpdateOption::IncludeThrottlingReasons });
         previousTimelineFrameRate = page->preferredRenderingUpdateFramesPerSecond({
             Page::PreferredRenderingUpdateOption::IncludeThrottlingReasons,
@@ -168,7 +168,7 @@ void DocumentTimelinesController::updateAnimationsAndSendEvents(ReducedResolutio
 
     // Ensure the timeline updates at the maximum frame rate we've encountered for our animations.
     if (previousMaximumAnimationFrameRate != maximumAnimationFrameRate) {
-        if (auto* page = m_document.page()) {
+        if (RefPtr page = m_document.page()) {
             if (previousTimelineFrameRate != maximumAnimationFrameRate)
                 page->timelineControllerMaximumAnimationFrameRateDidChange(*this);
         }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2698,7 +2698,7 @@ void Node::defaultEventHandler(Event& event)
 #if ENABLE(CONTEXT_MENUS)
     case EventType::contextmenu:
         if (RefPtr frame = document().frame()) {
-            if (auto* page = frame->page())
+            if (RefPtr page = frame->page())
                 page->contextMenuController().handleContextMenuEvent(event);
         }
         break;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -648,7 +648,7 @@ void Editor::pasteAsPlainText(const String& pastingText, bool smartReplace)
         return;
     auto sanitizedText = pastingText;
     Ref document = protectedDocument();
-    if (auto* page = document->page())
+    if (RefPtr page = document->page())
         sanitizedText = page->applyLinkDecorationFiltering(sanitizedText, LinkDecorationFilteringTrigger::Paste);
     target->dispatchEvent(TextEvent::createForPlainTextPaste(document->windowProxy(), WTFMove(sanitizedText), smartReplace));
 }
@@ -1441,7 +1441,7 @@ bool Editor::insertTextWithoutSendingTextEvent(const String& text, bool selectIn
             // then this code should conditionalize revealing selection on whether the ignoreSelectionChanges() bit
             // is set for the newly focused frame.
             if (client() && client()->shouldRevealCurrentSelectionAfterInsertion()) {
-                if (auto* page = document->page())
+                if (RefPtr page = document->page())
                     page->revealCurrentSelection();
             }
         }
@@ -1735,7 +1735,7 @@ void Editor::copyURL(const URL& url, const String& title)
 void Editor::copyURL(const URL& url, const String& title, Pasteboard& pasteboard)
 {
     auto sanitizedURL = url;
-    if (auto* page = document().page())
+    if (RefPtr page = document().page())
         sanitizedURL = page->applyLinkDecorationFiltering(url, LinkDecorationFilteringTrigger::Copy);
 
     PasteboardURL pasteboardURL;

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -872,7 +872,7 @@ bool WebContentReader::readURL(const URL& url, const String& title)
 #endif // PLATFORM(IOS_FAMILY)
 
     auto sanitizedURLString = [&] {
-        if (auto* page = frame->page())
+        if (RefPtr page = frame->page())
             return page->applyLinkDecorationFiltering(url, LinkDecorationFilteringTrigger::Paste);
         return url;
     }().string();

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -107,7 +107,7 @@ HTMLImageElement::~HTMLImageElement()
     document().removeDynamicMediaQueryDependentImage(*this);
     setForm(nullptr);
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-    if (auto* page = document().page())
+    if (RefPtr page = document().page())
         page->removeIndividuallyPlayingAnimationElement(*this);
 #endif
 }
@@ -880,7 +880,7 @@ void HTMLImageElement::setAllowsAnimation(std::optional<bool> allowsAnimation)
         if (auto* renderer = this->renderer())
             renderer->repaint();
 
-        if (auto* page = document().page()) {
+        if (RefPtr page = document().page()) {
             if (allowsAnimation.value_or(false))
                 page->addIndividuallyPlayingAnimationElement(*this);
             else

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -152,7 +152,7 @@ CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&& requ
         options.mode = FetchOptions::Mode::SameOrigin;
 
     if (options.mode != FetchOptions::Mode::NoCors) {
-        if (auto* page = document.page()) {
+        if (RefPtr page = document.page()) {
             if (page->shouldDisableCorsForRequestTo(request.url()))
                 options.mode = FetchOptions::Mode::NoCors;
         }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2106,7 +2106,7 @@ void LocalFrameView::viewportContentsChanged()
         return;
     }
 
-    if (auto* page = m_frame->page())
+    if (RefPtr page = m_frame->page())
         page->updateValidationBubbleStateIfNeeded();
 
     // When the viewport contents changes (scroll, resize, style recalc, layout, ...),
@@ -5873,7 +5873,7 @@ void LocalFrameView::setViewExposedRect(std::optional<FloatRect> viewExposedRect
         tiledBacking->setTiledScrollingIndicatorPosition(m_viewExposedRect ? m_viewExposedRect.value().location() : FloatPoint());
     }
 
-    if (auto* page = m_frame->page()) {
+    if (RefPtr page = m_frame->page()) {
         page->scheduleRenderingUpdate(RenderingUpdateStep::LayerFlush);
         page->pageOverlayController().didChangeViewExposedRect();
     }
@@ -6076,7 +6076,7 @@ float LocalFrameView::pageScaleFactor() const
 
 void LocalFrameView::didStartScrollAnimation()
 {
-    if (auto* page = m_frame->page())
+    if (RefPtr page = m_frame->page())
         page->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
 }
 

--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -69,7 +69,7 @@ void CaretAnimator::serviceCaretAnimation()
 
 void CaretAnimator::scheduleAnimation()
 {
-    if (auto* page = this->page())
+    if (RefPtr page = this->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::CaretAnimation);
 }
 

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -393,7 +393,7 @@ bool HitTestResult::hasEntireImage() const
     if (!innerFrame)
         return false;
 
-    if (auto page = innerFrame->page())
+    if (RefPtr page = innerFrame->page())
         return page->hasLocalDataForURL(imageURL);
 
     return false;
@@ -416,7 +416,7 @@ URL HitTestResult::absoluteImageURL() const
         || is<HTMLObjectElement>(*element)
         || is<SVGImageElement>(*element))) {
         auto imageURL = imageNode->document().completeURL(element->imageSourceURL());
-        if (auto* page = imageNode->document().page())
+        if (RefPtr page = imageNode->document().page())
             return page->applyLinkDecorationFiltering(imageURL, LinkDecorationFilteringTrigger::Unspecified);
         return imageURL;
     }
@@ -447,7 +447,7 @@ URL HitTestResult::absoluteMediaURL() const
 #if ENABLE(VIDEO)
     if (auto* element = mediaElement()) {
         auto sourceURL = element->currentSrc();
-        if (auto* page = element->document().page())
+        if (RefPtr page = element->document().page())
             return page->applyLinkDecorationFiltering(sourceURL, LinkDecorationFilteringTrigger::Unspecified);
         return sourceURL;
     }
@@ -687,7 +687,7 @@ URL HitTestResult::absoluteLinkURL() const
         return { };
 
     auto url = m_innerURLElement->absoluteLinkURL();
-    if (auto* page = m_innerURLElement->document().page())
+    if (RefPtr page = m_innerURLElement->document().page())
         return page->applyLinkDecorationFiltering(url, LinkDecorationFilteringTrigger::Unspecified);
 
     return url;

--- a/Source/WebCore/storage/StorageEventDispatcher.cpp
+++ b/Source/WebCore/storage/StorageEventDispatcher.cpp
@@ -49,7 +49,7 @@ static void dispatchStorageEvents(const String& key, const String& oldValue, con
         if (!storage)
             return;
         // Send events only to our page.
-        if (auto* page = window.page(); !page || !isRelevantPage(*page))
+        if (RefPtr page = window.page(); !page || !isRelevantPage(*page))
             return;
         if (isSourceStorage(*storage))
             return;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1278,7 +1278,7 @@ PostResolutionCallbackDisabler::~PostResolutionCallbackDisabler()
 
         auto& queue = memoryCacheClientCallsResumeQueue();
         for (size_t i = 0; i < queue.size(); ++i) {
-            if (auto* page = queue[i]->page())
+            if (RefPtr page = queue[i]->page())
                 page->setMemoryCacheClientCallsEnabled(true);
         }
         queue.clear();


### PR DESCRIPTION
#### 8536229d1337a28e61aa58fa74bf73899352b96e
<pre>
Use smart pointers when accessing Page
<a href="https://bugs.webkit.org/show_bug.cgi?id=279190">https://bugs.webkit.org/show_bug.cgi?id=279190</a>

Reviewed by Chris Dumez.

Use smart pointers when accessing Page based on
the [alpha.webkit.UncountedLocalVarsChecker] warning.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::getType):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::validateURL):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::minimalUpdateRendering):
* Source/WebCore/animation/DocumentTimelinesController.cpp:
(WebCore::DocumentTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::defaultEventHandler):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::pasteAsPlainText):
(WebCore::Editor::insertTextWithoutSendingTextEvent):
(WebCore::Editor::copyURL):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readURL):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::~HTMLImageElement):
(WebCore::HTMLImageElement::setAllowsAnimation):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createPotentialAccessControlRequest):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::viewportContentsChanged):
(WebCore::LocalFrameView::setViewExposedRect):
(WebCore::LocalFrameView::didStartScrollAnimation):
* Source/WebCore/platform/CaretAnimator.cpp:
(WebCore::CaretAnimator::scheduleAnimation):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::hasEntireImage const):
(WebCore::HitTestResult::absoluteImageURL const):
(WebCore::HitTestResult::absoluteMediaURL const):
(WebCore::HitTestResult::absoluteLinkURL const):
* Source/WebCore/storage/StorageEventDispatcher.cpp:
(WebCore::dispatchStorageEvents):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::PostResolutionCallbackDisabler::~PostResolutionCallbackDisabler):

Canonical link: <a href="https://commits.webkit.org/283255@main">https://commits.webkit.org/283255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff2fb773c36412bd3d8bebb6391ebf395549e43a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52659 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11233 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33287 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15064 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13928 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59977 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition.html imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56826 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60252 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebKitAccessibility:afterAll (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14485 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1526 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40760 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->