### PR TITLE
TestIPC.SimpleConnectionTest.ClearOutgoingMessages crashes the next test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -154,6 +154,8 @@ TEST_F(SimpleConnectionTest, ClearOutgoingMessages)
     // Try a sync send over the second connection, which should
     // fail immediately if the client handle has been released.
     secondServerConnection->sendSync(MockTestSyncMessage(), 0, IPC::Timeout::infinity(), IPC::SendSyncOption::UseFullySynchronousModeForTesting);
+    firstServerConnection->invalidate();
+    secondServerConnection->invalidate();
 }
 
 class ConnectionTest : public testing::Test, protected ConnectionTestBase {


### PR DESCRIPTION
#### f52aaa93744b0289e947da5fe4d6d1671d8258a8
<pre>
TestIPC.SimpleConnectionTest.ClearOutgoingMessages crashes the next test
<a href="https://bugs.webkit.org/show_bug.cgi?id=279192">https://bugs.webkit.org/show_bug.cgi?id=279192</a>
<a href="https://rdar.apple.com/135345130">rdar://135345130</a>

Reviewed by Simon Fraser.

Invalidate the connections at the test end. Otherwise there will be
pending callbacks in the runloop list, and these will be accessing
IPC::ConnectionClient (kMockConnectionClient) that is already
destroyed.

* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_F(SimpleConnectionTest, ClearOutgoingMessages)):

Canonical link: <a href="https://commits.webkit.org/283257@main">https://commits.webkit.org/283257@main</a>
</pre>
