### PR TITLE
Sidebar extensions should temporarily receive the activeTab permission when the user interacts with the sidebar.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
@@ -96,9 +96,9 @@ NS_SWIFT_NAME(WKWebExtension.Sidebar)
 
 /*!
  @abstract Indicate that the sidebar will be opened
- @discussion This method should be invoked by the browser when this sidebar will be opened -- i.e., its associated ``WKWebView`` will be
- displayed. If this method is not called before the sidebar is opened, then the ``WKWebView`` associated with this sidebar may not have a
- document loaded.
+ @discussion This method should be invoked by the browser when this sidebar will be opened due to some action by the user. If
+ this method is not called before the sidebar is opened, then the ``WKWebView`` associated with this sidebar may not have a
+ document loaded, and the extension may not receive the `activeTab` permission from this user interaction.
  */
 - (void)willOpenSidebar;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -91,14 +91,11 @@ static Expected<Ref<WebExtensionSidebar>, WebExtensionError> getOrCreateSidebarW
 }
 
 using UserTriggered = WebExtensionContext::UserTriggered;
-void WebExtensionContext::openSidebarForTab(WebExtensionTab& tab, const UserTriggered userTriggered)
+void WebExtensionContext::openSidebarForTab(WebExtensionTab& tab)
 {
     ASSERT(isLoaded());
     if (!isLoaded())
         return;
-
-    if (userTriggered == UserTriggered::Yes)
-        userGesturePerformed(tab);
 
     auto maybeSidebar = getOrCreateSidebar(tab);
     if (!maybeSidebar)
@@ -111,14 +108,11 @@ void WebExtensionContext::openSidebarForTab(WebExtensionTab& tab, const UserTrig
     fireActionClickedEventIfNeeded(&tab);
 }
 
-void WebExtensionContext::closeSidebarForTab(WebExtensionTab& tab, const UserTriggered userTriggered)
+void WebExtensionContext::closeSidebarForTab(WebExtensionTab& tab)
 {
     ASSERT(isLoaded());
     if (!isLoaded())
         return;
-
-    if (userTriggered == UserTriggered::Yes)
-        userGesturePerformed(tab);
 
     auto maybeSidebar = getOrCreateSidebar(tab);
     if (!maybeSidebar)
@@ -193,7 +187,7 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
     }
 
     if (sidebar.value()->opensSidebar())
-        openSidebarForTab(*tab, UserTriggered::No);
+        openSidebarForTab(*tab);
 
     completionHandler({ });
 }
@@ -225,7 +219,7 @@ void WebExtensionContext::sidebarClose(CompletionHandler<void(Expected<void, Web
         return;
     }
 
-    closeSidebarForTab(*tab, UserTriggered::No);
+    closeSidebarForTab(*tab);
 
     completionHandler({ });
 }
@@ -285,14 +279,14 @@ void WebExtensionContext::sidebarToggle(CompletionHandler<void(Expected<void, We
             return;
         }
 
-        closeSidebarForTab(*tab, UserTriggered::No);
+        closeSidebarForTab(*tab);
     } else {
         if (!sidebar->canProgrammaticallyOpenSidebar()) {
             completionHandler(toWebExtensionError(nil, nil, @"it is not implemented"));
             return;
         }
 
-        openSidebarForTab(*tab, UserTriggered::No);
+        openSidebarForTab(*tab);
     }
 
     completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -453,8 +453,8 @@ public:
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionWindow&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionTab&);
     RefPtr<WebExtensionSidebar> getOrCreateSidebar(RefPtr<WebExtensionTab>);
-    void openSidebarForTab(WebExtensionTab&, UserTriggered = UserTriggered::No);
-    void closeSidebarForTab(WebExtensionTab&, UserTriggered = UserTriggered::No);
+    void openSidebarForTab(WebExtensionTab&);
+    void closeSidebarForTab(WebExtensionTab&);
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     const CommandsVector& commands();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -104,11 +104,18 @@ public:
     String sidebarPath() const;
     void setSidebarPath(std::optional<String>);
 
