### PR TITLE
`background-clip: border-area` should do nothing on the root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  background-color: white;
+}
+body {
+  border: 20px solid green;
+  padding: 10px;
+}
+</style>
+
+There should be a 20px green border around the edge of the viewport. This text should be black on a white background.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">
+<link rel="match" href="clip-text-on-body-not-propagated-to-root-ref.html">
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  background-color: white;
+}
+body {
+  border: 20px solid transparent;
+  background-color: green;
+  background-clip: border-area;
+  padding: 10px;
+}
+</style>
+
+There should be a 20px green border around the edge of the viewport. This text should be black on a white background.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+:root {
+  background-color: green;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  color: transparent;
+  border: 20px solid transparent;
+}
+body {
+  background-color: green;
+  background-clip: border-area;
+}
+</style>
+
+The border should not be visible; the page should be entirely green.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-root-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+:root {
+  background-color: green;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-root.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  height: 100%;
+  color: transparent;
+  border: 20px solid transparent;
+  background-color: green;
+  background-clip: border-area;
+}
+</style>
+
+The border should not be visible; the page should be entirely green.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+html {
+    font-size: 24px;
+    background-color: white;
+    color: green;
+    font-family: Ahem;
+}
+</style>
+
+This text should be green<br>
+on a white background.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+html {
+    font-size: 24px;
+    background-color: white;
+    color: green;
+    font-family: Ahem;
+}
+</style>
+
+This text should be green<br>
+on a white background.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>background-clip:text on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="match" href="clip-text-on-body-not-propagated-to-root-ref.html">
+<style>
+html {
+  background-color: white;
+  font-size: 24px;
+  color: transparent;
+  font-family: Ahem;
+}
+body {
+  background-color: green;
+  background-clip: text;
+}
+</style>
+
+This text should be green<br>
+on a white background.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+:root {
+  background-color: green;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>background-clip:text on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html {
+  font-size: 80px;
+  color: transparent;
+  background-color: green;
+}
+body {
+  background-clip: text;
+}
+</style>
+
+This text should not be visible; the page should be entirely green.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-root-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+:root {
+  background-color: green;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-root.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>background-clip:text on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html {
+  font-size: 80px;
+  color: transparent;
+  background-color: green;
+  background-clip: text;
+}
+</style>
+
+This text should not be visible; the page should be entirely green.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/reference/green-root-background.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/reference/green-root-background.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+:root {
+  background-color: green;
+}
+</style>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -62,6 +62,10 @@ BackgroundPainter::BackgroundPainter(RenderBoxModelObject& renderer, const Paint
     : m_renderer(renderer)
     , m_paintInfo(paintInfo)
 {
+    // background-clip has no effect when painting the root background.
+    // https://www.w3.org/TR/css-backgrounds-3/#background-clip
+    if (m_renderer.isDocumentElementRenderer())
+        setOverrideClip(FillBox::BorderBox);
 }
 
 void BackgroundPainter::paintBackground(const LayoutRect& paintRect, BackgroundBleedAvoidance bleedAvoidance) const


### PR DESCRIPTION
#### 21c075d2c09ac20f39ea272e51173655478284c1
<pre>
`background-clip: border-area` should do nothing on the root
<a href="https://rdar.apple.com/134389029">rdar://134389029</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278441">https://bugs.webkit.org/show_bug.cgi?id=278441</a>

Reviewed by Alan Baradlay.

Implement the part of <a href="https://www.w3.org/TR/css-backgrounds-3/#background-clip">https://www.w3.org/TR/css-backgrounds-3/#background-clip</a> that says that `background-clip` does nothing
on the root by setting the override clip value in `BackgroundPainter` when it&apos;s created with the root renderer.

Previously, `background-clip: border-area` on the root could leave us with unpainted areas.

Add WPT testing `background-clip: text` and `background-clip: border-area` for backgrounds on or propagated to the root.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-on-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-on-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/reference/green-root-background.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::BackgroundPainter):

Canonical link: <a href="https://commits.webkit.org/283482@main">https://commits.webkit.org/283482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3557e15f5af26046c12c473740caf8921830cc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53168 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11773 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14761 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72015 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60793 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2074 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->