### PR TITLE
Unreviewed, reverting 278456@main (48d82b12d119) and 273922@main (fd1f0b783bb7)

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -291,11 +291,7 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool 
     }
 
     WebKitWebViewBase* webkitWebViewBase = WEBKIT_WEB_VIEW_BASE(m_viewWidget);
-#if USE(GTK4)
-    webkitWebViewBaseProcessAcceleratorsForKeyPressEvent(webkitWebViewBase, event.nativeEvent());
-#else
     webkitWebViewBasePropagateKeyEvent(webkitWebViewBase, event.nativeEvent());
-#endif
 }
 
 RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -292,6 +292,7 @@ struct _WebKitWebViewBasePrivate {
     RefPtr<WebPageProxy> pageProxy;
     IntSize viewSize { };
 #if USE(GTK4)
+    Vector<GRefPtr<GdkEvent>> keyEventsToPropagate;
     Vector<GRefPtr<GdkEvent>> wheelEventsToPropagate;
 #else
     bool shouldForwardNextKeyEvent { false };
@@ -1106,6 +1107,15 @@ static void webkitWebViewBaseUnmap(GtkWidget* widget)
     priv->pageProxy->activityStateDidChange(ActivityState::IsVisible);
 }
 
+static bool shouldForwardKeyEvent(WebKitWebViewBase* webViewBase, GdkEvent* event)
+{
+#if USE(GTK4)
+    return event && webViewBase->priv->keyEventsToPropagate.removeFirst(event);
+#else
+    return std::exchange(webViewBase->priv->shouldForwardNextKeyEvent, false);
+#endif
+}
+
 static bool shouldForwardWheelEvent(WebKitWebViewBase* webViewBase, GdkEvent* event)
 {
 #if USE(GTK4)
@@ -1152,11 +1162,6 @@ static gboolean webkitWebViewBaseFocusOutEvent(GtkWidget* widget, GdkEventFocus*
     webViewBase->priv->inputMethodFilter.notifyFocusedOut();
 
     return GTK_WIDGET_CLASS(webkit_web_view_base_parent_class)->focus_out_event(widget, event);
-}
-
-static bool shouldForwardKeyEvent(WebKitWebViewBase* webViewBase, GdkEvent* event)
-{
-    return std::exchange(webViewBase->priv->shouldForwardNextKeyEvent, false);
 }
 
 static gboolean webkitWebViewBaseKeyPressEvent(GtkWidget* widget, GdkEventKey* keyEvent)
@@ -1241,60 +1246,18 @@ static void webkitWebViewBaseFocusLeave(WebKitWebViewBase* webViewBase, GtkEvent
     webViewBase->priv->inputMethodFilter.notifyFocusedOut();
 }
 
-void webkitWebViewBaseProcessAcceleratorsForKeyPressEvent(WebKitWebViewBase* webViewBase, GdkEvent* event)
-{
-    // Event processing in GTK is synchronous, but in WebKit it is asynchronous because we don't
-    // want to block the UI process waiting for the web process to decide whether a DOM event has
-    // been handled (e.g. by using Event.stopPropagation). In GTK 3, we used a complicated scheme to
-    // synthesize and reinject new key and wheel events to continue event processing when the event
-    // is not handled by the web content, which the GTK developers did not approve of. We originally
-    // attempted this for GTK 4 as well, but it never worked properly, and GTK's support for event
-    // injection has been deprecated. Instead, the WebKitWebViewBase now always handles all events
-    // (by always returning GDK_EVENT_STOP).
-    //
-    // Web browsers must forward most key events to the web view for processing before they are
-    // processed by the window, because processing key press events on the window will activate
-    // action accelerators, but web content should be allowed to override most accelerators. E.g.
-    // on Google Docs Ctrl+O should open Google's document chooser, not the browser's file chooser,
-    // and Ctrl+F should open Google's find, not the browser's. See key_pressed_cb and
-    // should_view_receive_key_press_event_first in Epiphany's ephy-window.c for what this looks
-    // like on the browser side. (Those functions contain a comment that refers to this code in
-    // WebKit, so please update the comment there if needed when changing the code here.)
-    //
-    // This all creates a new problem with key events. If the browser implements the above strategy
-    // properly, then the browser's GtkWindow will never see the events and accelerators will not
-    // run, so we need to manually activate them here. (This function is called by PageClientImpl
-    // only after determining that the web process has not handled the event.) It's safe to do this
-    // even if the window already processed the events before WebKit, because in that case, no
-    // accelerator was activated (or it would have handled the event), so we'll fail to find any
-    // matching accelerator here. This clever strategy was proposed by Benjamin Otte.
-
-    GApplication* app = g_application_get_default();
-    if (!app || !GTK_IS_APPLICATION(app))
-        return;
-
-    ASSERT(gdk_event_get_event_type(event) == GDK_KEY_PRESS);
-    if (gdk_key_event_is_modifier(event))
-        return;
-
-    GUniquePtr<char> accelerator(gtk_accelerator_name_with_keycode(gtk_widget_get_display(GTK_WIDGET(webViewBase)), gdk_key_event_get_keyval(event), gdk_key_event_get_keycode(event), gdk_event_get_modifier_state(event)));
-    GUniquePtr<char*> actions(gtk_application_get_actions_for_accel(GTK_APPLICATION(app), accelerator.get()));
-    for (int i = 0; actions.get()[i]; ++i) {
-        const char* detailedAction = actions.get()[i];
-        GUniqueOutPtr<char> actionName;
-        GRefPtr<GVariant> targetValue;
-        GUniqueOutPtr<GError> error;
-        if (g_action_parse_detailed_name(detailedAction, &actionName.outPtr(), &targetValue.outPtr(), &error.outPtr()))
-            gtk_widget_activate_action_variant(GTK_WIDGET(webViewBase), actionName.get(), targetValue.get());
-        else
-            g_warning("Failed to parse detailed action %s: %s", detailedAction, error->message);
-    }
-}
-
 static gboolean webkitWebViewBaseKeyPressed(WebKitWebViewBase* webViewBase, unsigned keyval, unsigned, GdkModifierType state, GtkEventController* controller)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
     auto* event = gtk_event_controller_get_current_event(controller);
+
+    // Since WebProcess key event handling is not synchronous, handle the event in two passes.
+    // When WebProcess processes the input event, it will call PageClientImpl::doneWithKeyEvent
+    // with event handled status which determines whether to pass the input event to parent or not
+    // using gdk_display_put_event().
+    if (shouldForwardKeyEvent(webViewBase, event))
+        return GDK_EVENT_PROPAGATE;
+
     bool isAutoRepeat = priv->keyAutoRepeatHandler.keyPress(gdk_key_event_get_keycode(event));
 
 #if ENABLE(DEVELOPER_MODE) && OS(LINUX)
@@ -2647,13 +2610,17 @@ void webkitWebViewBaseDidPerformDragControllerAction(WebKitWebViewBase* webViewB
 }
 #endif // ENABLE(DRAG_SUPPORT)
 
-#if !USE(GTK4)
 void webkitWebViewBasePropagateKeyEvent(WebKitWebViewBase* webkitWebViewBase, GdkEvent* event)
 {
+#if USE(GTK4)
+    webkitWebViewBase->priv->keyEventsToPropagate.append(event);
+    // Note: the docs for gdk_display_put_event lie - this adds to the end of the queue, not the front.
+    gdk_display_put_event(gtk_widget_get_display(GTK_WIDGET(webkitWebViewBase)), event);
+#else
     webkitWebViewBase->priv->shouldForwardNextKeyEvent = true;
     gtk_main_do_event(event);
-}
 #endif
+}
 
 void webkitWebViewBasePropagateWheelEvent(WebKitWebViewBase* webkitWebViewBase, GdkEvent* event)
 {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -53,11 +53,7 @@ void webkitWebViewBaseCreateWebPage(WebKitWebViewBase*, Ref<API::PageConfigurati
 void webkitWebViewBaseSetTooltipText(WebKitWebViewBase*, const char*);
 void webkitWebViewBaseSetTooltipArea(WebKitWebViewBase*, const WebCore::IntRect&);
 void webkitWebViewBaseSetMouseIsOverScrollbar(WebKitWebViewBase*, WebKit::WebHitTestResultData::IsScrollbar);
-#if USE(GTK4)
-void webkitWebViewBaseProcessAcceleratorsForKeyPressEvent(WebKitWebViewBase*, GdkEvent*);
-#else
 void webkitWebViewBasePropagateKeyEvent(WebKitWebViewBase*, GdkEvent*);
-#endif
 void webkitWebViewBasePropagateWheelEvent(WebKitWebViewBase*, GdkEvent*);
 void webkitWebViewBaseChildMoveResize(WebKitWebViewBase*, GtkWidget*, const WebCore::IntRect&);
 #if ENABLE(FULLSCREEN_API)


### PR DESCRIPTION
#### 5978873cc8be887f2fbe1078d17419fb0c0ab096
<pre>
Unreviewed, reverting 278456@main (48d82b12d119) and 273922@main (fd1f0b783bb7)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273780">https://bugs.webkit.org/show_bug.cgi?id=273780</a>

REGRESSION(273922@main): [GTK] Epiphany keyboard shortcuts broken with non-Latin keyboard layout

Reverted changes:

    [GTK] Consider keycode when activating application accelerators
    <a href="https://bugs.webkit.org/show_bug.cgi?id=273780">https://bugs.webkit.org/show_bug.cgi?id=273780</a>
    278456@main (48d82b12d119)

    [GTK] Remove key event reinjection
    <a href="https://bugs.webkit.org/show_bug.cgi?id=261348">https://bugs.webkit.org/show_bug.cgi?id=261348</a>
    273922@main (fd1f0b783bb7)

I don&apos;t know how to fix keyboard shortcuts properly, so let&apos;s go back to
the previous behavior for now.

Canonical link: <a href="https://commits.webkit.org/283267@main">https://commits.webkit.org/283267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81956537350fcef7abea3289f5658fde81e0839c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16354 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16636 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11354 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38327 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71477 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14056 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56966 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1656 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->