### PR TITLE
Adjust svg/animations/animate-linear-discrete-additive*.svg

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1958,9 +1958,6 @@ webkit.org/b/151949 streams/pipe-to.html [ Failure ]
 webkit.org/b/189739 svg/gradients/spreadMethodClose2.svg [ ImageOnlyFailure ]
 webkit.org/b/189739 imported/mozilla/svg/linearGradient-basic-03.svg [ ImageOnlyFailure ]
 
-webkit.org/b/107018 svg/animations/animate-linear-discrete-additive.svg  [ Pass ImageOnlyFailure ]
-webkit.org/b/107018 svg/animations/animate-linear-discrete-additive-b.svg [ ImageOnlyFailure ]
-webkit.org/b/107018 svg/animations/animate-linear-discrete-additive-c.svg [ Pass ImageOnlyFailure ]
 webkit.org/b/107018 svg/animations/mozilla/animateMotion-mpath-pathLength-1.svg [ Pass ImageOnlyFailure ]
 
 webkit.org/b/151267 imported/blink/svg/animations/no-attr-radialgradient-spreadmethod.svg [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5513,9 +5513,6 @@ compositing/text-on-scaled-surface.html [ ImageOnlyFailure ]
 css3/filters/backdrop/backdrop-filter-with-border-radius-and-reflection-add.html [ ImageOnlyFailure ]
 css3/filters/backdrop/backdrop-filter-with-border-radius-and-reflection.html [ ImageOnlyFailure ]
 css3/filters/backdrop/backdrop-filter-with-clip-path.html [ ImageOnlyFailure ]
-svg/animations/animate-linear-discrete-additive-b.svg [ ImageOnlyFailure ]
-svg/animations/animate-linear-discrete-additive-c.svg [ ImageOnlyFailure ]
-svg/animations/animate-linear-discrete-additive.svg [ ImageOnlyFailure ]
 svg/animations/mozilla/animateMotion-mpath-pathLength-1.svg [ ImageOnlyFailure ]
 
 webkit.org/b/192045 css3/filters/blur-filter-page-scroll-parents.html

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -520,9 +520,6 @@ webkit.org/b/132421 fast/multicol/fixed-stack.html [ ImageOnlyFailure ]
 # Incomplete implementation of eventSender causes this test to fail
 webkit.org/b/42194 fast/scrolling/scroll-select-list.html [ ImageOnlyFailure ]
 
-webkit.org/b/107018 svg/animations/animate-linear-discrete-additive.svg [ ImageOnlyFailure Pass ]
-webkit.org/b/107018 svg/animations/animate-linear-discrete-additive-b.svg [ ImageOnlyFailure Pass ]
-webkit.org/b/107018 svg/animations/animate-linear-discrete-additive-c.svg  [ ImageOnlyFailure Pass ]
 webkit.org/b/107018 svg/animations/mozilla/animateMotion-mpath-pathLength-1.svg [ ImageOnlyFailure Pass ]
 
 webkit.org/b/124476 platform/mac-wk2/plugins/slow/asynchronous-plugin-initialization-multiple.html [ Pass Failure ]

--- a/LayoutTests/svg/animations/animate-linear-discrete-additive-b.svg
+++ b/LayoutTests/svg/animations/animate-linear-discrete-additive-b.svg
@@ -29,6 +29,8 @@ if (window.testRunner)
 
 function loaded() {
     document.documentElement.setCurrentTime(8);
+    // Pause the timeline to avoid it advancing before the result is sampled.
+    document.documentElement.pauseAnimations();
     if (window.testRunner)
         testRunner.notifyDone();
 }

--- a/LayoutTests/svg/animations/animate-linear-discrete-additive-c.svg
+++ b/LayoutTests/svg/animations/animate-linear-discrete-additive-c.svg
@@ -29,6 +29,8 @@ if (window.testRunner)
 
 function loaded() {
     document.documentElement.setCurrentTime(11);
+    // Pause the timeline to avoid it advancing before the result is sampled.
+    document.documentElement.pauseAnimations();
     if (window.testRunner)
         testRunner.notifyDone();
 }

--- a/LayoutTests/svg/animations/animate-linear-discrete-additive.svg
+++ b/LayoutTests/svg/animations/animate-linear-discrete-additive.svg
@@ -29,6 +29,8 @@ if (window.testRunner)
 
 function loaded() {
     document.documentElement.setCurrentTime(3);
+    // Pause the timeline to avoid it advancing before the result is sampled.
+    document.documentElement.pauseAnimations();
     if (window.testRunner)
         testRunner.notifyDone();
 }


### PR DESCRIPTION
#### 6893d43a0ed09751792b292fb60e6e0bfd561961
<pre>
Adjust svg/animations/animate-linear-discrete-additive*.svg

<a href="https://bugs.webkit.org/show_bug.cgi?id=279316">https://bugs.webkit.org/show_bug.cgi?id=279316</a>

Reviewed by Antoine Quint.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/a355f97c2b9962a162f7e96f92303deaa9fc97c2">https://chromium.googlesource.com/chromium/src.git/+/a355f97c2b9962a162f7e96f92303deaa9fc97c2</a>

In these tests we want to sample animation values at a certain point in
time. We are however sampling the animations at the next frame that is
painted - at which point the timeline may have advanced, and hence we
sample at t+&lt;framedelay&gt; (or thereabout) instead. Currently this works
&quot;fine&quot; because the first animation frame follows special scheduling
rules, making sure the timeline won&apos;t advance within this time window.
Rather than relying on this, just pause the timeline instead.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/svg/animations/animate-linear-discrete-additive-b.svg:
* LayoutTests/svg/animations/animate-linear-discrete-additive-c.svg:
* LayoutTests/svg/animations/animate-linear-discrete-additive.svg:

Canonical link: <a href="https://commits.webkit.org/283409@main">https://commits.webkit.org/283409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bafcb1c458b66ce30bf3f6c1fc3ea9272c204e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16824 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17105 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14709 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15700 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14446 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60748 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8398 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10029 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41395 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42471 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->