### PR TITLE
[Cocoa] Support Now Playing presentation suppression

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -558,7 +558,8 @@ std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
         false,
         m_currentIdentifier,
         isPlaying(),
-        !page->isVisibleAndActive()
+        !page->isVisibleAndActive(),
+        false
     };
 
     if (page->usesEphemeralSession() && !document->settings().allowPrivacySensitiveOperationsInNonPersistentDataStores())

--- a/Source/WebCore/PAL/pal/spi/mac/MediaRemoteSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/MediaRemoteSPI.h
@@ -27,8 +27,7 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
-#include <MediaRemote/MRNowPlayingTypes.h>
-#include <MediaRemote/MediaRemote.h>
+#import <MediaRemote/MediaRemote_Private.h>
 
 #else
 
@@ -139,5 +138,15 @@ void MRMediaRemoteSetNowPlayingInfoWithMergePolicy(CFDictionaryRef, MRMediaRemot
 CFArrayRef MRMediaRemoteCopyPickableRoutes();
 
 WTF_EXTERN_C_END
+
+@protocol MRUIControllable <NSObject>
+@end
+
+@protocol MRNowPlayingActivityUIControllable <MRUIControllable>
+@end
+
+@interface MRUIControllerProvider : NSObject
++ (id<MRNowPlayingActivityUIControllable>)nowPlayingActivityController;
+@end
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1309,7 +1309,8 @@ std::optional<NowPlayingInfo> MediaElementSession::computeNowPlayingInfo() const
         supportsSeeking,
         m_element.mediaUniqueIdentifier(),
         isPlaying,
-        allowsNowPlayingControlsVisibility
+        allowsNowPlayingControlsVisibility,
+        m_element.isVideo()
     };
 
     if (page->usesEphemeralSession() && !m_element.document().settings().allowPrivacySensitiveOperationsInNonPersistentDataStores()) {

--- a/Source/WebCore/platform/NowPlayingManager.h
+++ b/Source/WebCore/platform/NowPlayingManager.h
@@ -74,7 +74,7 @@ public:
 
 private:
     virtual void clearNowPlayingInfoPrivate();
-    virtual void setNowPlayingInfoPrivate(const NowPlayingInfo&);
+    virtual void setNowPlayingInfoPrivate(const NowPlayingInfo&, bool shouldUpdateNowPlayingSuppression);
     void ensureRemoteCommandListenerCreated();
     RefPtr<RemoteCommandListener> m_remoteCommandListener;
     WeakPtr<NowPlayingManagerClient> m_client;

--- a/Source/WebCore/platform/audio/NowPlayingInfo.h
+++ b/Source/WebCore/platform/audio/NowPlayingInfo.h
@@ -63,6 +63,7 @@ struct NowPlayingInfo {
     MediaUniqueIdentifier uniqueIdentifier;
     bool isPlaying { false };
     bool allowsNowPlayingControlsVisibility { false };
+    bool isVideo { false };
 
     friend bool operator==(const NowPlayingInfo&, const NowPlayingInfo&) = default;
 };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -64,7 +64,7 @@ public:
 
     std::optional<NowPlayingInfo> nowPlayingInfo() const final { return m_nowPlayingInfo; }
     static WEBCORE_EXPORT void clearNowPlayingInfo();
-    static WEBCORE_EXPORT void setNowPlayingInfo(bool setAsNowPlayingApplication, const NowPlayingInfo&);
+    static WEBCORE_EXPORT void setNowPlayingInfo(bool setAsNowPlayingApplication, bool shouldUpdateNowPlayingSuppression, const NowPlayingInfo&);
 
     static WEBCORE_EXPORT void updateMediaUsage(PlatformMediaSession&);
 
@@ -122,6 +122,10 @@ private:
     void possiblyChangeAudioCategory();
 
     std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const MediaConfiguration&) final;
+
+#if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
+    static void updateNowPlayingSuppression(const NowPlayingInfo*);
+#endif
 
     bool m_nowPlayingActive { false };
     bool m_registeredAsNowPlayingApplication { false };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -51,6 +51,12 @@
 
 static const size_t kLowPowerVideoBufferSize = 4096;
 
