### PR TITLE
Adopt more smart pointers in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -305,28 +305,26 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(FetchResponseLoader, FetchResponse::Loader)
 
 void FetchResponse::Loader::didSucceed(const NetworkLoadMetrics& metrics)
 {
-    ASSERT(m_response.hasPendingActivity());
+    Ref response = m_response.get();
+    ASSERT(response->hasPendingActivity());
 
-    m_response.didSucceed(metrics);
+    response->didSucceed(metrics);
 
-    if (m_loader->isStarted()) {
-        Ref<FetchResponse> protector(m_response);
-        m_response.m_loader = nullptr;
-    }
+    if (m_loader->isStarted())
+        response->m_loader = nullptr;
 }
 
 void FetchResponse::Loader::didFail(const ResourceError& error)
 {
-    ASSERT(m_response.hasPendingActivity());
+    Ref response = m_response.get();
+    ASSERT(response->hasPendingActivity());
 
-    m_response.setLoadingError(ResourceError { error });
-    m_response.processReceivedError();
+    response->setLoadingError(ResourceError { error });
+    response->processReceivedError();
 
     // Check whether didFail is called as part of FetchLoader::start.
-    if (m_loader && m_loader->isStarted()) {
-        Ref<FetchResponse> protector(m_response);
-        m_response.m_loader = nullptr;
-    }
+    if (m_loader && m_loader->isStarted())
+        response->m_loader = nullptr;
 }
 
 static std::atomic<uint64_t> nextOpaqueLoadIdentifier;
