### PR TITLE
[JSC] Reduce unnecessary function and scope allocations in Promise builtins

### DIFF
--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -32,28 +32,13 @@ function promiseAllSlow(iterable)
         @throwTypeError("|this| is not an object");
 
     var promiseCapability = @newPromiseCapability(this);
+    var resolve = promiseCapability.resolve;
+    var reject = promiseCapability.reject;
+    var promise = promiseCapability.promise;
 
     var values = [];
     var index = 0;
     var remainingElementsCount = 1;
-
-    function newResolveElement(index)
-    {
-        var alreadyCalled = false;
-        return (argument) => {
-            if (alreadyCalled)
-                return @undefined;
-            alreadyCalled = true;
-
-            @putByValDirect(values, index, argument);
-
-            --remainingElementsCount;
-            if (remainingElementsCount === 0)
-                return promiseCapability.resolve.@call(@undefined, values);
-
-            return @undefined;
-        };
-    }
 
     try {
         var promiseResolve = this.resolve;
@@ -63,20 +48,31 @@ function promiseAllSlow(iterable)
         for (var value of iterable) {
             @putByValDirect(values, index, @undefined);
             var nextPromise = promiseResolve.@call(this, value);
-            var resolveElement = newResolveElement(index);
+            let currentIndex = index++;
             ++remainingElementsCount;
-            nextPromise.then(resolveElement, promiseCapability.reject);
-            ++index;
+            nextPromise.then((argument) => {
+                if (currentIndex < 0)
+                    return @undefined;
+
+                @putByValDirect(values, currentIndex, argument);
+                currentIndex = -1;
+
+                --remainingElementsCount;
+                if (remainingElementsCount === 0)
+                    return resolve.@call(@undefined, values);
+
+                return @undefined;
+            }, reject);
         }
 
         --remainingElementsCount;
         if (remainingElementsCount === 0)
-            promiseCapability.resolve.@call(@undefined, values);
+            resolve.@call(@undefined, values);
     } catch (error) {
-        promiseCapability.reject.@call(@undefined, error);
+        reject.@call(@undefined, error);
     }
 
-    return promiseCapability.promise;
+    return promise;
 }
 
 @linkTimeConstant
@@ -188,6 +184,9 @@ function allSettled(iterable)
         @throwTypeError("|this| is not an object");
 
     var promiseCapability = @newPromiseCapability(this);
+    var resolve = promiseCapability.resolve;
+    var reject = promiseCapability.reject;
+    var promise = promiseCapability.promise;
 
     var values = [];
     var remainingElementsCount = 1;
@@ -203,34 +202,35 @@ function allSettled(iterable)
             var nextPromise = promiseResolve.@call(this, value);
             ++remainingElementsCount;
             let currentIndex = index++;
-            let alreadyCalled = false;
             nextPromise.then(
                 (value) => {
-                    if (alreadyCalled)
+                    if (currentIndex < 0)
                         return @undefined;
-                    alreadyCalled = true;
-                    var obj = {
+
+                    @putByValDirect(values, currentIndex, {
                         status: "fulfilled",
                         value
-                    };
-                    @putByValDirect(values, currentIndex, obj);
+                    });
+                    currentIndex = -1;
+
                     --remainingElementsCount;
                     if (remainingElementsCount === 0)
-                        return promiseCapability.resolve.@call(@undefined, values);
+                        return resolve.@call(@undefined, values);
                     return @undefined;
                 },
                 (reason) => {
-                    if (alreadyCalled)
+                    if (currentIndex < 0)
                         return @undefined;
-                    alreadyCalled = true;
-                    var obj = {
+
+                    @putByValDirect(values, currentIndex, {
                         status: "rejected",
                         reason
-                    };
-                    @putByValDirect(values, currentIndex, obj);
+                    });
+                    currentIndex = -1;
+
                     --remainingElementsCount;
                     if (remainingElementsCount === 0)
-                        return promiseCapability.resolve.@call(@undefined, values);
+                        return resolve.@call(@undefined, values);
                     return @undefined;
                 }
             );
@@ -238,12 +238,12 @@ function allSettled(iterable)
 
         --remainingElementsCount;
         if (remainingElementsCount === 0)
-            promiseCapability.resolve.@call(@undefined, values);
+            resolve.@call(@undefined, values);
     } catch (error) {
-        promiseCapability.reject.@call(@undefined, error);
+        reject.@call(@undefined, error);
     }
 
