### PR TITLE
Deploy more smart pointers in Source/WebKit/UIProcess/API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -176,137 +176,137 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (NSDictionary<NSString *, id> *)manifest
 {
-    return _webExtension->manifest();
+    return self._protectedWebExtension->manifest();
 }
 
 - (double)manifestVersion
 {
-    return _webExtension->manifestVersion();
+    return self._protectedWebExtension->manifestVersion();
 }
 
 - (BOOL)supportsManifestVersion:(double)version
 {
-    return _webExtension->supportsManifestVersion(version);
+    return self._protectedWebExtension->supportsManifestVersion(version);
 }
 
 - (NSLocale *)defaultLocale
 {
-    return _webExtension->defaultLocale();
+    return self._protectedWebExtension->defaultLocale();
 }
 
 - (NSString *)displayName
 {
-    return _webExtension->displayName();
+    return self._protectedWebExtension->displayName();
 }
 
 - (NSString *)displayShortName
 {
-    return _webExtension->displayShortName();
+    return self._protectedWebExtension->displayShortName();
 }
 
 - (NSString *)displayVersion
 {
-    return _webExtension->displayVersion();
+    return self._protectedWebExtension->displayVersion();
 }
 
 - (NSString *)displayDescription
 {
-    return _webExtension->displayDescription();
+    return self._protectedWebExtension->displayDescription();
 }
 
 - (NSString *)displayActionLabel
 {
-    return _webExtension->displayActionLabel();
+    return self._protectedWebExtension->displayActionLabel();
 }
 
 - (NSString *)version
 {
-    return _webExtension->version();
+    return self._protectedWebExtension->version();
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return _webExtension->icon(size);
+    return self._protectedWebExtension->icon(size);
 }
 
 - (CocoaImage *)actionIconForSize:(CGSize)size
 {
-    return _webExtension->actionIcon(size);
+    return self._protectedWebExtension->actionIcon(size);
 }
 
 - (NSSet<WKWebExtensionPermission> *)requestedPermissions
 {
-    return WebKit::toAPI(_webExtension->requestedPermissions());
+    return WebKit::toAPI(self._protectedWebExtension->requestedPermissions());
 }
 
 - (NSSet<WKWebExtensionPermission> *)optionalPermissions
 {
-    return WebKit::toAPI(_webExtension->optionalPermissions());
+    return WebKit::toAPI(self._protectedWebExtension->optionalPermissions());
 }
 
 - (NSSet<WKWebExtensionMatchPattern *> *)requestedPermissionMatchPatterns
 {
-    return toAPI(_webExtension->requestedPermissionMatchPatterns());
+    return toAPI(self._protectedWebExtension->requestedPermissionMatchPatterns());
 }
 
 - (NSSet<WKWebExtensionMatchPattern *> *)optionalPermissionMatchPatterns
 {
-    return toAPI(_webExtension->optionalPermissionMatchPatterns());
+    return toAPI(self._protectedWebExtension->optionalPermissionMatchPatterns());
 }
 
 - (NSSet<WKWebExtensionMatchPattern *> *)allRequestedMatchPatterns
 {
-    return toAPI(_webExtension->allRequestedMatchPatterns());
+    return toAPI(self._protectedWebExtension->allRequestedMatchPatterns());
 }
 
 - (NSArray<NSError *> *)errors
 {
-    return _webExtension->errors();
+    return self._protectedWebExtension->errors();
 }
 
 - (BOOL)hasBackgroundContent
 {
-    return _webExtension->hasBackgroundContent();
+    return self._protectedWebExtension->hasBackgroundContent();
 }
 
 - (BOOL)hasPersistentBackgroundContent
 {
-    return _webExtension->backgroundContentIsPersistent();
+    return self._protectedWebExtension->backgroundContentIsPersistent();
 }
 
 - (BOOL)hasInjectedContent
 {
-    return _webExtension->hasStaticInjectedContent();
+    return self._protectedWebExtension->hasStaticInjectedContent();
 }
 
 - (BOOL)hasOptionsPage
 {
-    return _webExtension->hasOptionsPage();
+    return self._protectedWebExtension->hasOptionsPage();
 }
 
 - (BOOL)hasOverrideNewTabPage
 {
-    return _webExtension->hasOverrideNewTabPage();
+    return self._protectedWebExtension->hasOverrideNewTabPage();
 }
 
 - (BOOL)hasCommands
 {
-    return _webExtension->hasCommands();
+    return self._protectedWebExtension->hasCommands();
 }
 
 - (BOOL)hasContentModificationRules
 {
-    return _webExtension->hasContentModificationRules();
+    return self._protectedWebExtension->hasContentModificationRules();
 }
 
 - (BOOL)_hasServiceWorkerBackgroundContent
 {
-    return _webExtension->backgroundContentIsServiceWorker();
+    return self._protectedWebExtension->backgroundContentIsServiceWorker();
 }
 
 - (BOOL)_hasModularBackgroundContent
 {
-    return _webExtension->backgroundContentUsesModules();
+    return self._protectedWebExtension->backgroundContentUsesModules();
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
@@ -329,6 +329,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 }
 
 - (WebKit::WebExtension&)_webExtension
