### PR TITLE
Adopt more smart pointers in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -122,7 +122,7 @@ public:
     template<typename... Arguments>
     inline void logAlways(const char* methodName, const Arguments&... arguments) const
     {
-        if (!m_manager.alwaysOnLoggingAllowed())
+        if (!m_manager->alwaysOnLoggingAllowed())
             return;
 
         m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, span(methodName), ' '), arguments...);
@@ -136,7 +136,7 @@ private:
     {
     }
 
-    WebMediaSessionManager& m_manager;
+    CheckedRef<WebMediaSessionManager> m_manager;
     Ref<Logger> m_logger;
 };
 

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
@@ -32,6 +32,7 @@
 #include "MediaPlaybackTargetPickerMock.h"
 #include "MediaProducer.h"
 #include "PlaybackTargetClientContextIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
@@ -43,8 +44,10 @@ class IntRect;
 class WebMediaSessionLogger;
 class WebMediaSessionManagerClient;
 
-class WebMediaSessionManager : public MediaPlaybackTargetPicker::Client {
+class WebMediaSessionManager : public MediaPlaybackTargetPicker::Client, public CanMakeCheckedPtr<WebMediaSessionManager> {
     WTF_MAKE_NONCOPYABLE(WebMediaSessionManager);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebMediaSessionManager);
 public:
 
     WEBCORE_EXPORT static WebMediaSessionManager& shared();

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
@@ -45,7 +45,7 @@ class PasteboardCustomData;
 class ScriptExecutionContext;
 struct PasteboardItemInfo;
 
-class ClipboardItem : public RefCounted<ClipboardItem> {
+class ClipboardItem : public RefCounted<ClipboardItem>, public CanMakeWeakPtr<ClipboardItem> {
 public:
     ~ClipboardItem();
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -145,7 +145,7 @@ void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destinati
     m_numberOfPendingClipboardTypes = m_itemPromises.size();
     m_itemTypeLoaders = m_itemPromises.map([&](auto& typeAndItem) {
         auto type = typeAndItem.key;
-        auto itemTypeLoader = ClipboardItemTypeLoader::create(destination, type, [this, protectedItem = Ref { m_item }] {
+        auto itemTypeLoader = ClipboardItemTypeLoader::create(destination, type, [this, protectedItem = Ref { m_item.get() }] {
             ASSERT(m_numberOfPendingClipboardTypes);
             if (!--m_numberOfPendingClipboardTypes)
                 invokeCompletionHandler();
@@ -154,7 +154,7 @@ void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destinati
         auto promise = typeAndItem.value;
         /* hack: gcc 8.4 will segfault if the WeakPtr is instantiated within the lambda captures */
         auto wl = WeakPtr { itemTypeLoader };
-        promise->whenSettled([this, protectedItem = Ref { m_item }, destination = m_writingDestination, promise, type, weakItemTypeLoader = WTFMove(wl)] () mutable {
+        promise->whenSettled([this, protectedItem = Ref { m_item.get() }, destination = m_writingDestination, promise, type, weakItemTypeLoader = WTFMove(wl)] () mutable {
             if (!weakItemTypeLoader)
                 return;
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemDataSource.h
@@ -51,7 +51,7 @@ public:
     virtual void collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&&) = 0;
 
 protected:
-    ClipboardItem& m_item;
+    WeakRef<ClipboardItem> m_item;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemPasteboardDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemPasteboardDataSource.cpp
@@ -52,8 +52,8 @@ Vector<String> ClipboardItemPasteboardDataSource::types() const
 
 void ClipboardItemPasteboardDataSource::getType(const String& type, Ref<DeferredPromise>&& promise)
 {
-    if (RefPtr clipboard = m_item.clipboard())
-        clipboard->getType(m_item, type, WTFMove(promise));
+    if (RefPtr clipboard = m_item->clipboard())
+        clipboard->getType(Ref { m_item.get() }, type, WTFMove(promise));
     else
         promise->reject(ExceptionCode::NotAllowedError);
 }

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
@@ -50,7 +50,7 @@ RefPtr<Clipboard> NavigatorClipboard::clipboard(Navigator& navigator)
 RefPtr<Clipboard> NavigatorClipboard::clipboard()
 {
     if (!m_clipboard)
-        m_clipboard = Clipboard::create(m_navigator);
+        m_clipboard = Clipboard::create(Ref { m_navigator.get() });
     return m_clipboard;
 }
 

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -48,7 +49,7 @@ private:
     static ASCIILiteral supplementName();
 
     RefPtr<Clipboard> m_clipboard;
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
 };
 
 }

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -86,7 +86,7 @@ void NavigatorBeacon::logError(const ResourceError& error)
 {
     ASSERT(!error.isNull());
 
-    RefPtr frame = m_navigator.frame();
+    RefPtr frame = m_navigator->frame();
     if (!frame)
         return;
 

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -30,6 +30,7 @@
 #include "ExceptionOr.h"
 #include "FetchBody.h"
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -59,7 +60,7 @@ private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void logError(const ResourceError&);
 
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
     Vector<CachedResourceHandle<CachedRawResource>> m_inflightBeacons;
 };
 

--- a/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
+++ b/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
@@ -66,7 +66,7 @@ public:
 private:
     static ASCIILiteral supplementName() { return "WorkerGlobalScopeCaches"_s; }
 
-    WorkerGlobalScope& m_scope;
+    WeakRef<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     mutable RefPtr<DOMCacheStorage> m_caches;
 };
 
@@ -121,8 +121,10 @@ WorkerGlobalScopeCaches* WorkerGlobalScopeCaches::from(WorkerGlobalScope& scope)
 
 DOMCacheStorage* WorkerGlobalScopeCaches::caches() const
 {
-    if (!m_caches)
-        m_caches = DOMCacheStorage::create(m_scope, m_scope.cacheStorageConnection());
+    if (!m_caches) {
+        Ref scope = m_scope.get();
+        m_caches = DOMCacheStorage::create(scope, scope->cacheStorageConnection());
+    }
     return m_caches.get();
 }
 

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
@@ -50,7 +50,7 @@ RefPtr<ContactsManager> NavigatorContacts::contacts(Navigator& navigator)
 RefPtr<ContactsManager> NavigatorContacts::contacts()
 {
     if (!m_contactsManager)
-        m_contactsManager = ContactsManager::create(m_navigator);
+        m_contactsManager = ContactsManager::create(Ref { m_navigator.get() });
     return m_contactsManager;
 }
 

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -48,7 +49,7 @@ private:
     static ASCIILiteral supplementName();
 
     RefPtr<ContactsManager> m_contactsManager;
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
 };
 
 }

--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp
@@ -50,7 +50,7 @@ void NavigatorCookieConsent::requestCookieConsent(RequestCookieConsentOptions&& 
     // FIXME: Support the 'More info' option.
     UNUSED_PARAM(options);
 
-    RefPtr frame = m_navigator.frame();
+    RefPtr frame = m_navigator->frame();
     if (!frame || !frame->isMainFrame() || !frame->page()) {
         promise->reject(ExceptionCode::NotAllowedError);
         return;

--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
@@ -53,7 +54,7 @@ private:
 
     void requestCookieConsent(RequestCookieConsentOptions&&, Ref<DeferredPromise>&&);
 
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -40,10 +40,12 @@
 #include "ResourceError.h"
 #include "ResourceResponse.h"
 #include "WindowEventLoop.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchBodyOwner);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(FetchBodyOwnerBlobLoader, FetchBodyOwner::BlobLoader);
 
 FetchBodyOwner::FetchBodyOwner(ScriptExecutionContext* context, std::optional<FetchBody>&& body, Ref<FetchHeaders>&& headers)
     : ActiveDOMObject(context)

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -38,6 +38,7 @@
 #include "FetchLoaderClient.h"
 #include "ResourceError.h"
 #include "SharedBuffer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -119,6 +120,9 @@ private:
     bool virtualHasPendingActivity() const final;
 
     struct BlobLoader final : FetchLoaderClient {
+        WTF_MAKE_TZONE_ALLOCATED(BlobLoader);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BlobLoader);
+    public:
         BlobLoader(FetchBodyOwner&);
 
         // FetchLoaderClient API

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -56,7 +56,7 @@ void FetchLoader::startLoadingBlobURL(ScriptExecutionContext& context, const URL
     m_urlForReading = { BlobURL::createPublicURL(context.securityOrigin()), context.topOrigin().data() };
 
     if (m_urlForReading.isEmpty()) {
-        m_client.didFail({ errorDomainWebKitInternal, 0, URL(), "Could not create URL for Blob"_s });
+        m_client->didFail({ errorDomainWebKitInternal, 0, URL(), "Could not create URL for Blob"_s });
         return;
     }
 
@@ -105,7 +105,7 @@ void FetchLoader::start(ScriptExecutionContext& context, const FetchRequest& req
         contentSecurityPolicy->upgradeInsecureRequestIfNeeded(fetchRequest, ContentSecurityPolicy::InsecureRequestType::Load);
 
         if (!context.shouldBypassMainWorldContentSecurityPolicy() && !contentSecurityPolicy->allowConnectToSource(fetchRequest.url())) {
-            m_client.didFail({ errorDomainWebKitInternal, 0, fetchRequest.url(), "Not allowed by ContentSecurityPolicy"_s, ResourceError::Type::AccessControl });
+            m_client->didFail({ errorDomainWebKitInternal, 0, fetchRequest.url(), "Not allowed by ContentSecurityPolicy"_s, ResourceError::Type::AccessControl });
             return;
         }
     }
@@ -147,13 +147,13 @@ RefPtr<FragmentedSharedBuffer> FetchLoader::startStreaming()
 
 void FetchLoader::didReceiveResponse(ScriptExecutionContextIdentifier, ResourceLoaderIdentifier, const ResourceResponse& response)
 {
-    m_client.didReceiveResponse(response);
+    m_client->didReceiveResponse(response);
 }
 
 void FetchLoader::didReceiveData(const SharedBuffer& buffer)
 {
     if (!m_consumer) {
-        m_client.didReceiveData(buffer);
+        m_client->didReceiveData(buffer);
         return;
     }
     m_consumer->append(buffer);
@@ -161,12 +161,12 @@ void FetchLoader::didReceiveData(const SharedBuffer& buffer)
 
 void FetchLoader::didFinishLoading(ScriptExecutionContextIdentifier, ResourceLoaderIdentifier, const NetworkLoadMetrics& metrics)
 {
-    m_client.didSucceed(metrics);
+    m_client->didSucceed(metrics);
 }
 
 void FetchLoader::didFail(ScriptExecutionContextIdentifier, const ResourceError& error)
 {
-    m_client.didFail(error);
+    m_client->didFail(error);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchLoader.h
+++ b/Source/WebCore/Modules/fetch/FetchLoader.h
@@ -66,7 +66,7 @@ private:
     void didFail(ScriptExecutionContextIdentifier, const ResourceError&) final;
 
 private:
-    FetchLoaderClient& m_client;
+    CheckedRef<FetchLoaderClient> m_client;
     RefPtr<ThreadableLoader> m_loader;
     FetchBodyConsumer* m_consumer;
     bool m_isStarted { false };

--- a/Source/WebCore/Modules/fetch/FetchLoaderClient.h
+++ b/Source/WebCore/Modules/fetch/FetchLoaderClient.h
@@ -29,13 +29,16 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class ResourceError;
 class ResourceResponse;
 
-class FetchLoaderClient {
+class FetchLoaderClient : public CanMakeCheckedPtr<FetchLoaderClient> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FetchLoaderClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FetchLoaderClient);
 public:
     virtual ~FetchLoaderClient() = default;
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -151,6 +151,7 @@ private:
 
     class Loader final : public FetchLoaderClient {
         WTF_MAKE_TZONE_ALLOCATED(Loader);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Loader);
     public:
         Loader(FetchResponse&, NotificationCallback&&);
         ~Loader();

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -26,6 +26,7 @@
 #include "ScriptWrappable.h"
 #include "ShareData.h"
 #include "Supplementable.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ class Navigator final
 #endif
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Navigator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Navigator);
 public:
     static Ref<Navigator> create(ScriptExecutionContext* context, LocalDOMWindow& window) { return adoptRef(*new Navigator(context, window)); }
     virtual ~Navigator();

--- a/Source/WebCore/page/NavigatorBase.cpp
+++ b/Source/WebCore/page/NavigatorBase.cpp
@@ -37,6 +37,7 @@
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
@@ -67,6 +68,8 @@
 #endif // ifndef WEBCORE_NAVIGATOR_VENDOR_SUB
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(NavigatorBase);
 
 NavigatorBase::NavigatorBase(ScriptExecutionContext* context)
     : ContextDestructionObserver(context)

--- a/Source/WebCore/page/NavigatorBase.h
+++ b/Source/WebCore/page/NavigatorBase.h
@@ -27,8 +27,10 @@
 
 #include "ContextDestructionObserver.h"
 #include "ExceptionOr.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -42,7 +44,9 @@ class StorageManager;
 class WebCoreOpaqueRoot;
 class WebLockManager;
 
-class NavigatorBase : public RefCounted<NavigatorBase>, public ContextDestructionObserver, public CanMakeWeakPtr<NavigatorBase> {
+class NavigatorBase : public RefCounted<NavigatorBase>, public ContextDestructionObserver, public CanMakeWeakPtr<NavigatorBase>, public CanMakeCheckedPtr<NavigatorBase> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigatorBase);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NavigatorBase);
 public:
     virtual ~NavigatorBase();
 

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -36,8 +36,11 @@
 #include "WorkerBadgeProxy.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerThread.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WorkerNavigator);
 
 WorkerNavigator::WorkerNavigator(ScriptExecutionContext& context, const String& userAgent, bool isOnline)
     : NavigatorBase(&context)

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -35,6 +35,8 @@ namespace WebCore {
 class GPU;
 
 class WorkerNavigator final : public NavigatorBase, public Supplementable<WorkerNavigator> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WorkerNavigator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerNavigator);
 public:
     static Ref<WorkerNavigator> create(ScriptExecutionContext& context, const String& userAgent, bool isOnline) { return adoptRef(*new WorkerNavigator(context, userAgent, isOnline)); }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -38,9 +38,12 @@
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SWContextManager.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WebServiceWorkerFetchTaskClientBlobLoader, WebServiceWorkerFetchTaskClient::BlobLoader);
 
 WebServiceWorkerFetchTaskClient::WebServiceWorkerFetchTaskClient(Ref<IPC::Connection>&& connection, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, FetchIdentifier fetchIdentifier, bool needsContinueDidReceiveResponseMessage)
     : m_connection(WTFMove(connection))
@@ -144,10 +147,10 @@ void WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinishInternal(Ref<Fo
             return;
         }
 
-        m_blobLoader.emplace(*this);
+        m_blobLoader = makeUnique<BlobLoader>(*this);
         auto loader = serviceWorkerThreadProxy->createBlobLoader(*m_blobLoader, blobURL);
         if (!loader) {
-            m_blobLoader = std::nullopt;
+            m_blobLoader = nullptr;
             didFail(internalError(blobURL));
             return;
         }
@@ -172,7 +175,7 @@ void WebServiceWorkerFetchTaskClient::didFinishBlobLoading()
 {
     didFinish({ });
 
-    std::exchange(m_blobLoader, std::nullopt);
+    std::exchange(m_blobLoader, nullptr);
 }
 
 void WebServiceWorkerFetchTaskClient::didFail(const ResourceError& error)

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -34,6 +34,7 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -77,6 +78,10 @@ private:
     void didFinishBlobLoading();
 
     struct BlobLoader final : WebCore::FetchLoaderClient {
+        WTF_MAKE_TZONE_ALLOCATED(BlobLoader);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BlobLoader);
+    public:
+
         explicit BlobLoader(WebServiceWorkerFetchTaskClient& client) : client(client) { }
 
         // FetchLoaderClient API
@@ -94,7 +99,7 @@ private:
     WebCore::SWServerConnectionIdentifier m_serverConnectionIdentifier;
     WebCore::ServiceWorkerIdentifier m_serviceWorkerIdentifier;
     WebCore::FetchIdentifier m_fetchIdentifier;
-    std::optional<BlobLoader> m_blobLoader;
+    std::unique_ptr<BlobLoader> m_blobLoader;
     bool m_needsContinueDidReceiveResponseMessage { false };
     bool m_waitingForContinueDidReceiveResponseMessage { false };
     std::variant<std::nullptr_t, WebCore::SharedBufferBuilder, Ref<WebCore::FormData>, UniqueRef<WebCore::ResourceError>> m_responseData;


### PR DESCRIPTION
#### 9fef1130b01da4c9e79a031162af50575b5317e4
<pre>
Adopt more smart pointers in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=279306">https://bugs.webkit.org/show_bug.cgi?id=279306</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionLogger::logAlways const):
* Source/WebCore/Modules/airplay/WebMediaSessionManager.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::collectDataForWriting):
* Source/WebCore/Modules/async-clipboard/ClipboardItemDataSource.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItemPasteboardDataSource.cpp:
(WebCore::ClipboardItemPasteboardDataSource::getType):
* Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp:
(WebCore::NavigatorClipboard::clipboard):
* Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h:
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::logError):
* Source/WebCore/Modules/beacon/NavigatorBeacon.h:
* Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp:
(WebCore::WorkerGlobalScopeCaches::caches const):
* Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp:
(WebCore::NavigatorContacts::contacts):
* Source/WebCore/Modules/contact-picker/NavigatorContacts.h:
* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp:
(WebCore::NavigatorCookieConsent::requestCookieConsent):
* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h:
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::startLoadingBlobURL):
(WebCore::FetchLoader::start):
(WebCore::FetchLoader::didReceiveResponse):
(WebCore::FetchLoader::didReceiveData):
(WebCore::FetchLoader::didFinishLoading):
(WebCore::FetchLoader::didFail):
* Source/WebCore/Modules/fetch/FetchLoader.h:
* Source/WebCore/Modules/fetch/FetchLoaderClient.h:
* Source/WebCore/Modules/fetch/FetchResponse.h:

Canonical link: <a href="https://commits.webkit.org/283328@main">https://commits.webkit.org/283328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0834591df1c417752c2c70b8088bf630ce74df6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52967 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14507 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60283 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60573 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8216 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9980 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41175 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->