-    return promiseCapability.promise;
+    return promise;
 }
 
 function any(iterable)
@@ -254,28 +254,13 @@ function any(iterable)
         @throwTypeError("|this| is not an object");
 
     var promiseCapability = @newPromiseCapability(this);
+    var resolve = promiseCapability.resolve;
+    var reject = promiseCapability.reject;
+    var promise = promiseCapability.promise;
 
     var errors = [];
     var remainingElementsCount = 1;
     var index = 0;
-
-    function newRejectElement(index)
-    {
-        var alreadyCalled = false;
-        return (reason) => {
-            if (alreadyCalled)
-                return @undefined;
-            alreadyCalled = true;
-
-            @putByValDirect(errors, index, reason);
-
-            --remainingElementsCount;
-            if (remainingElementsCount === 0)
-                return promiseCapability.reject.@call(@undefined, new @AggregateError(errors));
-
-            return @undefined;
-        };
-    }
 
     try {
         var promiseResolve = this.resolve;
@@ -285,20 +270,31 @@ function any(iterable)
         for (var value of iterable) {
             @putByValDirect(errors, index, @undefined);
             var nextPromise = promiseResolve.@call(this, value);
-            var rejectElement = newRejectElement(index);
+            let currentIndex = index++;
             ++remainingElementsCount;
-            nextPromise.then(promiseCapability.resolve, rejectElement);
-            ++index;
+            nextPromise.then(resolve, (reason) => {
+                if (currentIndex < 0)
+                    return @undefined;
+
+                @putByValDirect(errors, currentIndex, reason);
+                currentIndex = -1;
+
+                --remainingElementsCount;
+                if (remainingElementsCount === 0)
+                    return reject.@call(@undefined, new @AggregateError(errors));
+
+                return @undefined;
+            });
         }
 
         --remainingElementsCount;
         if (remainingElementsCount === 0)
             throw new @AggregateError(errors);
     } catch (error) {
-        promiseCapability.reject.@call(@undefined, error);
+        reject.@call(@undefined, error);
     }
 
-    return promiseCapability.promise;
+    return promise;
 }
 
 function race(iterable)
@@ -309,6 +305,9 @@ function race(iterable)
         @throwTypeError("|this| is not an object");
 
     var promiseCapability = @newPromiseCapability(this);
+    var resolve = promiseCapability.resolve;
+    var reject = promiseCapability.reject;
+    var promise = promiseCapability.promise;
 
     try {
         var promiseResolve = this.resolve;
@@ -317,13 +316,13 @@ function race(iterable)
 
         for (var value of iterable) {
             var nextPromise = promiseResolve.@call(this, value);
-            nextPromise.then(promiseCapability.resolve, promiseCapability.reject);
+            nextPromise.then(resolve, reject);
         }
     } catch (error) {
-        promiseCapability.reject.@call(@undefined, error);
+        reject.@call(@undefined, error);
     }
 
-    return promiseCapability.promise;
+    return promise;
 }
 
 function reject(reason)


### PR DESCRIPTION
#### 5fe28de3ddab1a007c885085fd8a51f9706e5f0a
<pre>
[JSC] Reduce unnecessary function and scope allocations in Promise builtins
<a href="https://bugs.webkit.org/show_bug.cgi?id=279311">https://bugs.webkit.org/show_bug.cgi?id=279311</a>
<a href="https://rdar.apple.com/135495572">rdar://135495572</a>

Reviewed by Keith Miller.

Inline some of promise handler creation functions and use `let` so that this patch
reduces unnecessary function creation like `newResolveElement`.
We also remove repeated promise capabilities property accesses.

* Source/JavaScriptCore/builtins/InternalPromiseConstructor.js:
(internalAll):
(internalAll.newResolveElement): Deleted.
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(linkTimeConstant.promiseAllSlow):
(allSettled):
(any):
(linkTimeConstant.promiseAllSlow.newResolveElement): Deleted.
(any.newRejectElement): Deleted.

Canonical link: <a href="https://commits.webkit.org/283358@main">https://commits.webkit.org/283358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b1507f7bb29fe1c3f9ad7c6aa5c87b65bfd60ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16553 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52923 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33558 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14466 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15429 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59058 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71676 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65188 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60237 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60527 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1813 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86955 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9996 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41125 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15297 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->