### PR TITLE
watchOS arm64_32 build broken due to ThreadSafeRefCounted layout

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -337,6 +337,12 @@
 #define UNUSED_FUNCTION __attribute__((unused))
 #endif
 
+/* UNUSED_MEMBER_VARIABLE */
+
+#if !defined(UNUSED_MEMBER_VARIABLE)
+#define UNUSED_MEMBER_VARIABLE __attribute__((unused))
+#endif
+
 /* UNUSED_TYPE_ALIAS */
 
 #if !defined(UNUSED_TYPE_ALIAS)

--- a/Source/WTF/wtf/RefCounted.cpp
+++ b/Source/WTF/wtf/RefCounted.cpp
@@ -21,8 +21,12 @@
 #include "config.h"
 #include <wtf/RefCounted.h>
 
+#include <wtf/ThreadSafeRefCounted.h>
+
 namespace WTF {
 
 bool RefCountedBase::areThreadingChecksEnabledGlobally { false };
+
+static_assert(sizeof(RefCountedBase) == sizeof(ThreadSafeRefCountedBase));
 
 }

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -107,6 +107,12 @@ protected:
 private:
     mutable std::atomic<unsigned> m_refCount { 1 };
 
+#if ASSERT_ENABLED
+    // Match the layout of RefCounted, which has flag bits for threading checks.
+    UNUSED_MEMBER_VARIABLE bool m_unused1;
+    UNUSED_MEMBER_VARIABLE bool m_unused2;
+#endif
+
 #if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
     bool deletionHasEnded() const;
 
@@ -116,6 +122,8 @@ private:
         Yes = 0xFEEDB0BA
     };
     mutable std::atomic<IsAllocatedMemory> m_isAllocatedMemory { IsAllocatedMemory::Yes };
+    // Match the layout of RefCounted.
+    UNUSED_MEMBER_VARIABLE bool m_unused3;
 #endif
 };
 


### PR DESCRIPTION
#### 02f9d93edf29a6339953ecec4dd49ff98cc3dd41
<pre>
watchOS arm64_32 build broken due to ThreadSafeRefCounted layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=279227">https://bugs.webkit.org/show_bug.cgi?id=279227</a>
<a href="https://rdar.apple.com/problem/135371304">rdar://problem/135371304</a>

Reviewed by Alex Christensen.

With assertions enabled, WTF::RefCounted has m_isOwnedByMainThread,
m_areThreadingChecksEnabled, and m_adoptionIsRequired boolean fields
which implement runtime assertion checks. On platforms with 8-byte
pointers, these are packed in to the object without affecting the
overall size of the class, but on arm64_32 they make it a byte larger.
This causes a GeneratedSerializers.mm assertion which compares the sizes
of WTF::ThreadSafeRefCounted and WTF::RefCounted to fail:

    error: static assertion failed due to requirement &apos;sizeof(ShouldBeSameSizeAsThreadSafeDataBufferImpl) == sizeof(WebCore::ThreadSafeDataBufferImpl)&apos;
     31638 |     static_assert(sizeof(ShouldBeSameSizeAsThreadSafeDataBufferImpl) == sizeof(WebCore::ThreadSafeDataBufferImpl));
    GeneratedSerializers.mm:31638:70: note: expression evaluates to &apos;28 == 24&apos;
     31638 |     static_assert(sizeof(ShouldBeSameSizeAsThreadSafeDataBufferImpl) == sizeof(WebCore::ThreadSafeDataBufferImpl));

To fix this without teaching IPC serializers about the different
implementations of refcounting, pad ThreadSafeRefCounted with the same
bool fields to get the expected layout.

* Source/WTF/wtf/Compiler.h: Add UNUSED_MEMBER_VARIABLE (unlike
  WK_UNUSED_INSTANCE_VARIABLE, it it not disabled in some API/SPI
  headers)
* Source/WTF/wtf/RefCounted.cpp:
* Source/WTF/wtf/ThreadSafeRefCounted.h:

Canonical link: <a href="https://commits.webkit.org/283247@main">https://commits.webkit.org/283247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e5b1ab5b6ba9cdcc598e53d3cbec384e9579a6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16306 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11318 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56858 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15182 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58811 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71429 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/64941 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9652 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56924 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7963 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86708 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15262 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41954 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->