### PR TITLE
Omitted left | right value of text-emphasis-position defaults to right

### DIFF
--- a/LayoutTests/fast/repaint/text-emphasis-h.html
+++ b/LayoutTests/fast/repaint/text-emphasis-h.html
@@ -15,14 +15,14 @@
     <div style="-webkit-text-emphasis: 'm';">
         1111
     </div>
-    <div style="-webkit-text-emphasis: 'm'; -webkit-text-emphasis-position: under;">
+    <div style="-webkit-text-emphasis: 'm'; text-emphasis-position: over left;">
         1111
     </div>
 
     <div style="-webkit-writing-mode: vertical-rl; -webkit-text-emphasis: 'm';">
         1111
     </div>
-    <div style="-webkit-writing-mode: vertical-rl; -webkit-text-emphasis: 'm'; -webkit-text-emphasis-position: under;">
+    <div style="-webkit-writing-mode: vertical-rl; -webkit-text-emphasis: 'm'; text-emphasis-position: over left">
         1111
     </div>
 </div>

--- a/LayoutTests/fast/text/emphasis-vertical-over-right-expected.html
+++ b/LayoutTests/fast/text/emphasis-vertical-over-right-expected.html
@@ -3,9 +3,9 @@
 <head>
 </head>
 <body>
-This test is testing that when text is in a vertical writing mode, the "under" and "left over" values of the
+This test is testing that when text is in a vertical writing mode, the "under" and "right over" values of the
 CSS text-emphasis-position property act the same
-<div style="-webkit-writing-mode: vertical-lr; -webkit-text-emphasis-style: filled dot; -webkit-text-emphasis-position: under;">Demo String</div>
+<div style="-webkit-writing-mode: vertical-lr; -webkit-text-emphasis-style: filled dot; -webkit-text-emphasis-position: right over;">Demo String</div>
 </body>
 </html>
 

--- a/LayoutTests/fast/text/emphasis-vertical-over-right.html
+++ b/LayoutTests/fast/text/emphasis-vertical-over-right.html
@@ -3,9 +3,9 @@
 <head>
 </head>
 <body>
-This test is testing that when text is in a vertical writing mode, the "under" and "left over" values of the
+This test is testing that when text is in a vertical writing mode, the "under" and "right over" values of the
 CSS text-emphasis-position property act the same
-<div style="-webkit-writing-mode: vertical-lr; -webkit-text-emphasis-style: filled dot; -webkit-text-emphasis-position: left over;">Demo String</div>
+<div style="-webkit-writing-mode: vertical-lr; -webkit-text-emphasis-style: filled dot; -webkit-text-emphasis-position: under;">Demo String</div>
 </body>
 </html>
 

--- a/LayoutTests/fast/text/emphasis-vertical.html
+++ b/LayoutTests/fast/text/emphasis-vertical.html
@@ -16,7 +16,7 @@
 </style>
 
 <div>
-    せっかく見つけたすばらしい記事<span style="-webkit-text-emphasis: '@';">がどこにあったか忘れてしま</span>った経験はありますか<span style="-webkit-text-emphasis: '*'; -webkit-text-emphasis-position: under;">ならタイトルとアドレスだけでなく、</span>訪問したウェブページのコンテンツからも検索することができます。
+    せっかく見つけたすばらしい記事<span style="-webkit-text-emphasis: '@';">がどこにあったか忘れてしま</span>った経験はありますか<span style="-webkit-text-emphasis: '*'; -webkit-text-emphasis-position: under left;">ならタイトルとアドレスだけでなく、</span>訪問したウェブページのコンテンツからも検索することができます。
 </div>
 
 <div>
@@ -28,5 +28,5 @@
 </div>
 
 <div style="line-height: 2;">
-    せっかく見つけたすばらしい記事<span style="-webkit-text-emphasis: filled;">がどこにあったか忘れてしま</span>った経験はありますか<span style="-webkit-text-emphasis: open; -webkit-text-emphasis-position: under;">ならタイトルとアドレスだけでなく、</span>訪問したウェブページのコンテンツからも検索することができます。
+    せっかく見つけたすばらしい記事<span style="-webkit-text-emphasis: filled;">がどこにあったか忘れてしま</span>った経験はありますか<span style="-webkit-text-emphasis: open; -webkit-text-emphasis-position: under left;">ならタイトルとアドレスだけでなく、</span>訪問したウェブページのコンテンツからも検索することができます。
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-default-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-default-001-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>text-emphasis-position default values</title>
+<style>
+p {
+	border: solid silver;
+	text-emphasis: dot;
+	margin: 0.5em;
+	text-emphasis-position: over right;
+}
+
+div {
+	float: left;
+	margin: 0.5em;
+}
+</style>
+
+<div style="writing-mode: horizontal-tb">
+	<p style="text-emphasis-position: over right">text
+	<p style="text-emphasis-position: over right">text
+	<p style="text-emphasis-position: under right">text
+</div>
+
+<div style="writing-mode: vertical-rl">
+	<p>text
+	<p>text
+	<p>text
+</div>
+
+<div style="writing-mode: vertical-lr">
+	<p>text
+	<p>text
+	<p>text
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-default-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-default-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>text-emphasis-position default values</title>
+<link rel="help" href="https://www.w3.org/TR/css-text-decor/#text-emphasis-position-property">
+<link rel="match" href="text-emphasis-position-default-001-ref.html">
+<style>
+p {
+	border: solid silver;
+	text-emphasis: dot;
+	margin: 0.5em;
+}
+
+div {
+	float: left;
+	margin: 0.5em;
+}
+</style>
+
+<div style="writing-mode: horizontal-tb">
+	<p>text
+	<p style="text-emphasis-position: over">text
+	<p style="text-emphasis-position: under">text
+</div>
+
+<div style="writing-mode: vertical-rl">
+	<p>text
+	<p style="text-emphasis-position: over">text
+	<p style="text-emphasis-position: under">text
+</div>
+
+<div style="writing-mode: vertical-lr">
+	<p>text
+	<p style="text-emphasis-position: over">text
+	<p style="text-emphasis-position: under">text
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -566,12 +566,12 @@ std::pair<InlineLayoutUnit, InlineLayoutUnit> InlineFormattingUtils::textEmphasi
     // Normally we resolve visual -> logical values at pre-layout time, but emphaisis values are not part of the general box geometry.
     auto hasAboveTextEmphasis = false;
     auto hasUnderTextEmphasis = false;