+    /// Should be called when a user action will open the sidebar
     void willOpenSidebar();
     void willCloseSidebar();
 
+    /// Should be called when the sidebar will be displayed, regardless of whether this stems from a user action.
+    void sidebarWillAppear();
+    void sidebarWillDisappear();
+
     void addChild(WebExtensionSidebar const& child);
     void removeChild(WebExtensionSidebar const& child);
+
+    void didReceiveUserInteraction();
 
     RetainPtr<SidebarViewControllerType> viewController();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
@@ -801,11 +801,11 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelAPIGlobalEnablePersists)
 {
     auto *script = @[
         @"let startingOptions = await browser.sidePanel.getOptions({})",
-        @"browser.test.assertFalse(startingOptions.enabled)",
+        @"browser.test.assertTrue(startingOptions.enabled)",
 
-        @"await browser.sidePanel.setOptions({ enabled: true })",
+        @"await browser.sidePanel.setOptions({ enabled: false })",
         @"let options = await browser.sidePanel.getOptions({})",
-        @"browser.test.assertTrue(options.enabled)",
+        @"browser.test.assertFalse(options.enabled)",
 
         @"browser.test.notifyPass()",
     ];
@@ -819,17 +819,17 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelAPITabEnablePersists)
         @"let tabs = await browser.tabs.query({})",
         @"let [tab1, tab2] = tabs",
         @"let startingOptions = await browser.sidePanel.getOptions({})",
-        @"browser.test.assertFalse(startingOptions.enabled)",
+        @"browser.test.assertTrue(startingOptions.enabled)",
 
-        @"await browser.sidePanel.setOptions({ tabId: tab1.id, enabled: true })",
+        @"await browser.sidePanel.setOptions({ tabId: tab1.id, enabled: false })",
 
         @"let tabOptions = await browser.sidePanel.getOptions({ tabId: tab1.id })",
         @"let otherTabOptions = await browser.sidePanel.getOptions({ tabId: tab2.id })",
         @"let globalOptions = await browser.sidePanel.getOptions({})",
 
-        @"browser.test.assertTrue(tabOptions.enabled)",
-        @"browser.test.assertFalse(otherTabOptions.enabled)",
-        @"browser.test.assertFalse(globalOptions.enabled)",
+        @"browser.test.assertFalse(tabOptions.enabled)",
+        @"browser.test.assertTrue(otherTabOptions.enabled)",
+        @"browser.test.assertTrue(globalOptions.enabled)",
 
         @"browser.test.notifyPass()",
     ];
@@ -903,15 +903,15 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelModifyGlobalEnable)
 {
     auto *script = @[
         @"let startingOptions = await browser.sidePanel.getOptions({})",
-        @"browser.test.assertFalse(startingOptions.enabled)",
-
-        @"await browser.sidePanel.setOptions({ enabled: true })",
-        @"let preModOptions = await browser.sidePanel.getOptions({})",
-        @"browser.test.assertTrue(preModOptions.enabled)",
+        @"browser.test.assertTrue(startingOptions.enabled)",
 
         @"await browser.sidePanel.setOptions({ enabled: false })",
+        @"let preModOptions = await browser.sidePanel.getOptions({})",
+        @"browser.test.assertFalse(preModOptions.enabled)",
+
+        @"await browser.sidePanel.setOptions({ enabled: true })",
         @"let postModOptions = await browser.sidePanel.getOptions({})",
-        @"browser.test.assertFalse(postModOptions.enabled)",
+        @"browser.test.assertTrue(postModOptions.enabled)",
 
         @"browser.test.notifyPass()",
     ];


### PR DESCRIPTION
#### 01d2ecafac25cb1c2defa2f65cec3a4ce7dac42d
<pre>
Sidebar extensions should temporarily receive the activeTab permission when the user interacts with the sidebar.
<a href="https://webkit.org/b/279281">https://webkit.org/b/279281</a>
<a href="https://rdar.apple.com/135375961">rdar://135375961</a>

Reviewed by Timothy Hatcher.

This patch introduces changes to WebExtensionSidebar that allow it to
detect when a user opens the sidebar or interacts with the sidebar&apos;s
WKWebView, so that we can grant activeTab to the sidebar&apos;s extension
upon such interactions. It also cleans up some existing code in the same
class that was made unnecessary by this change. This patch also
includes a change that will cause WebKit to post notifications to the
browser when the activeTab permission is granted or remove, so that the
browser can immediately update the extension&apos;s UI/actionIcon to reflect
the presence or absence of this permission. Finally, this patch also
fixes some sidebar tests and fixes WebExtensionSidebar::icon to reflect
recent changes to WebExtension::bestImageInIconsDictionary.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h: Amend doc
  comment to more accurately reflect the purpose of willOpenSidebar.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::WebExtensionContext::openSidebarForTab): Remove userTriggered