+// FIXME (135444366): Remove staging code once -suppressPresentationOverBundleIdentifiers: is available in SDKs
+@protocol WKStagedNowPlayingActivityUIControllable <MRNowPlayingActivityUIControllable>
+@optional
+- (void)suppressPresentationOverBundleIdentifiers:(NSSet *)bundleIdentifiers;
+@end
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerCocoa);
@@ -405,12 +411,23 @@ void MediaSessionManagerCocoa::clearNowPlayingInfo()
             WTFLogAlways("MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(stopped) failed with error %d", error);
 #endif
     });
+
+#if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
+    updateNowPlayingSuppression(nullptr);
+#endif
 }
 
-void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication, const NowPlayingInfo& nowPlayingInfo)
+void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication, bool shouldUpdateNowPlayingSuppression, const NowPlayingInfo& nowPlayingInfo)
 {
     if (!isMediaRemoteFrameworkAvailable())
         return;
+
+#if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
+    if (shouldUpdateNowPlayingSuppression)
+        updateNowPlayingSuppression(&nowPlayingInfo);
+#else
+    ASSERT_UNUSED(shouldUpdateNowPlayingSuppression, !shouldUpdateNowPlayingSuppression);
+#endif
 
     if (setAsNowPlayingApplication)
         MRMediaRemoteSetCanBeNowPlayingApplication(true);
@@ -607,6 +624,30 @@ std::optional<bool> MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForCon
     return this->supportsSpatialAudioPlayback();
 }
 #endif
+
+#if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
+
+static id<WKStagedNowPlayingActivityUIControllable> nowPlayingActivityController()
+{
+    static id<MRNowPlayingActivityUIControllable> controller = RetainPtr([getMRUIControllerProviderClass() nowPlayingActivityController]).leakRef();
+
+    // FIXME (135444366): Remove staging code once -suppressPresentationOverBundleIdentifiers: is available in SDKs
+    return (id<WKStagedNowPlayingActivityUIControllable>)controller;
+}
+
+void MediaSessionManagerCocoa::updateNowPlayingSuppression(const NowPlayingInfo* nowPlayingInfo)
+{
+    // FIXME (135444366): Remove staging code once -suppressPresentationOverBundleIdentifiers: is available in SDKs
+    if (![nowPlayingActivityController() respondsToSelector:@selector(suppressPresentationOverBundleIdentifiers:)])
+        return;
+
+    if (!nowPlayingInfo || !nowPlayingInfo->isVideo)
+        [nowPlayingActivityController() suppressPresentationOverBundleIdentifiers:nil];
+    else
+        [nowPlayingActivityController() suppressPresentationOverBundleIdentifiers:[NSSet setWithArray:@[nowPlayingInfo->metadata.sourceApplicationIdentifier]]];
+}
+
+#endif // USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mac/MediaRemoteSoftLink.h
+++ b/Source/WebCore/platform/mac/MediaRemoteSoftLink.h
@@ -93,3 +93,7 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, MediaRemote, kMRMediaRemoteCommandInfoPre
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, MediaRemote, MRMediaRemoteCopyPickableRoutes, CFArrayRef, (), ())
 #define MRMediaRemoteCopyPickableRoutes softLink_MediaRemote_MRMediaRemoteCopyPickableRoutes
 #endif
+
+#if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, MRUIControllerProvider);
+#endif

--- a/Source/WebCore/platform/mac/MediaRemoteSoftLink.mm
+++ b/Source/WebCore/platform/mac/MediaRemoteSoftLink.mm
@@ -63,3 +63,7 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, MediaRemote, kMRMediaRemoteCommandInfoPre
 #if PLATFORM(IOS_FAMILY)
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, MediaRemote, MRMediaRemoteCopyPickableRoutes, CFArrayRef, (), ());
 #endif
