### PR TITLE
Add `SVGImageElement.prototype.decode()` support

### DIFF
--- a/LayoutTests/fast/images/decode-static-svg-image-resolve-expected.html
+++ b/LayoutTests/fast/images/decode-static-svg-image-resolve-expected.html
@@ -1,0 +1,20 @@
+<style>
+    .boxes {
+        display: inline-block;
+    }
+    .box {
+        width: 100px;
+        height: 100px;
+        display: inline-block;
+    }
+    .green {
+        background-color: green;
+    }
+</style>
+<body>
+    <p>This tests passes if two green rectangles are drawn.</p>
+    <div class="boxes">
+        <div class="box green"></div>
+        <div class="box green"></div>
+    </div>
+</body>

--- a/LayoutTests/fast/images/decode-static-svg-image-resolve.html
+++ b/LayoutTests/fast/images/decode-static-svg-image-resolve.html
@@ -1,0 +1,37 @@
+<style>
+    canvas {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+</style>
+<body>
+    <p>This tests passes if two green rectangles are drawn.</p>
+    <svg width="100" height="100">
+        <image width="100%" height="100%"/>
+    </svg>
+    <canvas></canvas>
+    <script>
+        function loadImage(href) {
+            return new Promise((resolve) => {
+                let image = document.querySelector('image');
+                image.setAttribute("href", href);
+                image.decode().then(() => {
+                    resolve();
+                });
+            });
+        }
+
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        loadImage("resources/green-400x400.png").then(() => {
+            let canvas = document.querySelector("canvas");
+            let context = canvas.getContext("2d");
+            let image = document.querySelector('image');
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following good decode succeeds. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following good decode succeeds. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following bad decode fails. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following bad decode fails. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
+FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode. assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode. assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following good decode succeeds. assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following good decode succeeds. assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following bad decode fails.
+PASS SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following bad decode fails.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-svg.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-svg.tentative-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL SVGImageElement.prototype.decode(), basic tests. Image with PNG xlink:href decodes with undefined. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Image with PNG href decodes with undefined. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Image with PNG data URL xlink:href decodes with undefined. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Image with PNG data URL href decodes with undefined. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Image with SVG xlink:href decodes with undefined. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Image with SVG href decodes with undefined. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Non-existent xlink:href fails decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Non-existent href fails decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Corrupt image in xlink:href fails decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Corrupt image in href fails decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Image without xlink:href or href fails decode. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Multiple decodes with a xlink:href succeed. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
-FAIL SVGImageElement.prototype.decode(), basic tests. Multiple decodes with a href succeed. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
+PASS SVGImageElement.prototype.decode(), basic tests. Image with PNG xlink:href decodes with undefined.
+PASS SVGImageElement.prototype.decode(), basic tests. Image with PNG href decodes with undefined.
+PASS SVGImageElement.prototype.decode(), basic tests. Image with PNG data URL xlink:href decodes with undefined.
+PASS SVGImageElement.prototype.decode(), basic tests. Image with PNG data URL href decodes with undefined.
+PASS SVGImageElement.prototype.decode(), basic tests. Image with SVG xlink:href decodes with undefined.
+PASS SVGImageElement.prototype.decode(), basic tests. Image with SVG href decodes with undefined.
+PASS SVGImageElement.prototype.decode(), basic tests. Non-existent xlink:href fails decode.
+PASS SVGImageElement.prototype.decode(), basic tests. Non-existent href fails decode.
+PASS SVGImageElement.prototype.decode(), basic tests. Corrupt image in xlink:href fails decode.
+PASS SVGImageElement.prototype.decode(), basic tests. Corrupt image in href fails decode.
+PASS SVGImageElement.prototype.decode(), basic tests. Image without xlink:href or href fails decode.
+PASS SVGImageElement.prototype.decode(), basic tests. Multiple decodes with a xlink:href succeed.
+PASS SVGImageElement.prototype.decode(), basic tests. Multiple decodes with a href succeed.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-with-quick-attach-svg.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-with-quick-attach-svg.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SVGImageElement.prototype.decode(), attach to DOM before promise resolves. img.decode is not a function. (In 'img.decode()', 'img.decode' is undefined)
+PASS SVGImageElement.prototype.decode(), attach to DOM before promise resolves.
 

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -217,6 +217,11 @@ void SVGImageElement::didMoveToNewDocument(Document& oldDocument, Document& newD
 {
     m_imageLoader.elementDidMoveToNewDocument(oldDocument);
     SVGGraphicsElement::didMoveToNewDocument(oldDocument, newDocument);
+}
+
+void SVGImageElement::decode(Ref<DeferredPromise>&& promise)
+{
+    return m_imageLoader.decode(WTFMove(promise));
 }
 
 }

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -54,6 +54,8 @@ public:
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
+
+    void decode(Ref<DeferredPromise>&&);
 
 private:
     SVGImageElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGImageElement.idl
+++ b/Source/WebCore/svg/SVGImageElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,8 @@
     readonly attribute SVGAnimatedLength height;
     readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;
     attribute [AtomString] DOMString? crossOrigin;
+
+    Promise<undefined> decode();
 };
 
 SVGImageElement includes SVGURIReference;


### PR DESCRIPTION
#### f2adb8467c81d2df25e8fa651a54d6d9a00b9338
<pre>
Add `SVGImageElement.prototype.decode()` support

<a href="https://bugs.webkit.org/show_bug.cgi?id=279254">https://bugs.webkit.org/show_bug.cgi?id=279254</a>
<a href="https://rdar.apple.com/135404215">rdar://135404215</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

It extends `decode()` support from HTML Image Element as defined in web
specification [1], to SVG Image Element.

[1] <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding">https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding</a>

Credits to Said Abou-Hallawa for test case guidance.

* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::decode):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGImageElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-svg.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-with-quick-attach-svg.tentative-expected.txt:
* LayoutTests/fast/images/decode-static-svg-image-resolve-expected.html:
* LayoutTests/fast/images/decode-static-svg-image-resolve.html:

Canonical link: <a href="https://commits.webkit.org/283643@main">https://commits.webkit.org/283643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26e5b87e882e3b6a6b6235c6e9a10765370b6a2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19532 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17824 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/70945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69977 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/57894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/15286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15627 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10867 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/72646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57951 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14776 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/8927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44352 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42912 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->