### PR TITLE
Split align related css property parsing out into its own file

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1016,6 +1016,7 @@ css/parser/CSSParserObserverWrapper.cpp
 css/parser/CSSParserToken.cpp
 css/parser/CSSParserTokenRange.cpp
 css/parser/CSSPropertyParser.cpp
+css/parser/CSSPropertyParserConsumer+Align.cpp
 css/parser/CSSPropertyParserConsumer+Angle.cpp
 css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp
 css/parser/CSSPropertyParserConsumer+Color.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7296,8 +7296,7 @@
                 ],
                 "initial": "initialContentAlignment",
                 "converter": "ContentAlignmentData",
-                "parser-function": "consumeContentDistributionOverflowPosition",
-                "parser-function-requires-additional-parameters": ["isContentPositionKeyword"],
+                "parser-function": "consumeAlignContent",
                 "parser-grammar-unused": "normal | <baseline-position> | <content-distribution> | [ <overflow-position>? <content-position> ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals",
                 "comment": "Alternate definition in css-flexbox - flex-start | flex-end | center | space-between | space-around | stretch"
@@ -7365,8 +7364,7 @@
                 ],
                 "initial": "initialSelfAlignment",
                 "converter": "SelfOrDefaultAlignmentData",
-                "parser-function": "consumeSelfPositionOverflowPosition",
-                "parser-function-requires-additional-parameters": ["isSelfPositionKeyword"],
+                "parser-function": "consumeAlignSelf",
                 "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals.",
                 "comment": "Alternate definition in css-flexbox - auto | flex-start | flex-end | center | baseline | stretch"
@@ -7560,8 +7558,7 @@
             "codegen-properties": {
                 "initial": "initialSelfAlignment",
                 "converter": "SelfOrDefaultAlignmentData",
-                "parser-function": "consumeSelfPositionOverflowPosition",
-                "parser-function-requires-additional-parameters": ["isSelfPositionOrLeftOrRightKeyword"],
+                "parser-function": "consumeJustifySelf",
                 "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals."
             },

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -117,9 +117,7 @@ private:
     bool consumeGridShorthand(bool important);
     bool consumeGridAreaShorthand(bool important);
 
-    bool consumePlaceContentShorthand(bool important);
-    bool consumePlaceItemsShorthand(bool important);
-    bool consumePlaceSelfShorthand(bool important);
+    bool consumeAlignShorthand(const StylePropertyShorthand&, bool important);
 
     bool consumeFont(bool important);
     bool consumeTextDecorationSkip(bool important);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+Align.h"
