### PR TITLE
[JSC] Use get_internal_field bytecode instead of functions

### DIFF
--- a/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
@@ -54,13 +54,13 @@ function next(value)
 
     var promise = @newPromise();
 
-    if (!@isObject(this) || !@isObject(@asyncFromSyncIteratorGetSyncIterator(this))) {
+    if (!@isObject(this) || !@isObject(@getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldSyncIterator))) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @makeTypeError('Iterator is not an object.'));
         return promise;
     }
 
-    var syncIterator = @asyncFromSyncIteratorGetSyncIterator(this);
-    var nextMethod = @asyncFromSyncIteratorGetNextMethod(this);
+    var syncIterator = @getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldSyncIterator);
+    var nextMethod = @getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldNextMethod);
 
     try {
         var nextResult = @argumentCount() === 0 ? nextMethod.@call(syncIterator) : nextMethod.@call(syncIterator, value);
@@ -79,12 +79,12 @@ function return(value)
 
     var promise = @newPromise();
 
-    if (!@isObject(this) || !@isObject(@asyncFromSyncIteratorGetSyncIterator(this))) {
+    if (!@isObject(this) || !@isObject(@getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldSyncIterator))) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @makeTypeError('Iterator is not an object.'));
         return promise;
     }
 
-    var syncIterator = @asyncFromSyncIteratorGetSyncIterator(this);
+    var syncIterator = @getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldSyncIterator);
 
     var returnMethod;
 
@@ -123,12 +123,12 @@ function throw(exception)
 
     var promise = @newPromise();
 
-    if (!@isObject(this) || !@isObject(@asyncFromSyncIteratorGetSyncIterator(this))) {
+    if (!@isObject(this) || !@isObject(@getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldSyncIterator))) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @makeTypeError('Iterator is not an object.'));
         return promise;
     }
 
-    var syncIterator = @asyncFromSyncIteratorGetSyncIterator(this);
+    var syncIterator = @getAsyncFromSyncIteratorInternalField(this, @asyncFromSyncIteratorFieldSyncIterator);
 
     var throwMethod;
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -221,11 +221,7 @@ namespace JSC {
     macro(indexOf) \
     macro(pop) \
     macro(wrapForValidIteratorCreate) \
-    macro(wrapForValidIteratorGetIteratedIterator) \
-    macro(wrapForValidIteratorGetIteratedNextMethod) \
     macro(asyncFromSyncIteratorCreate) \
-    macro(asyncFromSyncIteratorGetSyncIterator) \
-    macro(asyncFromSyncIteratorGetNextMethod) \
 
 
 namespace Symbols {

--- a/Source/JavaScriptCore/builtins/WrapForValidIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/WrapForValidIteratorPrototype.js
@@ -35,7 +35,7 @@ function next()
         @throwTypeError("%WrapForValidIteratorPrototype%.next requires that |this| be a WrapForValidIteratorPrototype object");
 
     // 4. Return ? Call(iteratorRecord.[[NextMethod]], iteratorRecord.[[Iterator]]).
-    return @wrapForValidIteratorGetIteratedNextMethod(this).@call(@wrapForValidIteratorGetIteratedIterator(this));
+    return @getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedNextMethod).@call(@getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedIterator));
 }
 
 // https://tc39.es/proposal-iterator-helpers/#sec-wrapforvaliditeratorprototype.return
@@ -50,7 +50,7 @@ function return()
         @throwTypeError("%WrapForValidIteratorPrototype%.next requires that |this| be a WrapForValidIteratorPrototype object");
 
     // 3. Let iterator be O.[[Iterated]].[[Iterator]].
-    var iterator = @wrapForValidIteratorGetIteratedIterator(this);
+    var iterator = @getWrapForValidIteratorInternalField(this, @wrapForValidIteratorFieldIteratedIterator);
     // 4. Assert: iterator is an Object.
     @assert(@isObject(iterator));
     // 5. Let returnMethod be ? GetMethod(iterator, "return").

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -34,6 +34,7 @@
 #include "IdentifierInlines.h"
 #include "IterationKind.h"
 #include "JSArrayIterator.h"
+#include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
 #include "JSGenerator.h"
 #include "JSGlobalObject.h"
@@ -42,6 +43,7 @@
 #include "JSPromise.h"
 #include "JSSetIterator.h"
 #include "JSStringIterator.h"
+#include "JSWrapForValidIterator.h"
 #include "LinkTimeConstant.h"
 #include "Nodes.h"
 #include "StrongInlines.h"
