### PR TITLE
[CSS Typed OM] Fix reference cycle between the computed style property map and DOM elements

### DIFF
--- a/LayoutTests/css-typedom/computed-style-map-lifetime-expected.txt
+++ b/LayoutTests/css-typedom/computed-style-map-lifetime-expected.txt
@@ -1,0 +1,10 @@
+Tests that a reference to an elements computed style map will keep the element alive, even if it is disconnected from the document.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The test didn't crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/css-typedom/computed-style-map-lifetime.html
+++ b/LayoutTests/css-typedom/computed-style-map-lifetime.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<body>
+<div id="el" width="500" height="500"></div>
+<script src="../resources/js-test-pre.js"></script>
+<script>
+jsTestIsAsync = true;
+description("Tests that a reference to an elements computed style map will keep the element alive, even if it is disconnected from the document.");
+
+let computedStyleMap = el.computedStyleMap();
+document.body.removeChild(el)
+
+setTimeout(() => {
+    var count = 0;
+    let handle = setInterval(() => {
+        gc();
+        let _ = computedStyleMap.get("width") + computedStyleMap.get("height")
+
+        if (++count > 11) {
+            clearInterval(handle);
+            testPassed("The test didn't crash.");
+            finishJSTest();
+        }
+
+    }, 32);
+}, 10);
+
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -733,6 +733,7 @@ bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
 bindings/js/JSShadowRootCustom.cpp
 bindings/js/JSSourceBufferCustom.cpp
 bindings/js/JSStaticRangeCustom.cpp
+bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
 bindings/js/JSStyleSheetCustom.cpp
 bindings/js/JSSubscriberCustom.cpp
 bindings/js/JSTextCustom.cpp

--- a/Source/WebCore/bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSStylePropertyMapReadOnly.h"
+
+#include "ComputedStylePropertyMapReadOnly.h"
+#include "WebCoreOpaqueRootInlines.h"
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSStylePropertyMapReadOnly::visitAdditionalChildren(Visitor& visitor)
+{
+    if (auto* computedStylePropertyMap = dynamicDowncast<ComputedStylePropertyMapReadOnly>(wrapped()))
+        addWebCoreOpaqueRoot(visitor, computedStylePropertyMap->elementConcurrently());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSStylePropertyMapReadOnly);
+}

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -50,7 +50,7 @@ ComputedStylePropertyMapReadOnly::ComputedStylePropertyMapReadOnly(Element& elem
 
 RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::propertyValue(CSSPropertyID propertyID) const
 {
-    return ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed);
+    return ComputedStyleExtractor(m_element.get()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed);
 }
 
 String ComputedStylePropertyMapReadOnly::shorthandPropertySerialization(CSSPropertyID propertyID) const
@@ -61,41 +61,48 @@ String ComputedStylePropertyMapReadOnly::shorthandPropertySerialization(CSSPrope
 
 RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::customPropertyValue(const AtomString& property) const
 {
-    return ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property);
+    return ComputedStyleExtractor(m_element.get()).customPropertyValue(property);
 }
 
 unsigned ComputedStylePropertyMapReadOnly::size() const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-size
+    RefPtr element = protectedElement();
+    if (!element)
+        return 0;
 
-    ComputedStyleExtractor::updateStyleIfNeededForProperty(m_element.get(), CSSPropertyCustom);
+    ComputedStyleExtractor::updateStyleIfNeededForProperty(*element.get(), CSSPropertyCustom);
 
-    auto* style = m_element->computedStyle();
+    auto* style = element->computedStyle();
     if (!style)
         return 0;
 
-    return m_element->document().exposedComputedCSSPropertyIDs().size() + style->inheritedCustomProperties().size() + style->nonInheritedCustomProperties().size();
+    return element->document().exposedComputedCSSPropertyIDs().size() + style->inheritedCustomProperties().size() + style->nonInheritedCustomProperties().size();
 }
 
 Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMapReadOnly::entries(ScriptExecutionContext*) const
 {
+    RefPtr element = protectedElement();
+    if (!element)
+        return { };
+
     // https://drafts.css-houdini.org/css-typed-om-1/#the-stylepropertymap
     Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> values;
 
     // Ensure custom property counts are correct.
-    ComputedStyleExtractor::updateStyleIfNeededForProperty(m_element.get(), CSSPropertyCustom);
+    ComputedStyleExtractor::updateStyleIfNeededForProperty(*element.get(), CSSPropertyCustom);
 
-    auto* style = m_element->computedStyle();
+    auto* style = element->computedStyle();
     if (!style)
         return values;
 
-    Ref document = m_element->protectedDocument();
+    Ref document = element->protectedDocument();
     const auto& inheritedCustomProperties = style->inheritedCustomProperties();
     const auto& nonInheritedCustomProperties = style->nonInheritedCustomProperties();
     const auto& exposedComputedCSSPropertyIDs = document->exposedComputedCSSPropertyIDs();
     values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties.size() + nonInheritedCustomProperties.size());
 