-    if (style.isHorizontalWritingMode()) {
-        hasAboveTextEmphasis = emphasisPosition.contains(TextEmphasisPosition::Over);
-        hasUnderTextEmphasis = !hasAboveTextEmphasis && emphasisPosition.contains(TextEmphasisPosition::Under);
+    if (style.isVerticalWritingMode()) {
+        hasAboveTextEmphasis = !emphasisPosition.contains(TextEmphasisPosition::Left);
+        hasUnderTextEmphasis = !hasAboveTextEmphasis;
     } else {
-        hasAboveTextEmphasis = emphasisPosition.contains(TextEmphasisPosition::Right) || emphasisPosition == TextEmphasisPosition::Over;
-        hasUnderTextEmphasis = !hasAboveTextEmphasis && (emphasisPosition.contains(TextEmphasisPosition::Left) || emphasisPosition == TextEmphasisPosition::Under);
+        hasAboveTextEmphasis = !emphasisPosition.contains(TextEmphasisPosition::Under);
+        hasUnderTextEmphasis = !hasAboveTextEmphasis;
     }
 
     if (!hasAboveTextEmphasis && !hasUnderTextEmphasis)

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -2097,24 +2097,10 @@ std::optional<bool> RenderText::emphasisMarkExistsAndIsAbove(const RenderText& r
     if (style.textEmphasisMark() == TextEmphasisMark::None)
         return std::nullopt;
 
-    const OptionSet<TextEmphasisPosition> horizontalMask { TextEmphasisPosition::Left, TextEmphasisPosition::Right };
-
     auto emphasisPosition = style.textEmphasisPosition();
-    auto emphasisPositionHorizontalValue = emphasisPosition & horizontalMask;
-    ASSERT(!((emphasisPosition & TextEmphasisPosition::Over) && (emphasisPosition & TextEmphasisPosition::Under)));
-    ASSERT(emphasisPositionHorizontalValue != horizontalMask);
-
-    bool isAbove = false;
-    if (!emphasisPositionHorizontalValue)
-        isAbove = emphasisPosition.contains(TextEmphasisPosition::Over);
-    else if (style.isHorizontalWritingMode())
-        isAbove = emphasisPosition.contains(TextEmphasisPosition::Over);
-    else
-        isAbove = emphasisPositionHorizontalValue == TextEmphasisPosition::Right;
-
-    if ((style.isHorizontalWritingMode() && (emphasisPosition & TextEmphasisPosition::Under))
-        || (!style.isHorizontalWritingMode() && (emphasisPosition & TextEmphasisPosition::Left)))
-        return isAbove; // Ruby text is always over, so it cannot suppress emphasis marks under.
+    bool isAbove = !emphasisPosition.contains(TextEmphasisPosition::Under);
+    if (style.isVerticalWritingMode())
+        isAbove = !emphasisPosition.contains(TextEmphasisPosition::Left);
 
     auto findRubyAnnotation = [&]() -> RenderBlockFlow* {
         for (auto* baseCandidate = renderer.parent(); baseCandidate; baseCandidate = baseCandidate->parent()) {


### PR DESCRIPTION
#### 29304d7c911953125d52935c1281063b7157d707
<pre>
Omitted left | right value of text-emphasis-position defaults to right
<a href="https://bugs.webkit.org/show_bug.cgi?id=279217">https://bugs.webkit.org/show_bug.cgi?id=279217</a>
<a href="https://rdar.apple.com/problem/135366186">rdar://problem/135366186</a>

Reviewed by Alan Baradlay.

If [ left | right ] is omitted from text-emphasis-position, it defaults to right.
<a href="https://www.w3.org/TR/css-text-decor/#text-emphasis-position-property">https://www.w3.org/TR/css-text-decor/#text-emphasis-position-property</a>

* LayoutTests/fast/repaint/text-emphasis-h.html:
* LayoutTests/fast/text/emphasis-vertical-over-right-expected.html:
* LayoutTests/fast/text/emphasis-vertical-over-right.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-default-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-default-001.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::textEmphasisForInlineBox):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::emphasisMarkExistsAndIsAbove):

Canonical link: <a href="https://commits.webkit.org/283275@main">https://commits.webkit.org/283275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a4441fb8c8dc448df63eb63596d9c737fbce55b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52786 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11367 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14294 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15244 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60108 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1670 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40940 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->