### PR TITLE
[WPE] Fix device scale factor in the DRM platform

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
@@ -237,7 +237,7 @@ static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
         g_param_spec_double(
             "scale",
             nullptr, nullptr,
-            1, G_MAXDOUBLE, 1,
+            0., G_MAXDOUBLE, 1.,
             WEBKIT_PARAM_READWRITE);
 
     /**
@@ -480,7 +480,7 @@ gdouble wpe_monitor_get_scale(WPEMonitor* monitor)
 void wpe_monitor_set_scale(WPEMonitor* monitor, double scale)
 {
     g_return_if_fail(WPE_IS_MONITOR(monitor));
-    g_return_if_fail(scale >= 1);
+    g_return_if_fail(scale > 0);
 
     if (monitor->priv->scale == scale)
         return;

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -249,7 +249,7 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
         g_param_spec_double(
             "scale",
             nullptr, nullptr,
-            1., G_MAXDOUBLE, 1.,
+            0., G_MAXDOUBLE, 1.,
             WEBKIT_PARAM_READABLE);
 
     /**


### PR DESCRIPTION
#### a34b9541632aa06189b44a3429bf1615e95ccdbc
<pre>
[WPE] Fix device scale factor in the DRM platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=279272">https://bugs.webkit.org/show_bug.cgi?id=279272</a>

Reviewed by Carlos Garcia Campos.

Change the minimum specification of the DRM monitor scale from 1.0 to 0;
change the assertion check for arg passed in from 1.0 to 0.

* Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp:
(wpe_monitor_class_init):
(wpe_monitor_set_scale):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):

Canonical link: <a href="https://commits.webkit.org/283394@main">https://commits.webkit.org/283394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f607bb223b443c84ddcc4441237be810d34c15a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16758 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53080 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11665 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38662 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71882 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10103 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60692 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1980 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10022 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41329 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42405 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->