@@ -351,7 +349,7 @@ void FetchResponse::setReceivedInternalResponse(const ResourceResponse& resource
 FetchResponse::Loader::Loader(FetchResponse& response, NotificationCallback&& responseCallback)
     : m_response(response)
     , m_responseCallback(WTFMove(responseCallback))
-    , m_pendingActivity(m_response.makePendingActivity(m_response))
+    , m_pendingActivity(response.makePendingActivity(response))
 {
 }
 
@@ -359,15 +357,17 @@ FetchResponse::Loader::~Loader() = default;
 
 void FetchResponse::Loader::didReceiveResponse(const ResourceResponse& resourceResponse)
 {
-    m_response.setReceivedInternalResponse(resourceResponse, m_credentials);
+    Ref response = m_response.get();
+    response->setReceivedInternalResponse(resourceResponse, m_credentials);
 
     if (auto responseCallback = WTFMove(m_responseCallback))
-        responseCallback(Ref { m_response });
+        responseCallback(WTFMove(response));
 }
 
 void FetchResponse::Loader::didReceiveData(const SharedBuffer& buffer)
 {
-    ASSERT(m_response.m_readableStreamSource || m_consumeDataCallback);
+    Ref response = m_response.get();
+    ASSERT(response->m_readableStreamSource || m_consumeDataCallback);
 
     if (m_consumeDataCallback) {
         auto chunk = buffer.span();
@@ -375,14 +375,14 @@ void FetchResponse::Loader::didReceiveData(const SharedBuffer& buffer)
         return;
     }
 
-    auto& source = *m_response.m_readableStreamSource;
+    auto& source = *response->m_readableStreamSource;
 
     if (!source.isPulling()) {
-        m_response.body().consumer().append(buffer);
+        response->body().consumer().append(buffer);
         return;
     }
 
-    if (m_response.body().consumer().hasData() && !source.enqueue(m_response.body().consumer().takeAsArrayBuffer())) {
+    if (response->body().consumer().hasData() && !source.enqueue(response->body().consumer().takeAsArrayBuffer())) {
         stop();
         return;
     }
@@ -396,7 +396,7 @@ void FetchResponse::Loader::didReceiveData(const SharedBuffer& buffer)
 bool FetchResponse::Loader::start(ScriptExecutionContext& context, const FetchRequest& request, const String& initiator)
 {
     m_credentials = request.fetchOptions().credentials;
-    m_loader = makeUnique<FetchLoader>(*this, &m_response.m_body->consumer());
+    m_loader = makeUnique<FetchLoader>(*this, &m_response->m_body->consumer());
     m_loader->start(context, request, initiator);
 
     if (!m_loader->isStarted())

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -174,7 +174,7 @@ private:
         void didReceiveResponse(const ResourceResponse&) final;
         void didReceiveData(const SharedBuffer&) final;
 
-        FetchResponse& m_response;
+        WeakRef<FetchResponse> m_response;
         NotificationCallback m_responseCallback;
         ConsumeDataByChunkCallback m_consumeDataCallback;
         std::unique_ptr<FetchLoader> m_loader;

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -76,7 +76,7 @@ Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platf
 {
     unsigned index = platformGamepad.index();
     if (index >= m_gamepads.size() || !m_gamepads[index])
-        return Gamepad::create(m_navigator.document(), platformGamepad);
+        return Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
 
     return *m_gamepads[index];
 }
@@ -125,7 +125,7 @@ Seconds NavigatorGamepad::gamepadsRecentlyAccessedThreshold()
 
 const Vector<RefPtr<Gamepad>>& NavigatorGamepad::gamepads()
 {
-    if (RefPtr frame = m_navigator.frame()) {
+    if (RefPtr frame = m_navigator->frame()) {
         if (RefPtr page = frame->protectedPage())
             page->gamepadsRecentlyAccessed();
     }
@@ -157,7 +157,7 @@ void NavigatorGamepad::gamepadsBecameVisible()
         if (!platformGamepads[i])
             continue;
 
-        m_gamepads[i] = Gamepad::create(m_navigator.document(), *platformGamepads[i]);
+        m_gamepads[i] = Gamepad::create(m_navigator->protectedDocument().get(), *platformGamepads[i]);
     }
 }
 
@@ -176,9 +176,9 @@ void NavigatorGamepad::gamepadConnected(PlatformGamepad& platformGamepad)
     ASSERT(index <= m_gamepads.size());
 
     if (index < m_gamepads.size())
-        m_gamepads[index] = Gamepad::create(m_navigator.document(), platformGamepad);
+        m_gamepads[index] = Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
     else if (index == m_gamepads.size())
-        m_gamepads.append(Gamepad::create(m_navigator.document(), platformGamepad));
+        m_gamepads.append(Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad));
 }
 
 void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)
@@ -195,7 +195,7 @@ void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)
 
 RefPtr<Page> NavigatorGamepad::protectedPage() const
 {
-    RefPtr frame = m_navigator.frame();
+    RefPtr frame = m_navigator->frame();
     return frame ? frame->protectedPage() : nullptr;
 }
 

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -80,7 +81,7 @@ private:
 
     const Vector<RefPtr<Gamepad>>& gamepads();
 
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
     Vector<RefPtr<Gamepad>> m_gamepads;
 };
 

--- a/Source/WebCore/Modules/geolocation/GeolocationClient.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -34,7 +35,9 @@ class Geolocation;
 class GeolocationPositionData;
 class Page;
 
-class GeolocationClient {
+class GeolocationClient : public CanMakeCheckedPtr<GeolocationClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GeolocationClient);
 public:
     virtual void geolocationDestroyed() = 0;
 

--- a/Source/WebCore/Modules/geolocation/GeolocationController.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.h
@@ -60,7 +60,7 @@ public:
 
     std::optional<GeolocationPositionData> lastPosition();
 
-    GeolocationClient& client() { return m_client; }
+    GeolocationClient& client();
 
     WEBCORE_EXPORT static ASCIILiteral supplementName();
     static GeolocationController* from(Page* page) { return static_cast<GeolocationController*>(Supplement<Page>::from(page, supplementName())); }
@@ -70,8 +70,8 @@ public:
     void didNavigatePage();
 
 private:
-    Page& m_page;
-    GeolocationClient& m_client;
+    WeakRef<Page> m_page;
+    CheckedPtr<GeolocationClient> m_client; // Only becomes null in the class destructor
 
     void activityStateDidChange(OptionSet<ActivityState> oldActivityState, OptionSet<ActivityState> newActivityState) override;
 

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
@@ -76,7 +76,7 @@ Geolocation* NavigatorGeolocation::geolocation(Navigator& navigator)
 Geolocation* NavigatorGeolocation::geolocation() const
 {
     if (!m_geolocation)
-        m_geolocation = Geolocation::create(m_navigator);
+        m_geolocation = Geolocation::create(Ref { m_navigator.get() });
     return m_geolocation.get();
 }
 

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
@@ -23,6 +23,7 @@
 
 #include "LocalDOMWindowProperty.h"
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -48,7 +49,7 @@ private:
     static ASCIILiteral supplementName();
 
     mutable RefPtr<Geolocation> m_geolocation;
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -108,7 +108,7 @@ private:
 
     // IDBIndex objects are always owned by their referencing IDBObjectStore.
     // Indexes will never outlive ObjectStores so its okay to keep a raw C++ reference here.
-    IDBObjectStore& m_objectStore;
+    CheckedRef<IDBObjectStore> m_objectStore;
 };
 
 WebCoreOpaqueRoot root(IDBIndex*);

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -30,9 +30,11 @@
 #include "IDBCursorDirection.h"
 #include "IDBKeyPath.h"
 #include "IDBObjectStoreInfo.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakRef.h>
 
 namespace JSC {
 class CallFrame;
@@ -50,6 +52,7 @@ class IDBKeyRange;
 class IDBRequest;
 class IDBTransaction;
 class SerializedScriptValue;
+class WeakPtrImplWithEventTargetData;
 class WebCoreOpaqueRoot;
 
 struct IDBKeyRangeData;
@@ -58,8 +61,9 @@ namespace IndexedDB {
 enum class ObjectStoreOverwriteMode : uint8_t;
 }
 
-class IDBObjectStore final : public ActiveDOMObject {
+class IDBObjectStore final : public ActiveDOMObject, public CanMakeCheckedPtr<IDBObjectStore> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IDBObjectStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBObjectStore);
 public:
     static UniqueRef<IDBObjectStore> create(ScriptExecutionContext&, const IDBObjectStoreInfo&, IDBTransaction&);
     ~IDBObjectStore();
@@ -134,8 +138,8 @@ private:
     IDBObjectStoreInfo m_originalInfo;
 
     // IDBObjectStore objects are always owned by their referencing IDBTransaction.
-    // ObjectStores will never outlive transactions so its okay to keep a raw C++ reference here.
-    IDBTransaction& m_transaction;
+    // ObjectStores will never outlive transactions so its okay to keep a WeakRef here.
+    WeakRef<IDBTransaction, WeakPtrImplWithEventTargetData> m_transaction;
 
     bool m_deleted { false };
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -56,12 +56,12 @@ IDBConnectionProxy::IDBConnectionProxy(IDBConnectionToServer& connection)
 
 void IDBConnectionProxy::ref()
 {
-    m_connectionToServer.ref();
+    m_connectionToServer->ref();
 }
 
 void IDBConnectionProxy::deref()
 {
-    m_connectionToServer.deref();
+    m_connectionToServer->deref();
 }
 
 Ref<IDBOpenDBRequest> IDBConnectionProxy::openDatabase(ScriptExecutionContext& context, const IDBDatabaseIdentifier& databaseIdentifier, uint64_t version)
@@ -490,7 +490,7 @@ void IDBConnectionProxy::scheduleMainThreadTasks()
     if (m_mainThreadProtector)
         return;
 
-    m_mainThreadProtector = &m_connectionToServer;
+    m_mainThreadProtector = m_connectionToServer.ptr();
     callOnMainThread([this] {
         handleMainThreadTasks();
     });

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -138,9 +138,9 @@ private:
     void callConnectionOnMainThread(void (IDBConnectionToServer::*method)(Parameters...), Arguments&&... arguments)
     {
         if (isMainThread())
-            (m_connectionToServer.*method)(std::forward<Arguments>(arguments)...);
+            (m_connectionToServer.get().*method)(std::forward<Arguments>(arguments)...);
         else
-            postMainThreadTask(m_connectionToServer, method, arguments...);
+            postMainThreadTask(m_connectionToServer.get(), method, arguments...);
     }
 
     template<typename... Arguments>
@@ -155,7 +155,7 @@ private:
     void scheduleMainThreadTasks();
     void handleMainThreadTasks();
 
-    IDBConnectionToServer& m_connectionToServer;
+    CheckedRef<IDBConnectionToServer> m_connectionToServer;
     IDBConnectionIdentifier m_serverConnectionIdentifier;
 
     Lock m_databaseConnectionMapLock;

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -57,6 +57,8 @@ IDBConnectionToServer::IDBConnectionToServer(IDBConnectionToServerDelegate& dele
 {
 }
 
+IDBConnectionToServer::~IDBConnectionToServer() = default;
+
 IDBConnectionIdentifier IDBConnectionToServer::identifier() const
 {
     return m_delegate->identifier();

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -30,6 +30,7 @@
 #include "IDBDatabaseConnectionIdentifier.h"
 #include "IDBObjectStoreIdentifier.h"
 #include "IDBResourceIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
@@ -54,10 +55,12 @@ struct IDBIterateCursorData;
 
 namespace IDBClient {
 
-class IDBConnectionToServer : public ThreadSafeRefCounted<IDBConnectionToServer> {
+class IDBConnectionToServer final : public ThreadSafeRefCounted<IDBConnectionToServer>, public CanMakeThreadSafeCheckedPtr<IDBConnectionToServer> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBConnectionToServer, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBConnectionToServer);
 public:
     WEBCORE_EXPORT static Ref<IDBConnectionToServer> create(IDBConnectionToServerDelegate&);
+    WEBCORE_EXPORT ~IDBConnectionToServer();
 
     WEBCORE_EXPORT IDBConnectionIdentifier identifier() const;
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
@@ -29,7 +29,9 @@
 #include "IDBError.h"
 #include "IDBObjectStoreIdentifier.h"
 #include "IndexKey.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -56,7 +58,9 @@ enum class IndexRecordType : bool;
 
 namespace IDBServer {
 
-class IDBBackingStore {
+class IDBBackingStore : public CanMakeThreadSafeCheckedPtr<IDBBackingStore> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(IDBBackingStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBBackingStore);
 public:
     virtual ~IDBBackingStore() { RELEASE_ASSERT(!isMainThread()); }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -51,7 +51,7 @@ MemoryBackingStoreTransaction::MemoryBackingStoreTransaction(MemoryIDBBackingSto
 {
     if (m_info.mode() == IDBTransactionMode::Versionchange) {
         IDBDatabaseInfo info;
-        auto error = m_backingStore.getOrEstablishDatabaseInfo(info);
+        auto error = m_backingStore->getOrEstablishDatabaseInfo(info);
         if (error.isNull())
             m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(info);
     }
@@ -242,18 +242,18 @@ void MemoryBackingStoreTransaction::abort()
     m_originalIndexNames.clear();
 
     for (const auto& iterator : m_originalObjectStoreNames)
-        m_backingStore.renameObjectStoreForVersionChangeAbort(*iterator.key, iterator.value);
+        m_backingStore->renameObjectStoreForVersionChangeAbort(*iterator.key, iterator.value);
     m_originalObjectStoreNames.clear();
 
     for (const auto& objectStore : m_versionChangeAddedObjectStores)
-        m_backingStore.removeObjectStoreForVersionChangeAbort(*objectStore);
+        m_backingStore->removeObjectStoreForVersionChangeAbort(*objectStore);
     m_deletedIndexes.removeIf([&](auto& entry) {
         return m_versionChangeAddedObjectStores.contains(entry.value->objectStore().get());
     });
     m_versionChangeAddedObjectStores.clear();
 
     for (auto& objectStore : m_deletedObjectStores.values()) {
-        m_backingStore.restoreObjectStoreForVersionChangeAbort(*objectStore);
+        m_backingStore->restoreObjectStoreForVersionChangeAbort(*objectStore);
         ASSERT(!m_objectStores.contains(objectStore.get()));
         m_objectStores.add(objectStore);
     }
@@ -261,7 +261,7 @@ void MemoryBackingStoreTransaction::abort()
 
     if (m_originalDatabaseInfo) {
         ASSERT(m_info.mode() == IDBTransactionMode::Versionchange);
-        m_backingStore.setDatabaseInfo(*m_originalDatabaseInfo);
+        m_backingStore->setDatabaseInfo(*m_originalDatabaseInfo);
     }
 
     // Restore cleared index value stores before we re-insert values into object stores
@@ -291,7 +291,7 @@ void MemoryBackingStoreTransaction::abort()
     }
 
     for (auto& index : m_deletedIndexes.values()) {
-        RELEASE_ASSERT(m_backingStore.hasObjectStore(index->info().objectStoreIdentifier()));
+        RELEASE_ASSERT(m_backingStore->hasObjectStore(index->info().objectStoreIdentifier()));
         index->objectStore()->maybeRestoreDeletedIndex(*index);
     }
     m_deletedIndexes.clear();

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -30,6 +30,7 @@
 #include "IDBTransactionInfo.h"
 #include "IndexValueStore.h"
 #include "ThreadSafeDataBuffer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -77,7 +78,7 @@ public:
 private:
     void finish();
 
-    MemoryIDBBackingStore& m_backingStore;
+    CheckedRef<MemoryIDBBackingStore> m_backingStore;
     IDBTransactionInfo m_info;
 
     std::unique_ptr<IDBDatabaseInfo> m_originalDatabaseInfo;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -41,6 +41,7 @@ class MemoryObjectStore;
 
 class MemoryIDBBackingStore final : public IDBBackingStore {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MemoryIDBBackingStore, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MemoryIDBBackingStore);
 public:
     WEBCORE_EXPORT explicit MemoryIDBBackingStore(const IDBDatabaseIdentifier&);
     WEBCORE_EXPORT ~MemoryIDBBackingStore();

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -27,6 +27,7 @@
 
 #include "IDBIndexInfo.h"
 #include "IDBResourceIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
@@ -54,7 +55,9 @@ class MemoryBackingStoreTransaction;
 class MemoryIndexCursor;
 class MemoryObjectStore;
 
-class MemoryIndex : public RefCounted<MemoryIndex> {
+class MemoryIndex : public RefCounted<MemoryIndex>, public CanMakeThreadSafeCheckedPtr<MemoryIndex> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MemoryIndex);
 public:
     static Ref<MemoryIndex> create(const IDBIndexInfo&, MemoryObjectStore&);
 
@@ -82,6 +85,7 @@ public:
     IndexValueStore* valueStore() { return m_records.get(); }
 
     WeakPtr<MemoryObjectStore> objectStore() { return m_objectStore; }
+    RefPtr<MemoryObjectStore> protectedObjectStore() { return m_objectStore.get(); }
 
     void cursorDidBecomeClean(MemoryIndexCursor&);
     void cursorDidBecomeDirty(MemoryIndexCursor&);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.h
@@ -28,6 +28,7 @@
 #include "IDBCursorInfo.h"
 #include "IndexValueStore.h"
 #include "MemoryCursor.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -48,7 +49,9 @@ private:
     void currentData(IDBGetResult&) final;
     void iterate(const IDBKeyData&, const IDBKeyData& primaryKey, uint32_t count, IDBGetResult&) final;
 
-    MemoryIndex& m_index;
+    Ref<MemoryIndex> protectedIndex() const;
+
+    CheckedRef<MemoryIndex> m_index;
 
     IndexValueStore::Iterator m_currentIterator;
     IDBKeyData m_currentKey;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
@@ -194,8 +194,9 @@ void MemoryObjectStoreCursor::currentData(IDBGetResult& data)
     if (m_info.cursorType() == IndexedDB::CursorType::KeyOnly)
         data = { m_currentPositionKey, m_currentPositionKey };
     else {
-        IDBValue value = { m_objectStore.valueForKeyRange(m_currentPositionKey), { }, { } };
-        data = { m_currentPositionKey, m_currentPositionKey, WTFMove(value), m_objectStore.info().keyPath() };
+        Ref objectStore = m_objectStore.get();
+        IDBValue value = { objectStore->valueForKeyRange(m_currentPositionKey), { }, { } };
+        data = { m_currentPositionKey, m_currentPositionKey, WTFMove(value), objectStore->info().keyPath() };
     }
 }
 
@@ -321,7 +322,8 @@ void MemoryObjectStoreCursor::iterate(const IDBKeyData& key, const IDBKeyData& p
 
     ASSERT_UNUSED(primaryKeyData, primaryKeyData.isNull());
 
-    if (!m_objectStore.orderedKeys()) {
+    Ref objectStore = m_objectStore.get();
+    if (!objectStore->orderedKeys()) {
         m_currentPositionKey = { };
         outData = { };
         return;
@@ -333,7 +335,7 @@ void MemoryObjectStoreCursor::iterate(const IDBKeyData& key, const IDBKeyData& p
         return;
     }
 
-    auto* set = m_objectStore.orderedKeys();
+    auto* set = objectStore->orderedKeys();
     if (set) {
         if (m_info.isDirectionForward())
             incrementForwardIterator(*set, key, count);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.h
@@ -57,7 +57,7 @@ private:
 
     bool hasValidPosition() const;
 
-    MemoryObjectStore& m_objectStore;
+    WeakRef<MemoryObjectStore> m_objectStore;
 
     IDBKeyRangeData m_remainingRange;
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -52,6 +52,7 @@ class SQLiteIDBCursor;
 
 class SQLiteIDBBackingStore final : public IDBBackingStore {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SQLiteIDBBackingStore, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteIDBBackingStore);
 public:
     WEBCORE_EXPORT SQLiteIDBBackingStore(const IDBDatabaseIdentifier&, const String& databaseDirectory);
     WEBCORE_EXPORT ~SQLiteIDBBackingStore() final;

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp
@@ -99,7 +99,7 @@ void SQLiteIDBTransaction::moveBlobFilesIfNecessary()
 {
     ASSERT(!isReadOnly());
 
-    String databaseDirectory = m_backingStore.databaseDirectory();
+    String databaseDirectory = m_backingStore->databaseDirectory();
     for (auto& entry : m_blobTemporaryAndStoredFilenames) {
         if (!FileSystem::hardLinkOrCopyFile(entry.first, FileSystem::pathByAppendingComponent(databaseDirectory, entry.second)))
             LOG_ERROR("Failed to link/copy temporary blob file '%s' to location '%s'", entry.first.utf8().data(), FileSystem::pathByAppendingComponent(databaseDirectory, entry.second).utf8().data());
@@ -117,7 +117,7 @@ void SQLiteIDBTransaction::deleteBlobFilesIfNecessary()
     if (m_blobRemovedFilenames.isEmpty())
         return;
 
-    String databaseDirectory = m_backingStore.databaseDirectory();
+    String databaseDirectory = m_backingStore->databaseDirectory();
     for (auto& entry : m_blobRemovedFilenames) {
         String fullPath = FileSystem::pathByAppendingComponent(databaseDirectory, entry);
 
@@ -197,7 +197,7 @@ void SQLiteIDBTransaction::closeCursor(SQLiteIDBCursor& cursor)
 
     ASSERT(m_cursors.contains(cursor.identifier()));
 
-    m_backingStore.unregisterCursor(cursor);
+    m_backingStore->unregisterCursor(cursor);
     m_cursors.remove(cursor.identifier());
 }
 
@@ -219,7 +219,7 @@ void SQLiteIDBTransaction::notifyCursorsOfChanges(IDBObjectStoreIdentifier objec
 void SQLiteIDBTransaction::clearCursors()
 {
     for (auto& cursor : m_cursors.values())
-        m_backingStore.unregisterCursor(*cursor);
+        m_backingStore->unregisterCursor(*cursor);
 
     m_cursors.clear();
 }

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
@@ -73,7 +73,7 @@ public:
 
     SQLiteDatabase* sqliteDatabase() const;
     SQLiteTransaction* sqliteTransaction() const { return m_sqliteTransaction.get(); }
-    SQLiteIDBBackingStore& backingStore() { return m_backingStore; }
+    SQLiteIDBBackingStore& backingStore() { return m_backingStore.get(); }
 
     void addBlobFile(const String& temporaryPath, const String& storedFilename);
     void addRemovedBlobFile(const String& removedFilename);
@@ -88,7 +88,7 @@ private:
 
     IDBTransactionInfo m_info;
 
-    SQLiteIDBBackingStore& m_backingStore;
+    CheckedRef<SQLiteIDBBackingStore> m_backingStore;
     CheckedPtr<SQLiteDatabase> m_sqliteDatabase;
     std::unique_ptr<SQLiteTransaction> m_sqliteTransaction;
     HashMap<IDBResourceIdentifier, std::unique_ptr<SQLiteIDBCursor>> m_cursors;

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -393,6 +393,11 @@ Document* Navigator::document()
     return frame ? frame->document() : nullptr;
 }
 
+RefPtr<Document> Navigator::protectedDocument()
+{
+    return document();
+}
+
 void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -78,6 +78,7 @@ public:
     GPU* gpu();
 
     Document* document();
+    RefPtr<Document> protectedDocument();
 
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearAppBadge(Ref<DeferredPromise>&&);

--- a/Source/WebCore/platform/mock/GeolocationClientMock.h
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.h
@@ -45,6 +45,8 @@ class GeolocationController;
 // FIXME: this should not be in WebCore. It should be moved to WebKit.
 // Provides a mock object for the geolocation client.
 class GeolocationClientMock : public GeolocationClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GeolocationClientMock);
 public:
     GeolocationClientMock();
     virtual ~GeolocationClientMock();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -34,6 +34,7 @@ namespace WebKit {
 
 class WebGeolocationClient final : public WebCore::GeolocationClient {
     WTF_MAKE_TZONE_ALLOCATED(WebGeolocationClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebGeolocationClient);
 public:
     WebGeolocationClient(WebPage& page)
         : m_page(page)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.h
@@ -35,6 +35,7 @@ class GeolocationPositionData;
 
 class WebGeolocationClient : public WebCore::GeolocationClient {
     WTF_MAKE_TZONE_ALLOCATED(WebGeolocationClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebGeolocationClient);
 public:
     WebGeolocationClient(WebView *);
     WebView *webView() { return m_webView; }


### PR DESCRIPTION
#### 972641d1ddfeed83b7bfa1f5bc928f3abd4e235f
<pre>
Adopt more smart pointers in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=279364">https://bugs.webkit.org/show_bug.cgi?id=279364</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::Loader::didSucceed):
(WebCore::FetchResponse::Loader::didFail):
(WebCore::FetchResponse::Loader::Loader):
(WebCore::FetchResponse::Loader::didReceiveResponse):
(WebCore::FetchResponse::Loader::didReceiveData):
(WebCore::FetchResponse::Loader::start):
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::gamepadFromPlatformGamepad):
(WebCore::NavigatorGamepad::gamepads):
(WebCore::NavigatorGamepad::gamepadsBecameVisible):
(WebCore::NavigatorGamepad::gamepadConnected):
(WebCore::NavigatorGamepad::protectedPage const):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/Modules/geolocation/GeolocationClient.h:
* Source/WebCore/Modules/geolocation/GeolocationController.cpp:
(WebCore::GeolocationController::GeolocationController):
(WebCore::GeolocationController::~GeolocationController):
(WebCore::GeolocationController::client):
(WebCore::GeolocationController::addObserver):
(WebCore::GeolocationController::removeObserver):
(WebCore::GeolocationController::revokeAuthorizationToken):
(WebCore::GeolocationController::requestPermission):
(WebCore::GeolocationController::cancelPermissionRequest):
(WebCore::GeolocationController::lastPosition):
(WebCore::GeolocationController::activityStateDidChange):
(WebCore::GeolocationController::startUpdatingIfNecessary):
(WebCore::GeolocationController::stopUpdatingIfNecessary):
* Source/WebCore/Modules/geolocation/GeolocationController.h:
(WebCore::GeolocationController::client): Deleted.
* Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp:
(WebCore::NavigatorGeolocation::geolocation const):
* Source/WebCore/Modules/geolocation/NavigatorGeolocation.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::IDBIndex):
(WebCore::IDBIndex::~IDBIndex):
(WebCore::IDBIndex::virtualHasPendingActivity const):
(WebCore::IDBIndex::name const):
(WebCore::IDBIndex::setName):
(WebCore::IDBIndex::objectStore):
(WebCore::IDBIndex::keyPath const):
(WebCore::IDBIndex::unique const):
(WebCore::IDBIndex::multiEntry const):
(WebCore::IDBIndex::rollbackInfoForVersionChangeAbort):
(WebCore::IDBIndex::doOpenCursor):
(WebCore::IDBIndex::doOpenKeyCursor):
(WebCore::IDBIndex::doCount):
(WebCore::IDBIndex::doGet):
(WebCore::IDBIndex::doGetKey):
(WebCore::IDBIndex::doGetAll):
(WebCore::IDBIndex::doGetAllKeys):
(WebCore::IDBIndex::markAsDeleted):
(WebCore::IDBIndex::ref const):
(WebCore::IDBIndex::deref const):
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::IDBObjectStore):
(WebCore::IDBObjectStore::~IDBObjectStore):
(WebCore::IDBObjectStore::virtualHasPendingActivity const):
(WebCore::IDBObjectStore::name const):
(WebCore::IDBObjectStore::setName):
(WebCore::IDBObjectStore::keyPath const):
(WebCore::IDBObjectStore::indexNames const):
(WebCore::IDBObjectStore::transaction):
(WebCore::IDBObjectStore::autoIncrement const):
(WebCore::IDBObjectStore::doOpenCursor):
(WebCore::IDBObjectStore::doOpenKeyCursor):
(WebCore::IDBObjectStore::get):
(WebCore::IDBObjectStore::getKey):
(WebCore::IDBObjectStore::putOrAdd):
(WebCore::IDBObjectStore::doDelete):
(WebCore::IDBObjectStore::clear):
(WebCore::IDBObjectStore::createIndex):
(WebCore::IDBObjectStore::index):
(WebCore::IDBObjectStore::deleteIndex):
(WebCore::IDBObjectStore::doCount):
(WebCore::IDBObjectStore::doGetAll):
(WebCore::IDBObjectStore::doGetAllKeys):
(WebCore::IDBObjectStore::markAsDeleted):
(WebCore::IDBObjectStore::rollbackForVersionChangeAbort):
(WebCore::IDBObjectStore::ref const):
(WebCore::IDBObjectStore::deref const):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::ref):
(WebCore::IDBClient::IDBConnectionProxy::deref):
(WebCore::IDBClient::IDBConnectionProxy::scheduleMainThreadTasks):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::MemoryBackingStoreTransaction):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
(WebCore::IDBServer::MemoryIndex::protectedObjectStore):
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp:
(WebCore::IDBServer::MemoryIndexCursor::MemoryIndexCursor):
(WebCore::IDBServer::MemoryIndexCursor::currentData):
(WebCore::IDBServer::MemoryIndexCursor::iterate):
(WebCore::IDBServer::MemoryIndexCursor::protectedIndex const):
(WebCore::IDBServer::MemoryIndexCursor::indexRecordsAllChanged):
(WebCore::IDBServer::MemoryIndexCursor::indexValueChanged):
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp:
(WebCore::IDBServer::MemoryObjectStoreCursor::currentData):
(WebCore::IDBServer::MemoryObjectStoreCursor::iterate):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp:
(WebCore::IDBServer::SQLiteIDBTransaction::moveBlobFilesIfNecessary):
(WebCore::IDBServer::SQLiteIDBTransaction::deleteBlobFilesIfNecessary):
(WebCore::IDBServer::SQLiteIDBTransaction::closeCursor):
(WebCore::IDBServer::SQLiteIDBTransaction::clearCursors):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h:
(WebCore::IDBServer::SQLiteIDBTransaction::backingStore):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::protectedDocument):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/platform/mock/GeolocationClientMock.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.h:

Canonical link: <a href="https://commits.webkit.org/283365@main">https://commits.webkit.org/283365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b86a324f2890d27c0617b31470e75d3da1bfed38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16968 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11618 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71811 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10032 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14344 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60641 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1929 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9999 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41258 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->