### PR TITLE
NEW TEST (283218@main): [ macOS ] 2x TestWebKitAPI.WebPushD test are constant failures.

### DIFF
--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -32,7 +32,7 @@
 namespace WebKit::WebPushD {
 
 struct WebPushDaemonConnectionConfiguration {
-    Vector<uint8_t> hostAppAuditTokenData;
+    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -23,7 +23,7 @@
 webkit_platform_headers: "ArgumentCoders.h" "WebPushDaemonConnectionConfiguration.h"
 
 [CustomHeader, WebKitPlatform] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
-    Vector<uint8_t> hostAppAuditTokenData;
+    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -164,12 +164,15 @@ RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t conne
     audit_token_t hostAppAuditToken = handle.hostProcess.auditToken;
 #else
     audit_token_t hostAppAuditToken { };
-    if (configuration.hostAppAuditTokenData.size() != sizeof(audit_token_t)) {
-        RELEASE_LOG_ERROR(Push, "PushClientConnection::create failed: client attempted to set audit token with incorrect size");
-        return nullptr;
-    }
+    if (auto hostAppAuditTokenData = configuration.hostAppAuditTokenData) {
+        if (hostAppAuditTokenData->size() != sizeof(audit_token_t)) {
+            RELEASE_LOG_ERROR(Push, "PushClientConnection::create failed: client attempted to set audit token with incorrect size");
+            return nullptr;
+        }
 
-    memcpy(&hostAppAuditToken, configuration.hostAppAuditTokenData.data(), sizeof(hostAppAuditToken));
+        memcpy(&hostAppAuditToken, hostAppAuditTokenData->data(), sizeof(hostAppAuditToken));
+    } else
+        hostAppAuditToken = peerAuditToken;
 #endif
 
     bool hostAppHasWebPushEntitlement = hostAppHasEntitlement(hostAppAuditToken, hostAppWebPushEntitlement);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -2416,6 +2416,8 @@ TEST(WebPushD, WKWebPushDaemonConnectionRequestPushPermission)
     TestWebKitAPI::Util::run(&done);
 }
 
+#endif
+
 TEST(WebPushD, WKWebPushDaemonConnectionPushSubscription)
 {
     setUpTestWebPushD();
@@ -2462,8 +2464,6 @@ TEST(WebPushD, WKWebPushDaemonConnectionPushSubscription)
     }];
     TestWebKitAPI::Util::run(&done);
 }
-
-#endif
 
 class WebPushDPushNotificationEventTest : public WebPushDTest {
 public:


### PR DESCRIPTION
#### f38a9ddefa06b1729cf108a818ca74b1eaa791be
<pre>
NEW TEST (283218@main): [ macOS ] 2x TestWebKitAPI.WebPushD test are constant failures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279279">https://bugs.webkit.org/show_bug.cgi?id=279279</a>
<a href="https://rdar.apple.com/135435896">rdar://135435896</a>

Reviewed by Brady Eidson.

The tests fail as entitlement check does not work with public SDK, and PushClientConnection::create() falls to check
hostAppAuditTokenData in configuration. hostAppAuditTokenData is not set when PushClientConnection is created for
API::WebPushDaemonConnection, so validating the size of hostAppAuditTokenData would fail and PushClientConnection is not
created. To fix this, make hostAppAuditTokenData optional in WebPushDaemonConnectionConfiguration and skip validating
it when it is null. To ensure correctness, PushClientConnection::create() now uses audit token from peer connection
when hostAppAuditTokenData is not provided.

* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::create):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/283426@main">https://commits.webkit.org/283426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efeef7b7535bfdfa5b2f7bc95e2f31ff30e44c95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16763 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53094 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33732 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15639 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60405 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60697 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1983 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42410 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->