### PR TITLE
Implicit web clip mode should choose a web clip that is visible to the application

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -150,6 +150,10 @@
 @interface UIWebClip(Staging_134304426)
 + (NSString *)pathForWebClipWithIdentifier:(NSString *)identifier;
 @end
+
+@interface UIWebClip(Staging_131961097)
+@property (nonatomic, readonly) NSSet<NSString *> *trustedClientBundleIdentifiers;
+@end
 #endif
 
 #else // USE(APPLE_INTERNAL_SDK)
@@ -161,6 +165,7 @@
 @property (copy) NSString *identifier;
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, retain) NSURL *pageURL;
+@property (nonatomic, readonly) NSSet<NSString *> *trustedClientBundleIdentifiers;
 @end
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
@@ -231,19 +231,14 @@
     (require-all (vnode-type DIRECTORY) (home-literal "/Library/WebKit"))
     (require-all (vnode-type DIRECTORY) (home-literal "/Library/WebKit/WebPush")))
 
-;; Push database.
-(allow file*
-    (home-literal "/Library/WebKit/WebPush/PushDatabase.db")
-    (home-literal "/Library/WebKit/WebPush/PushDatabase.db-shm")
-    (home-literal "/Library/WebKit/WebPush/PushDatabase.db-wal")
-    (home-literal "/Library/WebKit/WebPush/PushDatabase.db-lock")
-    (home-literal "/Library/WebKit/WebPush/PushDatabase.db-journal"))
-
-;; Let SQLite open the parent directory of the database for fsync purposes.
-(allow file-read-data (require-all (vnode-type DIRECTORY) (home-prefix "/Library/WebKit/WebPush")))
+;; Push database and web clip cache.
+(allow file* (home-subpath "/Library/WebKit/WebPush"))
 
 ;; For MKBDeviceUnlockedSinceBoot.
 (allow iokit-open-service
     (iokit-registry-entry-class "AppleKeyStore"))
 (allow iokit-open-user-client
     (iokit-user-client-class "AppleKeyStoreUserClient"))
+
+;; Set home-relative tmpdir.
+(allow file* (home-subpath "/tmp/com.apple.webkit.webpushd"))

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2504,6 +2504,8 @@
 		EB355DA02B6365C1008DEAA1 /* RestrictedOpenerType.h in Headers */ = {isa = PBXBuildFile; fileRef = EB355D9F2B636559008DEAA1 /* RestrictedOpenerType.h */; };
 		EB36B16827A7B4500050E00D /* PushService.h in Headers */ = {isa = PBXBuildFile; fileRef = EB36B16627A7B4500050E00D /* PushService.h */; };
 		EB36B16927A7B4500050E00D /* PushService.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB36B16727A7B4500050E00D /* PushService.mm */; };
+		EB44A69B2C8A4F6E006595BF /* WebClipCache.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB44A69A2C8A4F6E006595BF /* WebClipCache.mm */; };
+		EB44A69C2C8A4F6E006595BF /* WebClipCache.h in Headers */ = {isa = PBXBuildFile; fileRef = EB44A6992C8A4F6E006595BF /* WebClipCache.h */; };
 		EB450E0F2996C7B6009724B1 /* WKWebsiteDataStoreRefPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB579C3729AEBD0800894C1C /* EarlyHintsResourceLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = EB579C3629AEBCF100894C1C /* EarlyHintsResourceLoader.h */; };
 		EB7D252B27B31B77009CB586 /* com.apple.WebKit.webpushd.mac.sb in Resources */ = {isa = PBXBuildFile; fileRef = EB7D252A27B31B3F009CB586 /* com.apple.WebKit.webpushd.mac.sb */; };
