### PR TITLE
[WTF] Add Malloc::nextCapacity feature and leverage it in InstructionStreamBuffer

### DIFF
--- a/Source/JavaScriptCore/bytecode/InstructionStream.h
+++ b/Source/JavaScriptCore/bytecode/InstructionStream.h
@@ -34,6 +34,10 @@ namespace JSC {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InstructionStream);
 
+struct InstructionStreamBufferMalloc final : public InstructionStreamMalloc {
+    static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity; }
+};
+
 template<typename InstructionType>
 class InstructionStream {
     WTF_MAKE_FAST_ALLOCATED;
@@ -41,7 +45,7 @@ class InstructionStream {
     template<typename> friend class InstructionStreamWriter;
     friend class CachedInstructionStream;
 public:
-    using InstructionBuffer = Vector<uint8_t, 0, UnsafeVectorOverflow, 16, InstructionStreamMalloc>;
+    using InstructionBuffer = Vector<uint8_t, 0, UnsafeVectorOverflow, 16, InstructionStreamBufferMalloc>;
 
     size_t sizeInBytes() const
     {

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1461,13 +1461,13 @@ public:
 
     JSInstructionStream* decode(Decoder& decoder) const
     {
-        Vector<uint8_t, 0, UnsafeVectorOverflow, 16, InstructionStreamMalloc> instructionsVector;
+        Vector<uint8_t, 0, UnsafeVectorOverflow, 16, InstructionStreamBufferMalloc> instructionsVector;
         m_instructions.decode(decoder, instructionsVector);
         return new JSInstructionStream(WTFMove(instructionsVector));
     }
 
 private:
-    CachedVector<uint8_t, 0, UnsafeVectorOverflow, InstructionStreamMalloc> m_instructions;
+    CachedVector<uint8_t, 0, UnsafeVectorOverflow, InstructionStreamBufferMalloc> m_instructions;
 };
 
 class CachedMetadataTable : public CachedObject<UnlinkedMetadataTable> {

--- a/Source/WTF/wtf/DebugHeap.h
+++ b/Source/WTF/wtf/DebugHeap.h
@@ -75,6 +75,8 @@ private:
         static void* tryRealloc(void* p, size_t size) { return debugHeap().realloc(p, size); } \
 \
         static void free(void* p) { debugHeap().free(p); } \
+\
+        static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity / 4 + 1; } \
     }
 
 #define DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Type) \

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -291,6 +291,11 @@ struct FastMalloc {
     }
     
     static void free(void* p) { fastFree(p); }
+
+    static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity)
+    {
+        return capacity + capacity / 4 + 1;
+    }
 };
 
 struct FastCompactMalloc {
@@ -328,6 +333,11 @@ struct FastCompactMalloc {
     }
 
     static void free(void* p) { fastFree(p); }
+
+    static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity)
+    {
+        return capacity + capacity / 4 + 1;
+    }
 };
 
 template<typename T>

--- a/Source/WTF/wtf/SystemMalloc.h
+++ b/Source/WTF/wtf/SystemMalloc.h
@@ -81,6 +81,11 @@ struct SystemMalloc {
     {
         ::free(p);
     }
+
+    static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity)
+    {
+        return capacity + capacity / 4 + 1;
+    }
 };
 
 #if HAVE(PROBABILISTIC_GUARD_MALLOC)

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1217,7 +1217,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 template<FailureAction action>
 bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::expandCapacity(size_t newMinCapacity)
 {
-    return reserveCapacity<action>(std::max(newMinCapacity, std::max(static_cast<size_t>(minCapacity), capacity() + capacity() / 4 + 1)));
+    return reserveCapacity<action>(std::max(newMinCapacity, std::max(static_cast<size_t>(minCapacity), Malloc::nextCapacity(capacity()))));
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>


### PR DESCRIPTION
#### 55b569c1a9f9b2891c3e529c61c2f94f97995109
<pre>
[WTF] Add Malloc::nextCapacity feature and leverage it in InstructionStreamBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=279212">https://bugs.webkit.org/show_bug.cgi?id=279212</a>
<a href="https://rdar.apple.com/135358535">rdar://135358535</a>

Reviewed by Keith Miller.

InstructionStreamBuffer gets shrinked at last. So increasing the size rapidly does not matter. And we know that this is a bottleneck in
BytecodeGenerator. This patch adds Malloc::nextCapacity which controls the next capacity based on the curent capacity. And we use customized
function for InstructionStreamBuffer.

* Source/JavaScriptCore/bytecode/InstructionStream.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedInstructionStream::decode const):
* Source/WTF/wtf/DebugHeap.h:
* Source/WTF/wtf/FastMalloc.h:
(WTF::FastMalloc::nextCapacity):
(WTF::FastCompactMalloc::nextCapacity):
* Source/WTF/wtf/SystemMalloc.h:
(WTF::SystemMalloc::nextCapacity):
* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::expandCapacity):

Canonical link: <a href="https://commits.webkit.org/283231@main">https://commits.webkit.org/283231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1431196a3fc44f3bb6a4c062001e642b9a6a1ca6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65622 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16231 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52696 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11272 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15107 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58736 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71354 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64866 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60009 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60283 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1563 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86633 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9946 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15251 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41879 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->