### PR TITLE
Split view transition related css property parsing out into its own file

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1043,6 +1043,7 @@ css/parser/CSSPropertyParserConsumer+TimingFunction.cpp
 css/parser/CSSPropertyParserConsumer+Transform.cpp
 css/parser/CSSPropertyParserConsumer+URL.cpp
 css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
+css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
 css/parser/CSSPropertyParserHelpers.cpp
 css/parser/CSSSelectorParser.cpp
 css/parser/CSSSelectorParserContext.cpp

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+ViewTransition.h"
+
+#include "CSSParserTokenRange.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSValueKeywords.h"
+#include "CSSValueList.h"
+
+namespace WebCore {
+namespace CSSPropertyParserHelpers {
+
+RefPtr<CSSValue> consumeViewTransitionClass(CSSParserTokenRange& range)
+{
+    // <'view-transition-class'> = none | <custom-ident>+
+    // https://drafts.csswg.org/css-view-transitions-2/#view-transition-class-prop
+
+    if (auto noneValue = consumeIdent<CSSValueNone>(range))
+        return noneValue;
+
+    CSSValueListBuilder list;
+    do {
+        if (range.peek().id() == CSSValueNone)
+            return nullptr;
+
+        auto ident = consumeCustomIdent(range);
+        if (!ident)
+            return nullptr;
+
+        list.append(ident.releaseNonNull());
+    } while (!range.atEnd());
+
+    if (list.isEmpty())
+        return nullptr;
+
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
+}
+
+RefPtr<CSSValue> consumeViewTransitionName(CSSParserTokenRange& range)
+{
+    // <'view-transition-name'> = none | <custom-ident>
+    // https://drafts.csswg.org/css-view-transitions-1/#propdef-view-transition-name
+
+    // NOTE: The values none and auto are excluded from <custom-ident>.
+
+    if (auto noneValue = consumeIdent<CSSValueNone>(range))
+        return noneValue;
+    if (identMatches<CSSValueAuto>(range.peek().id()))
+        return nullptr;
+    return consumeCustomIdent(range);
+}
+
+RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range)
+{
+    // <'types'> = none | <custom-ident>+
+    // https://www.w3.org/TR/css-view-transitions-2/#descdef-view-transition-types
+
+    if (range.peek().id() == CSSValueNone)
+        return consumeIdent(range);
+
+    CSSValueListBuilder list;
+    do {
+        if (range.peek().id() == CSSValueNone)
+            return nullptr;
+        auto type = consumeCustomIdent(range);
+        if (!type)
+            return nullptr;
+        if (type->customIdent().startsWith("-ua-"_s))
+            return nullptr;
+        list.append(type.releaseNonNull());
+    } while (!range.atEnd());
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
+}
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+class CSSValue;
+
+namespace CSSPropertyParserHelpers {
+
+RefPtr<CSSValue> consumeViewTransitionClass(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeViewTransitionName(CSSParserTokenRange&);
+
+// For @view-transition descriptor
+RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -2594,38 +2594,6 @@ RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange& range, CSSParserMode m
     return CSSOffsetRotateValue::create(WTFMove(modifier), WTFMove(angle));
 }
 
-RefPtr<CSSValue> consumeViewTransitionClass(CSSParserTokenRange& range)
-{
-    if (auto noneValue = consumeIdent<CSSValueNone>(range))
-        return noneValue;
-
-    CSSValueListBuilder list;
-    do {
-        if (range.peek().id() == CSSValueNone)
-            return nullptr;
-
-        auto ident = consumeCustomIdent(range);
-        if (!ident)
-            return nullptr;
-
-        list.append(ident.releaseNonNull());
-    } while (!range.atEnd());
-
-    if (list.isEmpty())
-        return nullptr;
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-RefPtr<CSSValue> consumeViewTransitionName(CSSParserTokenRange& range)
-{
-    if (auto noneValue = consumeIdent<CSSValueNone>(range))
-        return noneValue;
-    if (isAuto(range.peek().id()))
-        return nullptr;
-    return consumeCustomIdent(range);
-}
-
 // MARK: - @-rule descriptor consumers:
 
 // MARK: @counter-style
@@ -2926,25 +2894,6 @@ RefPtr<CSSPrimitiveValue> consumeAnchor(CSSParserTokenRange& range, CSSParserMod
     range = rangeCopy;
     auto anchor = CSSAnchorValue::create(WTFMove(anchorElement), WTFMove(anchorSide), WTFMove(fallback));
     return CSSPrimitiveValue::create(anchor);
-}
-
-RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range)
-{
-    if (range.peek().id() == CSSValueNone)
-        return consumeIdent(range);
-
-    CSSValueListBuilder list;
-    do {
-        if (range.peek().id() == CSSValueNone)
-            return nullptr;
-        auto type = consumeCustomIdent(range);
-        if (!type)
-            return nullptr;
-        if (type->customIdent().startsWith("-ua-"_s))
-            return nullptr;
-        list.append(type.releaseNonNull());
-    } while (!range.atEnd());
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -107,8 +107,6 @@ RefPtr<CSSValue> consumeScrollSnapType(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeScrollbarColor(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeScrollbarGutter(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextEdge(CSSPropertyID, CSSParserTokenRange&);
-RefPtr<CSSValue> consumeViewTransitionClass(CSSParserTokenRange&);
-RefPtr<CSSValue> consumeViewTransitionName(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeBorderRadiusCorner(CSSParserTokenRange&, CSSParserMode);
 bool consumeRadii(std::array<RefPtr<CSSValue>, 4>& horizontalRadii, std::array<RefPtr<CSSValue>, 4>& verticalRadii, CSSParserTokenRange&, CSSParserMode, bool useLegacyParsing);
 enum PathParsingOption : uint8_t { RejectRay = 1 << 0, RejectFillRule = 1 << 1 };
@@ -149,7 +147,6 @@ RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextUnderlinePosition(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSPrimitiveValue> consumeAnchor(CSSParserTokenRange&, CSSParserMode);
-RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange&);
 
 RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserContext&);
 

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3956,6 +3956,7 @@ class GenerateCSSPropertyParsing:
                     "CSSPropertyParserConsumer+TimingFunction.h",
                     "CSSPropertyParserConsumer+Transform.h",
                     "CSSPropertyParserConsumer+URL.h",
+                    "CSSPropertyParserConsumer+ViewTransition.h",
                     "CSSValuePool.h",
                     "DeprecatedGlobalSettings.h",
                 ]


### PR DESCRIPTION
#### 077a372d996a643901b58448bf8ca8abd8d8c236
<pre>
Split view transition related css property parsing out into its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=279298">https://bugs.webkit.org/show_bug.cgi?id=279298</a>

Reviewed by Tim Nguyen and Darin Adler.

Just splits the consumers out into their own file. No additional cleanup performed.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.h: Added.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/283306@main">https://commits.webkit.org/283306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ceba3c19b6b7c20ffcb2ffd9e6b3f6e2b00352a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16813 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68989 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9877 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9909 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/57133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8159 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41103 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->