### PR TITLE
[macOS] Cannot click to move cursor focus to mail body after using smart reply and clicking in subject field

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -290,6 +290,9 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
     m_impl->dismissContentRelativeChildWindowsWithAnimation(true);
     m_impl->clearPromisedDragImage();
     m_impl->pageDidScroll({0, 0});
+#if ENABLE(WRITING_TOOLS)
+    m_impl->hideTextAnimationView();
+#endif
 }
 
 void PageClientImpl::didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, std::span<const uint8_t> dataReference)

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.h
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.h
@@ -43,6 +43,8 @@ class WebViewImpl;
 - (void)addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)data;
 - (void)removeTextAnimationForAnimationID:(NSUUID *)uuid;
 
+- (void)hideTextAnimationView;
+
 - (BOOL)hasActiveTextAnimationType;
 
 - (void)suppressTextAnimationType;

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -81,7 +81,6 @@
 
     _effectView = adoptNS([PAL::alloc_WTTextEffectViewInstance() initWithAsyncSource:self]);
     [_effectView setFrame:webView.view().bounds];
-    [_webView->view() addSubview:_effectView.get()];
     return self;
 }
 
@@ -113,6 +112,11 @@
                 strongWebView->page().callCompletionHandlerForAnimationID(*animationID, runMode);
         }).get();
 
+        effect.get().completion = makeBlockPtr([weakSelf = WeakObjCPtr<WKTextAnimationManager>(self), uuid = RetainPtr(uuid)] {
+            if (auto strongSelf = weakSelf.get())
+                [strongSelf removeTextAnimationForAnimationID:uuid.get()];
+        }).get();
+
         break;
 
     case WebCore::TextAnimationType::Final:
@@ -124,9 +128,12 @@
                 strongWebView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, false);
         }).get();
 
-        effect.get().completion = makeBlockPtr([weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = data.unanimatedRangeUUID, uuid = RetainPtr(uuid), runMode = data.runMode] {
+        effect.get().completion = makeBlockPtr([weakSelf = WeakObjCPtr<WKTextAnimationManager>(self), weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = data.unanimatedRangeUUID, uuid = RetainPtr(uuid), runMode = data.runMode] {
             auto strongWebView = weakWebView.get();
             auto animationID = WTF::UUID::fromNSUUID(uuid.get());
+
+            if (auto strongSelf = weakSelf.get())
+                [strongSelf removeTextAnimationForAnimationID:uuid.get()];
 
             if (!strongWebView || !animationID)
                 return;
@@ -142,6 +149,9 @@
 
     ASSERT(effect);
 
+    if (![_effectView superview])
+        [_webView->view() addSubview:_effectView.get()];
+
     RetainPtr effectID = [_effectView addEffect:effect.get()];
     RetainPtr effectData = adoptNS([[WKTextAnimationTypeEffectData alloc] initWithEffectID:effectID.get() type:data.style]);
     [_chunkToEffect setObject:effectData.get() forKey:uuid];
@@ -154,6 +164,14 @@
         [_effectView removeEffect:[effectData effectID]];
         [_chunkToEffect removeObjectForKey:uuid];
     }
+
+    if (![self hasActiveTextAnimationType])
+        [_effectView removeFromSuperview];
+}
+
+- (void)hideTextAnimationView
+{
+    [_effectView removeFromSuperview];
 }
 
 - (BOOL)hasActiveTextAnimationType

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -746,6 +746,8 @@ public:
 
     void addTextAnimationForAnimationID(WTF::UUID, const WebCore::TextAnimationData&);
     void removeTextAnimationForAnimationID(WTF::UUID);
+
+    void hideTextAnimationView();
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4671,6 +4671,11 @@ void WebViewImpl::removeTextAnimationForAnimationID(WTF::UUID uuid)
     [m_textAnimationTypeManager removeTextAnimationForAnimationID:uuid];
 }
 
+void WebViewImpl::hideTextAnimationView()
+{
+    [m_textAnimationTypeManager hideTextAnimationView];
+}
+
 #endif // ENABLE(WRITING_TOOLS)
 
 ViewGestureController& WebViewImpl::ensureGestureController()


### PR DESCRIPTION
#### 3918b513f4cd13a5d13e03bbd6e1a6a680875882
<pre>
[macOS] Cannot click to move cursor focus to mail body after using smart reply and clicking in subject field
<a href="https://bugs.webkit.org/show_bug.cgi?id=279234">https://bugs.webkit.org/show_bug.cgi?id=279234</a>
<a href="https://rdar.apple.com/135281189">rdar://135281189</a>

Reviewed by Wenson Hsieh, Richard Robinson, and Abrar Rahman Protyasha.

A `_WTTextEffectView` is inserted into the view hierarchy when performing
Writing Tools animations. However, it is currently not being removed once the
animations are complete. This is problematic, as the `_WTTextEffectView`
prevents the `WKWebView` from becoming first responder, when clicking over the
web view.

Fix by removing the effect view once animations are complete.

Additionally, resolve memory leaks and actually remove text effects from a map
when they are finished. That is the signal used to remove the effect view.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didCommitLoadForMainFrame):

Remove the effect view when navigating to a different page.

* Source/WebKit/UIProcess/mac/WKTextAnimationManager.h:
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):

Add a completion handler for the source animation, in order to keep the
map of effects up-to-date and remove a memory leak.

Add the effect view to the view hierarchy when needed.

(-[WKTextAnimationManager removeTextAnimationForAnimationID:]):

Remove the effect view if there are no active effects.

(-[WKTextAnimationManager hideTextAnimationView]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::hideTextAnimationView):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, FocusWebViewAfterAnimation)):

Canonical link: <a href="https://commits.webkit.org/283274@main">https://commits.webkit.org/283274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e38529650eb8f0756cb8002c56d917a7f2395d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11378 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68840 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15258 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71505 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9728 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9760 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/8027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9962 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/41774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->