### PR TITLE
[WTF] Make CFStringGetCStringPtr the fast path for creating a string from a CFStringRef

### DIFF
--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -40,6 +40,11 @@ String::String(CFStringRef str)
         return;
     }
 
+    if (const char *ptr = CFStringGetCStringPtr(str, kCFStringEncodingISOLatin1)) {
+        m_impl = StringImpl::createFromCString(ptr);
+        return;
+    }
+
     {
         StringBuffer<LChar> buffer(size);
         CFIndex usedBufLen;


### PR DESCRIPTION
<pre>
[WTF] Make CFStringGetCStringPtr the fast path for creating a string from a CFStringRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=279198">https://bugs.webkit.org/show_bug.cgi?id=279198</a>

Reviewed by NOBODY (OOPS!).

CFStringGetCStringPtr should be the fast path and
is used in other implementations of converting
strings in macOS.

* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::String::String): Use CFStringGetCStringPtr for the fast path.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a86f27ba183be66ff1bbfa1c76bfa2f4131518

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52713 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11290 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33339 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38258 "Found 4 new test failures: imported/w3c/web-platform-tests/cookies/name/name-ctl.html imported/w3c/web-platform-tests/cookies/value/value-ctl.html imported/w3c/web-platform-tests/cors/origin.htm imported/w3c/web-platform-tests/xhr/headers-normalize-response.htm (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14211 "Found 6 new test failures: editing/pasteboard/copy-null-characters.html imported/w3c/web-platform-tests/cookies/name/name-ctl.html imported/w3c/web-platform-tests/cookies/value/value-ctl.html imported/w3c/web-platform-tests/cors/origin.htm imported/w3c/web-platform-tests/css/css-grid/subgrid/alignment-in-subgridded-axes-001.html imported/w3c/web-platform-tests/xhr/headers-normalize-response.htm (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15142 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58771 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60095 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14553 "Found 5 new test failures: editing/pasteboard/copy-null-characters.html imported/w3c/web-platform-tests/cookies/name/name-ctl.html imported/w3c/web-platform-tests/cookies/value/value-ctl.html imported/w3c/web-platform-tests/cors/origin.htm imported/w3c/web-platform-tests/xhr/headers-normalize-response.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71389 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64901 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9612 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13988 "Found 5 new test failures: editing/pasteboard/copy-null-characters.html imported/w3c/web-platform-tests/cookies/name/name-ctl.html imported/w3c/web-platform-tests/cookies/value/value-ctl.html imported/w3c/web-platform-tests/cors/origin.htm imported/w3c/web-platform-tests/xhr/headers-normalize-response.htm (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60308 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7938 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1591 "Found 5 new test failures: editing/pasteboard/copy-null-characters.html imported/w3c/web-platform-tests/cookies/name/name-ctl.html imported/w3c/web-platform-tests/cookies/value/value-ctl.html imported/w3c/web-platform-tests/cors/origin.htm imported/w3c/web-platform-tests/xhr/headers-normalize-response.htm (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86668 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15254 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41914 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->