@@ -122,7 +124,11 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_AsyncGeneratorSuspendReasonYield.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield)));
     m_AsyncGeneratorSuspendReasonAwait.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await)));
     m_AsyncGeneratorSuspendReasonNone.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::None)));
+    m_asyncFromSyncIteratorFieldSyncIterator.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncFromSyncIterator::Field::SyncIterator)));
+    m_asyncFromSyncIteratorFieldNextMethod.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncFromSyncIterator::Field::NextMethod)));
     m_abstractModuleRecordFieldState.set(m_vm, jsNumber(static_cast<int32_t>(AbstractModuleRecord::Field::State)));
+    m_wrapForValidIteratorFieldIteratedIterator.set(m_vm, jsNumber(static_cast<int32_t>(JSWrapForValidIterator::Field::IteratedIterator)));
+    m_wrapForValidIteratorFieldIteratedNextMethod.set(m_vm, jsNumber(static_cast<int32_t>(JSWrapForValidIterator::Field::IteratedNextMethod)));
 }
 
 std::optional<BytecodeIntrinsicRegistry::Entry> BytecodeIntrinsicRegistry::lookup(const Identifier& ident) const

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -49,6 +49,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getPrototypeOf) \
     macro(getPromiseInternalField) \
     macro(getGeneratorInternalField) \
+    macro(getAsyncFromSyncIteratorInternalField) \
     macro(getAsyncGeneratorInternalField) \
     macro(getAbstractModuleRecordInternalField) \
     macro(getArrayIteratorInternalField) \
@@ -56,6 +57,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getMapIteratorInternalField) \
     macro(getSetIteratorInternalField) \
     macro(getProxyInternalField) \
+    macro(getWrapForValidIteratorInternalField) \
     macro(idWithProfile) \
     macro(isObject) \
     macro(isCallable) \
@@ -173,7 +175,12 @@ enum class LinkTimeConstant : int32_t;
     macro(AsyncGeneratorSuspendReasonYield) \
     macro(AsyncGeneratorSuspendReasonAwait) \
     macro(AsyncGeneratorSuspendReasonNone) \
-    macro(abstractModuleRecordFieldState)
+    macro(asyncFromSyncIteratorFieldSyncIterator) \
+    macro(asyncFromSyncIteratorFieldNextMethod) \
+    macro(abstractModuleRecordFieldState) \
+    macro(wrapForValidIteratorFieldIteratedIterator) \
+    macro(wrapForValidIteratorFieldIteratedNextMethod) \
+
 
 #define JSC_COMMON_BYTECODE_INTRINSIC_CONSTANTS_CUSTOM_EACH_NAME(macro) \
     macro(orderedHashTableSentinel)

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -150,11 +150,7 @@ class JSGlobalObject;
     v(BigInt64Array, nullptr) \
     v(BigUint64Array, nullptr) \
     v(wrapForValidIteratorCreate, nullptr) \
-    v(wrapForValidIteratorGetIteratedIterator, nullptr) \
-    v(wrapForValidIteratorGetIteratedNextMethod, nullptr) \
     v(asyncFromSyncIteratorCreate, nullptr) \
-    v(asyncFromSyncIteratorGetSyncIterator, nullptr) \
-    v(asyncFromSyncIteratorGetNextMethod, nullptr) \
 
 
 #define DECLARE_LINK_TIME_CONSTANT(name, code) name,

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.cpp
@@ -71,22 +71,4 @@ JSC_DEFINE_HOST_FUNCTION(asyncFromSyncIteratorPrivateFuncCreate, (JSGlobalObject
     return JSValue::encode(asyncFromSyncIterator);
 }
 
-JSC_DEFINE_HOST_FUNCTION(asyncFromSyncIteratorPrivateFuncGetSyncIterator, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argument(0).isCell());
-
-    JSCell* cell = callFrame->uncheckedArgument(0).asCell();
-    JSAsyncFromSyncIterator* iterator = jsCast<JSAsyncFromSyncIterator*>(cell);
-    return JSValue::encode(iterator->syncIterator());
-}
-
-JSC_DEFINE_HOST_FUNCTION(asyncFromSyncIteratorPrivateFuncGetNextMethod, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argument(0).isCell());
-
-    JSCell* cell = callFrame->uncheckedArgument(0).asCell();
-    JSAsyncFromSyncIterator* iterator = jsCast<JSAsyncFromSyncIterator*>(cell);
-    return JSValue::encode(iterator->nextMethod());
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
@@ -84,7 +84,5 @@ private:
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncFromSyncIterator);
 
 JSC_DECLARE_HOST_FUNCTION(asyncFromSyncIteratorPrivateFuncCreate);
