### PR TITLE
Copying link to a common term in an article results in the incorrect part of the page being highlighted

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries-expected.txt
@@ -1,0 +1,1 @@
+:~:text=a%20very%20simple-,document,-.%20There%20is%20no

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we allow context generation to pass boundaries of inline elements</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNode(document.body.getElementsByTagName("b")[0])
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>This is a very simple <b>document</b>. There is no text before 'this'.</body>
+</html>
+

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1192,6 +1192,7 @@ dom/FormDataEvent.cpp
 dom/FragmentDirectiveGenerator.cpp
 dom/FragmentDirectiveRangeFinder.cpp
 dom/FragmentDirectiveParser.cpp
+dom/FragmentDirectiveUtilities.cpp
 dom/FullscreenManager.cpp
 dom/GCReachableRef.cpp
 dom/HashChangeEvent.cpp

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "DocumentType.h"
 #include "Editor.h"
+#include "FragmentDirectiveUtilities.h"
 #include "HTMLAudioElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLImageElement.h"
@@ -50,7 +51,9 @@
 #include "TextIterator.h"
 
 namespace WebCore {
+
 namespace FragmentDirectiveRangeFinder {
+using namespace FragmentDirectiveUtilities;
 
 enum class BoundaryPointIsAtEnd : bool { No, Yes };
 enum class WordBounded : bool { No, Yes };
@@ -92,18 +95,6 @@ static bool isNonSearchableSubtree(const Node& node)
         traversingNode = traversingNode->parentOrShadowHostNode();
     }
     return false;
-}
-
-// https://wicg.github.io/scroll-to-text-fragment/#nearest-block-ancestor
-static const Node& nearestBlockAncestor(const Node& node)
-{
-    const Node* currentNode = &node;
-    while (currentNode) {
-        if (!currentNode->isTextNode() && currentNode->renderer() && currentNode->renderer()->style().isDisplayBlockLevel())
-            return *currentNode;
-        currentNode = currentNode->parentNode();
-    }
-    return node.document();
 }
 
 // https://wicg.github.io/scroll-to-text-fragment/#get-boundary-point-at-index

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FragmentDirectiveUtilities.h"
+
+#include "NodeRenderStyle.h"
+#include "NodeTraversal.h"
+#include "RenderStyleInlines.h"
+
+namespace WebCore {
+
+namespace FragmentDirectiveUtilities {
+
+// https://wicg.github.io/scroll-to-text-fragment/#nearest-block-ancestor
+const Node& nearestBlockAncestor(const Node& node)
+{
+    for (RefPtr currentNode = &node; currentNode; currentNode = currentNode->parentNode()) {
+        if (!currentNode->isTextNode() && currentNode->renderer() && currentNode->renderer()->style().isDisplayBlockLevel())
+            return *currentNode;
+    }
+    return node.document();
+}
+
+} // namespace FragmentDirectiveUtilities
+
+} // WebCore

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.h
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class Node;
+
+namespace FragmentDirectiveUtilities {
+
+const Node& nearestBlockAncestor(const Node&);
+
+}
+
+} // namespace WebCore


### PR DESCRIPTION
#### 42ee0a01c846807e6b64f348ffa141e05e8188d4
<pre>
Copying link to a common term in an article results in the incorrect part of the page being highlighted
<a href="https://bugs.webkit.org/show_bug.cgi?id=279248">https://bugs.webkit.org/show_bug.cgi?id=279248</a>
<a href="https://rdar.apple.com/134882107">rdar://134882107</a>

Reviewed by Richard Robinson and Megan Gardner.

The fragment directive generation code was terminating its context walk when it hit
*any* node boundary, meaning that (for example) if you selected a word in its own &lt;b&gt;,
we wouldn&apos;t be able to generate any context, and the link would match the first
instance of that word on the page, not the correct one.

The intent was to match the fragment directive *search* code, which breaks across
block boundaries, not any element&apos;s boundary. Factor out this code (and add a
place where we can share code between generation and search, since we will likely
need more of that in the future).

* LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries.html: Added.
Add a test.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::positionsHaveSameBlockAncestor):
(WebCore::previousWordsFromPositionInSameBlock):
(WebCore::nextWordsFromPositionInSameBlock):
Make the aforementioned change, only terminating the context search when we exit the block.

(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):
Make sure layout is up to date before we go reading from the render tree.
Move the fragment directive prefix string closer to its use.

(WebCore::previousWordsFromPosition): Deleted.
(WebCore::nextWordsFromPosition): Deleted.

* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::nearestBlockAncestor): Deleted.
* Source/WebCore/dom/FragmentDirectiveUtilities.cpp: Added.
(WebCore::FragmentDirectiveUtilities::nearestBlockAncestor):
* Source/WebCore/dom/FragmentDirectiveUtilities.h: Added.
Factor out nearestBlockAncestor. I couldn&apos;t find anything similar in the rest
of the project, so for now kept it local to this code.

Canonical link: <a href="https://commits.webkit.org/283294@main">https://commits.webkit.org/283294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/780f44b7477b7b632a816275c8cdaf853b74073b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52875 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9846 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60479 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14518 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1764 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41072 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->