### PR TITLE
[JSC] Remove obsoleted methods for Temporal.PlainTime and Temporal.PlainDateTime

### DIFF
--- a/JSTests/stress/temporal-plaindatetime.js
+++ b/JSTests/stress/temporal-plaindatetime.js
@@ -279,10 +279,6 @@ shouldBe(pdt.with({ second: 15 }).toString(), '0001-02-03T04:05:15.007008009');
 shouldBe(pdt.with({ day: 30 }).toString(), '0001-02-28T04:05:06.007008009');
 shouldThrow(() => { pdt.with({ day: 30 }, { overflow: 'reject' }); }, RangeError);
 
-shouldBe(Temporal.PlainDateTime.prototype.withPlainDate.length, 1);
-shouldThrow(() => { pdt.withPlainDate(); }, TypeError);
-shouldBe(pdt.withPlainDate({ year: 2000, month: 10, day: 30 }).toString(), '2000-10-30T04:05:06.007008009');
-
 shouldBe(Temporal.PlainDateTime.prototype.withPlainTime.length, 0);
 shouldBe(pdt.withPlainTime().toString(), '0001-02-03T00:00:00');
 shouldBe(pdt.withPlainTime({ hour: 1, minute: 2, second: 3 }).toString(), '0001-02-03T01:02:03');

--- a/JSTests/stress/temporal-plaintime.js
+++ b/JSTests/stress/temporal-plaintime.js
@@ -145,9 +145,6 @@ shouldBe(String(Temporal.PlainTime.from('2007-01-09 03:24:30[u-ca=japanese]')), 
     let dateTime = Temporal.PlainDateTime.from('1995-12-07T03:24:30+01:00[Europe/Brussels]')
     shouldBe(Temporal.PlainTime.from(dateTime).toString(), time.toString());
 
-    let date = Temporal.PlainDate.from('1995-12-07T03:24:30+01:00[Europe/Brussels]');
-    shouldBe(time.toPlainDateTime(date).toString(), dateTime.toString());
-
     shouldBe(time.toJSON(), time.toString());
     shouldBe(time.toLocaleString(), time.toString());
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -40,7 +40,6 @@ static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncGetISOFields)
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncAdd);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSubtract);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith);
-static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithPlainDate);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithPlainTime);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncRound);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncEquals);
@@ -84,7 +83,6 @@ const ClassInfo TemporalPlainDateTimePrototype::s_info = { "Temporal.PlainDateTi
   add              temporalPlainDateTimePrototypeFuncAdd                DontEnum|Function 1
   subtract         temporalPlainDateTimePrototypeFuncSubtract           DontEnum|Function 1
   with             temporalPlainDateTimePrototypeFuncWith               DontEnum|Function 1
-  withPlainDate    temporalPlainDateTimePrototypeFuncWithPlainDate      DontEnum|Function 1
   withPlainTime    temporalPlainDateTimePrototypeFuncWithPlainTime      DontEnum|Function 0
   round            temporalPlainDateTimePrototypeFuncRound              DontEnum|Function 1
   equals           temporalPlainDateTimePrototypeFuncEquals             DontEnum|Function 1
@@ -241,22 +239,6 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
         return throwVMTypeError(globalObject, scope, "First argument to Temporal.PlainDateTime.prototype.with must be an object"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(plainDateTime->with(globalObject, asObject(temporalDateTimeLike), callFrame->argument(1))));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate
-JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithPlainDate, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
-    if (!plainDateTime)
-        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.withPlainDate called on value that's not a PlainDateTime"_s);
-
-    auto* plainDate = TemporalPlainDate::from(globalObject, callFrame->argument(0), std::nullopt);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDate->plainDate(), plainDateTime->plainTime())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -43,7 +43,6 @@ static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSince);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncRound);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncEquals);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncGetISOFields);
-static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToPlainDateTime);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToString);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToJSON);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToLocaleString);
@@ -74,7 +73,6 @@ const ClassInfo TemporalPlainTimePrototype::s_info = { "Temporal.PlainTime"_s, &
   round            temporalPlainTimePrototypeFuncRound              DontEnum|Function 1
   equals           temporalPlainTimePrototypeFuncEquals             DontEnum|Function 1
   getISOFields     temporalPlainTimePrototypeFuncGetISOFields       DontEnum|Function 0
-  toPlainDateTime  temporalPlainTimePrototypeFuncToPlainDateTime    DontEnum|Function 1
   toString         temporalPlainTimePrototypeFuncToString           DontEnum|Function 0
   toJSON           temporalPlainTimePrototypeFuncToJSON             DontEnum|Function 0
   toLocaleString   temporalPlainTimePrototypeFuncToLocaleString     DontEnum|Function 0
@@ -264,22 +262,6 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncGetISOFields, (JSGlobalOb
     fields->putDirect(vm, vm.propertyNames->isoNanosecond, jsNumber(plainTime->nanosecond()));
     fields->putDirect(vm, vm.propertyNames->isoSecond, jsNumber(plainTime->second()));
     return JSValue::encode(fields);
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.toplaindatetime
-JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToPlainDateTime, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
-    if (!plainTime)
-        return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toPlainDateTime called on value that's not a PlainTime"_s);
-
-    auto* plainDate = TemporalPlainDate::from(globalObject, callFrame->argument(0), std::nullopt);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDate->plainDate(), plainTime->plainTime())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring


### PR DESCRIPTION
#### 0bb3d02c4ce36b533f7013ef161ac3fbbb52e278
<pre>
[JSC] Remove obsoleted methods for Temporal.PlainTime and Temporal.PlainDateTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=279312">https://bugs.webkit.org/show_bug.cgi?id=279312</a>

Reviewed by Yusuke Suzuki.

Due to changes in Temporal from July 2024, several methods have become obsolete[1]. We have already
removed the methods of Temporal.Instant that were marked obsolete[2].

This patch removes the following methods from Temporal.PlainTime and Temporal.PlainDateTime:

- Temporal.PlainTime.prototype.toPlainDateTime
- Temporal.PlainDateTime.prototype.withPlainDate

Although there are other methods slated for removal in the Temporal changes[1], we had not yet
implemented those methods.

[1]: <a href="https://github.com/tc39/proposal-temporal/pull/2895">https://github.com/tc39/proposal-temporal/pull/2895</a>
[2]: <a href="https://commits.webkit.org/282400@main">https://commits.webkit.org/282400@main</a>

* JSTests/stress/temporal-plaindatetime.js:
* JSTests/stress/temporal-plaintime.js:
(shouldBe.String.Temporal.PlainTime.from):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp:

Canonical link: <a href="https://commits.webkit.org/283315@main">https://commits.webkit.org/283315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/272633727e774503a8b52fc29153bfa53cc0b2f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69974 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16554 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52924 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11508 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15430 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59059 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60360 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14814 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71677 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65189 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60238 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60529 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1814 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/86956 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41126 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15298 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->