### PR TITLE
AX: iframe within inert, hidden element is exposed to ATs

### DIFF
--- a/LayoutTests/accessibility/iframe-content-inert-expected.txt
+++ b/LayoutTests/accessibility/iframe-content-inert-expected.txt
@@ -1,0 +1,15 @@
+This test ensures that iframe content is ignored when the iframe has an inert tag.
+
+PASS: iframeWebArea.isIgnored === false
+PASS: iframeButton1.isIgnored === false
+PASS: iframeButton2.isIgnored === false
+
+document.getElementById('iframe1').setAttribute('inert', '');
+PASS: !body.childAtIndex(0) === true
+PASS: !accessibilityController.accessibleElementById('frame-button-1') === true
+PASS: !accessibilityController.accessibleElementById('frame-button-2') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/iframe-content-inert.html
+++ b/LayoutTests/accessibility/iframe-content-inert.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body id="body" role="group">
+
+<iframe id="iframe1" onload="runTest()" srcdoc="<body>
+    <button id='frame-button-1'>Click me</button>
+    <iframe id='iframe2' src='resources/iframe-button.html'></iframe>
+</body>"></iframe>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test ensures that iframe content is ignored when the iframe has an inert tag.\n\n";
+var iframeWebArea, iframeButton1, iframeButton2, body;
+
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    body = accessibilityController.accessibleElementById("body")
+    iframeWebArea = body.childAtIndex(0);
+    iframeButton1 = accessibilityController.accessibleElementById("frame-button-1");
+
+    setTimeout(async function() {
+        // Wait for the second iframe to load.
+        await waitFor(() => {
+            iframeButton2 = accessibilityController.accessibleElementById("frame-button-2");
+            return !!iframeButton2;
+        });
+
+        output += expect("iframeWebArea.isIgnored", "false");
+        output += expect("iframeButton1.isIgnored", "false");
+        output += expect("iframeButton2.isIgnored", "false");
+
+        output += `\n${evalAndReturn("document.getElementById('iframe1').setAttribute('inert', '');")}`;
+
+        // We expect the iframe's web area to be removed from the accessibility tree when it has an inert tag
+        output += await expectAsync("!body.childAtIndex(0)", "true");
+        output += await expectAsync("!accessibilityController.accessibleElementById('frame-button-1')", "true");
+        output += await expectAsync("!accessibilityController.accessibleElementById('frame-button-2')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/iframe-content-visibility-expected.txt
+++ b/LayoutTests/accessibility/iframe-content-visibility-expected.txt
@@ -1,0 +1,15 @@
+This test ensures that iframe content is ignored when the iframe has its visibility set to hidden.
+
+PASS: iframeWebArea.isIgnored === false
+PASS: iframeButton1.isIgnored === false
+PASS: iframeButton2.isIgnored === false
+
+document.getElementById('iframe1').style.visibility = 'hidden';
+PASS: !body.childAtIndex(0) === true
+PASS: !accessibilityController.accessibleElementById('frame-button-1') === true
+PASS: !accessibilityController.accessibleElementById('frame-button-2') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/iframe-content-visibility.html
+++ b/LayoutTests/accessibility/iframe-content-visibility.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body id="body" role="group">
+
+<iframe id="iframe1" onload="runTest()" srcdoc="<body>
+    <button id='frame-button-1'>Click me</button>
+    <iframe id='iframe2' src='resources/iframe-button.html'></iframe>
+</body>"></iframe>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test ensures that iframe content is ignored when the iframe has its visibility set to hidden.\n\n";
+var iframeWebArea, iframeButton1, iframeButton2, body;
+
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    body = accessibilityController.accessibleElementById("body")
+    iframeWebArea = body.childAtIndex(0);
+    iframeButton1 = accessibilityController.accessibleElementById("frame-button-1");
+
+    setTimeout(async function() {
+        // Wait for the second iframe to load.
+        await waitFor(() => {
+            iframeButton2 = accessibilityController.accessibleElementById("frame-button-2");
+            return !!iframeButton2;
+        });
+
+        output += expect("iframeWebArea.isIgnored", "false");
+        output += expect("iframeButton1.isIgnored", "false");
+        output += expect("iframeButton2.isIgnored", "false");
+
+        output += `\n${evalAndReturn("document.getElementById('iframe1').style.visibility = 'hidden';")}`;
+
+        // We expect the iframe's web area to be removed from the accessibility tree when it has a visibility: hidden style.
+        output += await expectAsync("!body.childAtIndex(0)", "true");
+        output += await expectAsync("!accessibilityController.accessibleElementById('frame-button-1')", "true");
+        output += await expectAsync("!accessibilityController.accessibleElementById('frame-button-2')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/resources/iframe-button.html
+++ b/LayoutTests/accessibility/resources/iframe-button.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<button id="frame-button-2">Click me</button>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3992,7 +3992,7 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
     if (useParentData && (m_isIgnoredFromParentData.isAXHidden || m_isIgnoredFromParentData.isPresentationalChildOfAriaRole))
         return AccessibilityObjectInclusion::IgnoreObject;
 
-    if (isARIAHidden())
+    if (isARIAHidden() || isWithinHiddenWebArea())
         return AccessibilityObjectInclusion::IgnoreObject;
 
     bool ignoreARIAHidden = isFocused();
@@ -4006,6 +4006,22 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
         return AccessibilityObjectInclusion::IncludeObject;
 
     return accessibilityPlatformIncludesObject();
+}
+
+bool AccessibilityObject::isWithinHiddenWebArea() const
+{
+    RefPtr webArea = this->containingWebArea();
+    CheckedPtr renderView = webArea ? dynamicDowncast<RenderView>(webArea->renderer()) : nullptr;
+    CheckedPtr frameRenderer = renderView ? renderView->frameView().frame().ownerRenderer() : nullptr;
+    while (frameRenderer) {
+        if (frameRenderer->style().usedVisibility() != Visibility::Visible || frameRenderer->style().effectiveInert())
+            return true;
+
+        renderView = frameRenderer->document().renderView();
+        frameRenderer = renderView ? renderView->frameView().frame().ownerRenderer() : nullptr;
+    }
+    return false;
+
 }
     
 bool AccessibilityObject::isIgnored() const
@@ -4411,6 +4427,14 @@ bool AccessibilityObject::ignoredByRowAncestor() const
     });
 
     return ancestor && ancestor->isTableRow();
+}
+
+AccessibilityObject* AccessibilityObject::containingWebArea() const
+{
+    CheckedPtr frameView = documentFrameView();
+    CheckedPtr cache = axObjectCache();
+    RefPtr root = cache ? dynamicDowncast<AccessibilityScrollView>(cache->getOrCreate(frameView.get())) : nullptr;
+    return root ? root->webAreaObject() : nullptr;
 }
 
 namespace Accessibility {

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -745,6 +745,8 @@ public:
 
     const AccessibilityScrollView* ancestorAccessibilityScrollView(bool includeSelf) const;
     virtual AccessibilityObject* webAreaObject() const { return nullptr; }
+    bool isWithinHiddenWebArea() const;
+    AccessibilityObject* containingWebArea() const;
 
     void clearIsIgnoredFromParentData() { m_isIgnoredFromParentData = { }; }
     void setIsIgnoredFromParentDataForChild(AccessibilityObject*);

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -137,7 +137,6 @@ public:
     
     String secureFieldValue() const override;
     void labelText(Vector<AccessibilityText>&) const override;
-
 protected:
     explicit AccessibilityRenderObject(RenderObject&);
     explicit AccessibilityRenderObject(Node&);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -147,6 +147,15 @@ void AccessibilityScrollView::updateScrollbars()
     if (!scrollView)
         return;
 
+    if (isWithinHiddenWebArea()) {
+        removeChildScrollbar(m_horizontalScrollbar.get());
+        m_horizontalScrollbar = nullptr;
+
+        removeChildScrollbar(m_verticalScrollbar.get());
+        m_verticalScrollbar = nullptr;
+        return;
+    }
+
     if (scrollView->horizontalScrollbar() && !m_horizontalScrollbar)
         m_horizontalScrollbar = addChildScrollbar(scrollView->horizontalScrollbar());
     else if (!scrollView->horizontalScrollbar() && m_horizontalScrollbar) {
@@ -168,6 +177,9 @@ void AccessibilityScrollView::removeChildScrollbar(AccessibilityObject* scrollba
     if (pos != notFound) {
         m_children[pos]->detachFromParent();
         m_children.remove(pos);
+
+        if (CheckedPtr cache = axObjectCache())
+            cache->remove(scrollbar->objectID());
     }
 }
     

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -44,6 +44,7 @@ public:
     virtual ~AccessibilityScrollView();
 
     AccessibilityObject* webAreaObject() const override;
+    void setNeedsToUpdateChildren() override { m_childrenDirty = true; }
 
 private:
     explicit AccessibilityScrollView(ScrollView*);
@@ -66,7 +67,6 @@ private:
     void clearChildren() override;
     AccessibilityObject* accessibilityHitTest(const IntPoint&) const override;
     void updateChildrenIfNecessary() override;
-    void setNeedsToUpdateChildren() override { m_childrenDirty = true; }
     void updateScrollbars();
     void setFocused(bool) override;
     bool canSetFocusAttribute() const override;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -869,7 +869,9 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
         if (visibilityChanged)
             protectedDocument()->invalidateRenderingDependentRegions();
 
-        if (visibilityChanged) {
+        bool inertChanged = m_style.effectiveInert() != newStyle.effectiveInert();
+
+        if (visibilityChanged || inertChanged) {
             Ref document = this->document();
             if (CheckedPtr cache = document->existingAXObjectCache())
                 cache->childrenChanged(checkedParent().get(), this);


### PR DESCRIPTION
#### 3d864212d2b1150cee5712c950dceac2b52b6b83
<pre>
AX: iframe within inert, hidden element is exposed to ATs
<a href="https://bugs.webkit.org/show_bug.cgi?id=278370">https://bugs.webkit.org/show_bug.cgi?id=278370</a>
<a href="https://rdar.apple.com/134318347">rdar://134318347</a>

Reviewed by Tyler Wilcock.

This patch fixes an issue where iFrames with a style of `visibility: hidden` or the inert attribute,
both of which should hide the element and its children to ATs, fails to hide the iFrame&apos;s children.

To fix this, isIgnored() needs to iterate up the web areas and their iFrame renderers, to check whether
they are non-visible or if they are effectively inert. These properties/styles don&apos;t get passed from
the iFrame&apos;s parent document to the iFrame&apos;s document, so this iteration is necessary.

For the isolated tree to update properly, the children of the iframe need to dirty its subtree. However,
when AXObjectCache::handleChildrenChanged tries to handle a ScrollView (which happens when attributes on
the iFrame element are changed), we bail before dirtying the subtree because scroll views don&apos;t have
nodes nor renderers. To resolve this, this patch adds logic in handleChildrenChanged to propogate
setNeedsToUpdateSubtree and setNeedsToUpdateChildren down to the iFrame&apos;s WebArea.

* LayoutTests/accessibility/iframe-content-inert-expected.txt: Added.
* LayoutTests/accessibility/iframe-content-inert.html: Added.
* LayoutTests/accessibility/iframe-content-visibility-expected.txt: Added.
* LayoutTests/accessibility/iframe-content-visibility.html: Added.
* LayoutTests/accessibility/resources/iframe-button.html: Added.

New tests to test `visibility: hidden`, `inert` style/attribute on iFrames.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleChildrenChanged):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::defaultObjectInclusion const):
(WebCore::AccessibilityObject::webArea const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::shouldWebAreaExposeChildren const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::shouldWebAreaExposeChildren const):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::updateScrollbars):
(WebCore::AccessibilityScrollView::removeChildScrollbar):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/283416@main">https://commits.webkit.org/283416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b2e259b98ec20ea6a2ab68555d924f15665bed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53032 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11614 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60642 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8280 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1919 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41249 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->