parameter, as this method should only be used for programmatic API
opening/closing.
(WebKit::WebExtensionContext::closeSidebarForTab): Remove userTriggered
parameter.
(WebKit::WebExtensionContext::sidebarOpen): Remove userTriggered
parameter from call to openSidebarForTab.
(WebKit::WebExtensionContext::sidebarClose): Remove userTriggered
parameter from call to closeSidebarForTab.
(WebKit::WebExtensionContext::sidebarToggle): Remove userTriggered
parameter from calls to openSidebarForTab and closeSidebarForTab.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::userGesturePerformed): Call
permissionsDidChange when activeTab is granted to post notification to
browser.
(WebKit::WebExtensionContext::clearUserGesture): Call
permissionsDidChange when activeTab is revoked to post notification to
browser.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(-[_WKWebExtensionSidebarViewController viewWillAppear]): Call
sidebar-&gt;sidebarWillAppear rather than sidebar-&gt;willOpenSidebar.
(-[_WKWebExtensionSidebarViewController viewWillDisappear]): Call
sidebar-&gt;sidebarWillDisappear rather than sidebar-&gt;willCloseSidebar.
(-[_WKWebExtensionSidebarWebView initWithFrame:configuration:webExtensionSidebar:]): Added.
(-[_WKWebExtensionSidebarWebView mouseDown:]): Added -- calls
sidebar-&gt;didReceiveUserInteraction when web view receives left mouse
click events.
(-[_WKWebExtensionSidebarWebView rightMouseDown:]): Added -- calls
sidebar-&gt;didReceiveUserInteraction when web view receives right mouse
click events.
(-[_WKWebExtensionSidebarWebView otherMouseDown:]): Added -- calls
sidebar-&gt;didReceiveUserInteraction when web view receives middle mouse
click events.
(WebKit::WebExtensionSidebar::icon): Update usage of
WebExtension::bestImageInIconsDictionary to reflect new signature.
(WebKit::WebExtensionSidebar::willOpenSidebar): Remove erroneous assert
and log statement, add call to didReceiveUserInteraction.
(WebKit::WebExtensionSidebar::sidebarWillAppear): Added.
(WebKit::WebExtensionSidebar::sidebarWillDisappear): Added.
(WebKit::WebExtensionSidebar::didReceiveUserInteraction): Helper method
to call WebExtensionContext::userGesturePerformed if all necessary
information is present.
(WebKit::WebExtensionSidebar::webView): Instantiate a
_WKWebExtensionSidebarWebView rather than a WKWebView.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Remove
  userTriggered parameter from declarations of openSidebarForTab and
closeSidebarForTab.
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Add
  declarations of sidebarWillAppear, sidebarWillDisappear, and
didReceiveUserInteraction.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPIGlobalEnablePersists)):
Invert asserts to reflect changed default enablement value.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPITabEnablePersists)):
Invert asserts to reflect changed default enablement value.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelModifyGlobalEnable)):
Invert asserts to reflect changed default enablement value.

Canonical link: <a href="https://commits.webkit.org/283300@main">https://commits.webkit.org/283300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fddb000241324e1999b05d21b000e9220ad443ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16437 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52848 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9783 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14124 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60152 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60436 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8078 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1724 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9974 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41009 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42085 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->