### PR TITLE
CSS grid should not eagerly evaluate calc() for repetitions value

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-repeat-calc-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-repeat-calc-expected.txt
@@ -5,8 +5,17 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS testDiv.style['grid-template-rows'] is ""
 testDiv.style['grid-template-rows'] = 'repeat(calc(1 + 1), 18px)'
-PASS testDiv.style['grid-template-rows'] is "repeat(2, 18px)"
+PASS testDiv.style['grid-template-rows'] is "repeat(calc(2), 18px)"
 PASS window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows') is "repeat(2, 18px)"
+testDiv.style['grid-template-rows'] = 'repeat(calc(-1), 18px)'
+PASS testDiv.style['grid-template-rows'] is "repeat(calc(-1), 18px)"
+PASS window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows') is "repeat(1, 18px)"
+testDiv.style['grid-template-rows'] = 'repeat(calc(2.2), 18px)'
+PASS testDiv.style['grid-template-rows'] is "repeat(calc(2.2), 18px)"
+PASS window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows') is "repeat(2, 18px)"
+testDiv.style['grid-template-rows'] = 'repeat(calc(10 + (sign(20cqw - 10px)) * 5), 18px)'
+PASS testDiv.style['grid-template-rows'] is "repeat(calc(10 + (5 * sign(20cqw - 10px))), 18px)"
+PASS window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows') is "repeat(5, 18px)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css-grid-layout/grid-repeat-calc.html
+++ b/LayoutTests/fast/css-grid-layout/grid-repeat-calc.html
@@ -1,17 +1,31 @@
 <!DOCTYPE html>
 <body>
 <script src="../../resources/js-test-pre.js"></script>
+<div style="container-type: inline-size; width: 10px;">
 <div id="testDiv" style="width: 400px; height: 400px"></div>
+</div>
 <script>
 description("Tests using calculated value in function() for 'grid-template-rows' CSS property works.");
 
 var testDiv = document.getElementById("testDiv");
-//grid-template-rows: repeat(1, 18px);
-// grid-template-columns: repeat(1, 15%);
+
 shouldBeEmptyString("testDiv.style['grid-template-rows']");
+
 evalAndLog("testDiv.style['grid-template-rows'] = 'repeat(calc(1 + 1), 18px)'");
-shouldBeEqualToString("testDiv.style['grid-template-rows']", "repeat(2, 18px)");
+shouldBeEqualToString("testDiv.style['grid-template-rows']", "repeat(calc(2), 18px)");
 shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows')", "repeat(2, 18px)");
