### PR TITLE
BlobLoader should not pass itself to its completion handler when cancelled

### DIFF
--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -265,7 +265,7 @@ String Blob::normalizedContentType(const String& contentType)
     return contentType.convertToASCIILowercase();
 }
 
-void Blob::loadBlob(FileReaderLoader::ReadType readType, CompletionHandler<void(BlobLoader&)>&& completionHandler)
+void Blob::loadBlob(FileReaderLoader::ReadType readType, Function<void(BlobLoader&)>&& completionHandler)
 {
     auto blobLoader = makeUnique<BlobLoader>([this, pendingActivity = makePendingActivity(*this), completionHandler = WTFMove(completionHandler)](BlobLoader& blobLoader) mutable {
         completionHandler(blobLoader);

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -151,7 +151,7 @@ protected:
     Blob(ScriptExecutionContext*, const URL& srcURL, long long start, long long end, unsigned long long memoryCost, const String& contentType);
 
 private:
-    void loadBlob(FileReaderLoader::ReadType, CompletionHandler<void(BlobLoader&)>&&);
+    void loadBlob(FileReaderLoader::ReadType, Function<void(BlobLoader&)>&&);
 
     String m_type;
     mutable std::optional<unsigned long long> m_size;

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -82,9 +82,7 @@ void NetworkSendQueue::enqueue(WebCore::Blob& blob)
 
 void NetworkSendQueue::clear()
 {
-    // Do not call m_queue.clear() here since destroying a BlobLoader will cause its completion
-    // handler to get called, which will call processMessages() to iterate over m_queue.
-    std::exchange(m_queue, { });
+    m_queue.clear();
 }
 
 void NetworkSendQueue::processMessages()

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -93,9 +93,7 @@ void ShareDataReader::didFinishLoading(int loadIndex, const String& fileName)
 
 void ShareDataReader::cancel()
 {
-    // Don't call m_pendingFileLoads.clear() here since destroying a BlobLoader will cause its completion handler
-    // to get called, which will call didFinishLoading() and try to access m_pendingFileLoads.
-    std::exchange(m_pendingFileLoads, { });
+    m_pendingFileLoads.clear();
 }
 
 }


### PR DESCRIPTION
#### 288e0b49de4f6ba5b1c221242c1f5e859d833231
<pre>
BlobLoader should not pass itself to its completion handler when cancelled
<a href="https://rdar.apple.com/135720087">rdar://135720087</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279355">https://bugs.webkit.org/show_bug.cgi?id=279355</a>

Reviewed by Alex Christensen.

<a href="https://commits.webkit.org/228429@main">https://commits.webkit.org/228429@main</a> made BlobLoader call its completion handler in the cancel case.
This is notably triggered when BlobLoader is destroyed while still loading.
FormDataConsumer lambda would then be called within its destructor.

We recently introduced ref counting of FormDataConsumer which triggered refing of FormDataConsumer within its destructor, which triggers an assert.
We fix this by having BlobLoader NOT call its completion callback in the cancel case.

Covered by existing tests.

* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::loadBlob):
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/BlobLoader.h:
(WebCore::BlobLoader::BlobLoader):
(WebCore::BlobLoader::cancel):
(WebCore::BlobLoader::didFinishLoading):
(WebCore::BlobLoader::didFail):
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
(WebCore::NetworkSendQueue::clear):
* Source/WebCore/page/ShareDataReader.cpp:
(WebCore::ShareDataReader::cancel):

Canonical link: <a href="https://commits.webkit.org/283752@main">https://commits.webkit.org/283752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/380a73b4bbf6377daebe8e6d658d0d41f41ac15e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53288 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14899 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15924 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60614 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60929 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2192 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41620 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->