### PR TITLE
Crash happens when applying filter and drawing text in 2D canvas

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-text-drawing-expected.html
+++ b/LayoutTests/fast/canvas/canvas-filter-text-drawing-expected.html
@@ -1,0 +1,33 @@
+<body>
+    <h3>This tests the filter is applied to the text correctly.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        let image = new Image;
+        image.onload = () => {
+            const canvas = document.getElementById('canvas');
+            const ctx = canvas.getContext('2d');
+
+            ctx.drawImage(image, 0, 0);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+
+        image.src = "data:image/svg+xml;charset=UTF-8, \
+            <svg xmlns='http://www.w3.org/2000/svg' width='300' height='150'> \
+                <style> \
+                    text { \
+                        font-size: 48px; \
+                        font-family: serif; \
+                    } \
+                </style> \
+                <filter id='svgDropShadow'> \
+                    <feDropShadow dx='5' dy='5' stdDeviation='0' flood-color='gray'/> \
+                </filter> \
+                <text x='10' y='40' fill='blue' filter='url(%23svgDropShadow)'>Hello world!</text> \
+                <text x='10' y='120' fill='none' stroke='red' filter='url(%23svgDropShadow)'>Hello world!</text> \
+            </svg>";
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-text-drawing.html
+++ b/LayoutTests/fast/canvas/canvas-filter-text-drawing.html
@@ -1,0 +1,20 @@
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-872" />
+<body>
+    <h3>This tests the filter is applied to the text correctly.</h3>
+    <canvas id="canvas"></canvas>
+    <svg style="position: absolute; top: -99999px">
+        <filter id="svgDropShadow">
+            <feDropShadow dx="5" dy="5" stdDeviation="0" flood-color="gray"/>
+        </filter>
+    </svg>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        ctx.filter = 'url(#svgDropShadow)';
+        ctx.fillStyle = "blue"
+        ctx.strokeStyle = "red"
+        ctx.font = "48px serif";
+        ctx.fillText("Hello world!", 10, 40);
+        ctx.strokeText("Hello world!", 10, 120);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-layer-filter-text-drawing-expected.html
+++ b/LayoutTests/fast/canvas/canvas-layer-filter-text-drawing-expected.html
@@ -1,0 +1,33 @@
+<body>
+    <h3>This tests the layer filter is applied to the text correctly.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        let image = new Image;
+        image.onload = () => {
+            const canvas = document.getElementById('canvas');
+            const ctx = canvas.getContext('2d');
+
+            ctx.drawImage(image, 0, 0);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+
+        image.src = "data:image/svg+xml;charset=UTF-8, \
+            <svg xmlns='http://www.w3.org/2000/svg' width='300' height='150'> \
+                <style> \
+                    text { \
+                        font-size: 48px; \
+                        font-family: serif; \
+                    } \
+                </style> \
+                <filter id='svgDropShadow'> \
+                    <feDropShadow dx='5' dy='5' stdDeviation='0' flood-color='gray'/> \
+                </filter> \
+                <text x='10' y='40' fill='blue' filter='url(%23svgDropShadow)'>Hello world!</text> \
+                <text x='10' y='120' fill='none' stroke='red' filter='url(%23svgDropShadow)'>Hello world!</text> \
+            </svg>";
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-layer-filter-text-drawing.html
+++ b/LayoutTests/fast/canvas/canvas-layer-filter-text-drawing.html
@@ -1,0 +1,23 @@
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-872" />
+<body>
+    <h3>This tests the layer filter is applied to the text correctly.</h3>
+    <canvas id="canvas"></canvas>
+    <svg style="position: absolute; top: -99999px" xmlns="http://www.w3.org/2000/svg">
+        <filter id="svgDropShadow">
+            <feDropShadow dx="5" dy="5" stdDeviation="0" flood-color="gray"/>
+        </filter>
+    </svg>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+
+        ctx.filter = 'url(#svgDropShadow)';
+        ctx.beginLayer();
+            ctx.fillStyle = "blue"
+            ctx.strokeStyle = "red"
+            ctx.font = "48px serif";
+            ctx.fillText("Hello world!", 10, 40);
+            ctx.strokeText("Hello world!", 10, 120);
+        ctx.endLayer();
+    </script>
+</body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1580,6 +1580,8 @@ webkit.org/b/273396 fast/borders/border-painting-correctness-dashed.html [ Image
 webkit.org/b/273396 fast/borders/border-painting-correctness-dotted.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/borders/outline-border-radius-simple.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/canvas/canvas-filter-drawing.html [ ImageOnlyFailure ]
+webkit.org/b/273396 fast/canvas/canvas-filter-text-drawing.html [ ImageOnlyFailure ]
+webkit.org/b/273396 fast/canvas/canvas-layer-filter-text-drawing.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/css/ignore-empty-focus-ring-rects.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/css3-text/css3-text-decoration/repaint/underline-outside-of-layout-rect.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 59e4b7c01999eaea1db9614660906c0ca6b57c34
<pre>
Crash happens when applying filter and drawing text in 2D canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=279348">https://bugs.webkit.org/show_bug.cgi?id=279348</a>
<a href="https://rdar.apple.com/135455808">rdar://135455808</a>

Reviewed by Simon Fraser.

CanvasRenderingContext2DBase::drawTextUnchecked() calls fontProxy() which returns
a pointer to state().font. Then drawTextUnchecked() calls save() through
CanvasFilterContextSwitcher::create(). This save() appends a new state to
m_stateStack. Vector::append() may reallocate its buffer. Reallocating the buffer
will make the pointer to fontProxy() invalid. This causes a crash when accessing
the members of fontProxy.

To fix this make sure, CanvasRenderingContext2D::fontProxy() is called after
calling CanvasFilterContextSwitcher::create().

* LayoutTests/fast/canvas/canvas-filter-text-drawing-expected.html: Added.
* LayoutTests/fast/canvas/canvas-filter-text-drawing.html: Added.
* LayoutTests/fast/canvas/canvas-layer-filter-text-drawing-expected.html: Added.
* LayoutTests/fast/canvas/canvas-layer-filter-text-drawing.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):

Canonical link: <a href="https://commits.webkit.org/283451@main">https://commits.webkit.org/283451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3cabd7b0bb39bdfcbd389a65f40d664c53e2bf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17237 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69411 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33860 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15830 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60845 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14620 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8499 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->