-    ComputedStyleExtractor extractor { m_element.ptr() };
+    ComputedStyleExtractor extractor { element.get() };
     values.appendContainerWithMapping(exposedComputedCSSPropertyIDs, [&](auto propertyID) {
         auto value = extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
         return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, document));

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
@@ -29,13 +29,19 @@
 
 namespace WebCore {
 class Element;
+class WeakPtrImplWithEventTargetData;
 
 class ComputedStylePropertyMapReadOnly final : public MainThreadStylePropertyMapReadOnly {
 public:
     static Ref<ComputedStylePropertyMapReadOnly> create(Element&);
 
+    Type type() const final { return Type::Computed; }
+    Element* elementConcurrently() const { return m_element.get(); }
+
 private:
     explicit ComputedStylePropertyMapReadOnly(Element&);
+
+    RefPtr<Element> protectedElement() const { return m_element.get(); }
 
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;
@@ -43,7 +49,9 @@ private:
     unsigned size() const final;
     Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
 
-    Ref<Element> m_element;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(ComputedStylePropertyMapReadOnly, WebCore::StylePropertyMapReadOnly::Type::Computed);

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -40,6 +40,7 @@ public:
 
     Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
     unsigned size() const final;
+    Type type() const final { return Type::Declared; }
 
 private:
     explicit DeclaredStylePropertyMap(CSSStyleRule&);
@@ -60,3 +61,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(DeclaredStylePropertyMap, WebCore::StylePropertyMapReadOnly::Type::Declared);

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
@@ -36,6 +36,7 @@ public:
     static Ref<HashMapStylePropertyMapReadOnly> create(HashMap<AtomString, RefPtr<CSSValue>>&&);
     ~HashMapStylePropertyMapReadOnly();
 
+    Type type() const final { return Type::HashMap; }
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;
     RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
@@ -49,3 +50,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(HashMapStylePropertyMapReadOnly, WebCore::StylePropertyMapReadOnly::Type::HashMap);

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.h
@@ -36,6 +36,8 @@ class InlineStylePropertyMap final : public StylePropertyMap {
 public:
     static Ref<InlineStylePropertyMap> create(StyledElement&);
 
+    Type type() const final { return Type::Inline; }
+
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;
     RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
@@ -55,3 +57,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(InlineStylePropertyMap, WebCore::StylePropertyMapReadOnly::Type::Inline);

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -41,6 +41,16 @@ class StyledElement;
 class StylePropertyMapReadOnly : public RefCounted<StylePropertyMapReadOnly> {
 public:
     using StylePropertyMapEntry = KeyValuePair<String, Vector<RefPtr<CSSStyleValue>>>;
+
+    enum class Type {
+        Computed,
+        Declared,
+        HashMap,
+        Inline,
+    };
+
+    virtual Type type() const = 0;
+
     class Iterator {
     public:
         explicit Iterator(StylePropertyMapReadOnly&, ScriptExecutionContext*);
@@ -66,3 +76,8 @@ protected:
 };
 
 } // namespace WebCore
+
+#define SPECIALIZE_TYPE_TRAITS_CSSOM_STYLE_PROPERTY_MAP(ToValueTypeName, predicate) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
+    static bool isType(const WebCore::StylePropertyMapReadOnly& value) { return value.type() == predicate; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
@@ -28,6 +28,7 @@
     Exposed=(Window,Worker,PaintWorklet),
     SkipVTableValidation,
     JSGenerateToJSObject,
+    JSCustomMarkFunction
 ] interface StylePropertyMapReadOnly {
     iterable<USVString, sequence<CSSStyleValue>>;
     // FIXME: should be (undefined or CSSStyleValue), not null


### PR DESCRIPTION
#### 002bcd5e72150ed17b53a718853ca784544080bc
<pre>
[CSS Typed OM] Fix reference cycle between the computed style property map and DOM elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=279268">https://bugs.webkit.org/show_bug.cgi?id=279268</a>
<a href="https://rdar.apple.com/135356992">rdar://135356992</a>

Reviewed by Chris Dumez and Matthieu Dubet.

There is a ref cycle between Element.computedStylePropertyMap and the
element itself. This change makes the back reference between
ComputedStylePropertyMapReadOnly and the element weak. To cover the case
where a JS reference is held to the computedStylePropertyMap but the
element has been disconnected from the document and is eligible for GC
the map will keep the element alive.

Verified fix with run-webkit-tests --world-leaks imported/w3c/web-platform-tests/css/css-typed-om
and the new layout test to verify GC behavior.

* LayoutTests/css-typedom/computed-style-map-lifetime-expected.txt: Added.
* LayoutTests/css-typedom/computed-style-map-lifetime.html: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSStylePropertyMapReadOnlyCustom.cpp: Copied from Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h.
(WebCore::JSStylePropertyMapReadOnly::visitAdditionalChildren):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.h:
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/InlineStylePropertyMap.h:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl:

Canonical link: <a href="https://commits.webkit.org/283490@main">https://commits.webkit.org/283490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0881fbcf62d852e92222113236eeabbefa7d1d1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53033 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11601 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14557 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10004 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14317 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1902 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->