### PR TITLE
ServiceWorkerClient.focus should resolve once the document event loop is running

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -516,6 +516,7 @@ public:
     bool isInitialAboutBlank() const { return m_isInitialAboutBlank; }
 
     bool navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument);
+    WEBCORE_EXPORT void whenDocumentIsCreated(Function<void(Document*)>&&);
 
 protected:
     WEBCORE_EXPORT DocumentLoader(const ResourceRequest&, const SubstituteData&);
@@ -779,6 +780,8 @@ private:
 #endif
 
     bool m_canUseServiceWorkers { true };
+
+    Function<void(Document*)> m_whenDocumentIsCreatedCallback;
 
 #if ASSERT_ENABLED
     bool m_hasEverBeenAttached { false };

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -429,16 +429,39 @@ void WebSWClientConnection::focusServiceWorkerClient(ScriptExecutionContextIdent
         return;
     }
 
-    WebPage::fromCorePage(*page)->sendWithAsyncReply(Messages::WebPageProxy::FocusFromServiceWorker { }, [clientIdentifier, callback = WTFMove(callback)]() mutable {
+    WebPage::fromCorePage(*page)->sendWithAsyncReply(Messages::WebPageProxy::FocusFromServiceWorker { }, [clientIdentifier, callback = WTFMove(callback)] () mutable {
+        auto doFocusSteps = [callback = WTFMove(callback)] (auto* document) mutable {
+            if (!document) {
+                callback({ });
+                return;
+            }
+
+            document->eventLoop().queueTask(TaskSource::Networking, [document = RefPtr { document }, callback = WTFMove(callback)] () mutable {
+                RefPtr frame = document ? document->frame() : nullptr;
+                RefPtr page = frame ? frame->page() : nullptr;
+
+                if (!page) {
+                    callback({ });
+                    return;
+                }
+
+                page->focusController().setFocusedFrame(frame.get());
+                callback(ServiceWorkerClientData::from(*document));
+            });
+        };
+
         RefPtr document = Document::allDocumentsMap().get(clientIdentifier);
-        RefPtr frame = document ? document->frame() : nullptr;
-        RefPtr page = frame ? frame->page() : nullptr;
-        if (!page) {
-            callback({ });
+        if (!document) {
+            RefPtr loader = DocumentLoader::fromScriptExecutionContextIdentifier(clientIdentifier);
+            if (!loader) {
+                callback({ });
+                return;
+            };
+            loader->whenDocumentIsCreated(WTFMove(doFocusSteps));
             return;
         }
-        page->focusController().setFocusedFrame(frame.get());
-        callback(ServiceWorkerClientData::from(*document));
+
+        doFocusSteps(document.get());
     });
 }
 


### PR DESCRIPTION
#### b17e57d6d9bea2b11d640a92ba7f57f95ca10161
<pre>
ServiceWorkerClient.focus should resolve once the document event loop is running
<a href="https://bugs.webkit.org/show_bug.cgi?id=279263">https://bugs.webkit.org/show_bug.cgi?id=279263</a>
<a href="https://rdar.apple.com/problem/135408068">rdar://problem/135408068</a>

Reviewed by Ben Nham.

<a href="https://w3c.github.io/ServiceWorker/#client-focus">https://w3c.github.io/ServiceWorker/#client-focus</a> says to queue a task on the document to focus to execute some steps, and then resolve the focus promise.
We are not ensuring this, and it may have an impact in case the document is not yet created or if its event loop is not yet running.
For that reason, we are now focusing the navigable and, once done and once the document is created, wwe enqueue a task on the document to do the focus step and trigger the focus promise resolution.

Covered by updated API test.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::~DocumentLoader):
(WebCore::DocumentLoader::mainReceivedError):
(WebCore::DocumentLoader::finishedLoading):
(WebCore::DocumentLoader::whenDocumentIsCreated):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::focusServiceWorkerClient):
(WebKit::WebSWClientConnection::addCookieChangeSubscriptions):
(WebKit::WebSWClientConnection::removeCookieChangeSubscriptions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((ServiceWorker, FocusNotYetLoadedClient)):

Canonical link: <a href="https://commits.webkit.org/283337@main">https://commits.webkit.org/283337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2065086259eb34610f113177f13e27f7e696803

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52984 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71746 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60302 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60592 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1873 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41194 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->