### PR TITLE
[JSC] Ensure StructureStubInfoClearingWatchpoint does not outlive its CodeBlock

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -297,6 +297,9 @@ CodeBlock::CodeBlock(VM& vm, Structure* structure, CopyParsedBlockTag, CodeBlock
     , m_functionDecls(other.m_functionDecls)
     , m_functionExprs(other.m_functionExprs)
     , m_creationTime(ApproximateTime::now())
+#if ASSERT_ENABLED
+    , m_magic(CODEBLOCK_MAGIC)
+#endif
 {
     ASSERT(heap()->isDeferred());
     ASSERT(m_scopeRegister.isLocal());
@@ -344,6 +347,9 @@ CodeBlock::CodeBlock(VM& vm, Structure* structure, ScriptExecutable* ownerExecut
     , m_instructionsRawPointer(unlinkedCodeBlock->instructions().rawPointer())
     , m_metadata(unlinkedCodeBlock->metadata().link())
     , m_creationTime(ApproximateTime::now())
+#if ASSERT_ENABLED
+    , m_magic(CODEBLOCK_MAGIC)
+#endif
 {
     ASSERT(heap()->isDeferred());
     ASSERT(m_scopeRegister.isLocal());
@@ -1699,7 +1705,13 @@ void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
 
 void CodeBlock::destroy(JSCell* cell)
 {
-    static_cast<CodeBlock*>(cell)->~CodeBlock();
+    auto cb = static_cast<CodeBlock*>(cell);
+    ASSERT(!cb->wasDestructed());
+    cb->~CodeBlock();
+#if ASSERT_ENABLED
+    cb->m_magic = 0;
+#endif
+    ASSERT(cb->wasDestructed());
 }
 
 void CodeBlock::getICStatusMap(const ConcurrentJSLocker&, ICStatusMap& result)
@@ -1763,37 +1775,6 @@ StructureStubInfo* CodeBlock::findStubInfo(CodeOrigin codeOrigin)
         return IterationStatus::Continue;
     });
     return result;
-}
-
-void CodeBlock::resetBaselineJITData()
-{
-    RELEASE_ASSERT(!JITCode::isJIT(jitType()));
-    ConcurrentJSLocker locker(m_lock);
-    
-    if (auto* jitData = baselineJITData()) {
-        // We can clear these because no other thread will have references to any stub infos, call
-        // link infos, or by val infos if we don't have JIT code. Attempts to query these data
-        // structures using the concurrent API (getICStatusMap and friends) will return nothing if we
-        // don't have JIT code. So it's safe to call this if we fail a baseline JIT compile.
-        //
-        // We also call this from finalizeUnconditionally when we degrade from baseline JIT to LLInt
-        // code. This is safe to do since all compiler threads are safepointed in finalizeUnconditionally,
-        // which means we've made it past bytecode parsing. Only the bytecode parser will hold onto
-        // references to these various *infos via its use of ICStatusMap. Also, OSR exit might point to
-        // these *infos, but when we have an OSR exit linked to this CodeBlock, we won't downgrade
-        // to LLInt.
-
-        for (auto& stubInfo : jitData->stubInfos()) {
-            stubInfo.aboutToDie();
-            stubInfo.deref();
-        }
-
-        // We can clear this because the DFG's queries to these data structures are guarded by whether
-        // there is JIT code.
-
-        m_jitData = nullptr;
-        delete jitData;
-    }
 }
 #endif
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -269,13 +269,6 @@ public:
     const JITCodeMap& jitCodeMap();
 
     std::optional<CodeOrigin> findPC(void* pc);
-
-    // We call this when we want to reattempt compiling something with the baseline JIT. Ideally
-    // the baseline JIT would not add data to CodeBlock, but instead it would put its data into
-    // a newly created JITCode, which could be thrown away if we bail on JIT compilation. Then we
-    // would be able to get rid of this silly function.
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=159061
-    void resetBaselineJITData();
 #endif // ENABLE(JIT)
 
     void unlinkOrUpgradeIncomingCalls(VM&, CodeBlock*);
@@ -473,6 +466,7 @@ public:
 #endif
 #if ASSERT_ENABLED
     bool hasIdentifier(UniquedStringImpl*);
+    bool wasDestructed();
 #endif
 
     Vector<WriteBarrier<Unknown>>& constants() { return m_constantRegisters; }
@@ -992,6 +986,7 @@ private:
 #if ASSERT_ENABLED
     Lock m_cachedIdentifierUidsLock;
     HashSet<UniquedStringImpl*> m_cachedIdentifierUids;
+    uint32_t m_magic;
 #endif
 };
 /* This check is for normal Release builds; ASSERT_ENABLED changes the size. */

