### PR TITLE
Selecting large text that ends with a common phrase results in text highlighting incorrectly

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries.html
@@ -8,7 +8,7 @@ if (window.testRunner)
 
 window.addEventListener('load', () => {
     const range = document.createRange();
-    range.selectNode(document.body.getElementsByTagName("b")[0])
+    range.selectNode(document.body.getElementsByTagName("b")[0]);
     document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
 });
 </script>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt
@@ -1,0 +1,1 @@
+:~:text=document

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we don't allow context generation to pass boundaries of block elements</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>This is a very simple <div id="test">document</div>. There is no text before 'this'.</body>
+</html>
+

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-expands-context-for-ambiguous-matches-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-expands-context-for-ambiguous-matches-expected.txt
@@ -1,0 +1,1 @@
+:~:text=one%20two%20three%20four%20five,five%20six%20seven%20eight%20nine,-ten%20I

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-expands-context-for-ambiguous-matches.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-expands-context-for-ambiguous-matches.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we expand context if necessary for ambiguous selections</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNode(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body><span id="test">one two three four five six seven eight nine ten A one two three four five six seven eight nine ten B one two three four five six seven eight nine ten C one two three four five six seven eight nine ten D one two three four five six seven eight nine ten E one two three four five six seven eight nine ten F one two three four five six seven eight nine ten G one two three four five six seven eight nine ten H one two three four five six seven eight nine</span> ten I one two three four five six seven eight nine ten J one two three four five six seven eight nine ten K one two three four five six seven eight nine ten L one two three four five six seven eight nine ten M one two three four five six seven eight nine ten N one two three four five six seven eight nine ten O one two three four five six seven eight nine ten P one two three four five six seven eight nine ten Q one two three four five six seven eight nine ten R</body>
+</html>
+

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1017,6 +1017,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/FocusOptions.h
     dom/FragmentDirectiveParser.h
     dom/FragmentDirectiveRangeFinder.h
+    dom/FragmentDirectiveUtilities.h
     dom/FullscreenManager.h
     dom/GCReachableRef.h
     dom/GetHTMLOptions.h

--- a/Source/WebCore/dom/FragmentDirectiveParser.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveParser.cpp
@@ -26,12 +26,12 @@
 #include "config.h"
 #include "FragmentDirectiveParser.h"
 
+#include "FragmentDirectiveUtilities.h"
 #include "Logging.h"
 #include <wtf/Deque.h>
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>
 #include <wtf/text/TextStream.h>
-
 
 namespace WebCore {
 
@@ -42,6 +42,8 @@ FragmentDirectiveParser::FragmentDirectiveParser(StringView fragmentDirective)
     m_fragmentDirective = fragmentDirective;
     m_isValid = true;
 }
+
+FragmentDirectiveParser::~FragmentDirectiveParser() = default;
 
 // https://wicg.github.io/scroll-to-text-fragment/#parse-a-text-directive
 void FragmentDirectiveParser::parseFragmentDirective(StringView fragmentDirective)
@@ -103,13 +105,13 @@ void FragmentDirectiveParser::parseFragmentDirective(StringView fragmentDirectiv
         }
         
         if (auto start = WTF::URLParser::formURLDecode(tokens.first()))
-            parsedTextDirective.textStart = WTFMove(*start);
+            parsedTextDirective.startText = WTFMove(*start);
         else
             LOG_WITH_STREAM(TextFragment, stream << " could not decode start ");
         
         if (tokens.size() == 2) {
             if (auto end = WTF::URLParser::formURLDecode(tokens.last()))
-                parsedTextDirective.textEnd = WTFMove(*end);
+                parsedTextDirective.endText = WTFMove(*end);
             else
                 LOG_WITH_STREAM(TextFragment, stream << " could not decode end ");
         }

--- a/Source/WebCore/dom/FragmentDirectiveParser.h
+++ b/Source/WebCore/dom/FragmentDirectiveParser.h
@@ -30,16 +30,12 @@
 
 namespace WebCore {
 
-struct ParsedTextDirective {
-    String textStart;
-    String textEnd;
-    String prefix;
-    String suffix;
-};
+struct ParsedTextDirective;
 
 class FragmentDirectiveParser {
 public:
     WEBCORE_EXPORT explicit FragmentDirectiveParser(StringView);
+    WEBCORE_EXPORT ~FragmentDirectiveParser();
     
     const Vector<ParsedTextDirective>& parsedTextDirectives() const { return m_parsedTextDirectives; };
     StringView fragmentDirective() const { return m_fragmentDirective; };

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.h
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.h
@@ -31,6 +31,13 @@ namespace WebCore {
 
 class Node;
 
+struct ParsedTextDirective {
+    String prefix;
+    String startText;
+    String endText;
+    String suffix;
+};
+
 namespace FragmentDirectiveUtilities {
 
 const Node& nearestBlockAncestor(const Node&);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -50,6 +50,7 @@
 #include "FocusController.h"
 #include "FragmentDirectiveParser.h"
 #include "FragmentDirectiveRangeFinder.h"
+#include "FragmentDirectiveUtilities.h"
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "FrameTree.h"

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -212,6 +212,7 @@
 #include <WebCore/FormState.h>
 #include <WebCore/FragmentDirectiveParser.h>
 #include <WebCore/FragmentDirectiveRangeFinder.h>
+#include <WebCore/FragmentDirectiveUtilities.h>
 #include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/FullscreenManager.h>


### PR DESCRIPTION
#### 17895dbfb088246548c5753ecddda506317e5d8d
<pre>
Selecting large text that ends with a common phrase results in text highlighting incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=279330">https://bugs.webkit.org/show_bug.cgi?id=279330</a>
<a href="https://rdar.apple.com/133786985">rdar://133786985</a>

Reviewed by Wenson Hsieh.

First, to fix the issue in the title (where a suffix might match multiple possible ranges),
we extend the fragment directive generator to be able to test directives that it generates,
and increase the amount of context that we vend if it doesn&apos;t match the correct range.

In order to keep links small, we add one word at a time, and give up if we add more than 4 words.
Add a test for this.

Secondly, fix an issue from 283294@main, where we now would allow context generation
to walk across block boundaries, caused by a spurious incorrect operator== for Node&amp;
(coming from CanMakeCheckedPtrBase). Work around this by comparing Node addresses instead.
Add a test for this too.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-can-pass-inline-boundaries.html:
* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries.html: Added.
Test for the operator== bug.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-expands-context-for-ambiguous-matches-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-expands-context-for-ambiguous-matches.html: Added.
Test for the main bug.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::positionsHaveSameBlockAncestor):
Fix for the operator== bug mentioned above.

(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):
Test the generated directive and increase context (up to a limit) if necessary to disambiguate matches.

* Source/WebCore/dom/FragmentDirectiveParser.cpp:
(WebCore::FragmentDirectiveParser::parseFragmentDirective):
* Source/WebCore/dom/FragmentDirectiveParser.h:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::findRangeFromTextDirective):
Make the fragment search code treat null and empty strings equally; neither is
acceptable to pass into string search code (and results in assertion failures).

* Source/WebCore/dom/FragmentDirectiveUtilities.h:
Move ParsedTextDirective here, so we can re-use it. Also make the order and
spelling of the struct members consistent with other code.

* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
Build fixes.

Canonical link: <a href="https://commits.webkit.org/283323@main">https://commits.webkit.org/283323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53daebdfaaa5ebba81ecf626e1e4bb3c0dcbb0c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52952 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14495 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14254 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60271 "Found 1 new test failure: media/video-multiple-concurrent-playback.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60564 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14543 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1842 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41157 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->