### PR TITLE
Adopt more smart pointers in the UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -53,7 +53,7 @@ public:
     explicit WebLockRegistryProxy(WebProcessProxy&);
     ~WebLockRegistryProxy();
 
-    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() { return m_process.sharedPreferencesForWebProcess(); }
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() { return m_process->sharedPreferencesForWebProcess(); }
 
     void processDidExit();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -66,7 +66,9 @@ private:
     void snapshot(WebCore::ClientOrigin&&, CompletionHandler<void(WebCore::WebLockManagerSnapshot&&)>&&);
     void clientIsGoingAway(WebCore::ClientOrigin&&, WebCore::ScriptExecutionContextIdentifier);
 
-    WebProcessProxy& m_process;
+    Ref<WebProcessProxy> protectedProcess() const { return m_process.get(); }
+
+    CheckedRef<WebProcessProxy> m_process;
     bool m_hasEverRequestedLocks { false };
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -536,7 +536,7 @@ WebPageProxy::ProcessActivityState::ProcessActivityState(WebPageProxy& page)
 
 void WebPageProxy::ProcessActivityState::takeVisibleActivity()
 {
-    m_isVisibleActivity = m_page.legacyMainFrameProcess().throttler().foregroundActivity("View is visible"_s).moveToUniquePtr();
+    m_isVisibleActivity = m_page->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("View is visible"_s).moveToUniquePtr();
 #if PLATFORM(MAC)
     *m_wasRecentlyVisibleActivity = nullptr;
 #endif
@@ -544,18 +544,18 @@ void WebPageProxy::ProcessActivityState::takeVisibleActivity()
 
 void WebPageProxy::ProcessActivityState::takeAudibleActivity()
 {
-    m_isAudibleActivity = m_page.legacyMainFrameProcess().throttler().foregroundActivity("View is playing audio"_s).moveToUniquePtr();
+    m_isAudibleActivity = m_page->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("View is playing audio"_s).moveToUniquePtr();
 }
 
 void WebPageProxy::ProcessActivityState::takeCapturingActivity()
 {
-    m_isCapturingActivity = m_page.legacyMainFrameProcess().throttler().foregroundActivity("View is capturing media"_s).moveToUniquePtr();
+    m_isCapturingActivity = m_page->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("View is capturing media"_s).moveToUniquePtr();
 }
 
 void WebPageProxy::ProcessActivityState::takeMutedCaptureAssertion()
 {
-    m_isMutedCaptureAssertion = ProcessAssertion::create(m_page.legacyMainFrameProcess(), "WebKit Muted Media Capture"_s, ProcessAssertionType::Background);
-    m_isMutedCaptureAssertion->setInvalidationHandler([weakPage = WeakPtr { m_page }] {
+    m_isMutedCaptureAssertion = ProcessAssertion::create(m_page->protectedLegacyMainFrameProcess(), "WebKit Muted Media Capture"_s, ProcessAssertionType::Background);
+    m_isMutedCaptureAssertion->setInvalidationHandler([weakPage = WeakPtr { m_page.get() }] {
         if (RefPtr protectedPage = weakPage.get()) {
             RELEASE_LOG(ProcessSuspension, "Muted capture assertion is invalidated");
             protectedPage->m_legacyMainFrameProcessActivityState.m_isMutedCaptureAssertion = nullptr;
@@ -581,9 +581,9 @@ void WebPageProxy::ProcessActivityState::dropVisibleActivity()
 {
 #if PLATFORM(MAC)
     if (WTF::numberOfProcessorCores() > 4)
-        *m_wasRecentlyVisibleActivity = m_page.legacyMainFrameProcess().throttler().backgroundActivity("View was recently visible"_s);
+        *m_wasRecentlyVisibleActivity = m_page->protectedLegacyMainFrameProcess()->throttler().backgroundActivity("View was recently visible"_s);
     else
-        *m_wasRecentlyVisibleActivity = m_page.legacyMainFrameProcess().throttler().foregroundActivity("View was recently visible"_s);
+        *m_wasRecentlyVisibleActivity = m_page->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("View was recently visible"_s);
 #endif
     m_isVisibleActivity = nullptr;
 }
@@ -626,7 +626,7 @@ bool WebPageProxy::ProcessActivityState::hasValidMutedCaptureAssertion() const
 #if PLATFORM(IOS_FAMILY)
 void WebPageProxy::ProcessActivityState::takeOpeningAppLinkActivity()
 {
-    m_openingAppLinkActivity = m_page.legacyMainFrameProcess().throttler().backgroundActivity("Opening AppLink"_s).moveToUniquePtr();
+    m_openingAppLinkActivity = m_page->protectedLegacyMainFrameProcess()->throttler().backgroundActivity("Opening AppLink"_s).moveToUniquePtr();
 }
 
 void WebPageProxy::ProcessActivityState::dropOpeningAppLinkActivity()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3161,7 +3161,7 @@ private:
 #endif
 
     private:
-        WebPageProxy& m_page;
+        WeakRef<WebPageProxy> m_page;
 
         std::unique_ptr<ProcessThrottlerActivity> m_isVisibleActivity;
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include "WebPageProxyIdentifier.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -57,7 +58,9 @@ private:
     // IPC Message handlers.
     void query(const WebCore::ClientOrigin&, const WebCore::PermissionDescriptor&, std::optional<WebPageProxyIdentifier>, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&);
 
-    WebProcessProxy& m_process;
+    Ref<WebProcessProxy> protectedProcess() const;
+
+    CheckedRef<WebProcessProxy> m_process;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -94,16 +94,16 @@ private:
         explicit UpdateBatch(WebPreferences& preferences)
             : m_preferences(preferences)
         {
-            m_preferences.startBatchingUpdates();
+            m_preferences->startBatchingUpdates();
         }
         
         ~UpdateBatch()
         {
-            m_preferences.endBatchingUpdates();
+            m_preferences->endBatchingUpdates();
         }
         
     private:
-        WebPreferences& m_preferences;
+        Ref<WebPreferences> m_preferences;
     };
 
     void updateStringValueForKey(const String& key, const String& value, bool ephemeral);

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -45,14 +45,14 @@ WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy&
     : m_page(page)
     , m_currentOrientation(orientation)
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
+    m_page->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess(), *this);
 }
 
 WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
 {
     unlockIfNecessary();
 
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
+    m_page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess());
 }
 
 void WebScreenOrientationManagerProxy::currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&& completionHandler)
@@ -69,7 +69,7 @@ void WebScreenOrientationManagerProxy::setCurrentOrientation(WebCore::ScreenOrie
     if (!m_shouldSendChangeNotifications)
         return;
 
-    m_page.legacyMainFrameProcess().send(Messages::WebScreenOrientationManager::OrientationDidChange(orientation), m_page.webPageIDInMainFrameProcess());
+    m_page->protectedLegacyMainFrameProcess()->send(Messages::WebScreenOrientationManager::OrientationDidChange(orientation), m_page->webPageIDInMainFrameProcess());
     if (m_currentLockRequest)
         m_currentLockRequest(std::nullopt);
 }
@@ -121,16 +121,17 @@ void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType l
 
     if (resolvedLockedOrientation != m_currentlyLockedOrientation) {
         bool didLockOrientation = false;
+        Ref page = m_page.get();
 #if ENABLE(FULLSCREEN_API)
-        if (m_page.fullScreenManager() && m_page.fullScreenManager()->isFullScreen()) {
-            if (!m_page.fullScreenManager()->lockFullscreenOrientation(resolvedLockedOrientation)) {
+        if (page->fullScreenManager() && page->fullScreenManager()->isFullScreen()) {
+            if (!page->fullScreenManager()->lockFullscreenOrientation(resolvedLockedOrientation)) {
                 m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
                 return;
             }
             didLockOrientation = true;
         }
 #endif
-        if (!didLockOrientation && !m_page.uiClient().lockScreenOrientation(m_page, resolvedLockedOrientation)) {
+        if (!didLockOrientation && !page->uiClient().lockScreenOrientation(page, resolvedLockedOrientation)) {
             m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
             return;
         }
@@ -149,14 +150,15 @@ void WebScreenOrientationManagerProxy::unlock()
         m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::AbortError, "Unlock request was received"_s });
 
     bool didUnlockOrientation = false;
+    Ref page = m_page.get();
 #if ENABLE(FULLSCREEN_API)
-    if (m_page.fullScreenManager() && m_page.fullScreenManager()->isFullScreen()) {
-        m_page.fullScreenManager()->unlockFullscreenOrientation();
+    if (page->fullScreenManager() && page->fullScreenManager()->isFullScreen()) {
+        page->fullScreenManager()->unlockFullscreenOrientation();
         didUnlockOrientation = true;
     }
 #endif
     if (!didUnlockOrientation)
-        m_page.uiClient().unlockScreenOrientation(m_page);
+        page->uiClient().unlockScreenOrientation(page);
 
     m_currentlyLockedOrientation = std::nullopt;
 }

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -62,7 +62,7 @@ private:
     void unlock();
     void setShouldSendChangeNotification(bool);
 
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
     WebCore::ScreenOrientationType m_currentOrientation;
     std::optional<WebCore::ScreenOrientationType> m_currentlyLockedOrientation;
     CompletionHandler<void(std::optional<WebCore::Exception>&&)> m_currentLockRequest;

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -78,6 +78,8 @@ private:
 
     bool webXREnabled() const;
 
+    Ref<WebPageProxy> protectedPage() const;
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
@@ -109,7 +111,7 @@ private:
     void setImmersiveSessionState(ImmersiveSessionState, CompletionHandler<void(bool)>&&);
     void invalidateImmersiveSessionState(ImmersiveSessionState nextSessionState = ImmersiveSessionState::Idle);
 
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_immersiveSessionActivity;
 };
 

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -59,7 +59,7 @@ private:
     void scrollToRect(WebCore::FloatPoint origin, WebCore::FloatRect targetRect);
     std::tuple<WebCore::FloatRect, double, double> smartMagnificationTargetRectAndZoomScales(WebCore::FloatRect targetRect, double minimumScale, double maximumScale, bool addMagnificationPadding);
 
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
     WKContentView *m_contentView;
 };
     

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -57,17 +57,17 @@ SmartMagnificationController::SmartMagnificationController(WKContentView *conten
     : m_webPageProxy(*contentView.page)
     , m_contentView(contentView)
 {
-    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess(), *this);
+    m_webPageProxy->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
 }
 
 SmartMagnificationController::~SmartMagnificationController()
 {
-    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void SmartMagnificationController::handleSmartMagnificationGesture(FloatPoint origin)
 {
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(origin), m_webPageProxy.webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(origin), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void SmartMagnificationController::handleResetMagnificationGesture(FloatPoint origin)
@@ -121,7 +121,7 @@ void SmartMagnificationController::didCollectGeometryForSmartMagnificationGestur
     // If the content already fits in the scroll view and we're already zoomed in to the target scale,
     // it is most likely that the user intended to scroll, so use a small distance threshold to initiate panning.
     float minimumScrollDistance;
-    if ([m_contentView bounds].size.width <= m_webPageProxy.unobscuredContentRect().width())
+    if ([m_contentView bounds].size.width <= m_webPageProxy->unobscuredContentRect().width())
         minimumScrollDistance = smartMagnificationPanScrollThresholdZoomedOut;
     else if (PAL::currentUserInterfaceIdiomIsSmallScreen())
         minimumScrollDistance = smartMagnificationPanScrollThresholdIPhone;

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -55,7 +55,7 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -43,12 +43,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDeviceOrientationUpdateProviderProxy);
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
+    m_page->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess(), *this);
 }
 
 WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy()
 {
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
+    m_page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()
@@ -73,12 +73,12 @@ void WebDeviceOrientationUpdateProviderProxy::stopUpdatingDeviceMotion()
 
 void WebDeviceOrientationUpdateProviderProxy::orientationChanged(double alpha, double beta, double gamma, double compassHeading, double compassAccuracy)
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebDeviceOrientationUpdateProvider::DeviceOrientationChanged(alpha, beta, gamma, compassHeading, compassAccuracy), m_page.webPageIDInMainFrameProcess());
+    m_page->protectedLegacyMainFrameProcess()->send(Messages::WebDeviceOrientationUpdateProvider::DeviceOrientationChanged(alpha, beta, gamma, compassHeading, compassAccuracy), m_page->webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::motionChanged(double xAcceleration, double yAcceleration, double zAcceleration, double xAccelerationIncludingGravity, double yAccelerationIncludingGravity, double zAccelerationIncludingGravity, std::optional<double> xRotationRate, std::optional<double> yRotationRate, std::optional<double> zRotationRate)
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebDeviceOrientationUpdateProvider::DeviceMotionChanged(xAcceleration, yAcceleration, zAcceleration, xAccelerationIncludingGravity, yAccelerationIncludingGravity, zAccelerationIncludingGravity, xRotationRate, yRotationRate, zRotationRate), m_page.webPageIDInMainFrameProcess());
+    m_page->protectedLegacyMainFrameProcess()->send(Messages::WebDeviceOrientationUpdateProvider::DeviceMotionChanged(xAcceleration, yAcceleration, zAcceleration, xAccelerationIncludingGravity, yAccelerationIncludingGravity, zAccelerationIncludingGravity, xRotationRate, yRotationRate, zRotationRate), m_page->webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### ef698474cd352fc1cf742a19c0e9df8da4f52f56
<pre>
Adopt more smart pointers in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279296">https://bugs.webkit.org/show_bug.cgi?id=279296</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
(WebKit::WebLockRegistryProxy::WebLockRegistryProxy):
(WebKit::WebLockRegistryProxy::~WebLockRegistryProxy):
(WebKit::WebLockRegistryProxy::requestLock):
(WebKit::WebLockRegistryProxy::releaseLock):
(WebKit::WebLockRegistryProxy::abortLockRequest):
(WebKit::WebLockRegistryProxy::snapshot):
(WebKit::WebLockRegistryProxy::clientIsGoingAway):
(WebKit::WebLockRegistryProxy::processDidExit):
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
(WebKit::WebPermissionControllerProxy::WebPermissionControllerProxy):
(WebKit::WebPermissionControllerProxy::~WebPermissionControllerProxy):
(WebKit::WebPermissionControllerProxy::protectedProcess const):
(WebKit::WebPermissionControllerProxy::query):
(WebKit::WebPermissionControllerProxy::mostReasonableWebPageProxy const):
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebPreferences.h:
(WebKit::WebPreferences::UpdateBatch::UpdateBatch):
(WebKit::WebPreferences::UpdateBatch::~UpdateBatch):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::setCurrentOrientation):
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::unlock):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::PlatformXRSystem):
(WebKit::PlatformXRSystem::~PlatformXRSystem):
(WebKit::PlatformXRSystem::sharedPreferencesForWebProcess const):
(WebKit::PlatformXRSystem::invalidate):
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
(WebKit::PlatformXRSystem::enumerateImmersiveXRDevices):
(WebKit::PlatformXRSystem::requestPermissionOnSessionFeatures):
(WebKit::PlatformXRSystem::protectedPage const):
(WebKit::PlatformXRSystem::initializeTrackingAndRendering):
(WebKit::PlatformXRSystem::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystem::requestFrame):
(WebKit::PlatformXRSystem::submitFrame):
(WebKit::PlatformXRSystem::sessionDidEnd):
(WebKit::PlatformXRSystem::sessionDidUpdateVisibilityState):
(WebKit::PlatformXRSystem::setImmersiveSessionState):
(WebKit::PlatformXRSystem::webXREnabled const):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::SmartMagnificationController):
(WebKit::SmartMagnificationController::~SmartMagnificationController):
(WebKit::SmartMagnificationController::handleSmartMagnificationGesture):
(WebKit::SmartMagnificationController::didCollectGeometryForSmartMagnificationGesture):
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::orientationChanged):
(WebKit::WebDeviceOrientationUpdateProviderProxy::motionChanged):

Canonical link: <a href="https://commits.webkit.org/283305@main">https://commits.webkit.org/283305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/707c8e82928823bf80109fdfcddf7b76a8ba5f7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16493 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52868 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11451 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38439 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60277 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14758 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71616 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14161 "Found 2 new test failures: http/tests/site-isolation/window-open-with-name-cross-site.html http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60472 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1759 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9976 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41065 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42141 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->