+
+#if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, MediaRemote, MRUIControllerProvider);
+#endif

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -475,6 +475,8 @@ function ios_family_process_webcontent_captiveportal_entitlements()
 
 function ios_family_process_gpu_entitlements()
 {
+    plistbuddy add :application-identifier string "${PRODUCT_BUNDLE_IDENTIFIER}"
+
     plistbuddy Add :com.apple.security.fatal-exceptions array
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
 
@@ -484,6 +486,7 @@ function ios_family_process_gpu_entitlements()
     plistbuddy Add :com.apple.developer.coremedia.allow-alternate-video-decoder-selection bool YES
     plistbuddy Add :com.apple.mediaremote.set-playback-state bool YES
     plistbuddy Add :com.apple.mediaremote.external-artwork-validation bool YES
+    plistbuddy add :com.apple.mediaremote.ui-control bool YES
     plistbuddy Add :com.apple.private.allow-explicit-graphics-priority bool YES
     plistbuddy Add :com.apple.private.coremedia.extensions.audiorecording.allow bool YES
     plistbuddy Add :com.apple.private.mediaexperience.startrecordinginthebackground.allow bool YES

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7111,6 +7111,7 @@ struct WebCore::NowPlayingInfo {
     WebCore::MediaUniqueIdentifier uniqueIdentifier;
     bool isPlaying;
     bool allowsNowPlayingControlsVisibility;
+    bool isVideo;
 }
 
 struct WebCore::VideoConfiguration {

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<WebCore::NowPlayingManager> WebMediaStrategy::createNowPlayingMa
                     connection->connection().send(Messages::GPUConnectionToWebProcess::ClearNowPlayingInfo { }, 0);
             }
 
-            void setNowPlayingInfoPrivate(const WebCore::NowPlayingInfo& nowPlayingInfo) final
+            void setNowPlayingInfoPrivate(const WebCore::NowPlayingInfo& nowPlayingInfo, bool) final
             {
                 Ref connection = WebProcess::singleton().ensureGPUProcessConnection().connection();
                 connection->send(Messages::GPUConnectionToWebProcess::SetNowPlayingInfo { nowPlayingInfo }, 0);


### PR DESCRIPTION
#### 87860a9045503955d1996eca13501ceb7a864436
<pre>
[Cocoa] Support Now Playing presentation suppression
<a href="https://bugs.webkit.org/show_bug.cgi?id=279288">https://bugs.webkit.org/show_bug.cgi?id=279288</a>
<a href="https://rdar.apple.com/132115578">rdar://132115578</a>

Reviewed by Eric Carlson.

Taught MediaSessionManagerCocoa to suppress the presentation of Now Playing information for
WebKit&apos;s presenting application when certain conditions are met (currently when video is playing).

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::nowPlayingInfo const):
  Set isVideo to false.

* Source/WebCore/PAL/pal/spi/mac/MediaRemoteSPI.h:
  Declared MRUIControllerProvider SPI.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::computeNowPlayingInfo const):
  Set isVideo based on whether the media element is a &lt;video&gt;.

* Source/WebCore/platform/NowPlayingManager.cpp:
(WebCore::NowPlayingManager::setNowPlayingInfo):
(WebCore::NowPlayingManager::setNowPlayingInfoPrivate):
  Computed shouldUpdateNowPlayingSuppression and passed it to MediaSessionManagerCocoa.

* Source/WebCore/platform/NowPlayingManager.h:
* Source/WebCore/platform/audio/NowPlayingInfo.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::clearNowPlayingInfo):
  Stopped suppressing presentation when clearing Now Playing info.

(WebCore::MediaSessionManagerCocoa::setNowPlayingInfo):
  Started or stopped suppressing presentation based on shouldUpdateNowPlayingSuppression.

(WebCore::nowPlayingActivityController):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingSuppression):
  Added a helper to start/stop presentation.

* Source/WebCore/platform/mac/MediaRemoteSoftLink.h:
* Source/WebCore/platform/mac/MediaRemoteSoftLink.mm:
  Soft-linked MRUIControllerProvider.
* Source/WebKit/Scripts/process-entitlements.sh:
  Added necessary entitlements to com.apple.WebKit.GPU.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
  Updated to serialize NowPlayingInfo::isVideo.

* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::createNowPlayingManager const):

Canonical link: <a href="https://commits.webkit.org/283290@main">https://commits.webkit.org/283290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43998eed2aa11b3fcc880d89edb6c68c750b58ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52845 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11422 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33477 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/65349 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14374 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71569 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9792 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14129 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60158 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1737 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->