### PR TITLE
[JSC] Make CallArguments tight

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -84,13 +84,13 @@ namespace JSC {
         RegisterID* thisRegister() { return m_argv[0].get(); }
         RegisterID* argumentRegister(unsigned i) { return m_argv[i + 1].get(); }
         unsigned stackOffset() { return -m_argv[0]->index() + CallFrame::headerSizeInRegisters; }
-        unsigned argumentCountIncludingThis() { return m_argv.size() - m_padding; }
+        unsigned argumentCountIncludingThis() { return m_argv.size(); }
         ArgumentsNode* argumentsNode() { return m_argumentsNode; }
 
     private:
         ArgumentsNode* m_argumentsNode;
-        Vector<RefPtr<RegisterID>, 8, UnsafeVectorOverflow> m_argv;
-        unsigned m_padding;
+        std::span<RefPtr<RegisterID>> m_argv;
+        Vector<RefPtr<RegisterID>, 8, UnsafeVectorOverflow> m_allocatedRegisters;
     };
 
     class Variable {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBase.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBase.h
@@ -64,6 +64,8 @@ public:
     // register with a refcount of 0 is considered "available", meaning that
     // the next instruction may overwrite it.
     RegisterID* newTemporary();
+    template<typename Functor>
+    void newTemporaries(size_t count, const Functor&);
 
     void emitLabel(GenericLabel<Traits>&);
     void recordOpcode(typename Traits::OpcodeID);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h
@@ -180,6 +180,18 @@ RegisterID* BytecodeGeneratorBase<Traits>::newTemporary()
     return result;
 }
 
+template<typename Traits>
+template<typename Functor>
+void BytecodeGeneratorBase<Traits>::newTemporaries(size_t count, const Functor& func)
+{
+    reclaimFreeRegisters();
+    for (size_t index = 0; index < count; ++index) {
+        RegisterID* result = newRegister();
+        result->setTemporary();
+        func(result);
+    }
+}
+
 // Adds an anonymous local var slot. To give this slot a name, add it to symbolTable().
 template<typename Traits>
 RegisterID* BytecodeGeneratorBase<Traits>::addVar()


### PR DESCRIPTION
#### ae1e21feca320eee3dcc608c58c4333f0d405e9a
<pre>
[JSC] Make CallArguments tight
<a href="https://bugs.webkit.org/show_bug.cgi?id=279207">https://bugs.webkit.org/show_bug.cgi?id=279207</a>
<a href="https://rdar.apple.com/135354950">rdar://135354950</a>

Reviewed by Keith Miller.

For large function, CallArguments is super frequently used. This patch makes code super tight for performance.
We avoid Vector&apos;s movement and use std::span instead for adjustment.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::CallArguments::argumentCountIncludingThis):
* Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBase.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h:
(JSC::BytecodeGeneratorBase&lt;Traits&gt;::newTemporaries):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::CallArguments::CallArguments):

Canonical link: <a href="https://commits.webkit.org/283232@main">https://commits.webkit.org/283232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d10a5163cc086ab6badcf36eb9c7cb664eb3c549

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16224 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52688 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33315 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14185 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15100 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58729 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71347 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64859 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60004 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60278 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7908 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86626 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9947 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15250 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41872 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->