+{
+    return *_webExtension;
+}
+
+- (Ref<WebKit::WebExtension>)_protectedWebExtension
 {
     return *_webExtension;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -65,90 +65,90 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 
 - (WKWebExtensionContext *)webExtensionContext
 {
-    if (auto *context = _webExtensionAction->extensionContext())
+    if (auto *context = self._protectedWebExtensionAction->extensionContext())
         return context->wrapper();
     return nil;
 }
 
 - (id<WKWebExtensionTab>)associatedTab
 {
-    if (RefPtr tab = _webExtensionAction->tab())
+    if (RefPtr tab = self._protectedWebExtensionAction->tab())
         return tab->delegate();
     return nil;
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return _webExtensionAction->icon(size);
+    return self._protectedWebExtensionAction->icon(size);
 }
 
 - (NSString *)label
 {
-    return _webExtensionAction->label();
+    return self._protectedWebExtensionAction->label();
 }
 
 - (NSString *)badgeText
 {
-    return _webExtensionAction->badgeText();
+    return self._protectedWebExtensionAction->badgeText();
 }
 
 - (BOOL)hasUnreadBadgeText
 {
-    return _webExtensionAction->hasUnreadBadgeText();
+    return self._protectedWebExtensionAction->hasUnreadBadgeText();
 }
 
 - (void)setHasUnreadBadgeText:(BOOL)hasUnreadBadgeText
 {
-    return _webExtensionAction->setHasUnreadBadgeText(hasUnreadBadgeText);
+    return self._protectedWebExtensionAction->setHasUnreadBadgeText(hasUnreadBadgeText);
 }
 
 - (NSString *)inspectionName
 {
-    return _webExtensionAction->popupWebViewInspectionName();
+    return self._protectedWebExtensionAction->popupWebViewInspectionName();
 }
 
 - (void)setInspectionName:(NSString *)name
 {
-    _webExtensionAction->setPopupWebViewInspectionName(name);
+    self._protectedWebExtensionAction->setPopupWebViewInspectionName(name);
 }
 
 - (BOOL)isEnabled
 {
-    return _webExtensionAction->isEnabled();
+    return self._protectedWebExtensionAction->isEnabled();
 }
 
 - (NSArray<CocoaMenuItem *> *)menuItems
 {
-    return _webExtensionAction->platformMenuItems();
+    return self._protectedWebExtensionAction->platformMenuItems();
 }
 
 - (BOOL)presentsPopup
 {
-    return _webExtensionAction->presentsPopup();
+    return self._protectedWebExtensionAction->presentsPopup();
 }
 
 #if PLATFORM(IOS_FAMILY)
 - (UIViewController *)popupViewController
 {
-    return _webExtensionAction->popupViewController();
+    return self._protectedWebExtensionAction->popupViewController();
 }
 #endif
 
 #if PLATFORM(MAC)
 - (NSPopover *)popupPopover
 {
-    return _webExtensionAction->popupPopover();
+    return self._protectedWebExtensionAction->popupPopover();
 }
 #endif
 
 - (WKWebView *)popupWebView
 {
-    return _webExtensionAction->popupWebView();
+    return self._protectedWebExtensionAction->popupWebView();
 }
 
 - (void)closePopup
 {
-    _webExtensionAction->closePopup();
+    self._protectedWebExtensionAction->closePopup();
 }
 
 #pragma mark WKObject protocol implementation
@@ -159,6 +159,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 }
 
 - (WebKit::WebExtensionAction&)_webExtensionAction
