### PR TITLE
[JSC] Remove asyncGeneratorQueueItemNext

### DIFF
--- a/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
@@ -37,7 +37,7 @@ function asyncGeneratorQueueEnqueue(generator, item)
 {
     "use strict";
 
-    @assert(@getByIdDirectPrivate(item, "asyncGeneratorQueueItemNext") === null);
+    @assert(@getByIdDirect(item, "next") === null);
 
     if (@getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueFirst) === null) {
         @assert(@getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueLast) === null);
@@ -46,7 +46,7 @@ function asyncGeneratorQueueEnqueue(generator, item)
         @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueLast, item);
     } else {
         var last = @getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueLast);
-        @putByIdDirectPrivate(last, "asyncGeneratorQueueItemNext", item);
+        @putByIdDirect(last, "next", item);
         @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueLast, item);
     }
 }
@@ -60,7 +60,7 @@ function asyncGeneratorQueueDequeue(generator)
 
     var result = @getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueFirst);
 
-    var updatedFirst = @getByIdDirectPrivate(result, "asyncGeneratorQueueItemNext");
+    var updatedFirst = @getByIdDirect(result, "next");
     @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueFirst, updatedFirst);
 
     if (updatedFirst === null)
@@ -289,7 +289,7 @@ function asyncGeneratorEnqueue(generator, value, resumeMode)
         return promise;
     }
 
-    @asyncGeneratorQueueEnqueue(generator, {resumeMode, value, promise, @asyncGeneratorQueueItemNext: null});
+    @asyncGeneratorQueueEnqueue(generator, {resumeMode, value, promise, next: null});
 
     if (!@isExecutionState(generator))
         @asyncGeneratorResumeNext(generator);

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -117,7 +117,6 @@ namespace JSC {
     macro(generatorResumeMode) \
     macro(syncIterator) \
     macro(nextMethod) \
-    macro(asyncGeneratorQueueItemNext) \
     macro(this) \
     macro(toIntegerOrInfinity) \
     macro(toLength) \


### PR DESCRIPTION
#### 0472dfb2c76f3510d90a636ee4ad19e309ab80b0
<pre>
[JSC] Remove asyncGeneratorQueueItemNext
<a href="https://bugs.webkit.org/show_bug.cgi?id=279336">https://bugs.webkit.org/show_bug.cgi?id=279336</a>
<a href="https://rdar.apple.com/135526100">rdar://135526100</a>

Reviewed by Michael Saboff.

Async generator function&apos;s queue item is not observable to users. Thus
we do not need to use @asyncGeneratorQueueItemNext private name.
Use &quot;next&quot; instead.

* Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js:
(linkTimeConstant.asyncGeneratorQueueEnqueue):
(linkTimeConstant.asyncGeneratorQueueDequeue):
(linkTimeConstant.asyncGeneratorEnqueue):
* Source/JavaScriptCore/builtins/BuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/283329@main">https://commits.webkit.org/283329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f12dd67c2c67a87c6351992a3abe9128cd4ffba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16609 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52973 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11556 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14516 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15485 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59114 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71733 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65244 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60291 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60581 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1863 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87011 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9981 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41181 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15309 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->