### PR TITLE
Use Manual Reference Counting Objective-C methods in non-ARC code

### DIFF
--- a/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
+++ b/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
@@ -724,10 +724,9 @@ JSObjectRef objCCallbackFunctionForMethod(JSContext *context, Class cls, Protoco
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[NSMethodSignature signatureWithObjCTypes:types]];
     [invocation setSelector:sel];
     if (!isInstanceMethod) {
-        [invocation setTarget:cls];
         // We need to retain the target Class because m_invocation doesn't retain it by default (and we don't want it to).
         // FIXME: What releases it?
-        CFRetain((__bridge CFTypeRef)cls);
+        [invocation setTarget:[cls retain]];
     }
     return objCCallbackFunctionForInvocation(context, invocation, isInstanceMethod ? CallbackInstanceMethod : CallbackClassMethod, isInstanceMethod ? cls : nil, _protocol_getMethodTypeEncoding(protocol, sel, YES, isInstanceMethod));
 }

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -124,7 +124,7 @@ static NSDictionary *attributesForAttributedStringConversion(bool useInterchange
     NSURL *baseURL = URL::fakeURLWithRelativePart(emptyString());
 
     // The output base URL needs +1 refcount to work around the fact that NSHTMLReader over-releases it.
-    CFRetain((__bridge CFTypeRef)baseURL);
+    [baseURL retain];
 
     return @{
         NSExcludedElementsDocumentAttribute: excludedElements.get(),

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -970,12 +970,12 @@ WebCore::WebMediaSessionManager& PageClientImpl::mediaSessionManager()
 
 void PageClientImpl::refView()
 {
-    CFRetain((__bridge CFTypeRef)m_view);
+    [m_view retain];
 }
 
 void PageClientImpl::derefView()
 {
-    CFRelease((__bridge CFTypeRef)m_view);
+    [m_view release];
 }
 
 void PageClientImpl::startWindowDrag()

--- a/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
+++ b/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
@@ -71,9 +71,8 @@ ObjCEventListener::ObjCEventListener(ObjCListener listener)
 ObjCEventListener::~ObjCEventListener()
 {
     listenerMap->remove(m_listener.get());
-    // Avoid executing arbitrary code during GC; e.g. inside Node::~Node. Use CF* to be ARC safe.
-    CFRetain((__bridge CFTypeRef)m_listener.get());
-    CFAutorelease((__bridge CFTypeRef)m_listener.get());
+    // Avoid executing arbitrary code during GC; e.g. inside Node::~Node.
+    [[m_listener.get() retain] autorelease];
 }
 
 void ObjCEventListener::handleEvent(ScriptExecutionContext&, Event& event)

--- a/Tools/DumpRenderTree/mac/ObjCPlugin.m
+++ b/Tools/DumpRenderTree/mac/ObjCPlugin.m
@@ -116,8 +116,7 @@ static BOOL _allowsScriptsFullAccess = NO;
 
 - (id)retainObject:(id)obj
 {
-    CFRetain((__bridge CFTypeRef)obj);
-    return obj;
+    return [obj retain];
 }
 
 - (id)classOfObject:(id)obj


### PR DESCRIPTION
<pre>Use Manual Reference Counting methods in non-ARC code
https://bugs.webkit.org/show_bug.cgi?id=279241

Reviewed by NOBODY (OOPS!).

CFRelease((__bridge)) workaround is ugly and is
not used in ARC code, so call the methods directly
instead of laundering retain counts through
Core Foundation.

* Source/JavaScriptCore/API/ObjCCallbackFunction.mm:
(objCCallbackFunctionForMethod): Use Manual Reference Counting methods.
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::attributesForAttributedStringConversion): Ditto.
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::refView): Ditto.
(WebKit::PageClientImpl::derefView): Ditto
* Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm:
(WebCore::ObjCEventListener::~ObjCEventListener): Ditto.
* Tools/DumpRenderTree/mac/ObjCPlugin.m:
(-[JSObjC retainObject:]): Ditto.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/699a86393bea86871f8937f81d7414e69196ab5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53434 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12018 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15101 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16174 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59801 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72423 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65932 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60765 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61100 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2381 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41869 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15422 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->