+
+evalAndLog("testDiv.style['grid-template-rows'] = 'repeat(calc(-1), 18px)'");
+shouldBeEqualToString("testDiv.style['grid-template-rows']", "repeat(calc(-1), 18px)");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows')", "repeat(1, 18px)");
+
+evalAndLog("testDiv.style['grid-template-rows'] = 'repeat(calc(2.2), 18px)'");
+shouldBeEqualToString("testDiv.style['grid-template-rows']", "repeat(calc(2.2), 18px)");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows')", "repeat(2, 18px)");
+
+evalAndLog("testDiv.style['grid-template-rows'] = 'repeat(calc(10 + (sign(20cqw - 10px)) * 5), 18px)'");
+shouldBeEqualToString("testDiv.style['grid-template-rows']", "repeat(calc(10 + (5 * sign(20cqw - 10px))), 18px)");
+shouldBeEqualToString("window.getComputedStyle(testDiv).getPropertyValue('grid-template-rows')", "repeat(5, 18px)");
 
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
@@ -35,22 +35,21 @@
 
 namespace WebCore {
 
-CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue(size_t repetitions, CSSValueListBuilder builder)
+CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue(Ref<CSSPrimitiveValue>&& repetitions, CSSValueListBuilder builder)
     : CSSValueContainingVector(GridIntegerRepeatClass, SpaceSeparator, WTFMove(builder))
-    , m_repetitions(repetitions)
+    , m_repetitions(WTFMove(repetitions))
 {
-    ASSERT(repetitions);
 }
 
-Ref<CSSGridIntegerRepeatValue> CSSGridIntegerRepeatValue::create(size_t repetitions, CSSValueListBuilder builder)
+Ref<CSSGridIntegerRepeatValue> CSSGridIntegerRepeatValue::create(Ref<CSSPrimitiveValue>&& repetitions, CSSValueListBuilder builder)
 {
-    return adoptRef(*new CSSGridIntegerRepeatValue(repetitions, WTFMove(builder)));
+    return adoptRef(*new CSSGridIntegerRepeatValue(WTFMove(repetitions), WTFMove(builder)));
 }
 
 String CSSGridIntegerRepeatValue::customCSSText() const
 {
     StringBuilder result;
-    result.append("repeat("_s, repetitions(), ", "_s);
+    result.append("repeat("_s, m_repetitions->cssText(), ", "_s);
     serializeItems(result);
     result.append(')');
     return result.toString();
@@ -58,7 +57,7 @@ String CSSGridIntegerRepeatValue::customCSSText() const
 
 bool CSSGridIntegerRepeatValue::equals(const CSSGridIntegerRepeatValue& other) const
 {
-    return m_repetitions == other.m_repetitions && itemsEqual(other);
+    return compareCSSValue(m_repetitions, other.m_repetitions) && itemsEqual(other);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.h
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveValue.h"
 #include "CSSValueList.h"
 
 namespace WebCore {
@@ -44,17 +45,26 @@ namespace WebCore {
 //                          [ <line-names>? <fixed-size> ]+ <line-names>? )
 class CSSGridIntegerRepeatValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSGridIntegerRepeatValue> create(size_t repetitions, CSSValueListBuilder);
+    static Ref<CSSGridIntegerRepeatValue> create(Ref<CSSPrimitiveValue>&& repetitions, CSSValueListBuilder);
 
-    size_t repetitions() const { return m_repetitions; }
+    const CSSPrimitiveValue& repetitions() const { return m_repetitions; }
 
     String customCSSText() const;
     bool equals(const CSSGridIntegerRepeatValue&) const;
 
-private:
-    CSSGridIntegerRepeatValue(size_t repetitions, CSSValueListBuilder);
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (CSSValueContainingVector::customVisitChildren(func) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_repetitions.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
 
-    size_t m_repetitions;
+private:
+    CSSGridIntegerRepeatValue(Ref<CSSPrimitiveValue>&& repetitions, CSSValueListBuilder);
+
+    Ref<CSSPrimitiveValue> m_repetitions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1093,12 +1093,6 @@ double CSSPrimitiveValue::doubleValue(const CSSToLengthConversionData& conversio
     return isCalculated() ? m_value.calc->doubleValue(conversionData, { }) : m_value.number;
 }
 
-double CSSPrimitiveValue::doubleValueNoConversionDataRequired() const
-{
-    ASSERT(!isCalculated());
-    return m_value.number;
-}
-
 double CSSPrimitiveValue::doubleValueDeprecated() const
 {
     return isCalculated() ? m_value.calc->doubleValueDeprecated({ }) : m_value.number;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -156,7 +156,7 @@ public:
 
     ~CSSPrimitiveValue();
 
-    CSSUnitType primitiveType() const;
+    WEBCORE_EXPORT CSSUnitType primitiveType() const;
 
     // Exposed for DeprecatedCSSOMPrimitiveValue. Throws if conversion to `targetUnit` is not allowed.
     ExceptionOr<float> getFloatValueDeprecated(CSSUnitType targetUnit) const;
@@ -279,7 +279,7 @@ private:
 
     // MARK: Non-converting
     double doubleValue(const CSSToLengthConversionData&) const;
-    double doubleValueNoConversionDataRequired() const;
+    double doubleValueNoConversionDataRequired() const { ASSERT(!isCalculated()); return m_value.number; }
     double doubleValueDeprecated() const;
     double doubleValueDividingBy100IfPercentage(const CSSToLengthConversionData&) const;
     double doubleValueDividingBy100IfPercentageNoConversionDataRequired() const;

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1259,7 +1259,7 @@ static Ref<CSSValue> valueForGridTrackList(GridTrackSizingDirection direction, R
         CSSValueListBuilder repeatedValues;
         for (auto& entry : repeat.list)
             repeatVisitor(repeatedValues, entry);
-        list.append(CSSGridIntegerRepeatValue::create(repeat.repeats, WTFMove(repeatedValues)));
+        list.append(CSSGridIntegerRepeatValue::create(CSSPrimitiveValue::createInteger(repeat.repeats), WTFMove(repeatedValues)));
     }, [&](const GridTrackEntryAutoRepeat& repeat) {
         CSSValueListBuilder repeatedValues;
         for (auto& entry : repeat.list)

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1440,7 +1440,7 @@ static Vector<String> authoredGridTrackSizes(Node* node, GridTrackSizingDirectio
         }
 
         if (auto* cssGridIntegerRepeatValue = dynamicDowncast<CSSGridIntegerRepeatValue>(currentValue)) {
-            size_t repetitions = cssGridIntegerRepeatValue->repetitions();
+            size_t repetitions = cssGridIntegerRepeatValue->repetitions().resolveAsIntegerDeprecated();
             for (size_t i = 0; i < repetitions; ++i) {
                 for (auto& integerRepeatValue : *cssGridIntegerRepeatValue)
                     handleValueIgnoringLineNames(integerRepeatValue);

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -80,7 +80,7 @@ struct MasonryAutoFlow {
     MasonryAutoFlowPlacementOrder placementOrder;
 };
 
-typedef std::variant<GridTrackSize, Vector<String>, GridTrackEntryRepeat, GridTrackEntryAutoRepeat, GridTrackEntrySubgrid, GridTrackEntryMasonry> GridTrackEntry;
+using GridTrackEntry = std::variant<GridTrackSize, Vector<String>, GridTrackEntryRepeat, GridTrackEntryAutoRepeat, GridTrackEntrySubgrid, GridTrackEntryMasonry>;
 struct GridTrackList {
     Vector<GridTrackEntry> list;
     friend bool operator==(const GridTrackList&, const GridTrackList&) = default;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1275,11 +1275,8 @@ inline std::optional<GridTrackList> BuilderConverter::createGridTrackList(Builde
     };
 
     auto addOne = [&](const CSSValue& currentValue) {
-        if (auto* lineNamesValue = dynamicDowncast<CSSGridLineNamesValue>(currentValue)) {
-            Vector<String> names;
-            for (auto& namedGridLineValue : lineNamesValue->names())
-                names.append(namedGridLineValue);
-            trackList.list.append(WTFMove(names));
+        if (auto* namesValue = dynamicDowncast<CSSGridLineNamesValue>(currentValue)) {
+            trackList.list.append(Vector<String>(namesValue->names()));
             return;
         }
 
@@ -1295,14 +1292,15 @@ inline std::optional<GridTrackList> BuilderConverter::createGridTrackList(Builde
             buildRepeatList(currentValue, repeat.list);
             trackList.list.append(WTFMove(repeat));
         } else if (auto* repeatValue = dynamicDowncast<CSSGridIntegerRepeatValue>(currentValue)) {
+            auto repetitions = clampTo(repeatValue->repetitions().resolveAsInteger(builderState.cssToLengthConversionData()), 1, GridPosition::max());
+
             GridTrackEntryRepeat repeat;
-            repeat.repeats = repeatValue->repetitions();
+            repeat.repeats = repetitions;
 
             buildRepeatList(currentValue, repeat.list);
             trackList.list.append(WTFMove(repeat));
-        } else {
+        } else
             trackList.list.append(createGridTrackSize(builderState, currentValue));
-        }
     };
 
     if (!valueList)

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
@@ -171,7 +171,7 @@ static unsigned computeNumberOfTracks(const CSSValueContainingVector& valueList)
             continue;
         if (is<CSSGridIntegerRepeatValue>(value)) {
             auto& repeatValue = downcast<CSSGridIntegerRepeatValue>(value);
-            numberOfTracks += repeatValue.repetitions() * computeNumberOfTracks(repeatValue);
+            numberOfTracks += repeatValue.repetitions().resolveAsIntegerNoConversionDataRequired() * computeNumberOfTracks(repeatValue);
             continue;
         }
         ++numberOfTracks;


### PR DESCRIPTION
#### 71e24b22e1d321b20aa881c422c45ed01674fc4b
<pre>
CSS grid should not eagerly evaluate calc() for repetitions value
<a href="https://bugs.webkit.org/show_bug.cgi?id=279308">https://bugs.webkit.org/show_bug.cgi?id=279308</a>

Reviewed by Darin Adler.

Replaces eager evaluation of calc() in CSS grid consumers with storing
the primitive value for resolution at style building time.

* LayoutTests/fast/css-grid-layout/grid-repeat-calc-expected.txt:
* LayoutTests/fast/css-grid-layout/grid-repeat-calc.html:
    - Adds tests for more calc() cases including use of relative-lengths and corrected
      existing test to ensure calc() is retained for the specified value.

* Source/WebCore/css/CSSGridIntegerRepeatValue.cpp:
* Source/WebCore/css/CSSGridIntegerRepeatValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
    - Store repetitions as a CSSPrimitiveValue to all it to retain calc().

* Source/WebCore/inspector/InspectorOverlay.cpp:
    - The use of `resolveAsIntegerDeprecated` is quite unfortunate. This code should
      probably not be using pre-style resolved inline styles.

* Source/WebCore/style/StyleBuilderConverter.h:
    - Resolve and clamp repetitions here now.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
    - The unit tests need to be able to call resolveAsIntegerNoConversionDataRequired(),
      a few inline/export changes are needed here.

* Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp:
    - Use resolveAsIntegerNoConversionDataRequired() to resolve the now
      CSSPrimitiveValue repetitions value. This is ok since we know all
      the cases have no relative lengths.

Canonical link: <a href="https://commits.webkit.org/283350@main">https://commits.webkit.org/283350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af5b6cc7a5c4ad99bdaee11c017f1fa0e83a49d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11603 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57183 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15539 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60626 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8266 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1905 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42310 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->