+{
+    return *_webExtensionAction;
+}
+
+- (Ref<WebKit::WebExtensionAction>)_protectedWebExtensionAction
 {
     return *_webExtensionAction;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionActionInternal.h
@@ -43,6 +43,8 @@ template<> struct WrapperTraits<WebExtensionAction> {
 
 @property (nonatomic, readonly) WebKit::WebExtensionAction& _webExtensionAction;
 
+- (Ref<WebKit::WebExtensionAction>)_protectedWebExtensionAction;
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -71,12 +71,13 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (NSString *)debugDescription
 {
-    return [NSString stringWithFormat:@"<%@: %p; identifier = %@; shortcut = %@>", NSStringFromClass(self.class), self, self.identifier, self.activationKey.length ? (NSString *)self._webExtensionCommand.shortcutString() : @"(none)"];
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@; shortcut = %@>", NSStringFromClass(self.class), self,
+        self.identifier, self.activationKey.length ? (NSString *)self._protectedWebExtensionCommand->shortcutString() : @"(none)"];
 }
 
 - (WKWebExtensionContext *)webExtensionContext
 {
-    if (auto *context = _webExtensionCommand->extensionContext())
+    if (auto *context = self._protectedWebExtensionCommand->extensionContext())
         return context->wrapper();
     return nil;
 }
@@ -100,13 +101,13 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (void)setActivationKey:(NSString *)activationKey
 {
-    bool result = _webExtensionCommand->setActivationKey(activationKey);
+    bool result = self._protectedWebExtensionCommand->setActivationKey(activationKey);
     NSAssert(result, @"Invalid parameter: an unsupported character was provided");
 }
 
 - (CocoaModifierFlags)modifierFlags
 {
-    return _webExtensionCommand->modifierFlags().toRaw();
+    return self._protectedWebExtensionCommand->modifierFlags().toRaw();
 }
 
 - (void)setModifierFlags:(CocoaModifierFlags)modifierFlags
@@ -114,12 +115,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
     auto optionSet = OptionSet<WebKit::WebExtension::ModifierFlags>::fromRaw(modifierFlags) & WebKit::WebExtension::allModifierFlags();
     NSAssert(optionSet.toRaw() == modifierFlags, @"Invalid parameter: an unsupported modifier flag was provided");
 
-    _webExtensionCommand->setModifierFlags(optionSet);
+    self._protectedWebExtensionCommand->setModifierFlags(optionSet);
 }
 
 - (CocoaMenuItem *)menuItem
 {
-    return _webExtensionCommand->platformMenuItem();
+    return self._protectedWebExtensionCommand->platformMenuItem();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -131,12 +132,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (NSString *)_shortcut
 {
-    return _webExtensionCommand->shortcutString();
+    return self._protectedWebExtensionCommand->shortcutString();
 }
 
 - (NSString *)_userVisibleShortcut
 {
-    return _webExtensionCommand->userVisibleShortcut();
+    return self._protectedWebExtensionCommand->userVisibleShortcut();
 }
 
 #if USE(APPKIT)
@@ -144,7 +145,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 {
     NSParameterAssert([event isKindOfClass:NSEvent.class]);
 
-    return _webExtensionCommand->matchesEvent(event);
+    return self._protectedWebExtensionCommand->matchesEvent(event);
 }
 #endif
 
@@ -156,6 +157,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 }
 
 - (WebKit::WebExtensionCommand&)_webExtensionCommand