@@ -8114,6 +8116,8 @@
 		EB355D9F2B636559008DEAA1 /* RestrictedOpenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RestrictedOpenerType.h; sourceTree = "<group>"; };
 		EB36B16627A7B4500050E00D /* PushService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushService.h; sourceTree = "<group>"; };
 		EB36B16727A7B4500050E00D /* PushService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PushService.mm; sourceTree = "<group>"; };
+		EB44A6992C8A4F6E006595BF /* WebClipCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebClipCache.h; sourceTree = "<group>"; };
+		EB44A69A2C8A4F6E006595BF /* WebClipCache.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebClipCache.mm; sourceTree = "<group>"; };
 		EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKWebsiteDataStoreRefPrivateMac.h; path = mac/WKWebsiteDataStoreRefPrivateMac.h; sourceTree = "<group>"; };
 		EB450E0E2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKWebsiteDataStoreRefPrivateMac.mm; path = mac/WKWebsiteDataStoreRefPrivateMac.mm; sourceTree = "<group>"; };
 		EB579C3529AEBCF100894C1C /* EarlyHintsResourceLoader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EarlyHintsResourceLoader.cpp; sourceTree = "<group>"; };
@@ -13044,6 +13048,8 @@
 				EB36B16727A7B4500050E00D /* PushService.mm */,
 				EBA8D3AF27A5E33F00CB7900 /* PushServiceConnection.h */,
 				EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */,
+				EB44A6992C8A4F6E006595BF /* WebClipCache.h */,
+				EB44A69A2C8A4F6E006595BF /* WebClipCache.mm */,
 				517B5F77275E9795002DC22D /* webpushd.cpp */,
 				512CD69D2723393A00F7F8EC /* WebPushDaemon.h */,
 				512CD69E2723393A00F7F8EC /* WebPushDaemon.mm */,
@@ -16937,6 +16943,7 @@
 				41897ED11F415D680016FA42 /* WebCacheStorageConnection.h in Headers */,
 				41D129DA1F3D101800D15E47 /* WebCacheStorageProvider.h in Headers */,
 				BC032D7510F4378D0058C15A /* WebChromeClient.h in Headers */,
+				EB44A69C2C8A4F6E006595BF /* WebClipCache.h in Headers */,
 				3F87B9BE158940190090FF62 /* WebColorChooser.h in Headers */,
 				3F87B9C0158940D80090FF62 /* WebColorPicker.h in Headers */,
 				728E86F11795188C0087879E /* WebColorPickerMac.h in Headers */,
@@ -19904,6 +19911,7 @@
 				575B1BB823CE9BFC0020639A /* WebAutomationSessionProxy.cpp in Sources */,
 				1C0A19531C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessageReceiver.cpp in Sources */,
 				0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */,
+				EB44A69B2C8A4F6E006595BF /* WebClipCache.mm in Sources */,
 				330934471315B9220097A7BC /* WebCookieManagerMessageReceiver.cpp in Sources */,
 				E39628DE23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp in Sources */,
 				E3866B0B2399A2DD00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -89,10 +89,6 @@ public:
 
     void didReceiveMessageWithReplyHandler(IPC::Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&) override;
 
-#if PLATFORM(IOS)
-    String associatedWebClipTitle() const;
-#endif
-
 private:
     PushClientConnection(xpc_connection_t, String&& hostAppCodeSigningIdentifier, bool hostAppHasPushInjectEntitlement, String&& pushPartitionString, std::optional<WTF::UUID>&& dataStoreIdentifier);
 
@@ -126,10 +122,6 @@ private:
     bool m_hostAppHasPushInjectEntitlement { false };
     String m_pushPartitionString;
     Markable<WTF::UUID> m_dataStoreIdentifier;
-
-#if PLATFORM(IOS)
-    mutable RetainPtr<UIWebClip> m_associatedWebClip;
-#endif
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -86,7 +86,7 @@ public:
     void didReceivePushMessage(NSString *topic, NSDictionary *userInfo, CompletionHandler<void()>&& = [] { });
 
 #if PLATFORM(IOS)
