### PR TITLE
AX: ButtonFace color has bad contrast with ButtonText color in dark mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
@@ -27,17 +27,17 @@ FAIL Property color value 'FieldText' resolves to the same color as text on a te
 PASS Property color value 'Mark' has the same color as the background-color of a mark element (light)
 PASS Property color value 'MarkText' has the same color as the color of a mark element (light)
 PASS Property color value 'LinkText' has the same color as the color of an anchor element (light)
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a button (dark) assert_equals: expected "rgba(255, 255, 255, 0.847) rgb(192, 192, 192)" but got "rgb(255, 255, 255)"
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a button (dark) assert_equals: expected "rgba(255, 255, 255, 0.847) rgba(255, 255, 255, 0.247)" but got "rgb(255, 255, 255)"
 PASS Property color value 'ButtonFace' resolves to the same color as the background-color of a button (dark)
 PASS Property color value 'ButtonText' resolves to the same color as text on a button (dark)
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a submit button (dark) assert_equals: expected "rgba(255, 255, 255, 0.847) rgb(192, 192, 192)" but got "rgb(255, 255, 255)"
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a submit button (dark) assert_equals: expected "rgba(255, 255, 255, 0.847) rgba(255, 255, 255, 0.247)" but got "rgb(255, 255, 255)"
 PASS Property color value 'ButtonFace' resolves to the same color as the background-color of a submit button (dark)
 PASS Property color value 'ButtonText' resolves to the same color as text on a submit button (dark)
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a reset button (dark) assert_equals: expected "rgba(255, 255, 255, 0.847) rgb(192, 192, 192)" but got "rgb(255, 255, 255)"
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a reset button (dark) assert_equals: expected "rgba(255, 255, 255, 0.847) rgba(255, 255, 255, 0.247)" but got "rgb(255, 255, 255)"
 PASS Property color value 'ButtonFace' resolves to the same color as the background-color of a reset button (dark)
 PASS Property color value 'ButtonText' resolves to the same color as text on a reset button (dark)
 FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a color picker (dark) assert_equals: expected "rgb(255, 255, 255) rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
-FAIL Property color value 'ButtonFace' resolves to the same color as the background-color of a color picker (dark) assert_equals: expected "rgb(30, 30, 30)" but got "rgb(192, 192, 192)"
+FAIL Property color value 'ButtonFace' resolves to the same color as the background-color of a color picker (dark) assert_equals: expected "rgb(30, 30, 30)" but got "rgba(255, 255, 255, 0.247)"
 FAIL Property color value 'ButtonText' resolves to the same color as text on a color picker (dark) assert_equals: expected "rgb(255, 255, 255)" but got "rgba(255, 255, 255, 0.847)"
 PASS Property color value 'CanvasText' has the same color as the color of the html element (dark)
 FAIL Property color value 'Field' resolves to the same color as the background-color of a text field (dark) assert_equals: expected "rgb(30, 30, 30)" but got "rgba(255, 255, 255, 0.247)"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
@@ -4,7 +4,7 @@ PASS System color CanvasText works
 PASS System color LinkText works
 PASS System color VisitedText works
 PASS System color ActiveText works
-FAIL System color ButtonFace works assert_not_equals: ButtonFace should react to color-scheme got disallowed value "rgb(192, 192, 192)"
+PASS System color ButtonFace works
 PASS System color ButtonText works
 PASS System color ButtonBorder works
 PASS System color Field works

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -480,12 +480,16 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
     auto color = [this, cssValueID, options, useDarkAppearance]() -> Color {
         LocalDefaultSystemAppearance localAppearance(useDarkAppearance);
 
-        auto selectCocoaColor = [cssValueID] () -> SEL {
+        auto selectCocoaColor = [cssValueID, useDarkAppearance] () -> SEL {
             switch (cssValueID) {
             case CSSValueActivecaption:
                 return @selector(windowFrameTextColor);
             case CSSValueAppworkspace:
                 return @selector(headerColor);
+            case CSSValueButtonface:
+            case CSSValueThreedface:
+                // Fallback to hardcoded color below in light mode.
+                return useDarkAppearance ? @selector(controlColor) : nullptr;
             case CSSValueButtonhighlight:
                 return @selector(controlHighlightColor);
             case CSSValueButtonshadow:
@@ -614,8 +618,10 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
 
         case CSSValueButtonface:
         case CSSValueThreedface:
+            // Dark mode uses [NSColor controlColor].
             // We selected this value instead of [NSColor controlColor] to avoid website incompatibilities.
             // We may want to consider changing to [NSColor controlColor] some day.
+            ASSERT(!localAppearance.usingDarkAppearance());
             return Color::lightGray;
 
         case CSSValueInfobackground:


### PR DESCRIPTION
#### f1063f2472a1a0b6db2de2733772440248437a26
<pre>
AX: ButtonFace color has bad contrast with ButtonText color in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=276476">https://bugs.webkit.org/show_bug.cgi?id=276476</a>
<a href="https://rdar.apple.com/131996608">rdar://131996608</a>

Reviewed by Aditya Keerthi.

Use a system color in dark mode instead of a hardcoded light color.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::systemColor const):

Canonical link: <a href="https://commits.webkit.org/283284@main">https://commits.webkit.org/283284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bd445023e36308df93d6a0b5fe8f86b4fc8fc71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11418 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38399 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15317 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9787 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57050 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8080 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9971 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->