-JSC_DECLARE_HOST_FUNCTION(asyncFromSyncIteratorPrivateFuncGetSyncIterator);
-JSC_DECLARE_HOST_FUNCTION(asyncFromSyncIteratorPrivateFuncGetNextMethod);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1544,22 +1544,10 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncFromSyncIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "asyncFromSyncIteratorCreate"_s, asyncFromSyncIteratorPrivateFuncCreate, ImplementationVisibility::Private));
     });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncFromSyncIteratorGetSyncIterator)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "asyncFromSyncIteratorGetSyncIterator"_s, asyncFromSyncIteratorPrivateFuncGetSyncIterator, ImplementationVisibility::Private));
-    });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncFromSyncIteratorGetNextMethod)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "asyncFromSyncIteratorGetNextMethod"_s, asyncFromSyncIteratorPrivateFuncGetNextMethod, ImplementationVisibility::Private));
-    });
 
     if (Options::useIteratorHelpers()) {
         m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::wrapForValidIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "wrapForValidIteratorCreate"_s, wrapForValidIteratorPrivateFuncCreate, ImplementationVisibility::Private));
-        });
-        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::wrapForValidIteratorGetIteratedIterator)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "wrapForValidIteratorGetIteratedIterator"_s, wrapForValidIteratorPrivateFuncGetIteratedIterator, ImplementationVisibility::Private));
-        });
-        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::wrapForValidIteratorGetIteratedNextMethod)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "wrapForValidIteratorGetIteratedNextMethod"_s, wrapForValidIteratorPrivateFuncGetIteratedNextMethod, ImplementationVisibility::Private));
         });
     }
 

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.cpp
@@ -72,22 +72,4 @@ JSC_DEFINE_HOST_FUNCTION(wrapForValidIteratorPrivateFuncCreate, (JSGlobalObject*
     return JSValue::encode(wrapForValidIterator);
 }
 
-JSC_DEFINE_HOST_FUNCTION(wrapForValidIteratorPrivateFuncGetIteratedIterator, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argument(0).isCell());
-
-    JSCell* cell = callFrame->uncheckedArgument(0).asCell();
-    JSWrapForValidIterator* iterator = jsCast<JSWrapForValidIterator*>(cell);
-    return JSValue::encode(iterator->iteratedIterator());
-}
-
-JSC_DEFINE_HOST_FUNCTION(wrapForValidIteratorPrivateFuncGetIteratedNextMethod, (JSGlobalObject*, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argument(0).isCell());
-
-    JSCell* cell = callFrame->uncheckedArgument(0).asCell();
-    JSWrapForValidIterator* iterator = jsCast<JSWrapForValidIterator*>(cell);
-    return JSValue::encode(iterator->iteratedNextMethod());
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
@@ -84,7 +84,5 @@ private:
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSWrapForValidIterator);
 
 JSC_DECLARE_HOST_FUNCTION(wrapForValidIteratorPrivateFuncCreate);
-JSC_DECLARE_HOST_FUNCTION(wrapForValidIteratorPrivateFuncGetIteratedIterator);
-JSC_DECLARE_HOST_FUNCTION(wrapForValidIteratorPrivateFuncGetIteratedNextMethod);
 
 } // namespace JSC


### PR DESCRIPTION
#### c1309ede3a65c5339009da87d848b3fdc4d420e8
<pre>
[JSC] Use get_internal_field bytecode instead of functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=279338">https://bugs.webkit.org/show_bug.cgi?id=279338</a>
<a href="https://rdar.apple.com/135527404">rdar://135527404</a>

Reviewed by Keith Miller.

This patch removes JSAsyncFromSyncIterator / JSWrapForValidIterator&apos;s
functions to access to its internal fields from JS. We should just use
bytecode intrinsic and get_internal_field bytecode.

* Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js:
(return):
(throw):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/WrapForValidIteratorPrototype.js:
(next):
(return):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::asyncFromSyncIteratorInternalFieldIndex):
(JSC::wrapForValidIteratorInternalFieldIndex):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getAsyncFromSyncIteratorInternalField):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getWrapForValidIteratorInternalField):
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.cpp:
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSWrapForValidIterator.cpp:
* Source/JavaScriptCore/runtime/JSWrapForValidIterator.h:

Canonical link: <a href="https://commits.webkit.org/283357@main">https://commits.webkit.org/283357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e487dc64ace4b1804ab62e0472e42c9b4a466d28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16616 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52982 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11562 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33617 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38544 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14522 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15492 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59121 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71740 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65251 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9962 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14282 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60586 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1869 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87018 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9995 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41188 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15312 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->