-    void updateSubscriptionSetState(const Vector<String>& allowedBundleIdentifiers, const HashSet<String>& webClipIdentifiers, CompletionHandler<void()>&&);
+    void updateSubscriptionSetState(const String& allowedBundleIdentifier, const HashSet<String>& webClipIdentifiers, CompletionHandler<void()>&&);
 #endif
 
 private:

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -702,9 +702,9 @@ void PushService::removeRecordsForBundleIdentifierAndDataStore(const String& bun
 
 #if PLATFORM(IOS)
 
-void PushService::updateSubscriptionSetState(const Vector<String>& allowedBundleIdentifiers, const HashSet<String>& installedWebClipIdentifiers, CompletionHandler<void()>&& completionHandler)
+void PushService::updateSubscriptionSetState(const String& allowedBundleIdentifier, const HashSet<String>& installedWebClipIdentifiers, CompletionHandler<void()>&& completionHandler)
 {
-    m_database->getPushSubscriptionSetRecords([this, weakThis = WeakPtr { *this }, allowedBundleIdentifiers, installedWebClipIdentifiers, completionHandler = WTFMove(completionHandler)](auto&& records) mutable {
+    m_database->getPushSubscriptionSetRecords([this, weakThis = WeakPtr { *this }, allowedBundleIdentifier, installedWebClipIdentifiers, completionHandler = WTFMove(completionHandler)](auto&& records) mutable {
         if (!weakThis)
             return completionHandler();
 
@@ -713,7 +713,7 @@ void PushService::updateSubscriptionSetState(const Vector<String>& allowedBundle
         for (const auto& record : records) {
             auto bundleIdentifier = record.identifier.bundleIdentifier;
             auto webClipIdentifier = record.identifier.pushPartition;
-            if (!allowedBundleIdentifiers.contains(bundleIdentifier) || !installedWebClipIdentifiers.contains(webClipIdentifier))
+            if (bundleIdentifier != allowedBundleIdentifier || !installedWebClipIdentifiers.contains(webClipIdentifier))
                 identifiersToRemove.add(record.identifier);
         }
 

--- a/Source/WebKit/webpushd/WebClipCache.h
+++ b/Source/WebKit/webpushd/WebClipCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,33 @@
 
 #pragma once
 
-#if USE(APPLE_INTERNAL_SDK)
-#include <dirhelper_priv.h>
-#else
+#if ENABLE(WEB_PUSH_NOTIFICATIONS) && PLATFORM(IOS)
 
-WTF_EXTERN_C_BEGIN
-char *_get_user_dir_suffix();
-bool _set_user_dir_suffix(const char *user_dir_suffix);
-WTF_EXTERN_C_END
+#include <WebCore/SecurityOriginData.h>
+#include <tuple>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebPushD {
+
+class WebClipCache {
+    WTF_MAKE_TZONE_ALLOCATED(WebClipCache);
+public:
+    WebClipCache(const String& path);
+
+    String preferredWebClipIdentifier(const String& bundleIdentifier, const WebCore::SecurityOriginData&);
+    HashSet<String> visibleWebClipIdentifiers(const String& bundleIdentifier);
+    bool isWebClipVisible(const String& bundleIdentifier, const String& webClipIdentifier);
+
+private:
+    void load();
+    void persist();
+
+    String m_path;
+    HashMap<std::tuple<String, WebCore::SecurityOriginData>, String> m_preferredWebClipIdentifiers;
+};
+
+} // namespace WebPushD
 
 #endif
-
-WTF_EXTERN_C_BEGIN
-
-void _CSCheckFixDisable();
-CFArrayRef _UTCopyDeclaredTypeIdentifiers(void);
-
-WTF_EXTERN_C_END

--- a/Source/WebKit/webpushd/WebClipCache.mm
+++ b/Source/WebKit/webpushd/WebClipCache.mm
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WebClipCache.h"
+
+#if ENABLE(WEB_PUSH_NOTIFICATIONS) && PLATFORM(IOS)
+
+#import "Logging.h"
+#import "UIKitSPI.h"
+#import <Foundation/Foundation.h>
+#import <wtf/FileSystem.h>
+#import <wtf/Vector.h>
+
+namespace WebPushD {
+
+WebClipCache::WebClipCache(const String& path)
+    : m_path(path)
+{
+    load();
+}
+
+static bool webClipExists(const String& webClipIdentifier)
+{
+    if (webClipIdentifier.isEmpty())
+        return false;
+
+    @autoreleasepool {
+        NSString *path = [UIWebClip pathForWebClipWithIdentifier:(NSString *)webClipIdentifier];
+        if (!path)
+            return false;
+        return [[NSFileManager defaultManager] fileExistsAtPath:path];
+    }
+}
+
+static String webClipIdentifierForOrigin(const String& bundleIdentifier, const WebCore::SecurityOriginData& origin)
+{
+    RetainPtr<NSString> oldestMatchingIdentifier;
+    WallTime oldestMatchingCreationTime = WallTime::infinity();
+
+    @autoreleasepool {
+        NSArray *webClips = [UIWebClip webClips];
+
+        for (UIWebClip *webClip in webClips) {
+            NSString *identifier = webClip.identifier;
+            if (!identifier)
+                continue;
+
+            auto clipOrigin = WebCore::SecurityOriginData::fromURL(webClip.pageURL);
+            if (origin != clipOrigin)
+                continue;
+
+            if (bundleIdentifier != "com.apple.SafariViewService"_s && [webClip respondsToSelector:@selector(trustedClientBundleIdentifiers)]) {
+                if (![webClip.trustedClientBundleIdentifiers containsObject:(NSString *)bundleIdentifier])
+                    continue;
+            }
+
+            NSString *path = [UIWebClip pathForWebClipWithIdentifier:identifier];
+            if (!path)
+                continue;
+
+            auto maybeCreationTime = FileSystem::fileCreationTime(path);
+            if (!maybeCreationTime)
+                continue;
+            auto creationTime = *maybeCreationTime;
+
+            if (creationTime < oldestMatchingCreationTime) {
+                oldestMatchingIdentifier = identifier;
+                oldestMatchingCreationTime = creationTime;
+            }
+        }
+    }
+
+    return oldestMatchingIdentifier.get();
+}
+
+String WebClipCache::preferredWebClipIdentifier(const String& bundleIdentifier, const WebCore::SecurityOriginData& origin)
+{
+    bool dirty = false;
+
+    auto it = m_preferredWebClipIdentifiers.find(std::make_tuple(bundleIdentifier, origin));
+    if (it != m_preferredWebClipIdentifiers.end()) {
+        auto identifier = it->value;
+        if (webClipExists(identifier))
+            return identifier;
+
+        m_preferredWebClipIdentifiers.remove(it);
+        dirty = true;
+    }
+
+    auto webClipIdentifier = webClipIdentifierForOrigin(bundleIdentifier, origin);
+    if (!webClipIdentifier.isEmpty()) {
+        m_preferredWebClipIdentifiers.set(std::make_tuple(bundleIdentifier, origin), webClipIdentifier);
+        dirty = true;
+    }
+
+    if (dirty)
+        persist();
+
+    return webClipIdentifier;
+}
+
+// Loads path as a plist and returns it if it has the shape [["a", "b", "c"], ["d", "e", "f"], ...]
+static RetainPtr<NSArray> loadWebClipCachePropertyList(NSString *path)
+{
+    @autoreleasepool {
+        NSError *error = nil;
+        NSData *data = [NSData dataWithContentsOfFile:path options:NSDataReadingMappedIfSafe error:&error];
+        if (!data) {
+            RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to read %{public}@: %{public}@", path, error);
+            return nil;
+        }
+
+        id propertyList = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:nullptr error:&error];
+        if (!propertyList) {
+            RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to deserialize %{public}@: %{public}@", path, error);
+            return nil;
+        }
+
+        if (![propertyList isKindOfClass:[NSArray class]]) {
+            RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to deserialize %{public}@: container isn't an array", path);
+            return nil;
+        }
+
+        NSArray *entries = (NSArray *)propertyList;
+        for (id entry in entries) {
+            if (![entry isKindOfClass:[NSArray class]] || [entry count] != 3) {
+                RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to deserialize %{public}@: entry isn't an array", path);
+                return nil;
+            }
+
+            NSArray *array = (NSArray *)entry;
+            for (id val in array) {
+                if (![val isKindOfClass:[NSString class]] || ![val length]) {
+                    RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to deserialize %{public}@: value isn't a string", path);
+                    return nil;
+                }
+            }
+        }
+
+        return entries;
+    }
+}
+
+void WebClipCache::load()
+{
+    RetainPtr entries = loadWebClipCachePropertyList(m_path);
+    if (!entries)
+        return;
+
+    for (NSArray *entry in entries.get()) {
+        NSString *bundleIdentifier = entry[0];
+        NSString *securityOriginString = entry[1];
+        NSString *webClipIdentifier = entry[2];
+
+        RetainPtr securityOriginURL = adoptNS([[NSURL alloc] initWithString:securityOriginString]);
+        auto origin = WebCore::SecurityOriginData::fromURL(URL { securityOriginURL.get() });
+        if (origin.isNull())
+            continue;
+
+        m_preferredWebClipIdentifiers.add(std::make_tuple(String { bundleIdentifier }, origin), String { webClipIdentifier });
+    }
+}
+
+void WebClipCache::persist()
+{
+    @autoreleasepool {
+        RetainPtr<NSMutableArray> entries = adoptNS([[NSMutableArray alloc] init]);
+        for (const auto& [bundleIdentifierAndOrigin, webClipIdentifier] : m_preferredWebClipIdentifiers) {
+            NSString *bundleIdentifier = (NSString *)std::get<0>(bundleIdentifierAndOrigin);
+            NSURL *url = (NSURL *)std::get<1>(bundleIdentifierAndOrigin).toURL();
+            NSString *securityOriginString = [url absoluteString];
+            if (!securityOriginString)
+                continue;
+            [entries addObject:@[bundleIdentifier, securityOriginString, (NSString *)webClipIdentifier]];
+        }
+
+        NSError *error = nil;
+        NSData *data = [NSPropertyListSerialization dataWithPropertyList:entries.get() format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
+        if (!data) {
+            RELEASE_LOG_ERROR(Push, "WebClipCache::persist failed to serialize plist: %{public}@", error);
+            return;
+        }
+
+        if (![data writeToFile:(NSString *)m_path options:NSDataWritingAtomic error:&error]) {
+            RELEASE_LOG_ERROR(Push, "WebClipCache::persist failed to write to disk: %{public}@", error);
+            return;
+        }
+    }
+}
+
+HashSet<String> WebClipCache::visibleWebClipIdentifiers(const String& bundleIdentifier)
+{
+    HashSet<String> result;
+
+    @autoreleasepool {
+        NSArray *webClips = [UIWebClip webClips];
+
+        for (UIWebClip *webClip in webClips) {
+            NSString *identifier = webClip.identifier;
+            if (!identifier)
+                continue;
+
+            // FIXME: Remove -respondsToSelector: check once we finish staging rdar://131961097.
+            if (bundleIdentifier == "com.apple.SafariViewService"_s || ![webClip respondsToSelector:@selector(trustedClientBundleIdentifiers)] || [webClip.trustedClientBundleIdentifiers containsObject:(NSString *)bundleIdentifier]) {
+                result.add(String { identifier });
+                continue;
+            }
+        }
+    }
+
+    return result;
+}
+
+bool WebClipCache::isWebClipVisible(const String& bundleIdentifier, const String& webClipIdentifier)
+{
+    if (!webClipExists(webClipIdentifier))
+        return false;
+
+    if (bundleIdentifier == "com.apple.SafariViewService"_s)
+        return true;
+
+    UIWebClip *webClip = [UIWebClip webClipWithIdentifier:webClipIdentifier];
+    if (![webClip respondsToSelector:@selector(trustedClientBundleIdentifiers)])
+        return true;
+
+    return [webClip.trustedClientBundleIdentifiers containsObject:(NSString *)bundleIdentifier];
+}
+
+} // namespace WebPushD
+
+#endif

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -48,6 +48,8 @@
 #include <wtf/spi/darwin/XPCSPI.h>
 
 #if PLATFORM(IOS)
+#include "WebClipCache.h"
+
 @class FBSOpenApplicationService;
 #endif
 
@@ -76,8 +78,12 @@ public:
     void connectionRemoved(xpc_connection_t);
 
     void startMockPushService();
-    void startPushService(const String& incomingPushServiceName, const String& pushDatabasePath);
+    void startPushService(const String& incomingPushServiceName, const String& pushDatabasePath, const String& webClipCachePath);
     void handleIncomingPush(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
+
+#if PLATFORM(IOS)
+    WebClipCache& ensureWebClipCache();
+#endif
 
     // Message handlers
     void setPushAndNotificationsEnabledForOrigin(PushClientConnection&, const String& originString, bool, CompletionHandler<void()>&& replySender);
@@ -162,6 +168,8 @@ private:
 
 #if PLATFORM(IOS)
     RetainPtr<FBSOpenApplicationService> m_openService;
+    std::unique_ptr<WebClipCache> m_webClipCache;
+    String m_webClipCachePath;
 #endif
 };
 


### PR DESCRIPTION
#### 77532e760a8b528addf86f4e1a73416e4dad0272
<pre>
Implicit web clip mode should choose a web clip that is visible to the application
<a href="https://bugs.webkit.org/show_bug.cgi?id=279278">https://bugs.webkit.org/show_bug.cgi?id=279278</a>
<a href="https://rdar.apple.com/135297386">rdar://135297386</a>

Reviewed by Per Arne Vollan.

The &quot;implicit web clip mode&quot; in webpushd that selects the oldest web clip associated with an origin
(added in 282857@main) doesn&apos;t totally work, because not all web clips are visible to all apps.

Instead, we now select the oldest web clip visible to the app (by checking
`trustedClientBundleIdentifiers`) and persist that selection to a plist. This also required some
other changes so that webpushd would write temp files to the appropriate directory.

Another change here is that we previously allowed multiple apps to access webpushd, but the design
from the beginning was to only allow one app to access it, so I changed methods that checked whether
apps were allowed to connect to webpushd to only allow a single app to connect.

The class that abstracts this is optimistically named WebClipCache, which doesn&apos;t actually cache a
whole lot at the moment, but will once I get around to making all the possible cache invalidation
events from system frameworks fire notifyd notifications.

I also made a drive-by fix an issue with the notification source being incorrect in
WebPushDaemon::showNotification.

* Source/WebCore/PAL/pal/spi/cocoa/CoreServicesSPI.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::subscriptionSetIdentifierForOrigin const):
(WebPushD::webClipIdentifierForOrigin): Deleted.
(WebPushD::PushClientConnection::associatedWebClipTitle const): Deleted.
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::updateSubscriptionSetState):
* Source/WebKit/webpushd/WebClipCache.h:
* Source/WebKit/webpushd/WebClipCache.mm: Added.
(WebPushD::WebClipCache::WebClipCache):
(WebPushD::webClipExists):
(WebPushD::webClipIdentifierForOrigin):
(WebPushD::WebClipCache::preferredWebClipIdentifier):
(WebPushD::loadWebClipCachePropertyList):
(WebPushD::WebClipCache::load):
(WebPushD::WebClipCache::persist):
(WebPushD::WebClipCache::visibleWebClipIdentifiers):
(WebPushD::WebClipCache::isWebClipVisible):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(getAllowedBundleIdentifiers):
(getAllowedBundleIdentifier):
(WebPushD::WebPushDaemon::startMockPushService):
(WebPushD::WebPushDaemon::startPushService):
(WebPushD::WebPushDaemon::ensureWebClipCache):
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::updateSubscriptionSetState):
(WebPushD::WebPushDaemon::handleIncomingPush):
(WebPushD::WebPushDaemon::showNotification):
(getInstalledWebClipIdentifiers): Deleted.
(webClipExists): Deleted.
(WebPushD::platformNotificationSourceForDisplay): Deleted.
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::WebPushDaemonMain):

Canonical link: <a href="https://commits.webkit.org/283438@main">https://commits.webkit.org/283438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/417aff78582df27c94da398ed7e991d73c8f06e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17157 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57372 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72001 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60485 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2068 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->