### PR TITLE
Fix unexpected smart pointer static analysis warnings in Source/WebKit/GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
@@ -80,14 +80,14 @@ void RemoteXRBinding::createProjectionLayer(WebCore::WebGPU::TextureFormat color
         .textureUsage = textureUsage,
         .scaleFactor = scaleFactor
     };
-    auto projectionLayer = protectedBacking()->createProjectionLayer(WTFMove(init));
+    RefPtr projectionLayer = protectedBacking()->createProjectionLayer(WTFMove(init));
     if (!projectionLayer) {
         // FIXME: Add MESSAGE_CHECK call
         return;
     }
 
     Ref objectHeap = m_objectHeap.get();
-    auto remoteProjectionLayer = RemoteXRProjectionLayer::create(*projectionLayer, objectHeap, protectedStreamConnection(), protectedGPU(), identifier);
+    Ref remoteProjectionLayer = RemoteXRProjectionLayer::create(*projectionLayer, objectHeap, protectedStreamConnection(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteProjectionLayer);
 }
 
@@ -100,13 +100,13 @@ void RemoteXRBinding::getViewSubImage(WebGPUIdentifier projectionLayerIdentifier
         return;
     }
 
-    auto subImage = protectedBacking()->getViewSubImage(*projectionLayer, eye);
+    RefPtr subImage = protectedBacking()->getViewSubImage(*projectionLayer, eye);
     if (!subImage) {
         // FIXME: Add MESSAGE_CHECK call
         return;
     }
 
-    auto remoteSubImage = RemoteXRSubImage::create(*subImage, objectHeap, protectedStreamConnection(), protectedGPU(), identifier);
+    Ref remoteSubImage = RemoteXRSubImage::create(*subImage, objectHeap, protectedStreamConnection(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteSubImage);
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -193,7 +193,7 @@ const Logger& RemoteLegacyCDMFactoryProxy::logger() const
         Ref logger = Logger::create(this);
         m_logger = logger.ptr();
         auto connection = m_gpuConnectionToWebProcess.get();
-        logger->setEnabled(this, connection ? connection->sessionID().isAlwaysOnLoggingAllowed() : false);
+        logger->setEnabled(this, connection && connection->sessionID().isAlwaysOnLoggingAllowed());
     }
 
     return *m_logger;


### PR DESCRIPTION
#### 62630ab18076a393dcd8958d2b4ad6b8d56a975a
<pre>
Fix unexpected smart pointer static analysis warnings in Source/WebKit/GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279346">https://bugs.webkit.org/show_bug.cgi?id=279346</a>

Unreviewed. Address Chris&apos; review comments.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp:
(WebKit::RemoteXRBinding::createProjectionLayer):
(WebKit::RemoteXRBinding::getViewSubImage):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::logger const):

Canonical link: <a href="https://commits.webkit.org/283366@main">https://commits.webkit.org/283366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63a6eb6142eaf178260032ec8d07fda9fa2274a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70139 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/16717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16998 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/16717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69174 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57228 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38626 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71841 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10062 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57290 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8311 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10000 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->