### PR TITLE
RTCRtpEncodingParameters has wrong default values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https-expected.txt
@@ -1,8 +1,8 @@
 
 FAIL addTrack, then sRD(simulcast recv offer) results in simulcast assert_equals: expected 1 but got 2
 FAIL simulcast is not supported for audio assert_equals: expected 1 but got 2
-FAIL sRD(recv simulcast answer) can narrow the simulcast envelope specified by addTransceiver assert_array_equals: expected property 0 to be 2 but got 1 (expected array [2] got [1])
-FAIL sRD(recv simulcast answer) can narrow the simulcast envelope from a previous negotiation assert_array_equals: expected property 0 to be 2 but got 1 (expected array [2] got [1])
+PASS sRD(recv simulcast answer) can narrow the simulcast envelope specified by addTransceiver
+PASS sRD(recv simulcast answer) can narrow the simulcast envelope from a previous negotiation
 FAIL sRD(simulcast offer) can narrow the simulcast envelope from a previous negotiation assert_array_equals: [[SendEncodings]] is not updated in have-remote-offer for reoffers lengths differ, expected array ["foo", "bar"] length 2, got ["foo"] length 1
 FAIL Duplicate rids in sRD(offer) are ignored assert_equals: expected 1 but got 2
 FAIL Choices in rids in sRD(offer) are ignored assert_equals: expected 1 but got 2

--- a/LayoutTests/webrtc/video-getParameters-expected.txt
+++ b/LayoutTests/webrtc/video-getParameters-expected.txt
@@ -1,3 +1,4 @@
 
+PASS default encodings values
 PASS Sender and receiver parameters
 

--- a/LayoutTests/webrtc/video-getParameters.html
+++ b/LayoutTests/webrtc/video-getParameters.html
@@ -9,6 +9,20 @@
     <body>
         <script src ="routines.js"></script>
         <script>