+{
+    return *_webExtensionCommand;
+}
+
+- (Ref<WebKit::WebExtensionCommand>)_protectedWebExtensionCommand
 {
     return *_webExtensionCommand;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandInternal.h
@@ -42,6 +42,7 @@ template<> struct WrapperTraits<WebExtensionCommand> {
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionCommand& _webExtensionCommand;
+- (Ref<WebKit::WebExtensionCommand>)_protectedWebExtensionCommand;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -88,14 +88,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<WebKit::WebExtensionContext>(self, extension._webExtension);
+    API::Object::constructInWrapper<WebKit::WebExtensionContext>(self, extension._protectedWebExtension.get());
 
     return self;
 }
 
 - (WKWebExtension *)webExtension
 {
-    return wrapper(&_webExtensionContext->extension());
+    return wrapper(_webExtensionContext->protectedExtension().get());
 }
 
 - (WKWebExtensionController *)webExtensionController
@@ -498,7 +498,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
     if (tab)
         NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
 
-    return toAPI(_webExtensionContext->permissionState(pattern._webExtensionMatchPattern, toImplNullable(tab, *_webExtensionContext).get()));
+    return toAPI(_webExtensionContext->permissionState(pattern._protectedWebExtensionMatchPattern, toImplNullable(tab, *_webExtensionContext).get()));
 }
 
 - (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forMatchPattern:(WKWebExtensionMatchPattern *)pattern
@@ -514,7 +514,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([pattern isKindOfClass:WKWebExtensionMatchPattern.class]);
 
-    _webExtensionContext->setPermissionState(toImpl(status), pattern._webExtensionMatchPattern, toImpl(expirationDate));
+    _webExtensionContext->setPermissionState(toImpl(status), pattern._protectedWebExtensionMatchPattern, toImpl(expirationDate));
 }
 
 - (BOOL)hasAccessToAllURLs
@@ -576,7 +576,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 {
     NSParameterAssert([command isKindOfClass:WKWebExtensionCommand.class]);
 
-    _webExtensionContext->performCommand(command._webExtensionCommand, WebKit::WebExtensionContext::UserTriggered::Yes);
+    _webExtensionContext->performCommand([command _protectedWebExtensionCommand].get(), WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
@@ -65,14 +65,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionCont
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<WebKit::WebExtensionController>(self, configuration._webExtensionControllerConfiguration.copy());
+    API::Object::constructInWrapper<WebKit::WebExtensionController>(self, configuration._protectedWebExtensionControllerConfiguration->copy());
 
     return self;
 }
 
 - (WKWebExtensionControllerConfiguration *)configuration
 {
-    return _webExtensionController->configuration().copy()->wrapper();
+    return _webExtensionController->protectedConfiguration()->copy()->wrapper();
 }
 
 - (BOOL)loadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)outError
@@ -93,7 +93,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionCont
 {
     NSParameterAssert([extension isKindOfClass:WKWebExtension.class]);
 
-    if (auto extensionContext = _webExtensionController->extensionContext(extension._webExtension))
+    if (auto extensionContext = _webExtensionController->extensionContext(extension._protectedWebExtension))
         return extensionContext->wrapper();
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
@@ -137,7 +137,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return _webExtensionControllerConfiguration->copy()->wrapper();
+    return self._protectedWebExtensionControllerConfiguration->copy()->wrapper();
 }
 
 - (BOOL)isEqual:(id)object
@@ -159,7 +159,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 
 - (NSUUID *)identifier
 {
-    if (auto identifier = _webExtensionControllerConfiguration->identifier())
+    if (auto identifier = self._protectedWebExtensionControllerConfiguration->identifier())
         return identifier.value();
     return nil;
 }
@@ -171,22 +171,23 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 
 - (WKWebViewConfiguration *)webViewConfiguration
 {
-    return _webExtensionControllerConfiguration->webViewConfiguration();
+    return self._protectedWebExtensionControllerConfiguration->webViewConfiguration();
 }
 
 - (void)setWebViewConfiguration:(WKWebViewConfiguration *)configuration
 {
-    _webExtensionControllerConfiguration->setWebViewConfiguration(configuration);
+    self._protectedWebExtensionControllerConfiguration->setWebViewConfiguration(configuration);
 }
 
 - (WKWebsiteDataStore *)defaultWebsiteDataStore
 {
-    return wrapper(_webExtensionControllerConfiguration->defaultWebsiteDataStore());
+    return wrapper(self._protectedWebExtensionControllerConfiguration->defaultWebsiteDataStore());
 }
 
 - (void)setDefaultWebsiteDataStore:(WKWebsiteDataStore *)dataStore
 {
-    _webExtensionControllerConfiguration->setDefaultWebsiteDataStore(dataStore ? dataStore->_websiteDataStore.get() : nullptr);
+    RefPtr websiteDataStore = dataStore ? dataStore->_websiteDataStore.get() : nullptr;
+    self._protectedWebExtensionControllerConfiguration->setDefaultWebsiteDataStore(websiteDataStore.get());
 }
 
 - (BOOL)_isTemporary
