### PR TITLE
Release assert in TimerBase::TimerBase on a worker thread

### DIFF
--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -289,7 +289,7 @@ static_assert(sizeof(DeferrableOneShotTimer) == sizeof(SameSizeAsDeferrableOneSh
 TimerBase::TimerBase()
 {
 #if USE(WEB_THREAD)
-    RELEASE_ASSERT(WebThreadIsLockedOrDisabled());
+    RELEASE_ASSERT(WebThreadIsLockedOrDisabledInMainOrWebThread());
 #endif
 }
 
@@ -511,7 +511,7 @@ void TimerBase::updateHeapIfNeeded(MonotonicTime oldTime)
 void TimerBase::setNextFireTime(MonotonicTime newTime)
 {
 #if USE(WEB_THREAD)
-    RELEASE_ASSERT(WebThreadIsLockedOrDisabled());
+    RELEASE_ASSERT(WebThreadIsLockedOrDisabledInMainOrWebThread());
 #endif
     ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
     RELEASE_ASSERT(canCurrentThreadAccessThreadLocalData(m_thread) || shouldSuppressThreadSafetyCheck());

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.h
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.h
@@ -64,7 +64,8 @@ WEBCORE_EXPORT void WebThreadUnlock(void);
 // ---------------------------------------------------------------------------------------------
 WEBCORE_EXPORT bool WebThreadIsLocked(void);
 WEBCORE_EXPORT bool WebThreadIsLockedOrDisabled(void);
-    
+WEBCORE_EXPORT bool WebThreadIsLockedOrDisabledInMainOrWebThread(void);
+
 WEBCORE_EXPORT void WebThreadLockPushModal(void);
 WEBCORE_EXPORT void WebThreadLockPopModal(void);
 

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -886,6 +886,20 @@ bool WebThreadIsLockedOrDisabled(void)
     return !WebThreadIsEnabled() || WebThreadIsLocked();
 }
 
+bool WebThreadIsLockedOrDisabledInMainOrWebThread(void)
+{
+    if (!WebThreadIsEnabled())
+        return true;
+
+    if (WebThreadIsCurrent())
+        return webThreadLockCount;
+
+    if (pthread_main_np())
+        return mainThreadLockCount;
+
+    return true;
+}
+
 void WebThreadLockPushModal(void)
 {
     if (WebThreadIsCurrent())


### PR DESCRIPTION
#### d9fd562a20d0bd13d46c135648f175c2b7598ff9
<pre>
Release assert in TimerBase::TimerBase on a worker thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=279275">https://bugs.webkit.org/show_bug.cgi?id=279275</a>

Reviewed by Chris Dumez.

Allow the release assert to pass in worker threads.

* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::TimerBase):
(WebCore::TimerBase::setNextFireTime):
* Source/WebCore/platform/ios/wak/WebCoreThread.h:
* Source/WebCore/platform/ios/wak/WebCoreThread.mm:
(WebThreadIsLockedOrDisabledInMainOrWebThread):

Canonical link: <a href="https://commits.webkit.org/283280@main">https://commits.webkit.org/283280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/692106262951cfbd3deb7ed84239115e231b4958

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52816 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11396 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14325 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15285 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14667 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71532 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60423 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8055 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1697 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9968 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->