### PR TITLE
[TZone] Add annotations to unannotated subclasses of html/TextFieldInputType and graphics/Mac/controls/PlatformControl

### DIFF
--- a/Source/WebCore/html/BaseTextInputType.cpp
+++ b/Source/WebCore/html/BaseTextInputType.cpp
@@ -29,9 +29,12 @@
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
 #include <JavaScriptCore/RegularExpression.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BaseTextInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/BaseTextInputType.h
+++ b/Source/WebCore/html/BaseTextInputType.h
@@ -31,12 +31,14 @@
 #pragma once
 
 #include "TextFieldInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 // Base of email, password, search, tel, text, and URL types.
 // They support maxlength, selection functions, and so on.
 class BaseTextInputType : public TextFieldInputType {
+    WTF_MAKE_TZONE_ALLOCATED(BaseTextInputType);
 public:
     bool patternMismatch(const String&) const final;
 

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -32,9 +32,12 @@
 #include "LocalizedStrings.h"
 #include <JavaScriptCore/RegularExpression.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EmailInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseTextInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class EmailInputType final : public BaseTextInputType {
+    WTF_MAKE_TZONE_ALLOCATED(EmailInputType);
 public:
     static Ref<EmailInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -48,8 +48,11 @@
 #include <limits>
 #include <wtf/ASCIICType.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NumberInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -32,10 +32,12 @@
 #pragma once
 
 #include "TextFieldInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class NumberInputType final : public TextFieldInputType {
+    WTF_MAKE_TZONE_ALLOCATED(NumberInputType);
 public:
     static Ref<NumberInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/PasswordInputType.cpp
+++ b/Source/WebCore/html/PasswordInputType.cpp
@@ -36,8 +36,11 @@
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
 #include <wtf/Assertions.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PasswordInputType);
 
 const AtomString& PasswordInputType::formControlType() const
 {

--- a/Source/WebCore/html/PasswordInputType.h
+++ b/Source/WebCore/html/PasswordInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseTextInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class PasswordInputType final : public BaseTextInputType {
+    WTF_MAKE_TZONE_ALLOCATED(PasswordInputType);
 public:
     static Ref<PasswordInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -44,8 +44,11 @@
 #include "ShadowRoot.h"
 #include "TextControlInnerElements.h"
 #include "UserAgentParts.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SearchInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -33,12 +33,14 @@
 
 #include "BaseTextInputType.h"
 #include "Timer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SearchFieldResultsButtonElement;
 
 class SearchInputType final : public BaseTextInputType {
+    WTF_MAKE_TZONE_ALLOCATED(SearchInputType);
 public:
     static Ref<SearchInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TelephoneInputType.cpp
+++ b/Source/WebCore/html/TelephoneInputType.cpp
@@ -33,8 +33,11 @@
 
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TelephoneInputType);
 
 const AtomString& TelephoneInputType::formControlType() const
 {

--- a/Source/WebCore/html/TelephoneInputType.h
+++ b/Source/WebCore/html/TelephoneInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseTextInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class TelephoneInputType final : public BaseTextInputType {
+    WTF_MAKE_TZONE_ALLOCATED(TelephoneInputType);
 public:
     static Ref<TelephoneInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TextInputType.cpp
+++ b/Source/WebCore/html/TextInputType.cpp
@@ -33,8 +33,11 @@
 
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/TextInputType.h
+++ b/Source/WebCore/html/TextInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseTextInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class TextInputType final : public BaseTextInputType {
+    WTF_MAKE_TZONE_ALLOCATED(TextInputType);
 public:
     static Ref<TextInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/URLInputType.cpp
+++ b/Source/WebCore/html/URLInputType.cpp
@@ -35,9 +35,12 @@
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
 #include "LocalizedStrings.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(URLInputType);
 
 const AtomString& URLInputType::formControlType() const
 {

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseTextInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class URLInputType final : public BaseTextInputType {
+    WTF_MAKE_TZONE_ALLOCATED(URLInputType);
 public:
     static Ref<URLInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
@@ -28,12 +28,14 @@
 #if ENABLE(APPLE_PAY)
 
 #import "PlatformControl.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ApplePayButtonPart;
 
 class ApplePayButtonCocoa final : public PlatformControl {
+    WTF_MAKE_TZONE_ALLOCATED(ApplePayButtonCocoa);
 public:
     ApplePayButtonCocoa(ApplePayButtonPart& owningMeterPart);
 

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
@@ -31,9 +31,12 @@
 #import "ApplePayButtonPart.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContextCG.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <pal/cocoa/PassKitSoftLink.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ApplePayButtonCocoa);
 
 ApplePayButtonCocoa::ApplePayButtonCocoa(ApplePayButtonPart& owningPart)
     : PlatformControl(owningPart)

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h
@@ -28,10 +28,12 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ButtonControlMac : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(ButtonControlMac);
 public:
     ButtonControlMac(ControlPart&, ControlFactoryMac&, NSButtonCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
@@ -29,8 +29,11 @@
 #if PLATFORM(MAC)
 
 #import <pal/spi/cocoa/NSButtonCellSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ButtonControlMac);
 
 ButtonControlMac::ButtonControlMac(ControlPart& part, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
     : ControlMac(part, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ButtonControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ButtonPart;
 
 class ButtonMac final : public ButtonControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(ButtonMac);
 public:
     ButtonMac(ButtonPart& owningPart, ControlFactoryMac&, NSButtonCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -32,8 +32,11 @@
 #import "ControlFactoryMac.h"
 #import "GraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ButtonMac);
 
 ButtonMac::ButtonMac(ButtonPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
     : ButtonControlMac(owningPart, controlFactory, buttonCell)

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC) && ENABLE(INPUT_TYPE_COLOR)
 
 #import "ButtonControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ColorWellPart;
 
 class ColorWellMac final : public ButtonControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(ColorWellMac);
 public:
     ColorWellMac(ColorWellPart& owningPart, ControlFactoryMac&, NSButtonCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
@@ -32,8 +32,11 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "LocalDefaultSystemAppearance.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ColorWellMac);
 
 ColorWellMac::ColorWellMac(ColorWellPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
     : ButtonControlMac(owningPart, controlFactory, buttonCell)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -29,6 +29,7 @@
 
 #import "LengthBox.h"
 #import "PlatformControl.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,6 +39,7 @@ class GraphicsContext;
 class IntSize;
 
 class ControlMac : public PlatformControl {
+    WTF_MAKE_TZONE_ALLOCATED(ControlMac);
 public:
     ControlMac(ControlPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -43,8 +43,11 @@
 #import <pal/spi/mac/NSGraphicsSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ControlMac);
 
 ControlMac::ControlMac(ControlPart& owningPart, ControlFactoryMac& controlFactory)
     : PlatformControl(owningPart)

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
@@ -28,6 +28,7 @@
 #if PLATFORM(MAC) && ENABLE(SERVICE_CONTROLS)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSServicesRolloverButtonCell;
 
@@ -36,6 +37,7 @@ namespace WebCore {
 class ImageControlsButtonPart;
 
 class ImageControlsButtonMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(ImageControlsButtonMac);
 public:
     ImageControlsButtonMac(ImageControlsButtonPart&, ControlFactoryMac&, NSServicesRolloverButtonCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -34,8 +34,11 @@
 #import "ImageControlsButtonPart.h"
 #import "LocalDefaultSystemAppearance.h"
 #import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageControlsButtonMac);
 
 ImageControlsButtonMac::ImageControlsButtonMac(ImageControlsButtonPart& owningPart, ControlFactoryMac& controlFactory, NSServicesRolloverButtonCell *servicesRolloverButtonCell)
     : ControlMac(owningPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class InnerSpinButtonPart;
 
 class InnerSpinButtonMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(InnerSpinButtonMac);
 public:
     InnerSpinButtonMac(InnerSpinButtonPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -35,8 +35,11 @@
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InnerSpinButtonMac);
 
 InnerSpinButtonMac::InnerSpinButtonMac(InnerSpinButtonPart& owningPart, ControlFactoryMac& controlFactory)
     : ControlMac(owningPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class MenuListButtonPart;
 
 class MenuListButtonMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(MenuListButtonMac);
 public:
     MenuListButtonMac(MenuListButtonPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -32,8 +32,11 @@
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "MenuListButtonPart.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MenuListButtonMac);
 
 MenuListButtonMac::MenuListButtonMac(MenuListButtonPart& owningPart, ControlFactoryMac& controlFactory)
     : ControlMac(owningPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class MenuListPart;
 
 class MenuListMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(MenuListMac);
 public:
     MenuListMac(MenuListPart& owningPart, ControlFactoryMac&, NSPopUpButtonCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -32,8 +32,11 @@
 #import "GraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "MenuListPart.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MenuListMac);
 
 MenuListMac::MenuListMac(MenuListPart& owningPart, ControlFactoryMac& controlFactory, NSPopUpButtonCell *popUpButtonCell)
     : ControlMac(owningPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -29,10 +29,12 @@
 
 #import "ControlMac.h"
 #import "MeterPart.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class MeterMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(MeterMac);
 public:
     MeterMac(MeterPart& owningMeterPart, ControlFactoryMac&, NSLevelIndicatorCell*);
 

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -33,8 +33,11 @@
 #import "LocalDefaultSystemAppearance.h"
 #import "MeterPart.h"
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MeterMac);
 
 MeterMac::MeterMac(MeterPart& owningMeterPart, ControlFactoryMac& controlFactory, NSLevelIndicatorCell* levelIndicatorCell)
     : ControlMac(owningMeterPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -29,12 +29,14 @@
 
 #import "ControlMac.h"
 #import "ProgressBarPart.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ProgressBarPart;
 
 class ProgressBarMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(ProgressBarMac);
 public:
     ProgressBarMac(ProgressBarPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProgressBarMac);
+
 ProgressBarMac::ProgressBarMac(ProgressBarPart& owningPart, ControlFactoryMac& controlFactory)
     : ControlMac(owningPart, controlFactory)
 {

--- a/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h
@@ -28,10 +28,12 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SearchControlMac : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(SearchControlMac);
 public:
     SearchControlMac(ControlPart&, ControlFactoryMac&, NSSearchFieldCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm
@@ -25,10 +25,13 @@
 
 #import "config.h"
 #import "SearchControlMac.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(MAC)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SearchControlMac);
 
 SearchControlMac::SearchControlMac(ControlPart& part, ControlFactoryMac& controlFactory, NSSearchFieldCell *searchFieldCell)
     : ControlMac(part, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class SliderThumbPart;
 
 class SliderThumbMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(SliderThumbMac);
 public:
     SliderThumbMac(SliderThumbPart&, ControlFactoryMac&, NSSliderCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -33,8 +33,11 @@
 #import "GraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "SliderThumbPart.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SliderThumbMac);
 
 SliderThumbMac::SliderThumbMac(SliderThumbPart& owningPart, ControlFactoryMac& controlFactory, NSSliderCell *sliderCell)
     : ControlMac(owningPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
@@ -29,10 +29,12 @@
 
 #import "ControlMac.h"
 #import "SliderTrackPart.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SliderTrackMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(SliderTrackMac);
 public:
     SliderTrackMac(SliderTrackPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -31,8 +31,11 @@
 #import "ColorSpaceCG.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SliderTrackMac);
 
 SliderTrackMac::SliderTrackMac(SliderTrackPart& part, ControlFactoryMac& controlFactory)
     : ControlMac(part, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
@@ -28,10 +28,12 @@
 
 #import "ControlMac.h"
 #import "SwitchThumbPart.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SwitchThumbMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(SwitchThumbMac);
 public:
     SwitchThumbMac(SwitchThumbPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -35,8 +35,11 @@
 #import "SwitchMacUtilities.h"
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SwitchThumbMac);
 
 SwitchThumbMac::SwitchThumbMac(SwitchThumbPart& part, ControlFactoryMac& controlFactory)
     : ControlMac(part, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
@@ -28,10 +28,12 @@
 
 #import "ControlMac.h"
 #import "SwitchTrackPart.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SwitchTrackMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(SwitchTrackMac);
 public:
     SwitchTrackMac(SwitchTrackPart&, ControlFactoryMac&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -37,8 +37,11 @@
 #import "SwitchMacUtilities.h"
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SwitchTrackMac);
 
 SwitchTrackMac::SwitchTrackMac(SwitchTrackPart& part, ControlFactoryMac& controlFactory)
     : ControlMac(part, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "PlatformControl.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class TextAreaPart;
 
 class TextAreaMac final : public PlatformControl {
+    WTF_MAKE_TZONE_ALLOCATED(TextAreaMac);
 public:
     TextAreaMac(TextAreaPart&);
 

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
@@ -32,8 +32,11 @@
 #import "LocalDefaultSystemAppearance.h"
 #import "TextAreaPart.h"
 #import <pal/spi/mac/NSCellSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextAreaMac);
 
 TextAreaMac::TextAreaMac(TextAreaPart& owningPart)
     : PlatformControl(owningPart)

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class TextFieldPart;
 
 class TextFieldMac final : public ControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(TextFieldMac);
 public:
     TextFieldMac(TextFieldPart& owningPart, ControlFactoryMac&, NSTextFieldCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
@@ -32,8 +32,11 @@
 #import "GraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "TextFieldPart.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextFieldMac);
 
 TextFieldMac::TextFieldMac(TextFieldPart& owningPart, ControlFactoryMac& controlFactory, NSTextFieldCell* textFieldCell)
     : ControlMac(owningPart, controlFactory)

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
@@ -28,12 +28,14 @@
 #if PLATFORM(MAC)
 
 #import "ButtonControlMac.h"
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ToggleButtonPart;
 
 class ToggleButtonMac final : public ButtonControlMac {
+    WTF_MAKE_TZONE_ALLOCATED(ToggleButtonMac);
 public:
     ToggleButtonMac(ToggleButtonPart& owningPart, ControlFactoryMac&, NSButtonCell *);
 

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -34,8 +34,11 @@
 #import "LocalDefaultSystemAppearance.h"
 #import "ToggleButtonPart.h"
 #import <pal/spi/cocoa/NSButtonCellSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ToggleButtonMac);
 
 ToggleButtonMac::ToggleButtonMac(ToggleButtonPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
     : ButtonControlMac(owningPart, controlFactory, buttonCell)


### PR DESCRIPTION
#### 38457483560babb2c611249337fc1c7cadc9a4fd
<pre>
[TZone] Add annotations to unannotated subclasses of html/TextFieldInputType and graphics/Mac/controls/PlatformControl
<a href="https://bugs.webkit.org/show_bug.cgi?id=279335">https://bugs.webkit.org/show_bug.cgi?id=279335</a>
<a href="https://rdar.apple.com/135526128">rdar://135526128</a>

Reviewed by Yusuke Suzuki.

Added TZone allocation annotation to unannotated subclasses of html/TextFieldInputType and graphics/Mac/controls/PlatformControl.

* Source/WebCore/html/BaseTextInputType.cpp:
* Source/WebCore/html/BaseTextInputType.h:
* Source/WebCore/html/EmailInputType.cpp:
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/NumberInputType.cpp:
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/PasswordInputType.cpp:
* Source/WebCore/html/PasswordInputType.h:
* Source/WebCore/html/SearchInputType.cpp:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/TelephoneInputType.cpp:
* Source/WebCore/html/TelephoneInputType.h:
* Source/WebCore/html/TextInputType.cpp:
* Source/WebCore/html/TextInputType.h:
* Source/WebCore/html/URLInputType.cpp:
* Source/WebCore/html/URLInputType.h:
* Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h:
* Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm:
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h:
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.h:
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h:
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm:
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h:
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm:

Canonical link: <a href="https://commits.webkit.org/283348@main">https://commits.webkit.org/283348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eccfa8f0aab96b3b8629e8b7d1ff891b1fd814b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52975 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9956 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14277 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60289 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60579 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8226 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1864 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9991 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41182 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->