### PR TITLE
Update three `svg/animations` tests still using `js-test-pre.js` and `SVGTestCase.js` of `dynamic-updates` directory

### DIFF
--- a/LayoutTests/svg/animations/animate-text-nested-transforms.html
+++ b/LayoutTests/svg/animations/animate-text-nested-transforms.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animateTransform-translate-attributetype-auto.html
+++ b/LayoutTests/svg/animations/animateTransform-translate-attributetype-auto.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animateTransform-translate-invalid-attributetype.html
+++ b/LayoutTests/svg/animations/animateTransform-translate-invalid-attributetype.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">


### PR DESCRIPTION
#### 6f51893919130c7a1b9f910d72482fd1cc913811
<pre>
Update three `svg/animations` tests still using `js-test-pre.js` and `SVGTestCase.js` of `dynamic-updates` directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=279314">https://bugs.webkit.org/show_bug.cgi?id=279314</a>
<a href="https://rdar.apple.com/problem/135501385">rdar://problem/135501385</a>

Reviewed by Simon Fraser.

This is just clean-up patch to leverage `SVGTestCase.js` of `animations`
directory, which was updated to be used `js-test.js` (recommended). It was
missed in the past clean-up. So it just deal with last three of these tests
as well.

* LayoutTests/svg/animations/animate-text-nested-transforms.html:
* LayoutTests/svg/animations/animateTransform-translate-attributetype-auto.html:
* LayoutTests/svg/animations/animateTransform-translate-invalid-attributetype.html:

Canonical link: <a href="https://commits.webkit.org/283312@main">https://commits.webkit.org/283312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/550dff2936ea871b9838cd3f6b9b7ae359031275

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52925 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1815 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41127 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->