### PR TITLE
Tiling gaps with feDisplacementMap in a CSS reference filter

### DIFF
--- a/LayoutTests/css3/filters/blur-clipped-with-overflow.html
+++ b/LayoutTests/css3/filters/blur-clipped-with-overflow.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-27300">
     <style>
         .filtered {
             overflow: hidden;

--- a/LayoutTests/css3/filters/fedisplacement-ref-filter-with-tiling-expected.html
+++ b/LayoutTests/css3/filters/fedisplacement-ref-filter-with-tiling-expected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<style>
+    body {
+        overflow: hidden;
+    }
+    .test {
+        height: 300px;
+        width: 600px;
+    }
+
+    .filtered {
+        background-color: green;
+        border: 10px solid black;
+        filter: url(#filter);
+    }
+    
+    .composited {
+        margin: 100px;
+        transform: translateZ(0);
+        width: 1024px;
+    }
+
+    svg {
+        position: absolute;
+        width: 0;
+        height: 0;
+    }
+</style>
+</head>
+<body>
+    <svg>
+    <filter id="filter" x=0 y=0 width="120%" height=100%>
+        <feFlood flood-color="black" flood-opacity="1"/>
+        <feDisplacementmap in="SourceGraphic" scale="100" xchannelselector="G"/>
+    </filter>
+    </svg>
+    <div class="composited">
+        <div class="test filtered"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/fedisplacement-ref-filter-with-tiling.html
+++ b/LayoutTests/css3/filters/fedisplacement-ref-filter-with-tiling.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<style>
+    body {
+        overflow: hidden;
+    }
+    .test {
+        height: 300px;
+        width: 600px;
+    }
+
+    .filtered {
+        background-color: green;
+        border: 10px solid black;
+        filter: url(#filter);
+    }
+    
+    .composited {
+        margin: 100px;
+        transform: translateZ(0);
+        width: 4097px; /* Make it tiled */
+    }
+
+    svg {
+        position: absolute;
+        width: 0;
+        height: 0;
+    }
+</style>
+</head>
+<body>
+    <svg>
+    <filter id="filter" x="0" y="0" width="120%" height=100%>
+        <feFlood flood-color="black" flood-opacity="1"/>
+        <feDisplacementmap in="SourceGraphic" scale="100" xchannelselector="G"/>
+    </filter>
+    </svg>
+    <div class="composited">
+        <div class="test filtered"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
@@ -81,6 +81,12 @@ FloatRect FEDisplacementMap::calculateImageRect(const Filter& filter, std::span<
     return filter.maxEffectRect(primitiveSubregion);
 }
 
+IntOutsets FEDisplacementMap::calculateOutsets(const FloatSize& maxDisplacement)
+{
+    auto intDisplacement = expandedIntSize(maxDisplacement);
+    return { intDisplacement.height(), intDisplacement.width(), intDisplacement.height(), intDisplacement.width() };
+}
+
 const DestinationColorSpace& FEDisplacementMap::resultColorSpace(std::span<const Ref<FilterImage>> inputs) const
 {
     // Spec: The 'color-interpolation-filters' property only applies to the 'in2' source image

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -52,6 +52,8 @@ public:
     float scale() const { return m_scale; }
     bool setScale(float);
 
+    static IntOutsets calculateOutsets(const FloatSize& maxDisplacement);
+
 private:
     FEDisplacementMap(ChannelSelectorType xChannelSelector, ChannelSelectorType yChannelSelector, float, DestinationColorSpace);
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -183,7 +183,7 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, std::span<const Re
 
     LOG_WITH_STREAM(Filters, stream
         << "FilterEffect " << filterName() << " " << this << " apply(): " << *this
-        << "\n  filterPrimitiveSubregion " << primitiveSubregion
+        << "  filterPrimitiveSubregion " << primitiveSubregion
         << "\n  absolutePaintRect " << absoluteImageRect
         << "\n  maxEffectRect " << filter.maxEffectRect(primitiveSubregion)
         << "\n  filter scale " << filter.filterScale());
@@ -223,7 +223,6 @@ TextStream& FilterEffect::externalRepresentation(TextStream& ts, FilterRepresent
     if (representation == FilterRepresentation::Debugging) {
         TextStream::IndentScope indentScope(ts);
         ts.dumpProperty("operating colorspace"_s, operatingColorSpace());
-        ts << '\n' << indent;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6367,8 +6367,8 @@ RenderLayerFilters& RenderLayer::ensureLayerFilters()
     if (m_filters)
         return *m_filters;
     
-    m_filters = RenderLayerFilters::create(*this);
-    m_filters->setFilterScale({ page().deviceScaleFactor(), page().deviceScaleFactor() });
+    auto scale = page().deviceScaleFactor();
+    m_filters = RenderLayerFilters::create(*this, { scale, scale });
     return *m_filters;
 }
 

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -48,7 +48,7 @@ class GraphicsContextSwitcher;
 class RenderLayerFilters final : public RefCounted<RenderLayerFilters>, private CachedSVGDocumentClient {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerFilters);
 public:
-    static Ref<RenderLayerFilters> create(RenderLayer&);
+    static Ref<RenderLayerFilters> create(RenderLayer&, FloatSize scale);
     virtual ~RenderLayerFilters();
 
     void detachFromLayer() { m_layer = nullptr; }
@@ -70,8 +70,6 @@ public:
     void updateReferenceFilterClients(const Style::Filter&);
     void removeReferenceFilterClients();
 
-    void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
-
     static bool isIdentity(RenderElement&);
     static IntOutsets calculateOutsets(RenderElement&, const FloatRect& targetBoundingBox);
 
@@ -82,7 +80,7 @@ public:
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:
-    explicit RenderLayerFilters(RenderLayer&);
+    explicit RenderLayerFilters(RenderLayer&, FloatSize scale);
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void resetDirtySourceRect() { m_dirtySourceRect = LayoutRect(); }
@@ -91,13 +89,12 @@ private:
     Vector<RefPtr<Element>> m_internalSVGReferences;
     Vector<CachedResourceHandle<CachedSVGDocument>> m_externalSVGReferences;
 
-    LayoutRect m_targetBoundingBox;
     LayoutRect m_dirtySourceRect;
     LayoutRect m_repaintRect;
 
-    OptionSet<FilterRenderingMode> m_preferredFilterRenderingModes { FilterRenderingMode::Software };
     FloatSize m_filterScale { 1, 1 };
-    FloatRect m_filterRegion;
+
+    OptionSet<FilterRenderingMode> m_preferredFilterRenderingModes { FilterRenderingMode::Software };
 
     RefPtr<CSSFilterRenderer> m_filter;
     std::unique_ptr<GraphicsContextSwitcher> m_targetSwitcher;

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -23,6 +23,7 @@
 
 #include "FEDisplacementMap.h"
 #include "NodeName.h"
+#include "SVGFilterRenderer.h"
 #include "SVGNames.h"
 #include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -120,6 +121,14 @@ void SVGFEDisplacementMapElement::svgAttributeChanged(const QualifiedName& attrN
         SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
         break;
     }
+}
+
+IntOutsets SVGFEDisplacementMapElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
+{
+    auto halfScale = std::abs(scale() / 2);
+    auto maxDisplacement = FloatSize { halfScale, halfScale };
+    auto adjustedDisplacement = SVGFilterRenderer::calculateResolvedSize(maxDisplacement, targetBoundingBox, primitiveUnits);
+    return FEDisplacementMap::calculateOutsets(adjustedDisplacement);
 }
 
 RefPtr<FilterEffect> SVGFEDisplacementMapElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -93,6 +93,7 @@ private:
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() }, AtomString { in2() } }; }
+    IntOutsets outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };


### PR DESCRIPTION
#### 25bd45233d1ada7a89d90c3d31007dec2807bc6d
<pre>
Tiling gaps with feDisplacementMap in a CSS reference filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=279290">https://bugs.webkit.org/show_bug.cgi?id=279290</a>
<a href="https://rdar.apple.com/135448018">rdar://135448018</a>

Reviewed by Said Abou-Hallawa.

webkit.org/b/266295 describes a number of tiling issues with SVG reference filters.
In many cases, the culprit was `&lt;feDisplacementMap&gt;`. This filter moves pixels, so
`SVGFEDisplacementMapElement` needs to implement `outsets()`; the max displacement
is based on half of the scale value. `FEDisplacementMap::calculateOutsets` converts
this into possible outsets on each side.

To fix rendering issues with tiling, we address the FIXME in `RenderLayerFilters::beginFilterEffect()`
by ensuring that the dirty rect does not affect `referenceBox`. This code is also simplified
to no longer store `m_filterRegion`, since we can read it from `m_filter`, and the two blocks
of code related to computing `filterRegion` are unified. There are two rects computed here,
with different roles:

`dirtyFilterRegion` designates the area of the input that needs to be redrawn; it&apos;s
the dirty rect inflated by filter outsets (to deal with filters that move pixels),
clipped to `filterBoxRect`. It&apos;s passed to `GraphicsContextSwitcher` and becomes the
bounds of the filter source image.

`filterRegion` is `dirtyFilterRegion` expanded by outsets to denote the bounds of
the filter result.

Filter geometry is still incorrect with LBSE, but using `objectBoundingBox()` as
input to the GraphicsContextSwitcher seems to improve things.

RenderLayerFilters now takes the scale at constructor time.

The test case exercises both issues.

Test: css3/filters/fedisplacement-ref-filter-with-tiling.html

* LayoutTests/css3/filters/blur-clipped-with-overflow.html:
* LayoutTests/css3/filters/fedisplacement-ref-filter-with-tiling-expected.html: Added.
* LayoutTests/css3/filters/fedisplacement-ref-filter-with-tiling.html: Added.
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp:
(WebCore::FEDisplacementMap::calculateOutsets):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.h:
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::apply):
(WebCore::FilterEffect::externalRepresentation const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::create):
(WebCore::RenderLayerFilters::RenderLayerFilters):
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::outsets const):
* Source/WebCore/svg/SVGFEDisplacementMapElement.h:

Canonical link: <a href="https://commits.webkit.org/304830@main">https://commits.webkit.org/304830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e419ccaa70fa51ef26e85825d58dd7c03982882

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144322 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c278436-1715-455e-a5ee-0a4f24e6640f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104450 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f733c166-9709-4f33-89aa-a5a3a20c431a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b6251d1d-6e3a-42c3-948d-188e9ee6e655) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4366 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4918 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147081 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112795 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7264 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113134 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6612 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62695 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8689 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36740 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72255 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8481 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->