### PR TITLE
Fix a smart pointer static analysis warning in ShapeDetection/RemoteBarcodeDetector.cpp

### DIFF
--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
@@ -54,15 +54,15 @@ RemoteBarcodeDetector::~RemoteBarcodeDetector() = default;
 
 const SharedPreferencesForWebProcess& RemoteBarcodeDetector::sharedPreferencesForWebProcess() const
 {
-    return m_backend->sharedPreferencesForWebProcess();
+    return protectedBackend()->sharedPreferencesForWebProcess();
 }
 
-Ref<WebCore::ShapeDetection::BarcodeDetector> RemoteBarcodeDetector::protectedBacking()
+Ref<WebCore::ShapeDetection::BarcodeDetector> RemoteBarcodeDetector::protectedBacking() const
 {
     return backing();
 }
 
-Ref<RemoteRenderingBackend> RemoteBarcodeDetector::protectedBackend()
+Ref<RemoteRenderingBackend> RemoteBarcodeDetector::protectedBackend() const
 {
     return m_backend.get();
 }

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
@@ -72,9 +72,9 @@ private:
     RemoteBarcodeDetector& operator=(const RemoteBarcodeDetector&) = delete;
     RemoteBarcodeDetector& operator=(RemoteBarcodeDetector&&) = delete;
 
-    WebCore::ShapeDetection::BarcodeDetector& backing() { return m_backing; }
-    Ref<WebCore::ShapeDetection::BarcodeDetector> protectedBacking();
-    Ref<RemoteRenderingBackend> protectedBackend();
+    WebCore::ShapeDetection::BarcodeDetector& backing() const { return m_backing; }
+    Ref<WebCore::ShapeDetection::BarcodeDetector> protectedBacking() const;
+    Ref<RemoteRenderingBackend> protectedBackend() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 


### PR DESCRIPTION
#### 5aeaacb24b8755a24400a7af91a1ab703550a870
<pre>
Fix a smart pointer static analysis warning in ShapeDetection/RemoteBarcodeDetector.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279340">https://bugs.webkit.org/show_bug.cgi?id=279340</a>

Reviewed by Chris Dumez.

Use protectedBackend() to fix the warning.

* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp:
(WebKit::RemoteBarcodeDetector::sharedPreferencesForWebProcess const):
(WebKit::RemoteBarcodeDetector::protectedBacking const):
(WebKit::RemoteBarcodeDetector::protectedBackend const):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h:
(WebKit::RemoteBarcodeDetector::backing const):

Canonical link: <a href="https://commits.webkit.org/283346@main">https://commits.webkit.org/283346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4361c06de6cd80d5d379915a64c595700fc35885

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16625 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52987 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11569 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38553 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9971 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14291 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60304 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60594 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1875 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9989 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41197 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->