### PR TITLE
Deploy more smart pointers in Source/WebKit/Platform to fix unexpected static analysis warnings

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -224,7 +224,7 @@ bool StreamServerConnection::dispatchStreamMessage(Decoder&& decoder, StreamMess
     if (decoder.isSyncMessage()) {
         result = m_buffer.releaseAll();
         if (m_syncReplyToDispatch)
-            m_connection->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTFMove(m_syncReplyToDispatch)));
+            protectedConnection()->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTFMove(m_syncReplyToDispatch)));
     } else
         result = m_buffer.release(decoder.currentBufferOffset());
     if (result == WakeUpClient::Yes)

--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
@@ -57,7 +57,7 @@
 {
     if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
-            _webView->page().setCaretBlinkingSuspended(false);
+            _webView->protectedPage()->setCaretBlinkingSuspended(false);
         return;
     }
 
@@ -66,7 +66,7 @@
         if (NSTextInputContext *context = _webView->inputContext())
             context.showsCursorAccessories = YES;
 
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
+        _webView->protectedPage()->setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
     }
 }
 
@@ -77,26 +77,26 @@
 
     _caretType = WebCore::CaretAnimatorType::Default;
     if (_webView)
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
+        _webView->protectedPage()->setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
 }
 
 - (void)dictationDidPause
 {
     if (_webView)
-        _webView->page().setCaretBlinkingSuspended(true);
+        _webView->protectedPage()->setCaretBlinkingSuspended(true);
 }
 
 - (void)dictationDidResume
 {
     if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
-            _webView->page().setCaretBlinkingSuspended(false);
+            _webView->protectedPage()->setCaretBlinkingSuspended(false);
         return;
     }
 
     _caretType = WebCore::CaretAnimatorType::Dictation;
     if (_webView)
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
+        _webView->protectedPage()->setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -210,6 +210,8 @@ public:
     NSWindow *window();
 
     WebPageProxy& page() { return m_page.get(); }
+    Ref<WebPageProxy> protectedPage() const;
+
     NSView *view() const { return m_view.getAutoreleased(); }
 
     void processWillSwap();
@@ -855,8 +857,6 @@ private:
 #endif
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
-
-    Ref<WebPageProxy> protectedPage() const;
 
     WeakObjCPtr<NSView<WebViewImplDelegate>> m_view;
     std::unique_ptr<PageClient> m_pageClient;


### PR DESCRIPTION
#### fc1b00d5cc7032e0b08ebfe2985c268f4e3899e8
<pre>
Deploy more smart pointers in Source/WebKit/Platform to fix unexpected static analysis warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=279350">https://bugs.webkit.org/show_bug.cgi?id=279350</a>

Reviewed by Chris Dumez.

Deployed more smart pointers in Source/WebKit/Platform.

* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessage):
* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm:
(-[_WKWebViewTextInputNotifications dictationDidStart]):
(-[_WKWebViewTextInputNotifications dictationDidEnd]):
(-[_WKWebViewTextInputNotifications dictationDidPause]):
(-[_WKWebViewTextInputNotifications dictationDidResume]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Canonical link: <a href="https://commits.webkit.org/283354@main">https://commits.webkit.org/283354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a08ac80637330b5923c4a24eaeb4f51f1e872a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16667 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16949 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57188 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38590 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14325 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60628 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1910 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9993 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->