### PR TITLE
[Content Visibility] onedrive.live.com: content-visibility does not apply to display: contents elements.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-on-display-contents-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-on-display-contents-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-on-display-contents.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-on-display-contents.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
+<meta name="assert" content="content-visibility on display contents element does not apply since size containment does not apply to it">
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="display: contents; content-visibility: hidden;">
+  <div>
+    <div style="width: 100px; height: 100px; background-color: green;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -987,7 +987,7 @@ inline bool isSkippedContentRoot(const RenderStyle& style, const Element* elemen
         return false;
     // FIXME (https://bugs.webkit.org/show_bug.cgi?id=265020): check more display types.
     // FIXME: try to avoid duplication with shouldApplySizeOrStyleContainment.
-    if (style.isDisplayTableOrTablePart() && style.display() != DisplayType::TableCaption)
+    if (auto displayType = style.display(); (displayType != DisplayType::TableCaption && style.isDisplayTableOrTablePart()) || displayType == DisplayType::Contents)
         return false;
     if (style.contentVisibility() == ContentVisibility::Hidden)
         return true;


### PR DESCRIPTION
#### 76f7fe96cdbb551285d6cd5c7fbf9eb1aa171a05
<pre>
[Content Visibility] onedrive.live.com: content-visibility does not apply to display: contents elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278477">https://bugs.webkit.org/show_bug.cgi?id=278477</a>
<a href="https://rdar.apple.com/134436437">rdar://134436437</a>

Reviewed by Alan Baradlay.

We attempt to apply some content-visibility: auto logic to a
display: contents item which results in descendant content not appearing
on OneDrive since the root element does not have an associated renderer.

The spec actually handles this case by stating that content-visibility
applies to: &quot;elements for which size containment can apply.&quot; The size
containment portion of the spec then states size containment has no
effect if, &quot;if the element does not generate a principal box (as is the
case with display: contents or display: none).&quot;

<a href="https://drafts.csswg.org/css-contain-2/#content-visibility">https://drafts.csswg.org/css-contain-2/#content-visibility</a>
<a href="https://drafts.csswg.org/css-contain-2/#size-containment">https://drafts.csswg.org/css-contain-2/#size-containment</a>

We can handle this by checking the display type in isSkippedContentRoot
which is used for, among other things, propagating the
usedContentVisibility value to descendant renderers. As a result, we
should not be propagating this content visibility information to
descendant renderers and they should go through layout as if
content-visibility was not set on the display: contents element.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-on-display-contents-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-on-display-contents.html: Added.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::isSkippedContentRoot):

Canonical link: <a href="https://commits.webkit.org/283345@main">https://commits.webkit.org/283345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6182a4cb0b66e7fee11a652d0b84a7bb0a457fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52869 "Passed tests") | [⏳ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33503 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14408 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9836 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60182 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 39 flakes 175 failures; Uploaded test results; 76 flakes 89 failures; Compiled WebKit; 4 flakes 86 failures; Passed layout tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1757 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41062 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->