### PR TITLE
Rename BlockFlowDirection to FlowDirection

### DIFF
--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -242,11 +242,11 @@ static String counterForSystemCJK(int number, const std::array<UChar, 17>& table
 String CSSCounterStyle::counterForSystemDisclosureClosed(TextFlow flow)
 {
     switch (flow.blockDirection) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         return span(flow.textDirection == TextDirection::LTR ? blackRightPointingSmallTriangle : blackLeftPointingSmallTriangle);
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
         return span(flow.textDirection == TextDirection::LTR ? blackDownPointingSmallTriangle : blackUpPointingSmallTriangle);
     }
     ASSERT_NOT_REACHED();
@@ -256,13 +256,13 @@ String CSSCounterStyle::counterForSystemDisclosureClosed(TextFlow flow)
 String CSSCounterStyle::counterForSystemDisclosureOpen(TextFlow flow)
 {
     switch (flow.blockDirection) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return span(blackDownPointingSmallTriangle);
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return span(blackUpPointingSmallTriangle);
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return span(blackRightPointingSmallTriangle);
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return span(blackLeftPointingSmallTriangle);
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1003,12 +1003,12 @@ inline ScrollAlignment toScrollAlignmentForInlineDirection(std::optional<ScrollL
     switch (position.value_or(ScrollLogicalPosition::Nearest)) {
     case ScrollLogicalPosition::Start: {
         switch (blockFlowDirection) {
-        case BlockFlowDirection::TopToBottom:
-        case BlockFlowDirection::BottomToTop: {
+        case FlowDirection::TopToBottom:
+        case FlowDirection::BottomToTop: {
             return isLTR ? ScrollAlignment::alignLeftAlways : ScrollAlignment::alignRightAlways;
         }
-        case BlockFlowDirection::LeftToRight:
-        case BlockFlowDirection::RightToLeft: {
+        case FlowDirection::LeftToRight:
+        case FlowDirection::RightToLeft: {
             return isLTR ? ScrollAlignment::alignTopAlways : ScrollAlignment::alignBottomAlways;
         }
         default:
@@ -1020,12 +1020,12 @@ inline ScrollAlignment toScrollAlignmentForInlineDirection(std::optional<ScrollL
         return ScrollAlignment::alignCenterAlways;
     case ScrollLogicalPosition::End: {
         switch (blockFlowDirection) {
-        case BlockFlowDirection::TopToBottom:
-        case BlockFlowDirection::BottomToTop: {
+        case FlowDirection::TopToBottom:
+        case FlowDirection::BottomToTop: {
             return isLTR ? ScrollAlignment::alignRightAlways : ScrollAlignment::alignLeftAlways;
         }
-        case BlockFlowDirection::LeftToRight:
-        case BlockFlowDirection::RightToLeft: {
+        case FlowDirection::LeftToRight:
+        case FlowDirection::RightToLeft: {
             return isLTR ? ScrollAlignment::alignBottomAlways : ScrollAlignment::alignTopAlways;
         }
         default:
@@ -1047,13 +1047,13 @@ inline ScrollAlignment toScrollAlignmentForBlockDirection(std::optional<ScrollLo
     switch (position.value_or(ScrollLogicalPosition::Start)) {
     case ScrollLogicalPosition::Start: {
         switch (blockFlowDirection) {
-        case BlockFlowDirection::TopToBottom:
+        case FlowDirection::TopToBottom:
             return ScrollAlignment::alignTopAlways;
-        case BlockFlowDirection::BottomToTop:
+        case FlowDirection::BottomToTop:
             return ScrollAlignment::alignBottomAlways;
-        case BlockFlowDirection::LeftToRight:
+        case FlowDirection::LeftToRight:
             return ScrollAlignment::alignLeftAlways;
-        case BlockFlowDirection::RightToLeft:
+        case FlowDirection::RightToLeft:
             return ScrollAlignment::alignRightAlways;
         default:
             ASSERT_NOT_REACHED();
@@ -1064,13 +1064,13 @@ inline ScrollAlignment toScrollAlignmentForBlockDirection(std::optional<ScrollLo
         return ScrollAlignment::alignCenterAlways;
     case ScrollLogicalPosition::End: {
         switch (blockFlowDirection) {
-        case BlockFlowDirection::TopToBottom:
+        case FlowDirection::TopToBottom:
             return ScrollAlignment::alignBottomAlways;
-        case BlockFlowDirection::BottomToTop:
+        case FlowDirection::BottomToTop:
             return ScrollAlignment::alignTopAlways;
-        case BlockFlowDirection::LeftToRight:
+        case FlowDirection::LeftToRight:
             return ScrollAlignment::alignRightAlways;
-        case BlockFlowDirection::RightToLeft:
+        case FlowDirection::RightToLeft:
             return ScrollAlignment::alignLeftAlways;
         default:
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -129,11 +129,11 @@ bool InlineFormattingUtils::inlineLevelBoxAffectsLineBox(const InlineLevelBox& i
 InlineRect InlineFormattingUtils::flipVisualRectToLogicalForWritingMode(const InlineRect& visualRect, WritingMode writingMode)
 {
     switch (writingModeToBlockFlowDirection(writingMode)) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         return visualRect;
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft: {
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft: {
         // FIXME: While vertical-lr and vertical-rl modes do differ in the ordering direction of line boxes
         // in a block container (see: https://drafts.csswg.org/css-writing-modes/#block-flow)
         // we ignore it for now as RenderBlock takes care of it for us.

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1017,14 +1017,14 @@ void InlineDisplayContentBuilder::collectInkOverflowForTextDecorations(InlineDis
             auto inflatedVisualOverflowRect = [&] {
                 auto inkOverflowRect = displayBox.inkOverflow();
                 switch (writingModeToBlockFlowDirection(writingMode)) {
-                case BlockFlowDirection::TopToBottom:
-                case BlockFlowDirection::BottomToTop:
+                case FlowDirection::TopToBottom:
+                case FlowDirection::BottomToTop:
                     inkOverflowRect.inflate(decorationOverflow.left, decorationOverflow.top, decorationOverflow.right, decorationOverflow.bottom);
                     break;
-                case BlockFlowDirection::LeftToRight:
+                case FlowDirection::LeftToRight:
                     inkOverflowRect.inflate(decorationOverflow.bottom, decorationOverflow.right, decorationOverflow.top, decorationOverflow.left);
                     break;
-                case BlockFlowDirection::RightToLeft:
+                case FlowDirection::RightToLeft:
                     inkOverflowRect.inflate(decorationOverflow.top, decorationOverflow.right, decorationOverflow.bottom, decorationOverflow.left);
                     break;
                 default:
@@ -1170,18 +1170,18 @@ void InlineDisplayContentBuilder::setInlineBoxGeometry(Layout::BoxGeometry& boxG
 InlineRect InlineDisplayContentBuilder::flipLogicalRectToVisualForWritingModeWithinLine(const InlineRect& logicalRect, const InlineRect& lineLogicalRect, WritingMode writingMode) const
 {
     switch (writingModeToBlockFlowDirection(writingMode)) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return logicalRect;
-    case BlockFlowDirection::BottomToTop: {
+    case FlowDirection::BottomToTop: {
         auto bottomOffset = lineLogicalRect.height() - logicalRect.bottom();
         return { bottomOffset, logicalRect.left(), logicalRect.width(), logicalRect.height() };
     }
-    case BlockFlowDirection::LeftToRight: {
+    case FlowDirection::LeftToRight: {
         // Flip content such that the top (visual left) is now relative to the line bottom instead of the line top.
         auto bottomOffset = lineLogicalRect.height() - logicalRect.bottom();
         return { logicalRect.left(), bottomOffset, logicalRect.height(), logicalRect.width() };
     }
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         // See InlineFormattingUtils for more info.
         return { logicalRect.left(), logicalRect.top(), logicalRect.height(), logicalRect.width() };
     default:
@@ -1194,14 +1194,14 @@ InlineRect InlineDisplayContentBuilder::flipLogicalRectToVisualForWritingModeWit
 InlineRect InlineDisplayContentBuilder::flipRootInlineBoxRectToVisualForWritingMode(const InlineRect& rootInlineBoxLogicalRect, WritingMode writingMode) const
 {
     switch (writingModeToBlockFlowDirection(writingMode)) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop: {
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop: {
         auto visualRect = rootInlineBoxLogicalRect;
         visualRect.moveBy({ m_displayLine.left(), m_displayLine.top() });
         return visualRect;
     }
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft: {
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft: {
         // See InlineFormattingUtils for more info.
         auto visualRect = InlineRect { rootInlineBoxLogicalRect.left(), rootInlineBoxLogicalRect.top(), rootInlineBoxLogicalRect.height(), rootInlineBoxLogicalRect.width() };
         visualRect.moveBy({ m_displayLine.left(), m_displayLine.top() });
@@ -1218,12 +1218,12 @@ template <typename BoxType, typename LayoutUnitType>
 void InlineDisplayContentBuilder::setLeftForWritingMode(BoxType& box, LayoutUnitType logicalLeft, WritingMode writingMode) const
 {
     switch (writingModeToBlockFlowDirection(writingMode)) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         box.setLeft(logicalLeft);
         break;
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
         box.setTop(logicalLeft);
         break;
     default:
@@ -1235,12 +1235,12 @@ void InlineDisplayContentBuilder::setLeftForWritingMode(BoxType& box, LayoutUnit
 void InlineDisplayContentBuilder::setRightForWritingMode(InlineDisplay::Box& displayBox, InlineLayoutUnit logicalRight, WritingMode writingMode) const
 {
     switch (writingModeToBlockFlowDirection(writingMode)) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         displayBox.setRight(logicalRight);
         break;
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
         displayBox.setBottom(logicalRight);
         break;
     default:

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -37,11 +37,11 @@ namespace Layout {
 static InlineRect flipLogicalLineRectToVisualForWritingMode(const InlineRect& lineLogicalRect, WritingMode writingMode)
 {
     switch (writingModeToBlockFlowDirection(writingMode)) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         return lineLogicalRect;
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
         // See InlineFormattingUtils for more info.
         return { lineLogicalRect.left(), lineLogicalRect.top(), lineLogicalRect.height(), lineLogicalRect.width() };
     default:

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -55,7 +55,7 @@ FlexLayout::~FlexLayout()
 }
 
 // FIXME: Merge these with the other integration layout functions.
-static inline Layout::BoxGeometry::Edges flexBoxLogicalBorder(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, BlockFlowDirection blockFlowDirection)
+static inline Layout::BoxGeometry::Edges flexBoxLogicalBorder(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, FlowDirection blockFlowDirection)
 {
     UNUSED_PARAM(isLeftToRightInlineDirection);
     UNUSED_PARAM(blockFlowDirection);
@@ -68,7 +68,7 @@ static inline Layout::BoxGeometry::Edges flexBoxLogicalBorder(const RenderBoxMod
     return { { borderLeft, borderRight }, { borderTop, borderBottom } };
 }
 
-static inline Layout::BoxGeometry::Edges flexBoxLogicalPadding(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, BlockFlowDirection blockFlowDirection)
+static inline Layout::BoxGeometry::Edges flexBoxLogicalPadding(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, FlowDirection blockFlowDirection)
 {
     UNUSED_PARAM(isLeftToRightInlineDirection);
     UNUSED_PARAM(blockFlowDirection);
@@ -85,7 +85,7 @@ void FlexLayout::updateFormattingRootGeometryAndInvalidate()
         auto isLeftToRightInlineDirection = flexBoxRenderer.style().isLeftToRightDirection();
         auto blockFlowDirection = writingModeToBlockFlowDirection(flexBoxRenderer.style().writingMode());
 
-        root.setContentBoxWidth(blockFlowDirection == BlockFlowDirection::TopToBottom ? flexBoxRenderer.contentWidth() : flexBoxRenderer.contentHeight());
+        root.setContentBoxWidth(blockFlowDirection == FlowDirection::TopToBottom ? flexBoxRenderer.contentWidth() : flexBoxRenderer.contentHeight());
         root.setPadding(flexBoxLogicalPadding(flexBoxRenderer, isLeftToRightInlineDirection, blockFlowDirection));
         root.setBorder(flexBoxLogicalBorder(flexBoxRenderer, isLeftToRightInlineDirection, blockFlowDirection));
         root.setHorizontalMargin({ });

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -151,14 +151,14 @@ static inline Layout::BoxGeometry::HorizontalEdges horizontalLogicalMargin(const
     return { retainMarginStart ? marginBottom : 0_lu, retainMarginEnd ? marginTop : 0_lu };
 }
 
-static inline Layout::BoxGeometry::VerticalEdges verticalLogicalMargin(const RenderBoxModelObject& renderer, BlockFlowDirection blockFlowDirection)
+static inline Layout::BoxGeometry::VerticalEdges verticalLogicalMargin(const RenderBoxModelObject& renderer, FlowDirection blockFlowDirection)
 {
     switch (blockFlowDirection) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         return { renderer.marginTop(), renderer.marginBottom() };
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
         return { renderer.marginRight(), renderer.marginLeft() };
     default:
         ASSERT_NOT_REACHED();
@@ -167,7 +167,7 @@ static inline Layout::BoxGeometry::VerticalEdges verticalLogicalMargin(const Ren
 }
 
 enum class IsPartOfFormattingContext : bool { No, Yes };
-static inline Layout::BoxGeometry::Edges logicalBorder(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, BlockFlowDirection blockFlowDirection, UseComputedValues useComputedValues = UseComputedValues::No, IsPartOfFormattingContext isPartOfFormattingContext = IsPartOfFormattingContext::No, bool retainBorderStart = true, bool retainBorderEnd = true)
+static inline Layout::BoxGeometry::Edges logicalBorder(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, FlowDirection blockFlowDirection, UseComputedValues useComputedValues = UseComputedValues::No, IsPartOfFormattingContext isPartOfFormattingContext = IsPartOfFormattingContext::No, bool retainBorderStart = true, bool retainBorderEnd = true)
 {
     auto& style = renderer.style();
     auto borderLeft = useComputedValues == UseComputedValues::No ? renderer.borderLeft() : LayoutUnit(style.borderLeftWidth());
@@ -175,7 +175,7 @@ static inline Layout::BoxGeometry::Edges logicalBorder(const RenderBoxModelObjec
     auto borderTop = useComputedValues == UseComputedValues::No ? renderer.borderTop() : LayoutUnit(style.borderTopWidth());
     auto borderBottom = useComputedValues == UseComputedValues::No ? renderer.borderBottom() : LayoutUnit(style.borderBottomWidth());
 
-    if (blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop) {
+    if (blockFlowDirection == FlowDirection::TopToBottom || blockFlowDirection == FlowDirection::BottomToTop) {
         if (isLeftToRightInlineDirection)
             return { { retainBorderStart ? borderLeft : 0_lu, retainBorderEnd ? borderRight : 0_lu }, { borderTop, borderBottom } };
         return { { retainBorderStart ? borderRight : 0_lu, retainBorderEnd ? borderLeft : 0_lu }, { borderTop, borderBottom } };
@@ -184,12 +184,12 @@ static inline Layout::BoxGeometry::Edges logicalBorder(const RenderBoxModelObjec
     auto borderLogicalLeft = retainBorderStart ? isLeftToRightInlineDirection ? borderTop : borderBottom : 0_lu;
     auto borderLogicalRight = retainBorderEnd ? isLeftToRightInlineDirection ? borderBottom : borderTop : 0_lu;
     // For boxes inside the formatting context, right border (padding) always points up, while when converting the formatting context root's border (padding) the directionality matters.
-    auto borderLogicalTop = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? borderRight : blockFlowDirection == BlockFlowDirection::LeftToRight ? borderLeft : borderRight;
-    auto borderLogicalBottom = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? borderLeft : blockFlowDirection == BlockFlowDirection::LeftToRight ? borderRight : borderLeft;
+    auto borderLogicalTop = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? borderRight : blockFlowDirection == FlowDirection::LeftToRight ? borderLeft : borderRight;
+    auto borderLogicalBottom = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? borderLeft : blockFlowDirection == FlowDirection::LeftToRight ? borderRight : borderLeft;
     return { { borderLogicalLeft, borderLogicalRight }, { borderLogicalTop, borderLogicalBottom } };
 }
 
-static inline Layout::BoxGeometry::Edges logicalPadding(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, BlockFlowDirection blockFlowDirection, UseComputedValues useComputedValues = UseComputedValues::No, IsPartOfFormattingContext isPartOfFormattingContext = IsPartOfFormattingContext::No, bool retainPaddingStart = true, bool retainPaddingEnd = true)
+static inline Layout::BoxGeometry::Edges logicalPadding(const RenderBoxModelObject& renderer, bool isLeftToRightInlineDirection, FlowDirection blockFlowDirection, UseComputedValues useComputedValues = UseComputedValues::No, IsPartOfFormattingContext isPartOfFormattingContext = IsPartOfFormattingContext::No, bool retainPaddingStart = true, bool retainPaddingEnd = true)
 {
     auto& style = renderer.style();
     auto paddingLeft = useComputedValues == UseComputedValues::No ? renderer.paddingLeft() : fixedValueOrZero(style.paddingLeft());
@@ -197,7 +197,7 @@ static inline Layout::BoxGeometry::Edges logicalPadding(const RenderBoxModelObje
     auto paddingTop = useComputedValues == UseComputedValues::No ? renderer.paddingTop() : fixedValueOrZero(style.paddingTop());
     auto paddingBottom = useComputedValues == UseComputedValues::No ? renderer.paddingBottom() : fixedValueOrZero(style.paddingBottom());
 
-    if (blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop) {
+    if (blockFlowDirection == FlowDirection::TopToBottom || blockFlowDirection == FlowDirection::BottomToTop) {
         if (isLeftToRightInlineDirection)
             return { { retainPaddingStart ? paddingLeft : 0_lu, retainPaddingEnd ? paddingRight : 0_lu }, { paddingTop, paddingBottom } };
         return { { retainPaddingStart ? paddingRight : 0_lu, retainPaddingEnd ? paddingLeft : 0_lu }, { paddingTop, paddingBottom } };
@@ -206,8 +206,8 @@ static inline Layout::BoxGeometry::Edges logicalPadding(const RenderBoxModelObje
     auto paddingLogicalLeft = retainPaddingStart ? isLeftToRightInlineDirection ? paddingTop : paddingBottom : 0_lu;
     auto paddingLogicalRight = retainPaddingEnd ? isLeftToRightInlineDirection ? paddingBottom : paddingTop : 0_lu;
     // For boxes inside the formatting context, right padding (border) always points up, while when converting the formatting context root's padding (border) the directionality matters.
-    auto paddingLogicalTop = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? paddingRight : blockFlowDirection == BlockFlowDirection::LeftToRight ? paddingLeft : paddingRight;
-    auto paddingLogicalBottom = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? paddingLeft : blockFlowDirection == BlockFlowDirection::LeftToRight ? paddingRight : paddingLeft;
+    auto paddingLogicalTop = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? paddingRight : blockFlowDirection == FlowDirection::LeftToRight ? paddingLeft : paddingRight;
+    auto paddingLogicalBottom = isPartOfFormattingContext == IsPartOfFormattingContext::Yes ? paddingLeft : blockFlowDirection == FlowDirection::LeftToRight ? paddingRight : paddingLeft;
     return { { paddingLogicalLeft, paddingLogicalRight }, { paddingLogicalTop, paddingLogicalBottom } };
 }
 
@@ -226,7 +226,7 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
     auto& layoutBox = const_cast<Layout::ElementBox&>(*renderBox.layoutBox());
     auto isLeftToRightInlineDirection = renderBox.parent()->style().isLeftToRightDirection();
     auto blockFlowDirection = writingModeToBlockFlowDirection(renderBox.parent()->style().writingMode());
-    auto isHorizontalWritingMode = blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop;
+    auto isHorizontalWritingMode = blockFlowDirection == FlowDirection::TopToBottom || blockFlowDirection == FlowDirection::BottomToTop;
 
     auto& boxGeometry = layoutState().ensureGeometryForBox(layoutBox);
     auto inlineMargin = horizontalLogicalMargin(renderBox, isLeftToRightInlineDirection, isHorizontalWritingMode, intrinsicWidthMode ? UseComputedValues::Yes : UseComputedValues::No);
@@ -287,7 +287,7 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
         return hasAppareance || !blockFlow->childrenInline() || blockFlow->hasLines() || blockFlow->hasLineIfEmpty();
     }();
     if (hasNonSyntheticBaseline) {
-        auto baseline = renderBox.baselinePosition(AlphabeticBaseline, false /* firstLine */, blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop ? HorizontalLine : VerticalLine, PositionOnContainingLine);
+        auto baseline = renderBox.baselinePosition(AlphabeticBaseline, false /* firstLine */, blockFlowDirection == FlowDirection::TopToBottom || blockFlowDirection == FlowDirection::BottomToTop ? HorizontalLine : VerticalLine, PositionOnContainingLine);
         layoutBox.setBaselineForIntegration(baseline);
     }
 
@@ -319,7 +319,7 @@ void BoxGeometryUpdater::updateInlineBoxDimensions(const RenderInline& renderInl
 
     auto isLeftToRightInlineDirection = renderInline.style().isLeftToRightDirection();
     auto blockFlowDirection = writingModeToBlockFlowDirection(renderInline.style().writingMode());
-    auto isHorizontalWritingMode = blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop;
+    auto isHorizontalWritingMode = blockFlowDirection == FlowDirection::TopToBottom || blockFlowDirection == FlowDirection::BottomToTop;
 
     auto inlineMargin = horizontalLogicalMargin(renderInline, isLeftToRightInlineDirection, isHorizontalWritingMode, intrinsicWidthMode ? UseComputedValues::Yes : UseComputedValues::No, !shouldNotRetainBorderPaddingAndMarginStart, !shouldNotRetainBorderPaddingAndMarginEnd);
     auto border = logicalBorder(renderInline, isLeftToRightInlineDirection, blockFlowDirection, intrinsicWidthMode ? UseComputedValues::Yes : UseComputedValues::No, IsPartOfFormattingContext::Yes, !shouldNotRetainBorderPaddingAndMarginStart, !shouldNotRetainBorderPaddingAndMarginEnd);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -723,12 +723,12 @@ LayoutUnit LineLayout::lastLinePhysicalBaseline() const
 LayoutUnit LineLayout::physicalBaselineForLine(const InlineDisplay::Line& line) const
 {
     switch (writingModeToBlockFlowDirection(rootLayoutBox().style().writingMode())) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         return LayoutUnit { line.lineBoxTop() + line.baseline() };
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return LayoutUnit { line.lineBoxLeft() + (line.lineBoxWidth() - line.baseline()) };
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return LayoutUnit { line.lineBoxLeft() + line.baseline() };
     default:
         ASSERT_NOT_REACHED();
@@ -745,10 +745,10 @@ LayoutUnit LineLayout::lastLineLogicalBaseline() const
 
     auto& lastLine = lastLineWithInlineContent(m_inlineContent->displayContent().lines);
     switch (writingModeToBlockFlowDirection(rootLayoutBox().style().writingMode())) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
         return LayoutUnit { lastLine.lineBoxTop() + lastLine.baseline() };
-    case BlockFlowDirection::LeftToRight: {
+    case FlowDirection::LeftToRight: {
         // FIXME: We should set the computed height on the root's box geometry (in RenderBlockFlow) so that
         // we could call m_layoutState.geometryForRootBox().borderBoxHeight() instead.
 
@@ -756,7 +756,7 @@ LayoutUnit LineLayout::lastLineLogicalBaseline() const
         auto lineLogicalTop = flow().logicalHeight() - lastLine.lineBoxRight();
         return LayoutUnit { lineLogicalTop + lastLine.baseline() };
     }
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return LayoutUnit { lastLine.lineBoxLeft() + lastLine.baseline() };
     default:
         ASSERT_NOT_REACHED();
@@ -886,11 +886,11 @@ LayoutRect LineLayout::firstInlineBoxRect(const RenderInline& renderInline) cons
     // is finished sizing in one go.
     auto firstBoxRect = Layout::toLayoutRect(firstBox->visualRectIgnoringBlockDirection());
     switch (writingModeToBlockFlowDirection(rootLayoutBox().style().writingMode())) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
+    case FlowDirection::LeftToRight:
         return firstBoxRect;
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         firstBoxRect.setX(flow().width() - firstBoxRect.maxX());
         return firstBoxRect;
     default:

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -177,7 +177,7 @@ Pagination::Mode paginationModeForRenderStyle(const RenderStyle& style)
     // is horizontal, then we use TextDirection to choose between those options. If the WritingMode
     // is vertical, then the block flow direction dictates the choice.
     if (overflow == Overflow::PagedX) {
-        if ((isHorizontalWritingMode && textDirection == TextDirection::LTR) || blockFlowDirection == BlockFlowDirection::LeftToRight)
+        if ((isHorizontalWritingMode && textDirection == TextDirection::LTR) || blockFlowDirection == FlowDirection::LeftToRight)
             return Pagination::Mode::LeftToRightPaginated;
         return Pagination::Mode::RightToLeftPaginated;
     }
@@ -185,7 +185,7 @@ Pagination::Mode paginationModeForRenderStyle(const RenderStyle& style)
     // paged-y always corresponds to TopToBottomPaginated or BottomToTopPaginated. If the WritingMode
     // is horizontal, then the block flow direction dictates the choice. If the WritingMode
     // is vertical, then we use TextDirection to choose between those options. 
-    if (blockFlowDirection == BlockFlowDirection::TopToBottom || (!isHorizontalWritingMode && textDirection == TextDirection::RTL))
+    if (blockFlowDirection == FlowDirection::TopToBottom || (!isHorizontalWritingMode && textDirection == TextDirection::RTL))
         return Pagination::Mode::TopToBottomPaginated;
     return Pagination::Mode::BottomToTopPaginated;
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -479,7 +479,7 @@ static IntSize reducePrecision(FloatSize size)
     };
 }
 
-static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets, ContainerNode& node, BlockFlowDirection direction)
+static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets, ContainerNode& node, FlowDirection direction)
 {
     CheckedPtr renderer = node.renderer();
     if (!renderer)
@@ -492,13 +492,13 @@ static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets,
 
         auto offset = [&] {
             switch (direction) {
-            case BlockFlowDirection::TopToBottom:
+            case FlowDirection::TopToBottom:
                 return bounds.y();
-            case BlockFlowDirection::BottomToTop:
+            case FlowDirection::BottomToTop:
                 return bounds.maxY();
-            case BlockFlowDirection::LeftToRight:
+            case FlowDirection::LeftToRight:
                 return bounds.x();
-            case BlockFlowDirection::RightToLeft:
+            case FlowDirection::RightToLeft:
                 return bounds.maxX();
             }
             ASSERT_NOT_REACHED();
@@ -583,11 +583,11 @@ RenderedText extractRenderedText(Element& element)
 
     bool ascendingOrder = [&] {
         switch (direction) {
-        case BlockFlowDirection::TopToBottom:
-        case BlockFlowDirection::LeftToRight:
+        case FlowDirection::TopToBottom:
+        case FlowDirection::LeftToRight:
             return true;
-        case BlockFlowDirection::BottomToTop:
-        case BlockFlowDirection::RightToLeft:
+        case FlowDirection::BottomToTop:
+        case FlowDirection::RightToLeft:
             return false;
         }
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/text/WritingMode.h
+++ b/Source/WebCore/platform/text/WritingMode.h
@@ -41,7 +41,7 @@ enum class TypographicMode : bool {
     Vertical,
 };
 
-enum class BlockFlowDirection : uint8_t {
+enum class FlowDirection : uint8_t {
     TopToBottom,
     BottomToTop,
     LeftToRight,
@@ -57,28 +57,28 @@ enum class WritingMode : uint8_t {
     SidewaysRl,
 };
 
-constexpr inline BlockFlowDirection writingModeToBlockFlowDirection(WritingMode writingMode)
+constexpr inline FlowDirection writingModeToBlockFlowDirection(WritingMode writingMode)
 {
     switch (writingMode) {
     case WritingMode::HorizontalTb:
-        return BlockFlowDirection::TopToBottom;
+        return FlowDirection::TopToBottom;
     case WritingMode::HorizontalBt:
-        return BlockFlowDirection::BottomToTop;
+        return FlowDirection::BottomToTop;
     case WritingMode::SidewaysLr:
     case WritingMode::VerticalLr:
-        return BlockFlowDirection::LeftToRight;
+        return FlowDirection::LeftToRight;
     case WritingMode::SidewaysRl:
     case WritingMode::VerticalRl:
-        return BlockFlowDirection::RightToLeft;
+        return FlowDirection::RightToLeft;
     }
     ASSERT_NOT_REACHED();
-    return BlockFlowDirection::TopToBottom;
+    return FlowDirection::TopToBottom;
 }
 
 // Define the text flow in terms of the writing mode and the text direction. The first
 // part is the block flow direction and the second part is the inline base direction.
 struct TextFlow {
-    BlockFlowDirection blockDirection;
+    FlowDirection blockDirection;
     TextDirection textDirection;
 
     constexpr inline bool isReversed()
@@ -88,14 +88,14 @@ struct TextFlow {
 
     constexpr inline bool isFlipped()
     {
-        return blockDirection == BlockFlowDirection::BottomToTop
-            || blockDirection == BlockFlowDirection::RightToLeft;
+        return blockDirection == FlowDirection::BottomToTop
+            || blockDirection == FlowDirection::RightToLeft;
     }
 
     constexpr inline bool isVertical()
     {
-        return blockDirection == BlockFlowDirection::LeftToRight
-            || blockDirection == BlockFlowDirection::RightToLeft;
+        return blockDirection == FlowDirection::LeftToRight
+            || blockDirection == FlowDirection::RightToLeft;
     }
 
     constexpr inline bool isFlippedLines()
@@ -255,19 +255,19 @@ constexpr LogicalBoxAxis mapPhysicalAxisToLogicalAxis(TextFlow flow, BoxAxis axi
     return isBlock ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
 }
 
-inline TextStream& operator<<(TextStream& stream, BlockFlowDirection blockFlow)
+inline TextStream& operator<<(TextStream& stream, FlowDirection blockFlow)
 {
     switch (blockFlow) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         stream << "top-to-bottom";
         break;
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         stream << "bottom-to-top";
         break;
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         stream << "left-to-right";
         break;
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         stream << "right-to-left";
         break;
     }

--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BaselineGroup);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BaselineAlignmentState);
 
-BaselineGroup::BaselineGroup(BlockFlowDirection blockFlow, ItemPosition childPreference)
+BaselineGroup::BaselineGroup(FlowDirection blockFlow, ItemPosition childPreference)
     : m_maxAscent(0), m_items()
 {
     m_blockFlow = blockFlow;
@@ -49,36 +49,36 @@ void BaselineGroup::update(const RenderBox& child, LayoutUnit ascent)
         m_maxAscent = std::max(m_maxAscent, ascent);
 }
 
-bool BaselineGroup::isOppositeBlockFlow(BlockFlowDirection blockFlow) const
+bool BaselineGroup::isOppositeBlockFlow(FlowDirection blockFlow) const
 {
     switch (blockFlow) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return false;
-    case BlockFlowDirection::LeftToRight:
-        return m_blockFlow == BlockFlowDirection::RightToLeft;
-    case BlockFlowDirection::RightToLeft:
-        return m_blockFlow == BlockFlowDirection::LeftToRight;
+    case FlowDirection::LeftToRight:
+        return m_blockFlow == FlowDirection::RightToLeft;
+    case FlowDirection::RightToLeft:
+        return m_blockFlow == FlowDirection::LeftToRight;
     default:
         ASSERT_NOT_REACHED();
         return false;
     }
 }
 
-bool BaselineGroup::isOrthogonalBlockFlow(BlockFlowDirection blockFlow) const
+bool BaselineGroup::isOrthogonalBlockFlow(FlowDirection blockFlow) const
 {
     switch (blockFlow) {
-    case BlockFlowDirection::TopToBottom:
-        return m_blockFlow != BlockFlowDirection::TopToBottom;
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
-        return m_blockFlow == BlockFlowDirection::TopToBottom;
+    case FlowDirection::TopToBottom:
+        return m_blockFlow != FlowDirection::TopToBottom;
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
+        return m_blockFlow == FlowDirection::TopToBottom;
     default:
         ASSERT_NOT_REACHED();
         return false;
     }
 }
 
-bool BaselineGroup::isCompatible(BlockFlowDirection childBlockFlow, ItemPosition childPreference) const
+bool BaselineGroup::isCompatible(FlowDirection childBlockFlow, ItemPosition childPreference) const
 {
     ASSERT(isBaselinePosition(childPreference));
     ASSERT(computeSize() > 0);

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -61,21 +61,21 @@ public:
 
 private:
     friend class BaselineAlignmentState;
-    BaselineGroup(BlockFlowDirection, ItemPosition childPreference);
+    BaselineGroup(FlowDirection, ItemPosition childPreference);
 
     // Determines whether a baseline-sharing group is compatible with an item, based on its 'block-flow' and
     // 'baseline-preference'
-    bool isCompatible(BlockFlowDirection, ItemPosition) const;
+    bool isCompatible(FlowDirection, ItemPosition) const;
 
     // Determines whether the baseline-sharing group's associated block-flow is opposite (LR vs RL) to particular
     // item's writing-mode.
-    bool isOppositeBlockFlow(BlockFlowDirection) const;
+    bool isOppositeBlockFlow(FlowDirection) const;
 
     // Determines whether the baseline-sharing group's associated block-flow is orthogonal (vertical vs horizontal)
     // to particular item's writing-mode.
-    bool isOrthogonalBlockFlow(BlockFlowDirection) const;
+    bool isOrthogonalBlockFlow(FlowDirection) const;
 
-    BlockFlowDirection m_blockFlow;
+    FlowDirection m_blockFlow;
     ItemPosition m_preference;
     LayoutUnit m_maxAscent;
     SingleThreadWeakHashSet<RenderBox> m_items;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3293,12 +3293,12 @@ void RenderBlock::adjustBorderBoxRectForPainting(LayoutRect& paintRect)
     if (style().isHorizontalWritingMode()) {
         LayoutUnit yOff = std::max(0_lu, (legend->height() - RenderBox::borderBefore()) / 2);
         paintRect.setHeight(paintRect.height() - yOff);
-        if (style().blockFlowDirection() == BlockFlowDirection::TopToBottom)
+        if (style().blockFlowDirection() == FlowDirection::TopToBottom)
             paintRect.setY(paintRect.y() + yOff);
     } else {
         LayoutUnit xOff = std::max(0_lu, (legend->width() - RenderBox::borderBefore()) / 2);
         paintRect.setWidth(paintRect.width() - xOff);
-        if (style().blockFlowDirection() == BlockFlowDirection::LeftToRight)
+        if (style().blockFlowDirection() == FlowDirection::LeftToRight)
             paintRect.setX(paintRect.x() + xOff);
     }
 }
@@ -3315,11 +3315,11 @@ LayoutRect RenderBlock::paintRectToClipOutFromBorder(const LayoutRect& paintRect
     LayoutUnit borderExtent = RenderBox::borderBefore();
     if (style().isHorizontalWritingMode()) {
         clipRect.setX(paintRect.x() + legend->x());
-        clipRect.setY(style().blockFlowDirection() == BlockFlowDirection::TopToBottom ? paintRect.y() : paintRect.y() + paintRect.height() - borderExtent);
+        clipRect.setY(style().blockFlowDirection() == FlowDirection::TopToBottom ? paintRect.y() : paintRect.y() + paintRect.height() - borderExtent);
         clipRect.setWidth(legend->width());
         clipRect.setHeight(borderExtent);
     } else {
-        clipRect.setX(style().blockFlowDirection() == BlockFlowDirection::LeftToRight ? paintRect.x() : paintRect.x() + paintRect.width() - borderExtent);
+        clipRect.setX(style().blockFlowDirection() == FlowDirection::LeftToRight ? paintRect.x() : paintRect.x() + paintRect.width() - borderExtent);
         clipRect.setY(paintRect.y() + legend->y());
         clipRect.setWidth(borderExtent);
         clipRect.setHeight(legend->height());
@@ -3359,28 +3359,28 @@ RectEdges<LayoutUnit> RenderBlock::borderWidths() const
 
 LayoutUnit RenderBlock::borderTop() const
 {
-    if (style().blockFlowDirection() != BlockFlowDirection::TopToBottom || !intrinsicBorderForFieldset())
+    if (style().blockFlowDirection() != FlowDirection::TopToBottom || !intrinsicBorderForFieldset())
         return RenderBox::borderTop();
     return RenderBox::borderTop() + intrinsicBorderForFieldset();
 }
 
 LayoutUnit RenderBlock::borderLeft() const
 {
-    if (style().blockFlowDirection() != BlockFlowDirection::LeftToRight || !intrinsicBorderForFieldset())
+    if (style().blockFlowDirection() != FlowDirection::LeftToRight || !intrinsicBorderForFieldset())
         return RenderBox::borderLeft();
     return RenderBox::borderLeft() + intrinsicBorderForFieldset();
 }
 
 LayoutUnit RenderBlock::borderBottom() const
 {
-    if (style().blockFlowDirection() != BlockFlowDirection::BottomToTop || !intrinsicBorderForFieldset())
+    if (style().blockFlowDirection() != FlowDirection::BottomToTop || !intrinsicBorderForFieldset())
         return RenderBox::borderBottom();
     return RenderBox::borderBottom() + intrinsicBorderForFieldset();
 }
 
 LayoutUnit RenderBlock::borderRight() const
 {
-    if (style().blockFlowDirection() != BlockFlowDirection::RightToLeft || !intrinsicBorderForFieldset())
+    if (style().blockFlowDirection() != FlowDirection::RightToLeft || !intrinsicBorderForFieldset())
         return RenderBox::borderRight();
     return RenderBox::borderRight() + intrinsicBorderForFieldset();
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3077,17 +3077,17 @@ static bool shouldFlipBeforeAfterMargins(const RenderStyle& containingBlockStyle
     auto childBlockFlowDirection = childStyle->blockFlowDirection();
     bool shouldFlip = false;
     switch (containingBlockStyle.blockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
-        shouldFlip = (childBlockFlowDirection == BlockFlowDirection::RightToLeft);
+    case FlowDirection::TopToBottom:
+        shouldFlip = (childBlockFlowDirection == FlowDirection::RightToLeft);
         break;
-    case BlockFlowDirection::BottomToTop:
-        shouldFlip = (childBlockFlowDirection == BlockFlowDirection::RightToLeft);
+    case FlowDirection::BottomToTop:
+        shouldFlip = (childBlockFlowDirection == FlowDirection::RightToLeft);
         break;
-    case BlockFlowDirection::RightToLeft:
-        shouldFlip = (childBlockFlowDirection == BlockFlowDirection::BottomToTop);
+    case FlowDirection::RightToLeft:
+        shouldFlip = (childBlockFlowDirection == FlowDirection::BottomToTop);
         break;
-    case BlockFlowDirection::LeftToRight:
-        shouldFlip = (childBlockFlowDirection == BlockFlowDirection::BottomToTop);
+    case FlowDirection::LeftToRight:
+        shouldFlip = (childBlockFlowDirection == FlowDirection::BottomToTop);
         break;
     }
 
@@ -5350,9 +5350,9 @@ LayoutRect RenderBox::visualOverflowRectForPropagation(const RenderStyle* parent
     
     // We are putting ourselves into our parent's coordinate space.  If there is a flipped block mismatch
     // in a particular axis, then we have to flip the rect along that axis.
-    if (style().blockFlowDirection() == BlockFlowDirection::RightToLeft || parentStyle->blockFlowDirection() == BlockFlowDirection::RightToLeft)
+    if (style().blockFlowDirection() == FlowDirection::RightToLeft || parentStyle->blockFlowDirection() == FlowDirection::RightToLeft)
         rect.setX(width() - rect.maxX());
-    else if (style().blockFlowDirection() == BlockFlowDirection::BottomToTop || parentStyle->blockFlowDirection() == BlockFlowDirection::BottomToTop)
+    else if (style().blockFlowDirection() == FlowDirection::BottomToTop || parentStyle->blockFlowDirection() == FlowDirection::BottomToTop)
         rect.setY(height() - rect.maxY());
 
     return rect;
@@ -5420,9 +5420,9 @@ LayoutRect RenderBox::layoutOverflowRectForPropagation(const RenderStyle* parent
     
     // We are putting ourselves into our parent's coordinate space.  If there is a flipped block mismatch
     // in a particular axis, then we have to flip the rect along that axis.
-    if (style().blockFlowDirection() == BlockFlowDirection::RightToLeft || parentStyle->blockFlowDirection() == BlockFlowDirection::RightToLeft)
+    if (style().blockFlowDirection() == FlowDirection::RightToLeft || parentStyle->blockFlowDirection() == FlowDirection::RightToLeft)
         rect.setX(width() - rect.maxX());
-    else if (style().blockFlowDirection() == BlockFlowDirection::BottomToTop || parentStyle->blockFlowDirection() == BlockFlowDirection::BottomToTop)
+    else if (style().blockFlowDirection() == FlowDirection::BottomToTop || parentStyle->blockFlowDirection() == FlowDirection::BottomToTop)
         rect.setY(height() - rect.maxY());
 
     return rect;

--- a/Source/WebCore/rendering/RenderDetailsMarker.cpp
+++ b/Source/WebCore/rendering/RenderDetailsMarker.cpp
@@ -81,19 +81,19 @@ static Path createRightArrowPath()
 RenderDetailsMarker::Orientation RenderDetailsMarker::orientation() const
 {
     switch (style().blockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         if (style().isLeftToRightDirection())
             return isOpen() ? Down : Right;
         return isOpen() ? Down : Left;
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         if (style().isLeftToRightDirection())
             return isOpen() ? Left : Down;
         return isOpen() ? Left : Up;
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         if (style().isLeftToRightDirection())
             return isOpen() ? Right : Down;
         return isOpen() ? Right : Up;
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         if (style().isLeftToRightDirection())
             return isOpen() ? Up : Right;
         return isOpen() ? Up : Left;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -539,7 +539,7 @@ bool RenderFlexibleBox::isHorizontalFlow() const
 bool RenderFlexibleBox::isLeftToRightFlow() const
 {
     if (isColumnFlow())
-        return style().blockFlowDirection() == BlockFlowDirection::TopToBottom || style().blockFlowDirection() == BlockFlowDirection::LeftToRight;
+        return style().blockFlowDirection() == FlowDirection::TopToBottom || style().blockFlowDirection() == FlowDirection::LeftToRight;
     return style().isLeftToRightDirection() ^ (style().flexDirection() == FlexDirection::RowReverse);
 }
 
@@ -736,22 +736,22 @@ std::optional<LayoutUnit> RenderFlexibleBox::computeMainAxisExtentForFlexItem(Re
     return flexItem.computeLogicalWidthInFragmentUsing(sizeType, size, mainAxisWidth, *this, { }) - flexItem.borderAndPaddingLogicalWidth();
 }
 
-BlockFlowDirection RenderFlexibleBox::transformedBlockFlowDirection() const
+FlowDirection RenderFlexibleBox::transformedBlockFlowDirection() const
 {
     auto blockFlowDirection = style().blockFlowDirection();
     if (!isColumnFlow())
         return blockFlowDirection;
     
     switch (blockFlowDirection) {
-    case BlockFlowDirection::TopToBottom:
-    case BlockFlowDirection::BottomToTop:
-        return style().isLeftToRightDirection() ? BlockFlowDirection::LeftToRight : BlockFlowDirection::RightToLeft;
-    case BlockFlowDirection::LeftToRight:
-    case BlockFlowDirection::RightToLeft:
-        return style().isLeftToRightDirection() ? BlockFlowDirection::TopToBottom : BlockFlowDirection::BottomToTop;
+    case FlowDirection::TopToBottom:
+    case FlowDirection::BottomToTop:
+        return style().isLeftToRightDirection() ? FlowDirection::LeftToRight : FlowDirection::RightToLeft;
+    case FlowDirection::LeftToRight:
+    case FlowDirection::RightToLeft:
+        return style().isLeftToRightDirection() ? FlowDirection::TopToBottom : FlowDirection::BottomToTop;
     }
     ASSERT_NOT_REACHED();
-    return BlockFlowDirection::TopToBottom;
+    return FlowDirection::TopToBottom;
 }
 
 LayoutUnit RenderFlexibleBox::flowAwareBorderStart() const
@@ -771,13 +771,13 @@ LayoutUnit RenderFlexibleBox::flowAwareBorderEnd() const
 LayoutUnit RenderFlexibleBox::flowAwareBorderBefore() const
 {
     switch (transformedBlockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return borderTop();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return borderBottom();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return borderLeft();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return borderRight();
     }
     ASSERT_NOT_REACHED();
@@ -787,13 +787,13 @@ LayoutUnit RenderFlexibleBox::flowAwareBorderBefore() const
 LayoutUnit RenderFlexibleBox::flowAwareBorderAfter() const
 {
     switch (transformedBlockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return borderBottom();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return borderTop();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return borderRight();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return borderLeft();
     }
     ASSERT_NOT_REACHED();
@@ -817,13 +817,13 @@ LayoutUnit RenderFlexibleBox::flowAwarePaddingEnd() const
 LayoutUnit RenderFlexibleBox::flowAwarePaddingBefore() const
 {
     switch (transformedBlockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return paddingTop();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return paddingBottom();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return paddingLeft();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return paddingRight();
     }
     ASSERT_NOT_REACHED();
@@ -833,13 +833,13 @@ LayoutUnit RenderFlexibleBox::flowAwarePaddingBefore() const
 LayoutUnit RenderFlexibleBox::flowAwarePaddingAfter() const
 {
     switch (transformedBlockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return paddingBottom();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return paddingTop();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return paddingRight();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return paddingLeft();
     }
     ASSERT_NOT_REACHED();
@@ -863,13 +863,13 @@ LayoutUnit RenderFlexibleBox::flowAwareMarginEndForFlexItem(const RenderBox& fle
 LayoutUnit RenderFlexibleBox::flowAwareMarginBeforeForFlexItem(const RenderBox& flexItem) const
 {
     switch (transformedBlockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return flexItem.marginTop();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return flexItem.marginBottom();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return flexItem.marginLeft();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return flexItem.marginRight();
     }
     ASSERT_NOT_REACHED();
@@ -2488,7 +2488,7 @@ void RenderFlexibleBox::performBaselineAlignment(LineState& lineState)
         return style().direction() == TextDirection::LTR ? WritingMode::VerticalLr : WritingMode::VerticalRl;
     };
 
-    auto shouldAdjustItemTowardsCrossAxisEnd = [&](const BlockFlowDirection& flexItemBlockFlowDirection, ItemPosition alignment) {
+    auto shouldAdjustItemTowardsCrossAxisEnd = [&](const FlowDirection& flexItemBlockFlowDirection, ItemPosition alignment) {
         ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
 
         // The direction in which we are aligning (i.e. direction of the cross axis) must be parallel with the direction of the flex item's used writing mode
@@ -2619,7 +2619,7 @@ std::optional<TextDirection> RenderFlexibleBox::leftRightAxisDirectionFromStyle(
         return style.direction();
 
     if (!style.isHorizontalWritingMode()) {
-        return (style.blockFlowDirection() == BlockFlowDirection::LeftToRight)
+        return (style.blockFlowDirection() == FlowDirection::LeftToRight)
             ? TextDirection::LTR : TextDirection::RTL;
     }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -50,7 +50,7 @@ public:
     RenderFlexibleBox(Type, Document&, RenderStyle&&);
     virtual ~RenderFlexibleBox();
 
-    using Direction = BlockFlowDirection;
+    using Direction = FlowDirection;
 
     ASCIILiteral renderName() const override;
 
@@ -71,19 +71,19 @@ public:
     inline Direction crossAxisDirection() const
     {
         switch (writingModeToBlockFlowDirection(style().writingMode())) {
-        case BlockFlowDirection::TopToBottom:
+        case FlowDirection::TopToBottom:
             if (style().isRowFlexDirection())
                 return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
             return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
-        case BlockFlowDirection::BottomToTop:
+        case FlowDirection::BottomToTop:
             if (style().isRowFlexDirection())
                 return (style().flexWrap() == FlexWrap::Reverse) ? Direction::TopToBottom : Direction::BottomToTop;
             return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
-        case BlockFlowDirection::LeftToRight:
+        case FlowDirection::LeftToRight:
             if (style().isRowFlexDirection())
                 return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
             return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
-        case BlockFlowDirection::RightToLeft:
+        case FlowDirection::RightToLeft:
             if (style().isRowFlexDirection())
                 return (style().flexWrap() == FlexWrap::Reverse) ? Direction::LeftToRight : Direction::RightToLeft;
             return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
@@ -168,7 +168,7 @@ private:
     LayoutUnit crossAxisContentExtent() const;
     LayoutUnit mainAxisContentExtent(LayoutUnit contentLogicalHeight);
     std::optional<LayoutUnit> computeMainAxisExtentForFlexItem(RenderBox& flexItem, SizeType, const Length& size);
-    BlockFlowDirection transformedBlockFlowDirection() const;
+    FlowDirection transformedBlockFlowDirection() const;
     LayoutUnit flowAwareBorderStart() const;
     LayoutUnit flowAwareBorderEnd() const;
     LayoutUnit flowAwareBorderBefore() const;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1134,7 +1134,7 @@ void RenderLayerScrollableArea::computeScrollOrigin()
     ASSERT(box);
 
     int scrollableLeftOverflow = roundToInt(overflowLeft() - box->borderLeft());
-    if (shouldPlaceVerticalScrollbarOnLeft() /*|| box->style().blockFlowDirection() == BlockFlowDirection::RightToLeft*/)
+    if (shouldPlaceVerticalScrollbarOnLeft() /*|| box->style().blockFlowDirection() == FlowDirection::RightToLeft*/)
         scrollableLeftOverflow -= verticalScrollbarWidth(IgnoreOverlayScrollbarSize, box->style().isHorizontalWritingMode());
     int scrollableTopOverflow = roundToInt(overflowTop() - box->borderTop());
     setScrollOrigin(IntPoint(-scrollableLeftOverflow, -scrollableTopOverflow));

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -332,11 +332,11 @@ RectEdges<LayoutUnit> RenderTableCell::padding() const
     auto left = computedCSSPaddingLeft();
 
     if (isHorizontalWritingMode()) {
-        bool isTopToBottom = style().blockFlowDirection() == BlockFlowDirection::TopToBottom;
+        bool isTopToBottom = style().blockFlowDirection() == FlowDirection::TopToBottom;
         top += isTopToBottom ? intrinsicPaddingBefore() : intrinsicPaddingAfter();
         bottom += isTopToBottom ? intrinsicPaddingAfter() : intrinsicPaddingBefore();
     } else {
-        bool isLeftToRight = style().blockFlowDirection() == BlockFlowDirection::LeftToRight;
+        bool isLeftToRight = style().blockFlowDirection() == FlowDirection::LeftToRight;
         left += isLeftToRight ? intrinsicPaddingBefore() : intrinsicPaddingAfter();
         right += isLeftToRight ? intrinsicPaddingAfter() : intrinsicPaddingBefore();
     }
@@ -354,7 +354,7 @@ LayoutUnit RenderTableCell::paddingTop() const
     LayoutUnit result = computedCSSPaddingTop();
     if (!isHorizontalWritingMode())
         return result;
-    return result + (style().blockFlowDirection() == BlockFlowDirection::TopToBottom ? intrinsicPaddingBefore() : intrinsicPaddingAfter());
+    return result + (style().blockFlowDirection() == FlowDirection::TopToBottom ? intrinsicPaddingBefore() : intrinsicPaddingAfter());
 }
 
 LayoutUnit RenderTableCell::paddingBottom() const
@@ -362,7 +362,7 @@ LayoutUnit RenderTableCell::paddingBottom() const
     LayoutUnit result = computedCSSPaddingBottom();
     if (!isHorizontalWritingMode())
         return result;
-    return result + (style().blockFlowDirection() == BlockFlowDirection::TopToBottom ? intrinsicPaddingAfter() : intrinsicPaddingBefore());
+    return result + (style().blockFlowDirection() == FlowDirection::TopToBottom ? intrinsicPaddingAfter() : intrinsicPaddingBefore());
 }
 
 LayoutUnit RenderTableCell::paddingLeft() const
@@ -370,7 +370,7 @@ LayoutUnit RenderTableCell::paddingLeft() const
     LayoutUnit result = computedCSSPaddingLeft();
     if (isHorizontalWritingMode())
         return result;
-    return result + (style().blockFlowDirection() == BlockFlowDirection::LeftToRight ? intrinsicPaddingBefore() : intrinsicPaddingAfter());
+    return result + (style().blockFlowDirection() == FlowDirection::LeftToRight ? intrinsicPaddingBefore() : intrinsicPaddingAfter());
 }
 
 LayoutUnit RenderTableCell::paddingRight() const
@@ -378,7 +378,7 @@ LayoutUnit RenderTableCell::paddingRight() const
     LayoutUnit result = computedCSSPaddingRight();
     if (isHorizontalWritingMode())
         return result;
-    return result + (style().blockFlowDirection() == BlockFlowDirection::LeftToRight ? intrinsicPaddingAfter() : intrinsicPaddingBefore());
+    return result + (style().blockFlowDirection() == FlowDirection::LeftToRight ? intrinsicPaddingAfter() : intrinsicPaddingBefore());
 }
 
 LayoutUnit RenderTableCell::paddingBefore() const

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -286,13 +286,13 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         bool overridden = o.style().borderImage().overridesBorderWidths();
         if (box->isFieldset()) {
             const auto& block = downcast<RenderBlock>(*box);
-            if (o.style().blockFlowDirection() == BlockFlowDirection::TopToBottom)
+            if (o.style().blockFlowDirection() == FlowDirection::TopToBottom)
                 borderTop -= block.intrinsicBorderForFieldset();
-            else if (o.style().blockFlowDirection() == BlockFlowDirection::BottomToTop)
+            else if (o.style().blockFlowDirection() == FlowDirection::BottomToTop)
                 borderBottom -= block.intrinsicBorderForFieldset();
-            else if (o.style().blockFlowDirection() == BlockFlowDirection::LeftToRight)
+            else if (o.style().blockFlowDirection() == FlowDirection::LeftToRight)
                 borderLeft -= block.intrinsicBorderForFieldset();
-            else if (o.style().blockFlowDirection() == BlockFlowDirection::RightToLeft)
+            else if (o.style().blockFlowDirection() == FlowDirection::RightToLeft)
                 borderRight -= block.intrinsicBorderForFieldset();
             
         }

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -201,10 +201,10 @@ static inline LayoutUnit borderBeforeInWritingMode(const RenderBox& renderer, Wr
 {
     auto blockFlowDirection = writingModeToBlockFlowDirection(writingMode);
     switch (blockFlowDirection) {
-    case BlockFlowDirection::TopToBottom: return renderer.borderTop();
-    case BlockFlowDirection::BottomToTop: return renderer.borderBottom();
-    case BlockFlowDirection::LeftToRight: return renderer.borderLeft();
-    case BlockFlowDirection::RightToLeft: return renderer.borderRight();
+    case FlowDirection::TopToBottom: return renderer.borderTop();
+    case FlowDirection::BottomToTop: return renderer.borderBottom();
+    case FlowDirection::LeftToRight: return renderer.borderLeft();
+    case FlowDirection::RightToLeft: return renderer.borderRight();
     }
 
     ASSERT_NOT_REACHED();
@@ -215,10 +215,10 @@ static inline LayoutUnit borderAndPaddingBeforeInWritingMode(const RenderBox& re
 {
     auto blockFlowDirection = writingModeToBlockFlowDirection(writingMode);
     switch (blockFlowDirection) {
-    case BlockFlowDirection::TopToBottom: return renderer.borderTop() + renderer.paddingTop();
-    case BlockFlowDirection::BottomToTop: return renderer.borderBottom() + renderer.paddingBottom();
-    case BlockFlowDirection::LeftToRight: return renderer.borderLeft() + renderer.paddingLeft();
-    case BlockFlowDirection::RightToLeft: return renderer.borderRight() + renderer.paddingRight();
+    case FlowDirection::TopToBottom: return renderer.borderTop() + renderer.paddingTop();
+    case FlowDirection::BottomToTop: return renderer.borderBottom() + renderer.paddingBottom();
+    case FlowDirection::LeftToRight: return renderer.borderLeft() + renderer.paddingLeft();
+    case FlowDirection::RightToLeft: return renderer.borderRight() + renderer.paddingRight();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3178,13 +3178,13 @@ Color RenderStyle::usedScrollbarTrackColor() const
 const BorderValue& RenderStyle::borderBefore() const
 {
     switch (blockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return borderTop();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return borderBottom();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return borderLeft();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return borderRight();
     }
     ASSERT_NOT_REACHED();
@@ -3194,13 +3194,13 @@ const BorderValue& RenderStyle::borderBefore() const
 const BorderValue& RenderStyle::borderAfter() const
 {
     switch (blockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return borderBottom();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return borderTop();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return borderRight();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return borderLeft();
     }
     ASSERT_NOT_REACHED();
@@ -3224,13 +3224,13 @@ const BorderValue& RenderStyle::borderEnd() const
 float RenderStyle::borderBeforeWidth() const
 {
     switch (blockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return borderTopWidth();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return borderBottomWidth();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return borderLeftWidth();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return borderRightWidth();
     }
     ASSERT_NOT_REACHED();
@@ -3240,13 +3240,13 @@ float RenderStyle::borderBeforeWidth() const
 float RenderStyle::borderAfterWidth() const
 {
     switch (blockFlowDirection()) {
-    case BlockFlowDirection::TopToBottom:
+    case FlowDirection::TopToBottom:
         return borderBottomWidth();
-    case BlockFlowDirection::BottomToTop:
+    case FlowDirection::BottomToTop:
         return borderTopWidth();
-    case BlockFlowDirection::LeftToRight:
+    case FlowDirection::LeftToRight:
         return borderRightWidth();
-    case BlockFlowDirection::RightToLeft:
+    case FlowDirection::RightToLeft:
         return borderLeftWidth();
     }
     ASSERT_NOT_REACHED();
@@ -3822,7 +3822,7 @@ float RenderStyle::outlineOffset() const
 
 bool RenderStyle::shouldPlaceVerticalScrollbarOnLeft() const
 {
-    return (!isLeftToRightDirection() && isHorizontalWritingMode()) || blockFlowDirection() == BlockFlowDirection::RightToLeft;
+    return (!isLeftToRightDirection() && isHorizontalWritingMode()) || blockFlowDirection() == FlowDirection::RightToLeft;
 }
 
 std::span<const PaintType, 3> RenderStyle::paintTypesForPaintOrder(PaintOrder order)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -111,7 +111,7 @@ enum class AspectRatioType : uint8_t;
 enum class AutoRepeatType : uint8_t;
 enum class BackfaceVisibility : uint8_t;
 enum class BlendMode : uint8_t;
-enum class BlockFlowDirection : uint8_t;
+enum class FlowDirection : uint8_t;
 enum class BlockStepInsert : bool;
 enum class BorderCollapse : bool;
 enum class BorderStyle : uint8_t;
@@ -1084,7 +1084,7 @@ public:
     inline bool isVerticalWritingMode() const;
     inline bool isFlippedLinesWritingMode() const;
     inline bool isFlippedBlocksWritingMode() const;
-    BlockFlowDirection blockFlowDirection() const;
+    FlowDirection blockFlowDirection() const;
     TypographicMode typographicMode() const;
 
     inline ImageOrientation imageOrientation() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -957,7 +957,7 @@ constexpr bool RenderStyle::preserveNewline(WhiteSpace mode)
     return mode != WhiteSpace::Normal && mode != WhiteSpace::NoWrap;
 }
 
-inline BlockFlowDirection RenderStyle::blockFlowDirection() const
+inline FlowDirection RenderStyle::blockFlowDirection() const
 {
     return writingModeToBlockFlowDirection(writingMode());
 }

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -325,7 +325,7 @@ float overlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineBo
     auto overBecomesUnder = [&] {
         // If 'right' causes the underline to be drawn on the "over" side of the text, then an overline also switches sides and is drawn on the "under" side.
         if (underlinePosition.contains(TextUnderlinePosition::Right))
-            return style.typographicMode() == TypographicMode::Vertical || style.blockFlowDirection() == BlockFlowDirection::RightToLeft;
+            return style.typographicMode() == TypographicMode::Vertical || style.blockFlowDirection() == FlowDirection::RightToLeft;
         return false;
     };
     return overBecomesUnder() ? inlineBoxContentBoxHeight(inlineBox) + defaultGap(style) : (0.f - defaultGap(style));

--- a/Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp
@@ -38,14 +38,14 @@ using namespace WebCore;
 namespace TestWebKitAPI {
 
 constexpr std::array<TextFlow, 8> flows = {
-    TextFlow { BlockFlowDirection::TopToBottom, TextDirection::LTR },
-    TextFlow { BlockFlowDirection::TopToBottom, TextDirection::RTL },
-    TextFlow { BlockFlowDirection::BottomToTop, TextDirection::LTR },
-    TextFlow { BlockFlowDirection::BottomToTop, TextDirection::RTL },
-    TextFlow { BlockFlowDirection::LeftToRight, TextDirection::LTR },
-    TextFlow { BlockFlowDirection::LeftToRight, TextDirection::RTL },
-    TextFlow { BlockFlowDirection::RightToLeft, TextDirection::LTR },
-    TextFlow { BlockFlowDirection::RightToLeft, TextDirection::RTL }
+    TextFlow { FlowDirection::TopToBottom, TextDirection::LTR },
+    TextFlow { FlowDirection::TopToBottom, TextDirection::RTL },
+    TextFlow { FlowDirection::BottomToTop, TextDirection::LTR },
+    TextFlow { FlowDirection::BottomToTop, TextDirection::RTL },
+    TextFlow { FlowDirection::LeftToRight, TextDirection::LTR },
+    TextFlow { FlowDirection::LeftToRight, TextDirection::RTL },
+    TextFlow { FlowDirection::RightToLeft, TextDirection::LTR },
+    TextFlow { FlowDirection::RightToLeft, TextDirection::RTL }
 };
 
 inline std::string textFlowString(TextFlow flow)


### PR DESCRIPTION
#### 2c4181eb99b6eff148a6d1d604839ea3632af9f7
<pre>
Rename BlockFlowDirection to FlowDirection
<a href="https://bugs.webkit.org/show_bug.cgi?id=279233">https://bugs.webkit.org/show_bug.cgi?id=279233</a>
<a href="https://rdar.apple.com/problem/135376714">rdar://problem/135376714</a>

Reviewed by Alan Baradlay.

Shortens and generalizes the name of the BlockFlowDirection enum.
This improves readability by reducing redundancy in code (the block-axis
context is clear from variable names) and allows the enum to be re-used
in additional contexts that need a flow direction enum.

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemDisclosureClosed):
(WebCore::CSSCounterStyle::counterForSystemDisclosureOpen):
* Source/WebCore/dom/Element.cpp:
(WebCore::toScrollAlignmentForInlineDirection):
(WebCore::toScrollAlignmentForBlockDirection):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::flipVisualRectToLogicalForWritingMode):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::collectInkOverflowForTextDecorations):
(WebCore::Layout::InlineDisplayContentBuilder::flipLogicalRectToVisualForWritingModeWithinLine const):
(WebCore::Layout::InlineDisplayContentBuilder::flipRootInlineBoxRectToVisualForWritingMode const):
(WebCore::Layout::InlineDisplayContentBuilder::setLeftForWritingMode const):
(WebCore::Layout::InlineDisplayContentBuilder::setRightForWritingMode const):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::flipLogicalLineRectToVisualForWritingMode):
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::flexBoxLogicalBorder):
(WebCore::LayoutIntegration::flexBoxLogicalPadding):
(WebCore::LayoutIntegration::FlexLayout::updateFormattingRootGeometryAndInvalidate):
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::verticalLogicalMargin):
(WebCore::LayoutIntegration::logicalBorder):
(WebCore::LayoutIntegration::logicalPadding):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateInlineBoxDimensions):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::physicalBaselineForLine const):
(WebCore::LayoutIntegration::LineLayout::lastLineLogicalBaseline const):
(WebCore::LayoutIntegration::LineLayout::firstInlineBoxRect const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::paginationModeForRenderStyle):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedTokens):
(WebCore::TextExtraction::extractRenderedText):
* Source/WebCore/platform/text/WritingMode.h:
(WebCore::writingModeToBlockFlowDirection):
(WebCore::TextFlow::isFlipped):
(WebCore::TextFlow::isVertical):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/BaselineAlignment.cpp:
(WebCore::BaselineGroup::BaselineGroup):
(WebCore::BaselineGroup::isOppositeBlockFlow const):
(WebCore::BaselineGroup::isOrthogonalBlockFlow const):
(WebCore::BaselineGroup::isCompatible const):
* Source/WebCore/rendering/BaselineAlignment.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::adjustBorderBoxRectForPainting):
(WebCore::RenderBlock::paintRectToClipOutFromBorder):
(WebCore::RenderBlock::borderTop const):
(WebCore::RenderBlock::borderLeft const):
(WebCore::RenderBlock::borderBottom const):
(WebCore::RenderBlock::borderRight const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::shouldFlipBeforeAfterMargins):
(WebCore::RenderBox::visualOverflowRectForPropagation const):
(WebCore::RenderBox::layoutOverflowRectForPropagation const):
* Source/WebCore/rendering/RenderDetailsMarker.cpp:
(WebCore::RenderDetailsMarker::orientation const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::isLeftToRightFlow const):
(WebCore::RenderFlexibleBox::transformedBlockFlowDirection const):
(WebCore::RenderFlexibleBox::flowAwareBorderBefore const):
(WebCore::RenderFlexibleBox::flowAwareBorderAfter const):
(WebCore::RenderFlexibleBox::flowAwarePaddingBefore const):
(WebCore::RenderFlexibleBox::flowAwarePaddingAfter const):
(WebCore::RenderFlexibleBox::flowAwareMarginBeforeForFlexItem const):
(WebCore::RenderFlexibleBox::performBaselineAlignment):
(WebCore::RenderFlexibleBox::leftRightAxisDirectionFromStyle):
* Source/WebCore/rendering/RenderFlexibleBox.h:
(WebCore::RenderFlexibleBox::crossAxisDirection const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::computeScrollOrigin):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::padding const):
(WebCore::RenderTableCell::paddingTop const):
(WebCore::RenderTableCell::paddingBottom const):
(WebCore::RenderTableCell::paddingLeft const):
(WebCore::RenderTableCell::paddingRight const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::borderBeforeInWritingMode):
(WebCore::borderAndPaddingBeforeInWritingMode):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::borderBefore const):
(WebCore::RenderStyle::borderAfter const):
(WebCore::RenderStyle::borderBeforeWidth const):
(WebCore::RenderStyle::borderAfterWidth const):
(WebCore::RenderStyle::shouldPlaceVerticalScrollbarOnLeft const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::blockFlowDirection const):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::overlineOffsetForTextBoxPainting):
* Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp:

Canonical link: <a href="https://commits.webkit.org/283249@main">https://commits.webkit.org/283249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f10c0b93a9d4388006e6c78c65759d8e34f47c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52723 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11297 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14218 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60038 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60315 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14478 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1597 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->