### PR TITLE
Remove unused primitive value "Raw" consumers

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
@@ -24,23 +24,14 @@
 
 #include "config.h"
 #include "CSSPropertyParserConsumer+Integer.h"
+#include "CSSPropertyParserConsumer+IntegerDefinitions.h"
 
 #include "CSSCalcSymbolTable.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
-#include "CSSPropertyParserConsumer+IntegerDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
-#include "CSSPropertyParserConsumer+RawResolver.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
-
-template<typename IntType, IntegerValueRange integerRange>
-static std::optional<IntType> consumeIntegerTypeRaw(CSSParserTokenRange& range)
-{
-    if (auto result = RawResolver<IntegerRaw<IntType, integerRange>>::consumeAndResolve(range, { }, { }, { }))
-        return result->value;
-    return std::nullopt;
-}
 
 template<typename IntType, IntegerValueRange integerRange>
 static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range)
@@ -48,29 +39,14 @@ static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range)
     return CSSPrimitiveValueResolver<IntegerRaw<IntType, integerRange>>::consumeAndResolve(range, { }, { }, { });
 }
 
-std::optional<int> consumeIntegerRaw(CSSParserTokenRange& range)
-{
-    return consumeIntegerTypeRaw<int, IntegerValueRange::All>(range);
-}
-
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange& range)
 {
     return consumeIntegerType<int, IntegerValueRange::All>(range);
 }
 
-std::optional<int> consumeNonNegativeIntegerRaw(CSSParserTokenRange& range)
-{
-    return consumeIntegerTypeRaw<int, IntegerValueRange::NonNegative>(range);
-}
-
 RefPtr<CSSPrimitiveValue> consumeNonNegativeInteger(CSSParserTokenRange& range)
 {
     return consumeIntegerType<int, IntegerValueRange::NonNegative>(range);
-}
-
-std::optional<unsigned> consumePositiveIntegerRaw(CSSParserTokenRange& range)
-{
-    return consumeIntegerTypeRaw<unsigned, IntegerValueRange::Positive>(range);
 }
 
 RefPtr<CSSPrimitiveValue> consumePositiveInteger(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.h
@@ -36,11 +36,8 @@ namespace CSSPropertyParserHelpers {
 
 enum class IntegerValueRange : uint8_t;
 
-std::optional<int> consumeIntegerRaw(CSSParserTokenRange&);
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange&);
-std::optional<int> consumeNonNegativeIntegerRaw(CSSParserTokenRange&);
 RefPtr<CSSPrimitiveValue> consumeNonNegativeInteger(CSSParserTokenRange&);
-std::optional<unsigned> consumePositiveIntegerRaw(CSSParserTokenRange&);
 RefPtr<CSSPrimitiveValue> consumePositiveInteger(CSSParserTokenRange&);
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange&, IntegerValueRange);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp
@@ -33,7 +33,6 @@
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
-#include "CSSPropertyParserConsumer+RawResolver.h"
 #include "CalculationCategory.h"
 
 namespace WebCore {
@@ -74,14 +73,6 @@ std::optional<PercentRaw> PercentKnownTokenTypePercentConsumer::consume(CSSParse
 }
 
 // MARK: - Consumer functions
-
-std::optional<PercentRaw> consumePercentRaw(CSSParserTokenRange& range, ValueRange valueRange)
-{
-    const auto options = CSSPropertyParserOptions {
-        .valueRange = valueRange
-    };
-    return RawResolver<PercentRaw>::consumeAndResolve(range, { }, { }, options);
-}
 
 RefPtr<CSSPrimitiveValue> consumePercent(CSSParserTokenRange& range, ValueRange valueRange)
 {
@@ -130,14 +121,6 @@ RefPtr<CSSPrimitiveValue> consumePercentDividedBy100OrNumber(CSSParserTokenRange
     }
 
     return nullptr;
-}
-
-std::optional<PercentOrNumberRaw> consumePercentOrNumberRaw(CSSParserTokenRange& range, ValueRange valueRange)
-{
-    const auto options = CSSPropertyParserOptions {
-        .valueRange = valueRange
-    };
-    return RawResolver<PercentRaw, NumberRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h
@@ -39,11 +39,9 @@ namespace CSSPropertyParserHelpers {
 // MARK: - Consumer functions
 
 // MARK: - Percent
-std::optional<PercentRaw> consumePercentRaw(CSSParserTokenRange&, ValueRange = ValueRange::All);
 RefPtr<CSSPrimitiveValue> consumePercent(CSSParserTokenRange&, ValueRange = ValueRange::All);
 
 // MARK: - Percent or Number
-std::optional<PercentOrNumberRaw> consumePercentOrNumberRaw(CSSParserTokenRange&, ValueRange = ValueRange::All);
 RefPtr<CSSPrimitiveValue> consumePercentOrNumber(CSSParserTokenRange&, ValueRange = ValueRange::All);
 
 // FIXME: Users of this function are likely getting incorrect results when used with calc() producing a percent, as it is not getting divided by 100.


### PR DESCRIPTION
#### c9f8bbd20eca674413b0c75208135863ef638954
<pre>
Remove unused primitive value &quot;Raw&quot; consumers
<a href="https://bugs.webkit.org/show_bug.cgi?id=279393">https://bugs.webkit.org/show_bug.cgi?id=279393</a>

Reviewed by Tim Nguyen.

Removes a few unused &quot;Raw&quot; consumer functions.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h:

Canonical link: <a href="https://commits.webkit.org/283380@main">https://commits.webkit.org/283380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dbc22de2c91a2adee71f8f8d18492effdf2c40e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16736 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11648 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15612 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10081 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14580 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8324 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->