+
+#include "CSSContentDistributionValue.h"
+#include "CSSParserIdioms.h"
+#include "CSSParserTokenRange.h"
+#include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSValueKeywords.h"
+#include "CSSValuePair.h"
+#include <optional>
+
+namespace WebCore {
+namespace CSSPropertyParserHelpers {
+
+using PositionKeywordPredicate = bool (*)(CSSValueID);
+
+static bool isBaselineKeyword(CSSValueID id)
+{
+    return identMatches<CSSValueFirst, CSSValueLast, CSSValueBaseline>(id);
+}
+
+static bool isNormalOrStretch(CSSValueID id)
+{
+    return identMatches<CSSValueNormal, CSSValueStretch>(id);
+}
+
+static bool isLeftOrRightKeyword(CSSValueID id)
+{
+    return identMatches<CSSValueLeft, CSSValueRight>(id);
+}
+
+static bool isContentDistributionKeyword(CSSValueID id)
+{
+    return identMatches<CSSValueSpaceBetween, CSSValueSpaceAround, CSSValueSpaceEvenly, CSSValueStretch>(id);
+}
+
+static bool isOverflowKeyword(CSSValueID id)
+{
+    return identMatches<CSSValueUnsafe, CSSValueSafe>(id);
+}
+
+static bool isContentPositionKeyword(CSSValueID id)
+{
+    return identMatches<CSSValueStart, CSSValueEnd, CSSValueCenter, CSSValueFlexStart, CSSValueFlexEnd>(id);
+}
+
+static bool isContentPositionOrLeftOrRightKeyword(CSSValueID id)
+{
+    return isContentPositionKeyword(id) || isLeftOrRightKeyword(id);
+}
+
+static bool isSelfPositionKeyword(CSSValueID id)
+{
+    return identMatches<CSSValueStart, CSSValueEnd, CSSValueCenter, CSSValueSelfStart, CSSValueSelfEnd, CSSValueFlexStart, CSSValueFlexEnd>(id);
+}
+
+static bool isSelfPositionOrLeftOrRightKeyword(CSSValueID id)
+{
+    return isSelfPositionKeyword(id) || isLeftOrRightKeyword(id);
+}
+
+static RefPtr<CSSPrimitiveValue> consumeOverflowPositionKeyword(CSSParserTokenRange& range)
+{
+    return isOverflowKeyword(range.peek().id()) ? consumeIdent(range) : nullptr;
+}
+
+static std::optional<CSSValueID> consumeBaselineKeywordRaw(CSSParserTokenRange& range)
+{
+    auto preference = consumeIdentRaw<CSSValueFirst, CSSValueLast>(range);
+    if (!consumeIdent<CSSValueBaseline>(range))
+        return std::nullopt;
+    return preference == CSSValueLast ? CSSValueLastBaseline : CSSValueBaseline;
+}
+
+static RefPtr<CSSValue> consumeBaselineKeyword(CSSParserTokenRange& range)
+{
+    auto keyword = consumeBaselineKeywordRaw(range);
+    if (!keyword)
+        return nullptr;
+    if (*keyword == CSSValueLastBaseline)
+        return CSSValuePair::create(CSSPrimitiveValue::create(CSSValueLast), CSSPrimitiveValue::create(CSSValueBaseline));
+    return CSSPrimitiveValue::create(CSSValueBaseline);
+}
+
+static RefPtr<CSSValue> consumeContentDistributionOverflowPosition(CSSParserTokenRange& range, PositionKeywordPredicate isPositionKeyword)
+{
+    ASSERT(isPositionKeyword);
+    auto id = range.peek().id();
+    if (identMatches<CSSValueNormal>(id))
+        return CSSContentDistributionValue::create(CSSValueInvalid, range.consumeIncludingWhitespace().id(), CSSValueInvalid);
+    if (isBaselineKeyword(id)) {
+        auto baseline = consumeBaselineKeywordRaw(range);
+        if (!baseline)
+            return nullptr;
+        return CSSContentDistributionValue::create(CSSValueInvalid, *baseline, CSSValueInvalid);
+    }
+    if (isContentDistributionKeyword(id))
+        return CSSContentDistributionValue::create(range.consumeIncludingWhitespace().id(), CSSValueInvalid, CSSValueInvalid);
+    auto overflow = isOverflowKeyword(id) ? range.consumeIncludingWhitespace().id() : CSSValueInvalid;
+    if (isPositionKeyword(range.peek().id()))
+        return CSSContentDistributionValue::create(CSSValueInvalid, range.consumeIncludingWhitespace().id(), overflow);
+    return nullptr;
+}
+
+static RefPtr<CSSValue> consumeSelfPositionOverflowPosition(CSSParserTokenRange& range, PositionKeywordPredicate isPositionKeyword)
+{
+    ASSERT(isPositionKeyword);
+    auto id = range.peek().id();
+    if (identMatches<CSSValueAuto>(id) || isNormalOrStretch(id))
+        return consumeIdent(range);
+    if (isBaselineKeyword(id))
+        return consumeBaselineKeyword(range);
+    auto overflowPosition = consumeOverflowPositionKeyword(range);
+    if (!isPositionKeyword(range.peek().id()))
+        return nullptr;
+    auto selfPosition = consumeIdent(range);
+    if (overflowPosition)
+        return CSSValuePair::create(overflowPosition.releaseNonNull(), selfPosition.releaseNonNull());
+    return selfPosition;
+}
+
+RefPtr<CSSValue> consumeAlignContent(CSSParserTokenRange& range)
+{
+    // <'align-content'> = normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>
+    // https://drafts.csswg.org/css-align/#propdef-align-content
+
+    return consumeContentDistributionOverflowPosition(range, isContentPositionKeyword);
+}
+
+RefPtr<CSSValue> consumeJustifyContent(CSSParserTokenRange& range)
+{
+    // <'justify-content'> = normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]
+    // https://drafts.csswg.org/css-align/#propdef-justify-content
+
+    // justify-content property does not allow the <baseline-position> values.
+    if (isBaselineKeyword(range.peek().id()))
+        return nullptr;
+    return consumeContentDistributionOverflowPosition(range, isContentPositionOrLeftOrRightKeyword);
+}
+
+RefPtr<CSSValue> consumeAlignSelf(CSSParserTokenRange& range)
+{
+    // <'align-self'> = auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position>
+    // https://drafts.csswg.org/css-align/#propdef-align-self
+
+    return consumeSelfPositionOverflowPosition(range, isSelfPositionKeyword);
+}
+
+RefPtr<CSSValue> consumeJustifySelf(CSSParserTokenRange& range)
+{
+    // <'justify-self'> = auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ]
+    // https://drafts.csswg.org/css-align/#propdef-justify-self
+
+    return consumeSelfPositionOverflowPosition(range, isSelfPositionOrLeftOrRightKeyword);
+}
+
+RefPtr<CSSValue> consumeAlignItems(CSSParserTokenRange& range)
+{
+    // <'align-items'> = normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]
+    // https://drafts.csswg.org/css-align/#propdef-align-items
+
+    // align-items property does not allow the 'auto' value.
+    if (identMatches<CSSValueAuto>(range.peek().id()))
+        return nullptr;
+    return consumeSelfPositionOverflowPosition(range, isSelfPositionKeyword);
+}
+
+RefPtr<CSSValue> consumeJustifyItems(CSSParserTokenRange& range)
+{
+    // <'justify-items'> = normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ]
+    // https://drafts.csswg.org/css-align/#propdef-justify-items
+
+    // justify-items property does not allow the 'auto' value.
+    if (identMatches<CSSValueAuto>(range.peek().id()))
+        return nullptr;
+    CSSParserTokenRange rangeCopy = range;
+    auto legacy = consumeIdent<CSSValueLegacy>(rangeCopy);
+    auto positionKeyword = consumeIdent<CSSValueCenter, CSSValueLeft, CSSValueRight>(rangeCopy);
+    if (!legacy)
+        legacy = consumeIdent<CSSValueLegacy>(rangeCopy);
+    if (legacy) {
+        range = rangeCopy;
+        if (positionKeyword)
+            return CSSValuePair::create(legacy.releaseNonNull(), positionKeyword.releaseNonNull());
+        return legacy;
+    }
+    return consumeSelfPositionOverflowPosition(range, isSelfPositionOrLeftOrRightKeyword);
+}
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+class CSSValue;
+
+namespace CSSPropertyParserHelpers {
+
+// MARK: <'align-content'>
+// https://drafts.csswg.org/css-align/#propdef-align-content
+RefPtr<CSSValue> consumeAlignContent(CSSParserTokenRange&);
+
+// MARK: <'justify-content'>
+// https://drafts.csswg.org/css-align/#propdef-justify-content
+RefPtr<CSSValue> consumeJustifyContent(CSSParserTokenRange&);
+
+// MARK: <'align-self'>
+// https://drafts.csswg.org/css-align/#propdef-align-self
+RefPtr<CSSValue> consumeAlignSelf(CSSParserTokenRange&);
+
+// MARK: <'justify-self'>
+// https://drafts.csswg.org/css-align/#propdef-justify-self
+RefPtr<CSSValue> consumeJustifySelf(CSSParserTokenRange&);
+
+// MARK: <'align-items'>
+// https://drafts.csswg.org/css-align/#propdef-align-items
+RefPtr<CSSValue> consumeAlignItems(CSSParserTokenRange&);
+
+// MARK: <'justify-items'>
+// https://drafts.csswg.org/css-align/#propdef-justify-items
+RefPtr<CSSValue> consumeJustifyItems(CSSParserTokenRange&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -61,13 +61,7 @@ RefPtr<CSSPrimitiveValue> consumeSingleContainerName(CSSParserTokenRange&);
 
 RefPtr<CSSValue> consumeAspectRatio(CSSParserTokenRange&);
 
-using IsPositionKeyword = bool (*)(CSSValueID);
 bool isFlexBasisIdent(CSSValueID);
-bool isBaselineKeyword(CSSValueID);
-bool isContentPositionKeyword(CSSValueID);
-bool isContentPositionOrLeftOrRightKeyword(CSSValueID);
-bool isSelfPositionKeyword(CSSValueID);
-bool isSelfPositionOrLeftOrRightKeyword(CSSValueID);
 
 RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeWillChange(CSSParserTokenRange&, const CSSParserContext&);
@@ -113,8 +107,6 @@ enum PathParsingOption : uint8_t { RejectRay = 1 << 0, RejectFillRule = 1 << 1 }
 RefPtr<CSSValue> consumePathOperation(CSSParserTokenRange&, const CSSParserContext&, OptionSet<PathParsingOption>);
 RefPtr<CSSValue> consumePath(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeShapeOutside(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeContentDistributionOverflowPosition(CSSParserTokenRange&, IsPositionKeyword);
-RefPtr<CSSValue> consumeJustifyContent(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeBorderImageRepeat(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeBorderImageSlice(CSSPropertyID, CSSParserTokenRange&);
 RefPtr<CSSValue> consumeBorderImageOutset(CSSParserTokenRange&);
@@ -128,9 +120,6 @@ RefPtr<CSSValue> consumeBackgroundSize(CSSPropertyID, CSSParserTokenRange&, CSSP
 RefPtr<CSSValue> consumeSingleBackgroundSize(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeSingleMaskSize(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeSingleWebkitBackgroundSize(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeSelfPositionOverflowPosition(CSSParserTokenRange&, IsPositionKeyword);
-RefPtr<CSSValue> consumeAlignItems(CSSParserTokenRange&);
-RefPtr<CSSValue> consumeJustifyItems(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeLineBoxContain(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeContainerName(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeWebkitInitialLetter(CSSParserTokenRange&);

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3935,6 +3935,7 @@ class GenerateCSSPropertyParsing:
                     "CSSParserContext.h",
                     "CSSParserIdioms.h",
                     "CSSPropertyParser.h",
+                    "CSSPropertyParserConsumer+Align.h",
                     "CSSPropertyParserConsumer+Angle.h",
                     "CSSPropertyParserConsumer+Color.h",
                     "CSSPropertyParserConsumer+Filter.h",


### PR DESCRIPTION
#### d489dc4fc3730b5fc9c554d02b32ef2828088e4d
<pre>
Split align related css property parsing out into its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=279299">https://bugs.webkit.org/show_bug.cgi?id=279299</a>

Reviewed by Darin Adler.

Splits property consumers for CSS Align properties into their own file and refactor
them a bit to hide the implementation details.

We now have explicit functions for each property, named appropriately to match the
property. The implementations remain the same, still calling to shared consumers
and passing predicates to refine behavior, but from the outside, things are much
more clear.

The shorthands were also refactored and now all use a shared consumeAlignShorthand
consumer function.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.h: Added.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/283317@main">https://commits.webkit.org/283317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d903948a36c4e5f7c44a76a62f3511a18afcb8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52944 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14487 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14246 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57172 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1834 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41148 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->