### PR TITLE
input 'week' may display the wrong date when the first week or last week of a year is selected

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1726,8 +1726,8 @@
 /* Unwanted software warning title */
 "Website With Harmful Software Warning" = "Website With Harmful Software Warning";
 
-/* Week label for week of year input type */
-"Week" = "Week";
+/* Week of year input type label with week number and year */
+"Week %1$d, %2$d" = "Week %1$d, %2$d";
 
 /* Writing Tools context menu item */
 "Writing Tools" = "Writing Tools";

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "LocalizedStrings.h"
 
+#include "DateComponents.h"
 #include "IntSize.h"
 #include "NotImplemented.h"
 #include <wtf/MathExtras.h>
@@ -1534,9 +1535,11 @@ String datePickerYearLabelTitle()
 
 #if ENABLE(INPUT_TYPE_WEEK_PICKER)
 
-String inputWeekLabel()
+String inputWeekLabel(const DateComponents& dateComponents)
 {
-    return WEB_UI_STRING_KEY("Week", "Week", "Week label for week of year input type");
+    int week = dateComponents.week();
+    int year = dateComponents.fullYear();
+    return WEB_UI_FORMAT_STRING("Week %1$d, %2$d", "Week of year input type label with week number and year", week, year);
 }
 
 #endif

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -40,6 +40,7 @@
 namespace WebCore {
 
     class IntSize;
+    class DateComponents;
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT String truncatedStringForMenuItem(const String&);
@@ -403,7 +404,7 @@ namespace WebCore {
 #endif
 
 #if ENABLE(INPUT_TYPE_WEEK_PICKER)
-    WEBCORE_EXPORT String inputWeekLabel();
+    WEBCORE_EXPORT String inputWeekLabel(const DateComponents&);
 #endif
 
 #if ENABLE(WEB_AUTHN)

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -93,11 +93,16 @@ String LocaleCocoa::formatDateTime(const DateComponents& dateComponents, FormatT
     DateComponentsType type = dateComponents.type();
 
     ASSERT(type != DateComponentsType::Invalid);
-#if !ENABLE(INPUT_TYPE_WEEK_PICKER)
-    // "week" type not supported.
-    if (type == DateComponentsType::Week)
+
+    if (type == DateComponentsType::Week) {
+#if ENABLE(INPUT_TYPE_WEEK_PICKER)
+        // NSDateFormatter is not used here because it handles week numbering differently than ISO-8601.
+        return inputWeekLabel(dateComponents);
+#else
         return String();
 #endif
+    }
+
     // Incoming msec value is milliseconds since 1970-01-01 00:00:00 UTC. The 1970 epoch.
     NSTimeInterval secondsSince1970 = (msec / 1000);
     NSDate *date = [NSDate dateWithTimeIntervalSince1970:secondsSince1970];


### PR DESCRIPTION
#### 0bb11f0f467f2a3476f670ce1a913fcd5f204672
<pre>
input &apos;week&apos; may display the wrong date when the first week or last week of a year is selected
<a href="https://bugs.webkit.org/show_bug.cgi?id=279276">https://bugs.webkit.org/show_bug.cgi?id=279276</a>
<a href="https://rdar.apple.com/132954506">rdar://132954506</a>

Reviewed by Aditya Keerthi.

The &apos;week&apos; input could show the wrong week number and/or year number depending on the first weekday of the selected year and the number of weeks in that year according to ISO-8601. A related issue could also cause the wrong week to appear as selected when reopening the calendar view after selecting a week depending on the user&apos;s locale, timezone, and the number of ISO-8601 weeks in that year.

The first issue was resolved by constructing a displayed string which directly uses DateComponents rather than using NSDateFormatter.

The second issue was resolved by updating the formatter used to calculate the initial value for input &quot;week&quot; to interpret the parsed date as having a time of 00:00 in the user&apos;s own timezone, preventing cases where timezone adjustments could cause the date to be interpreted as the day previous to the correct one.

* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::formatDateTime):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker iso8601DateFormatterForCalendarView]):
(-[WKDateTimePicker setWeekPickerToInitialValue]):

Canonical link: <a href="https://commits.webkit.org/283427@main">https://commits.webkit.org/283427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2572a98b3f084100e34de28717ecf22d0c1ed18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53064 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11646 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10070 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14374 "Found 1 new test failure: http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60378 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60670 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1956 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41296 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->