### PR TITLE
NetworkTransportReceiveStream should have a virtual destructor

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp
@@ -32,4 +32,6 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportReceiveStream);
 
+NetworkTransportReceiveStream::~NetworkTransportReceiveStream() = default;
+
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
@@ -49,6 +49,8 @@ class NetworkTransportReceiveStream : public RefCounted<NetworkTransportReceiveS
 public:
     template<typename... Args> static Ref<NetworkTransportReceiveStream> create(Args&&... args) { return adoptRef(*new NetworkTransportReceiveStream(std::forward<Args>(args)...)); }
 
+    virtual ~NetworkTransportReceiveStream();
+
     WebTransportStreamIdentifier identifier() const { return m_identifier; }
 
 protected:


### PR DESCRIPTION
#### 68d2cb16fa85cde6b2ec50eb4c81f47656e55bd0
<pre>
NetworkTransportReceiveStream should have a virtual destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=279291">https://bugs.webkit.org/show_bug.cgi?id=279291</a>

Reviewed by David Kilzer.

NetworkTransportBidirectionalStream subclasses this class and needs to run its own destructor.
Fixed the bug by adding the virtual destructor to NetworkTransportReceiveStream.

* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h:

Canonical link: <a href="https://commits.webkit.org/283322@main">https://commits.webkit.org/283322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52c71938f4bc54744f5dc6f21073279cbb25e3c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69921 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16501 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52876 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38448 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71624 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9847 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14168 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60191 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60481 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1765 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9979 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41073 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->