@@ -214,6 +215,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 }
 
 - (WebKit::WebExtensionControllerConfiguration&)_webExtensionControllerConfiguration
+{
+    return *_webExtensionControllerConfiguration;
+}
+
+- (Ref<WebKit::WebExtensionControllerConfiguration>)_protectedWebExtensionControllerConfiguration
 {
     return *_webExtensionControllerConfiguration;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationInternal.h
@@ -43,6 +43,8 @@ template<> struct WrapperTraits<WebExtensionControllerConfiguration> {
 
 @property (nonatomic, readonly) WebKit::WebExtensionControllerConfiguration& _webExtensionControllerConfiguration;
 
+- (Ref<WebKit::WebExtensionControllerConfiguration>)_protectedWebExtensionControllerConfiguration;
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
@@ -64,22 +64,22 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionDataRecord, WebExtensionData
 
 - (NSSet<WKWebExtensionDataType> *)containedDataTypes
 {
-    return toAPI(_webExtensionDataRecord->types());
+    return toAPI(self._protectedWebExtensionDataRecord->types());
 }
 
 - (NSUInteger)totalSizeInBytes
 {
-    return _webExtensionDataRecord->totalSize();
+    return self._protectedWebExtensionDataRecord->totalSize();
 }
 
 - (NSUInteger)sizeInBytesOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes
 {
-    return _webExtensionDataRecord->sizeOfTypes(WebKit::toWebExtensionDataTypes(dataTypes));
+    return self._protectedWebExtensionDataRecord->sizeOfTypes(WebKit::toWebExtensionDataTypes(dataTypes));
 }
 
 - (NSArray<NSError *> *)errors
 {
-    return _webExtensionDataRecord->errors();
+    return self._protectedWebExtensionDataRecord->errors();
 }
 
 #pragma mark WKObject protocol implementation
@@ -90,6 +90,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionDataRecord, WebExtensionData
 }
 
 - (WebKit::WebExtensionDataRecord&)_webExtensionDataRecord
+{
+    return *_webExtensionDataRecord;
+}
+
+- (Ref<WebKit::WebExtensionDataRecord>)_protectedWebExtensionDataRecord
 {
     return *_webExtensionDataRecord;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionInternal.h
@@ -43,6 +43,8 @@ template<> struct WrapperTraits<WebExtension> {
 
 @property (nonatomic, readonly) WebKit::WebExtension& _webExtension;
 
+-(Ref<WebKit::WebExtension>)_protectedWebExtension;
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
@@ -171,28 +171,31 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
 
 - (NSString *)scheme
 {
-    if (_webExtensionMatchPattern->scheme().isNull())
+    Ref pattern = *_webExtensionMatchPattern;
+    if (pattern->scheme().isNull())
         return nil;
-    return _webExtensionMatchPattern->scheme();
+    return pattern->scheme();
 }
 
 - (NSString *)host
 {
-    if (_webExtensionMatchPattern->host().isNull())
+    Ref pattern = *_webExtensionMatchPattern;
+    if (pattern->host().isNull())
         return nil;
-    return _webExtensionMatchPattern->host();
+    return pattern->host();
 }
 
 - (NSString *)path
 {
-    if (_webExtensionMatchPattern->path().isNull())
+    Ref pattern = *_webExtensionMatchPattern;
+    if (pattern->path().isNull())
         return nil;
-    return _webExtensionMatchPattern->path();
+    return pattern->path();
 }
 
 - (NSString *)string
 {
-    return _webExtensionMatchPattern->string();
+    return self._protectedWebExtensionMatchPattern->string();
 }
 
 - (BOOL)matchesAllURLs
@@ -202,7 +205,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
 
 - (BOOL)matchesAllHosts
 {
-    return _webExtensionMatchPattern->matchesAllHosts();
+    return self._protectedWebExtensionMatchPattern->matchesAllHosts();
 }
 
 - (BOOL)matchesURL:(NSURL *)urlToMatch
@@ -235,7 +238,7 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(WKWebExtensio
 
     NSParameterAssert([urlToMatch isKindOfClass:NSURL.class]);
 
-    return _webExtensionMatchPattern->matchesURL(urlToMatch, toImpl(options));
+    return self._protectedWebExtensionMatchPattern->matchesURL(urlToMatch, toImpl(options));
 }
 
 - (BOOL)matchesPattern:(WKWebExtensionMatchPattern *)patternToMatch
@@ -250,7 +253,7 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(WKWebExtensio
 
     NSParameterAssert([patternToMatch isKindOfClass:WKWebExtensionMatchPattern.class]);
 
-    return _webExtensionMatchPattern->matchesPattern(patternToMatch._webExtensionMatchPattern, toImpl(options));
+    return self._protectedWebExtensionMatchPattern->matchesPattern([patternToMatch _protectedWebExtensionMatchPattern], toImpl(options));
 }
 
 #pragma mark WKObject protocol implementation
@@ -261,6 +264,11 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(WKWebExtensio
 }
 
 - (WebKit::WebExtensionMatchPattern&)_webExtensionMatchPattern
+{
+    return *_webExtensionMatchPattern;
+}
+
+- (Ref<WebKit::WebExtensionMatchPattern>)_protectedWebExtensionMatchPattern
 {
     return *_webExtensionMatchPattern;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternInternal.h
@@ -43,6 +43,8 @@ template<> struct WrapperTraits<WebExtensionMatchPattern> {
 
 @property (nonatomic, readonly) WebKit::WebExtensionMatchPattern& _webExtensionMatchPattern;
 
+- (Ref<WebKit::WebExtensionMatchPattern>)_protectedWebExtensionMatchPattern;
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
@@ -63,7 +63,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
 
 - (BOOL)isDisconnected
 {
-    return _webExtensionMessagePort->isDisconnected();
+    return self._protectedWebExtensionMessagePort->isDisconnected();
 }
 
 - (void)sendMessage:(id)message completionHandler:(void (^)(NSError *))completionHandler
@@ -71,7 +71,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
     if (!completionHandler)
         completionHandler = ^(NSError *) { };
 
-    _webExtensionMessagePort->sendMessage(message, [completionHandler = makeBlockPtr(completionHandler)](WebKit::WebExtensionMessagePort::Error error) {
+    self._protectedWebExtensionMessagePort->sendMessage(message, [completionHandler = makeBlockPtr(completionHandler)](WebKit::WebExtensionMessagePort::Error error) {
         if (error) {
             completionHandler(toAPI(error.value()));
             return;
@@ -88,7 +88,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
 
 - (void)disconnectWithError:(NSError *)error
 {
-    _webExtensionMessagePort->disconnect(WebKit::toWebExtensionMessagePortError(error));
+    self._protectedWebExtensionMessagePort->disconnect(WebKit::toWebExtensionMessagePortError(error));
 }
 
 #pragma mark WKObject protocol implementation
@@ -99,6 +99,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
 }
 
 - (WebKit::WebExtensionMessagePort&)_webExtensionMessagePort
+{
+    return *_webExtensionMessagePort;
+}
+
+- (Ref<WebKit::WebExtensionMessagePort>)_protectedWebExtensionMessagePort
 {
     return *_webExtensionMessagePort;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
@@ -42,7 +42,7 @@
 
 - (NSData *)data
 {
-    if (auto messageData = _message->data())
+    if (auto messageData = self._protectedMessage->data())
         return toNSData(*messageData).get();
 
     return nil;
@@ -59,6 +59,11 @@
 }
 
 - (API::Object&)_apiObject
+{
+    return *_message;
+}
+
+- (Ref<API::WebPushMessage>)_protectedMessage
 {
     return *_message;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
@@ -39,25 +39,30 @@
 
 - (NSURL *)endpoint
 {
-    return _data->endpoint();
+    return self._protectedData->endpoint();
 }
 
 - (NSData *)applicationServerKey
 {
-    return toNSData(_data->applicationServerKey()).get();
+    return toNSData(self._protectedData->applicationServerKey()).get();
 }
 
 - (NSData *)authenticationSecret
 {
-    return toNSData(_data->sharedAuthenticationSecret()).get();
+    return toNSData(self._protectedData->sharedAuthenticationSecret()).get();
 }
 
 - (NSData *)ecdhPublicKey
 {
-    return toNSData(_data->clientECDHPublicKey()).get();
+    return toNSData(self._protectedData->clientECDHPublicKey()).get();
 }
 
 - (API::Object&)_apiObject
+{
+    return *_data;
+}
+
+- (Ref<API::WebPushSubscriptionData>)_protectedData
 {
     return *_data;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -292,6 +292,7 @@ public:
     bool isLoaded() const { return !!m_extensionController; }
 
     WebExtension& extension() const { return *m_extension; }
+    Ref<WebExtension> protectedExtension() const { return extension(); }
     WebExtensionController* extensionController() const { return m_extensionController.get(); }
 
     const URL& baseURL() const { return m_baseURL; }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -104,6 +104,7 @@ public:
     enum class ForPrivateBrowsing { No, Yes };
 
     WebExtensionControllerConfiguration& configuration() const { return m_configuration.get(); }
+    Ref<WebExtensionControllerConfiguration> protectedConfiguration() const { return m_configuration; }
     WebExtensionControllerParameters parameters() const;
 
     bool operator==(const WebExtensionController& other) const { return (this == &other); }


### PR DESCRIPTION
#### b6e85c7bf092e2b0315d9d9e4952cd5de33033e1
<pre>
Deploy more smart pointers in Source/WebKit/UIProcess/API
<a href="https://bugs.webkit.org/show_bug.cgi?id=279388">https://bugs.webkit.org/show_bug.cgi?id=279388</a>

Reviewed by Timothy Hatcher.

Deployed more smart pointers in Source/WebKit/UIProcess/API as warned by the clang static analyzer.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension manifest]):
(-[WKWebExtension manifestVersion]):
(-[WKWebExtension supportsManifestVersion:]):
(-[WKWebExtension defaultLocale]):
(-[WKWebExtension displayName]):
(-[WKWebExtension displayShortName]):
(-[WKWebExtension displayVersion]):
(-[WKWebExtension displayDescription]):
(-[WKWebExtension displayActionLabel]):
(-[WKWebExtension version]):
(-[WKWebExtension iconForSize:]):
(-[WKWebExtension actionIconForSize:]):
(-[WKWebExtension requestedPermissions]):
(-[WKWebExtension optionalPermissions]):
(-[WKWebExtension requestedPermissionMatchPatterns]):
(-[WKWebExtension optionalPermissionMatchPatterns]):
(-[WKWebExtension allRequestedMatchPatterns]):
(-[WKWebExtension errors]):
(-[WKWebExtension hasBackgroundContent]):
(-[WKWebExtension hasPersistentBackgroundContent]):
(-[WKWebExtension hasInjectedContent]):
(-[WKWebExtension hasOptionsPage]):
(-[WKWebExtension hasOverrideNewTabPage]):
(-[WKWebExtension hasCommands]):
(-[WKWebExtension hasContentModificationRules]):
(-[WKWebExtension _hasServiceWorkerBackgroundContent]):
(-[WKWebExtension _hasModularBackgroundContent]):
(-[WKWebExtension _protectedWebExtension]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm:
(-[WKWebExtensionAction webExtensionContext]):
(-[WKWebExtensionAction associatedTab]):
(-[WKWebExtensionAction iconForSize:]):
(-[WKWebExtensionAction label]):
(-[WKWebExtensionAction badgeText]):
(-[WKWebExtensionAction hasUnreadBadgeText]):
(-[WKWebExtensionAction setHasUnreadBadgeText:]):
(-[WKWebExtensionAction inspectionName]):
(-[WKWebExtensionAction setInspectionName:]):
(-[WKWebExtensionAction isEnabled]):
(-[WKWebExtensionAction menuItems]):
(-[WKWebExtensionAction presentsPopup]):
(-[WKWebExtensionAction popupViewController]):
(-[WKWebExtensionAction popupPopover]):
(-[WKWebExtensionAction popupWebView]):
(-[WKWebExtensionAction closePopup]):
(-[WKWebExtensionAction _protectedWebExtensionAction]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionActionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand debugDescription]):
(-[WKWebExtensionCommand webExtensionContext]):
(-[WKWebExtensionCommand setActivationKey:]):
(-[WKWebExtensionCommand modifierFlags]):
(-[WKWebExtensionCommand setModifierFlags:]):
(-[WKWebExtensionCommand menuItem]):
(-[WKWebExtensionCommand _shortcut]):
(-[WKWebExtensionCommand _userVisibleShortcut]):
(-[WKWebExtensionCommand _matchesEvent:]):
(-[WKWebExtensionCommand _protectedWebExtensionCommand]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext initForExtension:]):
(-[WKWebExtensionContext webExtension]):
(-[WKWebExtensionContext permissionStatusForMatchPattern:inTab:]):
(-[WKWebExtensionContext setPermissionStatus:forMatchPattern:expirationDate:]):
(-[WKWebExtensionContext performCommand:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm:
(-[WKWebExtensionController initWithConfiguration:]):
(-[WKWebExtensionController configuration]):
(-[WKWebExtensionController extensionContextForExtension:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm:
(-[WKWebExtensionControllerConfiguration copyWithZone:]):
(-[WKWebExtensionControllerConfiguration identifier]):
(-[WKWebExtensionControllerConfiguration webViewConfiguration]):
(-[WKWebExtensionControllerConfiguration setWebViewConfiguration:]):
(-[WKWebExtensionControllerConfiguration defaultWebsiteDataStore]):
(-[WKWebExtensionControllerConfiguration setDefaultWebsiteDataStore:]):
(-[WKWebExtensionControllerConfiguration _protectedWebExtensionControllerConfiguration]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm:
(-[WKWebExtensionDataRecord containedDataTypes]):
(-[WKWebExtensionDataRecord totalSizeInBytes]):
(-[WKWebExtensionDataRecord sizeInBytesOfTypes:]):
(-[WKWebExtensionDataRecord errors]):
(-[WKWebExtensionDataRecord _protectedWebExtensionDataRecord]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm:
(-[WKWebExtensionMatchPattern scheme]):
(-[WKWebExtensionMatchPattern host]):
(-[WKWebExtensionMatchPattern path]):
(-[WKWebExtensionMatchPattern string]):
(-[WKWebExtensionMatchPattern matchesAllHosts]):
(-[WKWebExtensionMatchPattern matchesURL:options:]):
(-[WKWebExtensionMatchPattern matchesPattern:options:]):
(-[WKWebExtensionMatchPattern _protectedWebExtensionMatchPattern]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm:
(-[WKWebExtensionMessagePort isDisconnected]):
(-[WKWebExtensionMessagePort sendMessage:completionHandler:]):
(-[WKWebExtensionMessagePort disconnectWithError:]):
(-[WKWebExtensionMessagePort _protectedWebExtensionMessagePort]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnection getPushPermissionStateForOrigin:completionHandler:]):
(-[_WKWebPushDaemonConnection requestPushPermissionForOrigin:completionHandler:]):
(-[_WKWebPushDaemonConnection setAppBadge:origin:]):
(-[_WKWebPushDaemonConnection subscribeToPushServiceForScope:applicationServerKey:completionHandler:]):
(-[_WKWebPushDaemonConnection unsubscribeFromPushServiceForScope:completionHandler:]):
(-[_WKWebPushDaemonConnection getSubscriptionForScope:completionHandler:]):
(-[_WKWebPushDaemonConnection getNextPendingPushMessage:]):
(-[_WKWebPushDaemonConnection _protectedConnection]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm:
(-[_WKWebPushMessage data]):
(-[_WKWebPushMessage _protectedMessage]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm:
(-[_WKWebPushSubscriptionData endpoint]):
(-[_WKWebPushSubscriptionData applicationServerKey]):
(-[_WKWebPushSubscriptionData authenticationSecret]):
(-[_WKWebPushSubscriptionData ecdhPublicKey]):
(-[_WKWebPushSubscriptionData _protectedData]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::protectedExtension const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::protectedConfiguration const):

Canonical link: <a href="https://commits.webkit.org/283385@main">https://commits.webkit.org/283385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58e5695cb3be34a41402571de1c9b9612b62473e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16755 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17036 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33716 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38664 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15631 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59259 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60690 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1974 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10012 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->