### PR TITLE
Fix unexpected smart pointer static analysis warnings in Source/WebKit/GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
@@ -47,10 +47,25 @@ RemoteXRBinding::RemoteXRBinding(WebCore::WebGPU::XRBinding& xrBinding, WebGPU::
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteXRBinding::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteXRBinding::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteXRBinding::~RemoteXRBinding() = default;
+
+Ref<IPC::StreamServerConnection> RemoteXRBinding::protectedStreamConnection()
+{
+    return m_streamConnection;
+}
+
+Ref<WebCore::WebGPU::XRBinding> RemoteXRBinding::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<RemoteGPU> RemoteXRBinding::protectedGPU()
+{
+    return m_gpu.get();
+}
 
 void RemoteXRBinding::destruct()
 {
@@ -65,37 +80,39 @@ void RemoteXRBinding::createProjectionLayer(WebCore::WebGPU::TextureFormat color
         .textureUsage = textureUsage,
         .scaleFactor = scaleFactor
     };
-    auto projectionLayer = m_backing->createProjectionLayer(WTFMove(init));
+    auto projectionLayer = protectedBacking()->createProjectionLayer(WTFMove(init));
     if (!projectionLayer) {
         // FIXME: Add MESSAGE_CHECK call
         return;
     }
 
-    auto remoteProjectionLayer = RemoteXRProjectionLayer::create(*projectionLayer, m_objectHeap, m_streamConnection.copyRef(), m_gpu, identifier);
-    m_objectHeap->addObject(identifier, remoteProjectionLayer);
+    Ref objectHeap = m_objectHeap.get();
+    auto remoteProjectionLayer = RemoteXRProjectionLayer::create(*projectionLayer, objectHeap, protectedStreamConnection(), protectedGPU(), identifier);
+    objectHeap->addObject(identifier, remoteProjectionLayer);
 }
 
 void RemoteXRBinding::getViewSubImage(WebGPUIdentifier projectionLayerIdentifier, WebCore::WebGPU::XREye eye, WebGPUIdentifier identifier)
 {
-    auto projectionLayer = m_objectHeap->convertXRProjectionLayerFromBacking(projectionLayerIdentifier);
+    Ref objectHeap = m_objectHeap.get();
+    auto projectionLayer = objectHeap->convertXRProjectionLayerFromBacking(projectionLayerIdentifier);
     if (!projectionLayer) {
         // FIXME: Add MESSAGE_CHECK call
         return;
     }
 
-    auto subImage = m_backing->getViewSubImage(*projectionLayer, eye);
+    auto subImage = protectedBacking()->getViewSubImage(*projectionLayer, eye);
     if (!subImage) {
         // FIXME: Add MESSAGE_CHECK call
         return;
     }
 
-    auto remoteSubImage = RemoteXRSubImage::create(*subImage, m_objectHeap, m_streamConnection.copyRef(), m_gpu, identifier);
-    m_objectHeap->addObject(identifier, remoteSubImage);
+    auto remoteSubImage = RemoteXRSubImage::create(*subImage, objectHeap, protectedStreamConnection(), protectedGPU(), identifier);
+    objectHeap->addObject(identifier, remoteSubImage);
 }
 
 void RemoteXRBinding::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteXRBinding::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteXRBinding::messageReceiverName(), m_identifier.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
@@ -78,7 +78,12 @@ private:
     RemoteXRBinding& operator=(const RemoteXRBinding&) = delete;
     RemoteXRBinding& operator=(RemoteXRBinding&&) = delete;
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+
     WebCore::WebGPU::XRBinding& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::XRBinding> protectedBacking();
+
+    Ref<RemoteGPU> protectedGPU();
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
@@ -46,14 +46,24 @@ RemoteXRProjectionLayer::RemoteXRProjectionLayer(WebCore::WebGPU::XRProjectionLa
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteXRProjectionLayer::~RemoteXRProjectionLayer() = default;
 
+Ref<IPC::StreamServerConnection> RemoteXRProjectionLayer::protectedStreamConnection()
+{
+    return m_streamConnection;
+}
+
+Ref<RemoteGPU> RemoteXRProjectionLayer::protectedGPU() const
+{
+    return m_gpu.get();
+}
+
 RefPtr<IPC::Connection> RemoteXRProjectionLayer::connection() const
 {
-    RefPtr connection = m_gpu->gpuConnectionToWebProcess();
+    RefPtr connection = protectedGPU()->gpuConnectionToWebProcess();
     if (!connection)
         return nullptr;
     return &connection->connection();
@@ -76,7 +86,7 @@ void RemoteXRProjectionLayer::endFrame()
 
 void RemoteXRProjectionLayer::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -89,6 +89,9 @@ private:
     RemoteXRProjectionLayer& operator=(const RemoteXRProjectionLayer&) = delete;
     RemoteXRProjectionLayer& operator=(RemoteXRProjectionLayer&&) = delete;
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+    Ref<RemoteGPU> protectedGPU() const;
+
     RefPtr<IPC::Connection> connection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp
@@ -46,10 +46,15 @@ RemoteXRSubImage::RemoteXRSubImage(WebCore::WebGPU::XRSubImage& xrSubImage, WebG
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteXRSubImage::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteXRSubImage::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteXRSubImage::~RemoteXRSubImage() = default;
+
+Ref<IPC::StreamServerConnection> RemoteXRSubImage::protectedStreamConnection()
+{
+    return m_streamConnection;
+}
 
 RefPtr<IPC::Connection> RemoteXRSubImage::connection() const
 {
@@ -66,7 +71,7 @@ void RemoteXRSubImage::destruct()
 
 void RemoteXRSubImage::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteXRSubImage::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteXRSubImage::messageReceiverName(), m_identifier.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
@@ -87,6 +87,8 @@ private:
     RemoteXRSubImage& operator=(const RemoteXRSubImage&) = delete;
     RemoteXRSubImage& operator=(RemoteXRSubImage&&) = delete;
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+
     WebCore::WebGPU::XRSubImage& backing() { return m_backing; }
 
     RefPtr<IPC::Connection> connection() const;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
@@ -44,7 +44,12 @@ RemoteXRView::RemoteXRView(WebCore::WebGPU::XRView& xrView, WebGPU::ObjectHeap& 
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
+}
+
+Ref<IPC::StreamServerConnection> RemoteXRView::protectedStreamConnection()
+{
+    return m_streamConnection;
 }
 
 RemoteXRView::~RemoteXRView() = default;
@@ -56,7 +61,7 @@ void RemoteXRView::destruct()
 
 void RemoteXRView::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
@@ -86,6 +86,8 @@ private:
     RemoteXRView& operator=(const RemoteXRView&) = delete;
     RemoteXRView& operator=(RemoteXRView&&) = delete;
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+
     WebCore::WebGPU::XRView& backing() { return m_backing; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -170,7 +170,7 @@ void RemoteLegacyCDMFactoryProxy::removeSession(RemoteLegacyCDMSessionIdentifier
     m_sessions.remove(identifier);
 
     if (connection && allowsExitUnderMemoryPressure())
-        connection->gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
+        connection->protectedGPUProcess()->tryExitIfUnusedAndUnderMemoryPressure();
 }
 
 RemoteLegacyCDMSessionProxy* RemoteLegacyCDMFactoryProxy::getSession(const RemoteLegacyCDMSessionIdentifier& identifier) const
@@ -190,9 +190,10 @@ bool RemoteLegacyCDMFactoryProxy::allowsExitUnderMemoryPressure() const
 const Logger& RemoteLegacyCDMFactoryProxy::logger() const
 {
     if (!m_logger) {
-        m_logger = Logger::create(this);
+        Ref logger = Logger::create(this);
+        m_logger = logger.ptr();
         auto connection = m_gpuConnectionToWebProcess.get();
-        m_logger->setEnabled(this, connection ? connection->sessionID().isAlwaysOnLoggingAllowed() : false);
+        logger->setEnabled(this, connection ? connection->sessionID().isAlwaysOnLoggingAllowed() : false);
     }
 
     return *m_logger;


### PR DESCRIPTION
#### cd38a1d1c8c83c9ad9e8fb0b7d40ac4c51cb2b06
<pre>
Fix unexpected smart pointer static analysis warnings in Source/WebKit/GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279346">https://bugs.webkit.org/show_bug.cgi?id=279346</a>

Reviewed by Chris Dumez and Mike Wyrzykowski.

Deploy more smart pointers in Source/WebKit/GPUProcess to fix the static analysis warnings.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp:
(WebKit::RemoteXRBinding::RemoteXRBinding):
(WebKit::RemoteXRBinding::protectedStreamConnection):
(WebKit::RemoteXRBinding::protectedBacking):
(WebKit::RemoteXRBinding::protectedGPU):
(WebKit::RemoteXRBinding::createProjectionLayer):
(WebKit::RemoteXRBinding::getViewSubImage):
(WebKit::RemoteXRBinding::stopListeningForIPC):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp:
(WebKit::RemoteXRProjectionLayer::RemoteXRProjectionLayer):
(WebKit::RemoteXRProjectionLayer::protectedStreamConnection):
(WebKit::RemoteXRProjectionLayer::protectedGPU const):
(WebKit::RemoteXRProjectionLayer::connection const):
(WebKit::RemoteXRProjectionLayer::stopListeningForIPC):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp:
(WebKit::RemoteXRSubImage::RemoteXRSubImage):
(WebKit::RemoteXRSubImage::protectedStreamConnection):
(WebKit::RemoteXRSubImage::stopListeningForIPC):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp:
(WebKit::RemoteXRView::RemoteXRView):
(WebKit::RemoteXRView::protectedStreamConnection):
(WebKit::RemoteXRView::stopListeningForIPC):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::removeSession):
(WebKit::RemoteLegacyCDMFactoryProxy::logger const):

Canonical link: <a href="https://commits.webkit.org/283359@main">https://commits.webkit.org/283359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/923e2f30b330526e9630bfe55181321be1b9bb72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16664 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53021 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11604 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38585 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10010 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14323 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60627 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1909 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9997 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41236 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->