--- a/Source/JavaScriptCore/bytecode/CodeBlockInlines.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockInlines.h
@@ -33,6 +33,8 @@
 
 namespace JSC {
 
+#define CODEBLOCK_MAGIC 0xc0deb10c
+
 template<typename Functor>
 void CodeBlock::forEachValueProfile(const Functor& func)
 {
@@ -117,6 +119,13 @@ ALWAYS_INLINE StringJumpTable& CodeBlock::dfgStringSwitchJumpTable(int tableInde
 {
     ASSERT(jitType() == JITType::DFGJIT);
     return static_cast<DFG::JITCode*>(m_jitCode.get())->m_stringSwitchJumpTables[tableIndex];
+}
+#endif
+
+#if ASSERT_ENABLED
+ALWAYS_INLINE bool CodeBlock::wasDestructed()
+{
+    return m_magic != CODEBLOCK_MAGIC;
 }
 #endif
 

--- a/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp
@@ -26,13 +26,14 @@
 #include "config.h"
 #include "CodeBlockJettisoningWatchpoint.h"
 
-#include "CodeBlock.h"
+#include "CodeBlockInlines.h"
 #include "DFGCommon.h"
 
 namespace JSC {
 
 void CodeBlockJettisoningWatchpoint::fireInternal(VM&, const FireDetail& detail)
 {
+    ASSERT(!m_owner->wasDestructed());
     // If CodeBlock is no longer live, we do not fire it.
     // This works since CodeBlock is the owner of this watchpoint. When it gets destroyed, then this watchpoint also gets destroyed.
     // Only problematic case is, (1) CodeBlock is dead, but (2) destructor is not called yet. In this case, isLive() check guards correctly.

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -7828,6 +7828,10 @@ void InlineCacheHandler::aboutToDie()
 {
     if (m_stubRoutine)
         m_stubRoutine->aboutToDie();
+    // A reference to InlineCacheHandler may keep it alive later than the CodeBlock that "owns" this
+    // watchpoint but the watchpoint must not fire after the CodeBlock has finished destruction,
+    // so clear the watchpoint eagerly.
+    m_watchpoint.reset();
 }
 
 CallLinkInfo* InlineCacheHandler::callLinkInfoAt(const ConcurrentJSLocker& locker, unsigned index)

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "LLIntPrototypeLoadAdaptiveStructureWatchpoint.h"
 
-#include "CodeBlock.h"
+#include "CodeBlockInlines.h"
 #include "Instruction.h"
 #include "JSCellInlines.h"
 
@@ -48,6 +48,11 @@ LLIntPrototypeLoadAdaptiveStructureWatchpoint::LLIntPrototypeLoadAdaptiveStructu
 {
 }
 
+LLIntPrototypeLoadAdaptiveStructureWatchpoint::~LLIntPrototypeLoadAdaptiveStructureWatchpoint()
+{
+    ASSERT(!m_owner || !m_owner->wasDestructed());
+}
+
 void LLIntPrototypeLoadAdaptiveStructureWatchpoint::initialize(CodeBlock* codeBlock, const ObjectPropertyCondition& key, BytecodeIndex bytecodeOffset)
 {
     m_owner = codeBlock;
@@ -64,6 +69,7 @@ void LLIntPrototypeLoadAdaptiveStructureWatchpoint::install(VM&)
 
 void LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
+    ASSERT(!m_owner->wasDestructed());
     if (!m_owner->isLive())
         return;
 

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
@@ -38,6 +38,8 @@ public:
     LLIntPrototypeLoadAdaptiveStructureWatchpoint(CodeBlock*, const ObjectPropertyCondition&, BytecodeIndex);
     LLIntPrototypeLoadAdaptiveStructureWatchpoint();
 
+    ~LLIntPrototypeLoadAdaptiveStructureWatchpoint();
+
     void initialize(CodeBlock*, const ObjectPropertyCondition&, BytecodeIndex);
 
     void install(VM&);

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(JIT)
 
-#include "CodeBlock.h"
+#include "CodeBlockInlines.h"
 #include "JSCellInlines.h"
 #include "StructureStubInfo.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -39,8 +39,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(StructureStubInfoClearingWatchpoint);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AdaptiveValueStructureStubClearingWatchpoint);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StructureTransitionStructureStubClearingWatchpoint);
 
+StructureStubInfoClearingWatchpoint::~StructureStubInfoClearingWatchpoint()
+{
+    ASSERT(!m_owner->wasDestructed());
+}
+
 void StructureStubInfoClearingWatchpoint::fireInternal(VM&, const FireDetail&)
 {
+    ASSERT(!m_owner->wasDestructed());
     if (!m_owner->isLive())
         return;
 

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -52,6 +52,8 @@ public:
     {
     }
 
+    ~StructureStubInfoClearingWatchpoint();
+
     void fireInternal(VM&, const FireDetail&);
 
 private:

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(DFG_JIT)
 
-#include "CodeBlock.h"
+#include "CodeBlockInlines.h"
 #include "JSCellInlines.h"
 
 namespace JSC { namespace DFG {
@@ -65,6 +65,7 @@ void AdaptiveStructureWatchpoint::install(VM&)
 
 void AdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail& detail)
 {
+    ASSERT(!m_codeBlock->wasDestructed());
     if (!m_codeBlock->isLive())
         return;
 


### PR DESCRIPTION
#### 9ce98e026db34cb0c1acf073da731354b622a6f6
<pre>
[JSC] Ensure StructureStubInfoClearingWatchpoint does not outlive its CodeBlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=279384">https://bugs.webkit.org/show_bug.cgi?id=279384</a>
<a href="https://rdar.apple.com/122375587">rdar://122375587</a>

Reviewed by Yusuke Suzuki.

StructureStubInfoClearingWatchpoint is kept alive by references from
both the CodeBlock and the Executable. If the CodeBlock is destructed
first and the Executable destruction is delayed, the watchpoint could
fire after the CodeBlock destruction and the JSCell:isLive() call for
the CodeBlock could try to walk a MarkedBlock that has already been
freed, leading to crashes.

Instead, proactively free the watchpoint when the CodeBlock is being
destructed.

Also add some debug-only code to help catch these sort of lifetime
issues involving CodeBlock and Watchpoint.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::CodeBlock):
(JSC::CodeBlock::destroy):
(JSC::CodeBlock::findStubInfo):
(JSC::CodeBlock::resetBaselineJITData): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/CodeBlockInlines.h:
(JSC::CodeBlock::wasDestructed):
* Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp:
(JSC::CodeBlockJettisoningWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::aboutToDie):
* Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp:
(JSC::LLIntPrototypeLoadAdaptiveStructureWatchpoint::~LLIntPrototypeLoadAdaptiveStructureWatchpoint):
(JSC::LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
(JSC::StructureStubInfoClearingWatchpoint::~StructureStubInfoClearingWatchpoint):
(JSC::StructureStubInfoClearingWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp:
(JSC::DFG::AdaptiveStructureWatchpoint::fireInternal):

Canonical link: <a href="https://commits.webkit.org/283454@main">https://commits.webkit.org/283454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f7c11682bdb2f27e9a3e91182ef6c45ab9cb676

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53196 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11808 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14795 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15803 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72053 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65561 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2103 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87328 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10051 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41499 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15354 "Found 4 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42576 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->