### PR TITLE
Fix NoUncountedMemberChecker warnings in WebScreenOrientationManagerProxy, WebModelPlayerProvider, and WebSpeechSynthesisClient.

### DIFF
--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -123,8 +123,8 @@ void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType l
         bool didLockOrientation = false;
         Ref page = m_page.get();
 #if ENABLE(FULLSCREEN_API)
-        if (page->fullScreenManager() && page->fullScreenManager()->isFullScreen()) {
-            if (!page->fullScreenManager()->lockFullscreenOrientation(resolvedLockedOrientation)) {
+        if (CheckedPtr fullscreenManager = page->fullScreenManager(); fullscreenManager && fullscreenManager->isFullScreen()) {
+            if (!fullscreenManager->lockFullscreenOrientation(resolvedLockedOrientation)) {
                 m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
                 return;
             }
@@ -152,8 +152,8 @@ void WebScreenOrientationManagerProxy::unlock()
     bool didUnlockOrientation = false;
     Ref page = m_page.get();
 #if ENABLE(FULLSCREEN_API)
-    if (page->fullScreenManager() && page->fullScreenManager()->isFullScreen()) {
-        page->fullScreenManager()->unlockFullscreenOrientation();
+    if (CheckedPtr fullScreenManager = page->fullScreenManager(); fullScreenManager && fullScreenManager->isFullScreen()) {
+        fullScreenManager->unlockFullscreenOrientation();
         didUnlockOrientation = true;
     }
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -55,7 +55,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
 WebModelPlayerProvider::WebModelPlayerProvider(WebPage& page)
     : m_page { page }
 {
-    UNUSED_PARAM(m_page);
 }
 
 WebModelPlayerProvider::~WebModelPlayerProvider() = default;
@@ -64,20 +63,22 @@ WebModelPlayerProvider::~WebModelPlayerProvider() = default;
 
 RefPtr<WebCore::ModelPlayer> WebModelPlayerProvider::createModelPlayer(WebCore::ModelPlayerClient& client)
 {
+    Ref page = m_page.get();
+    UNUSED_PARAM(page);
 #if ENABLE(MODEL_PROCESS)
-    if (m_page.corePage()->settings().modelProcessEnabled())
-        return WebProcess::singleton().modelProcessModelPlayerManager().createModelProcessModelPlayer(m_page, client);
+    if (page->corePage()->settings().modelProcessEnabled())
+        return WebProcess::singleton().modelProcessModelPlayerManager().createModelProcessModelPlayer(page, client);
 #endif
 #if ENABLE(ARKIT_INLINE_PREVIEW_MAC)
-    if (m_page.useARKitForModel())
-        return ARKitInlinePreviewModelPlayerMac::create(m_page, client);
+    if (page->useARKitForModel())
+        return ARKitInlinePreviewModelPlayerMac::create(page, client);
 #endif
 #if HAVE(SCENEKIT)
-    if (m_page.useSceneKitForModel())
+    if (page->useSceneKitForModel())
         return WebCore::SceneKitModelPlayer::create(client);
 #endif
 #if ENABLE(ARKIT_INLINE_PREVIEW_IOS)
-    return ARKitInlinePreviewModelPlayerIOS::create(m_page, client);
+    return ARKitInlinePreviewModelPlayerIOS::create(page, client);
 #endif
 
     UNUSED_PARAM(client);

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/ModelPlayerProvider.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -42,7 +43,7 @@ private:
     // WebCore::ModelPlayerProvider overrides.
     virtual RefPtr<WebCore::ModelPlayer> createModelPlayer(WebCore::ModelPlayerClient&) final;
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 };
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
@@ -48,11 +48,7 @@ class WebPage;
 class WebSpeechSynthesisClient : public WebCore::SpeechSynthesisClient {
     WTF_MAKE_TZONE_ALLOCATED(WebSpeechSynthesisClient);
 public:
-    WebSpeechSynthesisClient(WebPage& page)
-        : m_page(page)
-    {
-    }
-    
+    explicit WebSpeechSynthesisClient(WebPage&);
     virtual ~WebSpeechSynthesisClient() { }
     
     const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& voiceList() override;
@@ -60,14 +56,17 @@ public:
     void cancel() override;
     void pause() override;
     void resume() override;
+
 private:
+    Ref<WebPage> protectedPage() const;
+
     void setObserver(WeakPtr<WebCore::SpeechSynthesisClientObserver> observer) override { m_observer = observer; }
     WeakPtr<WebCore::SpeechSynthesisClientObserver> observer() const override { return m_observer; }
     void resetState() override;
 
     WebCore::SpeechSynthesisClientObserver* corePageObserver() const;
     
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     WeakPtr<WebCore::SpeechSynthesisClientObserver> m_observer;
     Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>> m_voices;
 };


### PR DESCRIPTION
#### 39d2925d59524e6104e93f5b1b08eb6b7e3dc781
<pre>
Fix NoUncountedMemberChecker warnings in WebScreenOrientationManagerProxy, WebModelPlayerProvider, and WebSpeechSynthesisClient.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279286">https://bugs.webkit.org/show_bug.cgi?id=279286</a>

Reviewed by Chris Dumez.

Use more smart pointers for member variables in these classes.

* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::setCurrentOrientation):
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::unlock):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:
(WebKit::WebModelPlayerProvider::createModelPlayer):
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
(WebKit::WebSpeechSynthesisClient::WebSpeechSynthesisClient):
(WebKit::WebSpeechSynthesisClient::protectedPage const):
(WebKit::WebSpeechSynthesisClient::voiceList):
(WebKit::WebSpeechSynthesisClient::corePageObserver const):
(WebKit::WebSpeechSynthesisClient::resetState):
(WebKit::WebSpeechSynthesisClient::speak):
(WebKit::WebSpeechSynthesisClient::cancel):
(WebKit::WebSpeechSynthesisClient::pause):
(WebKit::WebSpeechSynthesisClient::resume):
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h:
(WebKit::WebSpeechSynthesisClient::WebSpeechSynthesisClient): Deleted.

Canonical link: <a href="https://commits.webkit.org/283330@main">https://commits.webkit.org/283330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/074c742b2e6a3f5d2ff257a60814592a0137aa17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70014 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52960 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38527 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71716 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60566 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1850 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41165 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->