### PR TITLE
Mark the unused _fullScreenEnabled SPI as deprecated

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -104,7 +104,9 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setDefaultFixedPitchFontSize:) NSUInteger _defaultFixedPitchFontSize WK_API_AVAILABLE(macos(10.12), ios(10.0));
 @property (nonatomic, copy, setter=_setFixedPitchFontFamily:) NSString *_fixedPitchFontFamily WK_API_AVAILABLE(macos(10.12), ios(10.0));
 
-@property (nonatomic, setter=_setFullScreenEnabled:) BOOL _fullScreenEnabled WK_API_AVAILABLE(macos(10.11), ios(9.0), tvos(17.0));
+@property (nonatomic, setter=_setFullScreenEnabled:) BOOL _fullScreenEnabled WK_API_DEPRECATED_WITH_REPLACEMENT("elementFullscreenEnabled", macos(10.11, 12.3), ios(9.0, 15.4));
+
+WK_API_AVAILABLE(macos(10.11), ios(9.0), tvos(17.0));
 @property (nonatomic, setter=_setShouldSuppressKeyboardInputDuringProvisionalNavigation:) BOOL _shouldSuppressKeyboardInputDuringProvisionalNavigation WK_API_AVAILABLE(macos(10.12.4), ios(10.3));
 @property (nonatomic, setter=_setAllowsPictureInPictureMediaPlayback:) BOOL _allowsPictureInPictureMediaPlayback WK_API_AVAILABLE(macos(10.13), ios(11.0));
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CloseWebViewAfterEnterFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CloseWebViewAfterEnterFullscreen.mm
@@ -60,7 +60,7 @@ namespace TestWebKitAPI {
 TEST(CloseWebViewAfterEnterFullscreen, VideoFullscreen)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<CloseWebViewAfterEnterFullscreenUIDelegate> handler = adoptNS([[CloseWebViewAfterEnterFullscreenUIDelegate alloc] init]);
     [webView _setFullscreenDelegate:handler.get()];
@@ -80,7 +80,7 @@ TEST(CloseWebViewAfterEnterFullscreen, VideoFullscreen)
 TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<CloseWebViewAfterEnterFullscreenUIDelegate> handler = adoptNS([[CloseWebViewAfterEnterFullscreenUIDelegate alloc] init]);
     [webView _setFullscreenDelegate:handler.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CloseWebViewDuringEnterFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CloseWebViewDuringEnterFullscreen.mm
@@ -60,7 +60,7 @@ namespace TestWebKitAPI {
 TEST(CloseWebViewDuringEnterFullscreen, VideoFullscreen)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<CloseWebViewDuringEnterFullscreenUIDelegate> handler = adoptNS([[CloseWebViewDuringEnterFullscreenUIDelegate alloc] init]);
     [webView _setFullscreenDelegate:handler.get()];
@@ -80,7 +80,7 @@ TEST(CloseWebViewDuringEnterFullscreen, VideoFullscreen)
 TEST(CloseWebViewDuringEnterFullscreen, DISABLED_ElementFullscreen)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<CloseWebViewDuringEnterFullscreenUIDelegate> handler = adoptNS([[CloseWebViewDuringEnterFullscreenUIDelegate alloc] init]);
     [webView _setFullscreenDelegate:handler.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm
@@ -74,7 +74,7 @@ TEST(ExitFullscreenOnEnterPiP, VideoFullscreen)
 #endif
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<ExitFullscreenOnEnterPiPUIDelegate> handler = adoptNS([[ExitFullscreenOnEnterPiPUIDelegate alloc] init]);
@@ -109,7 +109,7 @@ TEST(ExitFullscreenOnEnterPiP, DISABLED_ElementFullscreen)
         @"WebKit2Logging": @"Fullscreen=debug",
     }];
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<ExitFullscreenOnEnterPiPUIDelegate> handler = adoptNS([[ExitFullscreenOnEnterPiPUIDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitPiPOnSuspendVideoElement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitPiPOnSuspendVideoElement.mm
@@ -67,7 +67,7 @@ TEST(PictureInPicture, DISABLED_ExitPiPOnSuspendVideoElement)
     }];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     RetainPtr<ExitPiPOnSuspendVideoElementUIDelegate> handler = adoptNS([[ExitPiPOnSuspendVideoElementUIDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenAlert.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenAlert.mm
@@ -41,7 +41,7 @@ static bool isOutOfFullscreen = false;
 TEST(Fullscreen, DISABLED_Alert)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
 
     auto checkFullscreen = [&] {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm
@@ -82,7 +82,7 @@ namespace TestWebKitAPI {
 TEST(Fullscreen, Delegate)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     RetainPtr<FullscreenDelegateMessageHandler> handler = adoptNS([[FullscreenDelegateMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"fullscreenChangeHandler"];
@@ -121,7 +121,7 @@ TEST(Fullscreen, VisibilityChangeNotDispatched)
 #endif
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     RetainPtr<FullscreenDelegateMessageHandler> handler = adoptNS([[FullscreenDelegateMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"fullscreenChangeHandler"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLayoutConstraints.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLayoutConstraints.mm
@@ -54,7 +54,7 @@ namespace TestWebKitAPI {
 TEST(Fullscreen, LayoutConstraints)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     RetainPtr<FullscreenStateChangeMessageHandler> handler = adoptNS([[FullscreenStateChangeMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"fullscreenStateChangeHandler"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenRemoveNodeBeforeEnter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenRemoveNodeBeforeEnter.mm
@@ -40,7 +40,7 @@ namespace TestWebKitAPI {
 TEST(Fullscreen, RemoveNodeBeforeEnter)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -83,7 +83,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 + (RetainPtr<FullscreenVideoTextRecognitionWebView>)create
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    configuration.preferences._fullScreenEnabled = YES;
+    configuration.preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
     return webView;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
@@ -104,7 +104,7 @@ namespace TestWebKitAPI {
 TEST(PictureInPicture, WKUIDelegate)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
     RetainPtr<PictureInPictureUIDelegate> handler = adoptNS([[PictureInPictureUIDelegate alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"pictureInPictureChangeHandler"];
@@ -170,7 +170,7 @@ TEST(PictureInPicture, AudioCannotTogglePictureInPicture)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 54) configuration:configuration.get()]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
     RetainPtr<PictureInPictureUIDelegate> handler = adoptNS([[PictureInPictureUIDelegate alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"pictureInPictureChangeHandler"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TopContentInset.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TopContentInset.mm
@@ -54,7 +54,7 @@ namespace TestWebKitAPI {
 TEST(TopContentInset, Fullscreen)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     RetainPtr<FullscreenChangeMessageHandler> handler = adoptNS([[FullscreenChangeMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"fullscreenChangeHandler"];
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
@@ -138,7 +138,7 @@ TEST(WKWebViewCloseAllMediaPresentations, VideoFullscreen)
 #endif
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    [[configuration preferences] _setFullScreenEnabled:YES];
+    configuration.preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=video-with-audio.mp4 webkit-playsinline playsinline loop></video>"];
@@ -175,7 +175,7 @@ TEST(WKWebViewCloseAllMediaPresentations, ElementFullscreen)
 #endif
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    [[configuration preferences] _setFullScreenEnabled:YES];
+    configuration.preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<div id=\"target\" style=\"width:100px;height:100px;background-color:red\"></div>"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
@@ -114,7 +114,7 @@ TEST(WKWebViewSuspendAllMediaPlayback, PauseWhenResume)
 TEST(WKWebViewSuspendAllMediaPlayback, FullscreenWhileSuspended)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [[configuration preferences] _setFullScreenEnabled:YES];
+    configuration.get().preferences.elementFullscreenEnabled = YES;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenFocus.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenFocus.mm
@@ -63,7 +63,7 @@ TEST(Fullscreen, Focus)
 #endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     auto handler = adoptNS([[FullscreenFocusUIDelegate alloc] init]);
     [webView _setFullscreenDelegate:handler.get()];

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenPointerLeave.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenPointerLeave.mm
@@ -39,7 +39,7 @@ namespace TestWebKitAPI {
 TEST(Fullscreen, PointerLeave)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration preferences]._fullScreenEnabled = YES;
+    configuration.get().preferences.elementFullscreenEnabled = YES;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     bool pointerenter = false;


### PR DESCRIPTION
#### 02078e1966d8db5dc55b78bd7099364c9e726401
<pre>
Mark the unused _fullScreenEnabled SPI as deprecated
<a href="https://bugs.webkit.org/show_bug.cgi?id=279237">https://bugs.webkit.org/show_bug.cgi?id=279237</a>
&lt;<a href="https://rdar.apple.com/problem/135380328">rdar://problem/135380328</a>&gt;

Reviewed by Andy Estes.

No one should be using the WKPreference class&apos;s &apos;_fullScreenEnabled&apos; property. This
private property no longer used, in favor of the &apos;elementFullscreenEnabled&apos; API.

I noticed that some older tests still use the deprecated version of this property, so
corrected those tests to use the modern API.

There should be no behavior changes with this correction, since both properties internally modified the same state variable used to control the actual feature.

* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CloseWebViewAfterEnterFullscreen.mm:
(TestWebKitAPI::TEST(CloseWebViewAfterEnterFullscreen, VideoFullscreen)):
(TestWebKitAPI::TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CloseWebViewDuringEnterFullscreen.mm:
(TestWebKitAPI::TEST(CloseWebViewDuringEnterFullscreen, VideoFullscreen)):
(TestWebKitAPI::TEST(CloseWebViewDuringEnterFullscreen, DISABLED_ElementFullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm:
(TestWebKitAPI::TEST(ExitFullscreenOnEnterPiP, VideoFullscreen)):
(TestWebKitAPI::TEST(ExitFullscreenOnEnterPiP, DISABLED_ElementFullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitPiPOnSuspendVideoElement.mm:
(TestWebKitAPI::TEST(PictureInPicture, DISABLED_ExitPiPOnSuspendVideoElement)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenAlert.mm:
(TestWebKitAPI::TEST(Fullscreen, DISABLED_Alert)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm:
(TestWebKitAPI::TEST(Fullscreen, Delegate)):
(TestWebKitAPI::TEST(Fullscreen, VisibilityChangeNotDispatched)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLayoutConstraints.mm:
(TestWebKitAPI::TEST(Fullscreen, LayoutConstraints)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenRemoveNodeBeforeEnter.mm:
(TestWebKitAPI::TEST(Fullscreen, RemoveNodeBeforeEnter)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
(+[FullscreenVideoTextRecognitionWebView create]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm:
(TestWebKitAPI::TEST(PictureInPicture, WKUIDelegate)):
(TestWebKitAPI::TEST(PictureInPicture, AudioCannotTogglePictureInPicture)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TopContentInset.mm:
(TestWebKitAPI::TEST(TopContentInset, Fullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm:
(TEST(WKWebViewCloseAllMediaPresentations, VideoFullscreen)):
(TEST(WKWebViewCloseAllMediaPresentations, ElementFullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm:
(TEST(WKWebViewSuspendAllMediaPlayback, FullscreenWhileSuspended)):
* Tools/TestWebKitAPI/Tests/mac/FullscreenFocus.mm:
(TestWebKitAPI::TEST(Fullscreen, Focus)):
* Tools/TestWebKitAPI/Tests/mac/FullscreenPointerLeave.mm:
(TestWebKitAPI::TEST(Fullscreen, PointerLeave)):

Canonical link: <a href="https://commits.webkit.org/283360@main">https://commits.webkit.org/283360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb196afed9dedd64d2f60b87fff5ed3a5b8dfd14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16957 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11611 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14571 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15552 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14334 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60636 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14572 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1915 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41247 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->