+test(() => {
+    const pc = new RTCPeerConnection;
+    const transceiver = pc.addTransceiver("video", { sendEncodings: [
+        { rid:"a" }, { rid:"b" }, { rid:"c" }
+    ]});
+    const parameters = transceiver.sender.getParameters();
+    assert_equals(parameters.encodings[0].rid, "a");
+    assert_equals(parameters.encodings[1].rid, "b");
+    assert_equals(parameters.encodings[2].rid, "c");
+    assert_equals(parameters.encodings[0].scaleResolutionDownBy, 4);
+    assert_equals(parameters.encodings[1].scaleResolutionDownBy, 2);
+    assert_equals(parameters.encodings[2].scaleResolutionDownBy, 1);
+}, "default encodings values");
+
 var firstConnection, secondConnection;
 promise_test((test) => {
     if (window.testRunner)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -152,7 +152,7 @@ public:
     ExceptionOr<void> removeTrack(RTCRtpSender&);
 
     using AddTransceiverTrackOrKind = std::variant<RefPtr<MediaStreamTrack>, String>;
-    ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiver(AddTransceiverTrackOrKind&&, const RTCRtpTransceiverInit&);
+    ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiver(AddTransceiverTrackOrKind&&, RTCRtpTransceiverInit&&);
 
     // 6.1 Peer-to-peer data API
     ExceptionOr<Ref<RTCDataChannel>> createDataChannel(String&&, RTCDataChannelInit&&);

--- a/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h
@@ -43,9 +43,9 @@ struct RTCRtpEncodingParameters : RTCRtpCodingParameters {
     bool active { false};
     RTCPriorityType priority { RTCPriorityType::Low };
     std::optional<RTCPriorityType> networkPriority;
-    unsigned long maxBitrate { 0 };
-    unsigned long maxFramerate { 0 };
-    double scaleResolutionDownBy { 1 };
+    std::optional<unsigned long> maxBitrate;
+    std::optional<unsigned long> maxFramerate;
+    std::optional<double> scaleResolutionDownBy;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl
@@ -38,5 +38,5 @@
     RTCPriorityType networkPriority;
     unsigned long maxBitrate;
     unsigned long maxFramerate;
-    double scaleResolutionDownBy = 1;
+    double scaleResolutionDownBy;
 };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -116,13 +116,13 @@ GUniquePtr<GstStructure> fromRTCEncodingParameters(const RTCRtpEncodingParameter
         gst_structure_set(rtcParameters.get(), "ssrc", G_TYPE_UINT, parameters.ssrc, nullptr);
 
     if (parameters.maxBitrate)
-        gst_structure_set(rtcParameters.get(), "max-bitrate", G_TYPE_ULONG, parameters.maxBitrate, nullptr);
+        gst_structure_set(rtcParameters.get(), "max-bitrate", G_TYPE_ULONG, *parameters.maxBitrate, nullptr);
 
     if (parameters.maxFramerate)
-        gst_structure_set(rtcParameters.get(), "max-framerate", G_TYPE_ULONG, parameters.maxFramerate, nullptr);
+        gst_structure_set(rtcParameters.get(), "max-framerate", G_TYPE_ULONG, *parameters.maxFramerate, nullptr);
 
     if (parameters.scaleResolutionDownBy)
-        gst_structure_set(rtcParameters.get(), "scale-resolution-down-by", G_TYPE_DOUBLE, parameters.scaleResolutionDownBy, nullptr);
+        gst_structure_set(rtcParameters.get(), "scale-resolution-down-by", G_TYPE_DOUBLE, *parameters.scaleResolutionDownBy, nullptr);
 
     if (parameters.networkPriority)
         gst_structure_set(rtcParameters.get(), "network-priority", G_TYPE_INT, *parameters.networkPriority, nullptr);

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -255,11 +255,11 @@ void updateRTCRtpSendParameters(const RTCRtpSendParameters& parameters, webrtc::
     for (size_t i = 0; i < parameters.encodings.size(); ++i) {
         rtcParameters.encodings[i].active = parameters.encodings[i].active;
         if (parameters.encodings[i].maxBitrate)
-            rtcParameters.encodings[i].max_bitrate_bps = parameters.encodings[i].maxBitrate;
+            rtcParameters.encodings[i].max_bitrate_bps = *parameters.encodings[i].maxBitrate;
         if (parameters.encodings[i].maxFramerate)
-            rtcParameters.encodings[i].max_framerate = parameters.encodings[i].maxFramerate;
+            rtcParameters.encodings[i].max_framerate = *parameters.encodings[i].maxFramerate;
         if (parameters.encodings[i].scaleResolutionDownBy)
-            rtcParameters.encodings[i].scale_resolution_down_by = parameters.encodings[i].scaleResolutionDownBy;
+            rtcParameters.encodings[i].scale_resolution_down_by = *parameters.encodings[i].scaleResolutionDownBy;
         rtcParameters.encodings[i].bitrate_priority = toWebRTCBitRatePriority(parameters.encodings[i].priority);
         if (parameters.encodings[i].networkPriority)
             rtcParameters.encodings[i].network_priority = fromRTCPriorityType(*parameters.encodings[i].networkPriority);


### PR DESCRIPTION
#### cbd18cef463390326c7b022f088ce149f8bd4cbd
<pre>
RTCRtpEncodingParameters has wrong default values
<a href="https://bugs.webkit.org/show_bug.cgi?id=279193">https://bugs.webkit.org/show_bug.cgi?id=279193</a>
<a href="https://rdar.apple.com/135345629">rdar://135345629</a>

Reviewed by Philippe Normand.

We update the WebIDL according the spec.
The default values, in particular scaleResolutionDownBy, triggered an interop issue:
- Safari would return 1 on all layers
- Chrome would return undefined (meaning default value 1,2, 4 is to be applied).
- Firefox would return 1, 2, 4 as defined in the spec.

By updating the WebIDL and binding code to libwebrtc, we align with Chrome.
This includes aligning on failures in LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https.html.
This is probably the safest approach for now, until we reach out consensus within the WebRTC WG.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https-expected.txt:
* LayoutTests/webrtc/video-getParameters-expected.txt:
* LayoutTests/webrtc/video-getParameters.html:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::isAudioTransceiver):
(WebCore::validateSendEncodings):
(WebCore::RTCPeerConnection::addTransceiver):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h:
* Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::fromRTCEncodingParameters):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::updateRTCRtpSendParameters):

Canonical link: <a href="https://commits.webkit.org/283750@main">https://commits.webkit.org/283750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb46c20a67dd8c65e6712e762c9ecb92ec975f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67108 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53821 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12279 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16595 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61292 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61371 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2703 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42292 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43369 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->