### PR TITLE
Always honor scrollIntoView alignment

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-align-scrollport-covering-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-align-scrollport-covering-child-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scrollIntoView scrolls scrollport-covering child in both axes assert_equals: center sets top expected 100 but got 0
+PASS scrollIntoView scrolls scrollport-covering child in both axes
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2010, Google Inc. All rights reserved.
- * Copyright (C) 2008, 2011, 2014-2016 Apple Inc. All Rights Reserved.
+ * Copyright (c) 2010-2023 Google Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All Rights Reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -915,10 +915,8 @@ LayoutRect ScrollableArea::getRectToExposeForScrollIntoView(const LayoutRect& vi
             // then treat it as fully visible to avoid unnecessary horizontal scrolling
             scrollX = alignX.getVisibleBehavior();
         } else if (intersectWidth == visibleBounds.width()) {
-            // If the rect is bigger than the visible area, don't bother trying to center. Other alignments will work.
+            // The rect is bigger than the visible area.
             scrollX = alignX.getVisibleBehavior();
-            if (scrollX == ScrollAlignment::Behavior::AlignCenter)
-                scrollX = ScrollAlignment::Behavior::NoScroll;
         } else if (intersectWidth > 0)
             // If the rectangle is partially visible, but not above the minimum threshold, use the specified partial behavior
             scrollX = alignX.getPartialBehavior();
@@ -957,10 +955,8 @@ LayoutRect ScrollableArea::getRectToExposeForScrollIntoView(const LayoutRect& vi
             // If the rectangle is fully visible, use the specified visible behavior.
             scrollY = alignY.getVisibleBehavior();
         } else if (intersectHeight == visibleBounds.height()) {
-            // If the rect is bigger than the visible area, don't bother trying to center. Other alignments will work.
+            // The rect is bigger than the visible area.
             scrollY = alignY.getVisibleBehavior();
-            if (scrollY == ScrollAlignment::Behavior::AlignCenter)
-                scrollY = ScrollAlignment::Behavior::NoScroll;
         } else if (intersectHeight > 0)
             // If the rectangle is partially visible, use the specified partial behavior
             scrollY = alignY.getPartialBehavior();


### PR DESCRIPTION
#### b518f48885b952050847dcfda0a61b946b4efef4
<pre>
Always honor scrollIntoView alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=279305">https://bugs.webkit.org/show_bug.cgi?id=279305</a>
<a href="https://rdar.apple.com/135484284">rdar://135484284</a>

Reviewed by Darin Adler.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/5105296">https://chromium-review.googlesource.com/c/chromium/src/+/5105296</a>

The specification [1] does not say to treat &quot;center&quot; differently from
&quot;start&quot; and &quot;end&quot;.

[1] <a href="https://drafts.csswg.org/cssom-view/#scroll-a-target-into-view">https://drafts.csswg.org/cssom-view/#scroll-a-target-into-view</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-align-scrollport-covering-child-expected.txt:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::getRectToExposeForScrollIntoView const):

Canonical link: <a href="https://commits.webkit.org/283314@main">https://commits.webkit.org/283314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06e351267f6b50f2e69eff24de67e5142ff99a67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52902 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11486 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14445 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71652 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1792 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->