### PR TITLE
[Part 3] All numeric CSSPrimitiveValue resolvers need to take CSSToLengthConversionData: media queries

### DIFF
--- a/Source/WebCore/css/CSSAspectRatioValue.cpp
+++ b/Source/WebCore/css/CSSAspectRatioValue.cpp
@@ -35,12 +35,13 @@ namespace WebCore {
 
 String CSSAspectRatioValue::customCSSText() const
 {
-    return makeString(m_numeratorValue, " / "_s, m_denominatorValue);
+    return makeString(m_numeratorValue->customCSSText(), " / "_s, m_denominatorValue->customCSSText());
 }
 
 bool CSSAspectRatioValue::equals(const CSSAspectRatioValue& other) const
 {
-    return m_numeratorValue == other.m_numeratorValue && m_denominatorValue == other.m_denominatorValue;
+    return compareCSSValue(m_numeratorValue, other.m_numeratorValue)
+        && compareCSSValue(m_denominatorValue, other.m_denominatorValue);
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/css/CSSAspectRatioValue.h
+++ b/Source/WebCore/css/CSSAspectRatioValue.h
@@ -34,28 +34,28 @@ namespace WebCore {
 
 class CSSAspectRatioValue final : public CSSValue {
 public:
-    static Ref<CSSAspectRatioValue> create(float numeratorValue, float denominatorValue)
+    static Ref<CSSAspectRatioValue> create(Ref<CSSPrimitiveValue> numeratorValue, Ref<CSSPrimitiveValue> denominatorValue)
     {
-        return adoptRef(*new CSSAspectRatioValue(numeratorValue, denominatorValue));
+        return adoptRef(*new CSSAspectRatioValue(WTFMove(numeratorValue), WTFMove(denominatorValue)));
     }
 
     String customCSSText() const;
 
-    float numeratorValue() const { return m_numeratorValue; }
-    float denominatorValue() const { return m_denominatorValue; }
+    const CSSPrimitiveValue& numeratorValue() const { return m_numeratorValue; }
+    const CSSPrimitiveValue& denominatorValue() const { return m_denominatorValue; }
 
     bool equals(const CSSAspectRatioValue&) const;
 
 private:
-    CSSAspectRatioValue(float numeratorValue, float denominatorValue)
+    CSSAspectRatioValue(Ref<CSSPrimitiveValue>&& numeratorValue, Ref<CSSPrimitiveValue>&& denominatorValue)
         : CSSValue(AspectRatioClass)
-        , m_numeratorValue(numeratorValue)
-        , m_denominatorValue(denominatorValue)
+        , m_numeratorValue(WTFMove(numeratorValue))
+        , m_denominatorValue(WTFMove(denominatorValue))
     {
     }
 
-    float m_numeratorValue;
-    float m_denominatorValue;
+    Ref<CSSPrimitiveValue> m_numeratorValue;
+    Ref<CSSPrimitiveValue> m_denominatorValue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -135,9 +135,9 @@ const FeatureSchema& aspectRatio()
             : SizeFeatureSchema("aspect-ratio"_s, FeatureSchema::Type::Range, FeatureSchema::ValueType::Ratio)
         { }
 
-        EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData&) const override
+        EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
         {
-            return evaluateRatioFeature(feature, renderer.contentSize());
+            return evaluateRatioFeature(feature, renderer.contentSize(), conversionData);
         }
     };
 

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
@@ -30,17 +30,14 @@
 #include "LayoutUnit.h"
 
 namespace WebCore {
-
-class RenderElement;
-
 namespace MQ {
 
 EvaluationResult evaluateLengthFeature(const Feature&, LayoutUnit, const CSSToLengthConversionData&);
-EvaluationResult evaluateRatioFeature(const Feature&, FloatSize);
-EvaluationResult evaluateBooleanFeature(const Feature&, bool);
-EvaluationResult evaluateIntegerFeature(const Feature&, int);
-EvaluationResult evaluateNumberFeature(const Feature&, double);
-EvaluationResult evaluateResolutionFeature(const Feature&, float);
+EvaluationResult evaluateRatioFeature(const Feature&, FloatSize, const CSSToLengthConversionData&);
+EvaluationResult evaluateBooleanFeature(const Feature&, bool, const CSSToLengthConversionData&);
+EvaluationResult evaluateIntegerFeature(const Feature&, int, const CSSToLengthConversionData&);
+EvaluationResult evaluateNumberFeature(const Feature&, double, const CSSToLengthConversionData&);
+EvaluationResult evaluateResolutionFeature(const Feature&, float, const CSSToLengthConversionData&);
 EvaluationResult evaluateIdentifierFeature(const Feature&, CSSValueID);
 
 template<typename ConcreteEvaluator>

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -55,7 +55,7 @@ struct BooleanSchema : public FeatureSchema {
 
     EvaluationResult evaluate(const Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        return evaluateBooleanFeature(feature, valueFunction(context));
+        return evaluateBooleanFeature(feature, valueFunction(context), context.conversionData);
     }
 
 private:
@@ -72,7 +72,7 @@ struct IntegerSchema : public FeatureSchema {
 
     EvaluationResult evaluate(const Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        return evaluateIntegerFeature(feature, valueFunction(context));
+        return evaluateIntegerFeature(feature, valueFunction(context), context.conversionData);
     }
 
 private:
@@ -89,7 +89,7 @@ struct NumberSchema : public FeatureSchema {
 
     EvaluationResult evaluate(const Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        return evaluateNumberFeature(feature, valueFunction(context));
+        return evaluateNumberFeature(feature, valueFunction(context), context.conversionData);
     }
 
 private:
@@ -123,7 +123,7 @@ struct RatioSchema : public FeatureSchema {
 
     EvaluationResult evaluate(const Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        return evaluateRatioFeature(feature, valueFunction(context));
+        return evaluateRatioFeature(feature, valueFunction(context), context.conversionData);
     }
 
 private:
@@ -140,7 +140,7 @@ struct ResolutionSchema : public FeatureSchema {
 
     EvaluationResult evaluate(const Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        return evaluateResolutionFeature(feature, valueFunction(context));
+        return evaluateResolutionFeature(feature, valueFunction(context), context.conversionData);
     }
 
 private:


### PR DESCRIPTION
#### cd230facf21b8af25325cc19df473495b3382948
<pre>
[Part 3] All numeric CSSPrimitiveValue resolvers need to take CSSToLengthConversionData: media queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=279208">https://bugs.webkit.org/show_bug.cgi?id=279208</a>

Reviewed by NOBODY (OOPS!).

Pipes conversion data to all the numeric media query resolvers in the same
way we currently pipe it to the length resolver. Also requires keeping the
numerator and denominator of CSSAspectRatioValue as CSSPrimitiveValues to
avoid eager evaluation before the conversion data is available.

* Source/WebCore/css/CSSAspectRatioValue.cpp:
(WebCore::CSSAspectRatioValue::customCSSText const):
(WebCore::CSSAspectRatioValue::equals const):
* Source/WebCore/css/CSSAspectRatioValue.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::aspectRatio):
* Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp:
(WebCore::MQ::evaluateNumberComparison):
(WebCore::MQ::evaluateIntegerComparison):
(WebCore::MQ::evaluateResolutionComparison):
(WebCore::MQ::evaluateRatioComparison):
(WebCore::MQ::evaluateRatioFeature):
(WebCore::MQ::evaluateBooleanFeature):
(WebCore::MQ::evaluateIntegerFeature):
(WebCore::MQ::evaluateNumberFeature):
(WebCore::MQ::evaluateResolutionFeature):
* Source/WebCore/css/query/GenericMediaQueryEvaluator.h:
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::consumeRatioWithSlash):
(WebCore::MQ::FeatureParser::validateFeatureAgainstSchema):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd230facf21b8af25325cc19df473495b3382948

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16228 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16508 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52689 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33316 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38230 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15104 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60066 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14516 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71351 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9573 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13957 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60006 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60280 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7910 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1558 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40800 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->