### PR TITLE
Remaining text still visible when animation is running.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -54,7 +54,7 @@ struct TextAnimationRange {
     WebCore::CharacterRange range;
 };
 
-struct TextAnimationUnstyledRangeData {
+struct TextAnimationUnanimatedRangeData {
     WTF::UUID animationUUID;
     WebCore::SimpleRange range;
 };
@@ -100,7 +100,7 @@ private:
     WeakPtr<WebPage> m_webPage;
 
     std::optional<WTF::UUID> m_initialAnimationID;
-    std::optional<TextAnimationUnstyledRangeData> m_unstyledRange;
+    std::optional<TextAnimationUnanimatedRangeData> m_unanimatedRangeData;
     std::optional<ReplacedRangeAndString> m_alreadyReplacedRange;
     RefPtr<WebCore::Range> m_manuallyEnabledAnimationRange;
     Vector<TextAnimationRange> m_textAnimationRanges;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -132,8 +132,8 @@ std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForText
         }
     }
 
-    if (m_unstyledRange && m_unstyledRange->animationUUID == animationUUID)
-        return m_unstyledRange->range;
+    if (m_unanimatedRangeData && m_unanimatedRangeData->animationUUID == animationUUID)
+        return m_unanimatedRangeData->range;
 
     return std::nullopt;
 }
@@ -151,7 +151,7 @@ void TextAnimationController::removeTransparentMarkersForActiveWritingToolsSessi
     for (auto textAnimationRange : textAnimationRanges)
         removeTransparentMarkersForTextAnimationID(textAnimationRange.animationUUID);
 
-    if (auto rangeData = m_unstyledRange)
+    if (auto rangeData = m_unanimatedRangeData)
         removeTransparentMarkersForTextAnimationID(rangeData->animationUUID);
 }
 
@@ -272,12 +272,18 @@ void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSe
 
     auto replacedRangeAfterReplace = WebCore::resolveCharacterRange(*sessionRange, replacedCharacterRange, defaultTextAnimationControllerTextIteratorBehaviors);
 
-    auto unstyledRange = *sessionRange;
-    unstyledRange.start.container = replacedRangeAfterReplace.endContainer();
-    unstyledRange.start.offset = replacedRangeAfterReplace.endOffset();
+    auto endPosition = makeContainerOffsetPosition(sessionRange->start);
+    auto endBoundaryPoint = makeBoundaryPoint(endOfEditableContent(endPosition));
 
-    auto unstyledRangeUUID = WTF::UUID::createVersion4();
-    m_unstyledRange = { unstyledRangeUUID, unstyledRange };
+    WTF::UUID unanimatedRangeUUID { WTF::UUID::emptyValue };
+    if (endBoundaryPoint) {
+        auto unanimatedRange = makeSimpleRangeHelper(replacedRangeAfterReplace.end, *endBoundaryPoint);
+
+        if (unanimatedRange) {
+            unanimatedRangeUUID = WTF::UUID::createVersion4();
+            m_unanimatedRangeData = { unanimatedRangeUUID, *unanimatedRange };
+        }
+    }
 
     auto textIndicatorData = createTextIndicatorForRange(replacedRangeAfterReplace);
 
@@ -286,7 +292,7 @@ void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSe
         return;
     }
 
-    m_webPage->addTextAnimationForAnimationID(destinationAnimationUUID, { WebCore::TextAnimationType::Final, WebCore::TextAnimationRunMode::RunAnimation, unstyledRangeUUID, sourceAnimationUUID }, *textIndicatorData, [weakWebPage = WeakPtr { *m_webPage }](WebCore::TextAnimationRunMode runMode) mutable {
+    m_webPage->addTextAnimationForAnimationID(destinationAnimationUUID, { WebCore::TextAnimationType::Final, WebCore::TextAnimationRunMode::RunAnimation, unanimatedRangeUUID, sourceAnimationUUID }, *textIndicatorData, [weakWebPage = WeakPtr { *m_webPage }](WebCore::TextAnimationRunMode runMode) mutable {
         if (runMode == WebCore::TextAnimationRunMode::DoNotRun)
             return;
 
@@ -331,7 +337,6 @@ void TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID(c
                 completionHandler();
             return;
         }
-
         document->markers().addTransparentContentMarker(*animationRange, uuid);
     }
 
@@ -395,7 +400,7 @@ void TextAnimationController::clearAnimationsForActiveWritingToolsSession()
         m_webPage->removeTextAnimationForAnimationID(textAnimationRange.animationUUID);
 
     m_alreadyReplacedRange = std::nullopt;
-    m_unstyledRange = std::nullopt;
+    m_unanimatedRangeData = std::nullopt;
 }
 
 // FIXME: This shouldn't be called anymore, make sure that that is true, and remove.


### PR DESCRIPTION
#### 3aeaf8d06ed9516e282c3cefe9eb4c38aeb1a86d
<pre>
Remaining text still visible when animation is running.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279389">https://bugs.webkit.org/show_bug.cgi?id=279389</a>
<a href="https://rdar.apple.com/135603636">rdar://135603636</a>

Reviewed by Aditya Keerthi.

The range to turn off visibility was not set properly.
Also took the opportunity to give this a more descriptive name.

* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::contextRangeForTextAnimationID const):
(WebKit::TextAnimationController::removeTransparentMarkersForActiveWritingToolsSession):
(WebKit::TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::TextAnimationController::saveSnapshotOfTextPlaceholderForAnimation):
(WebKit::TextAnimationController::clearAnimationsForActiveWritingToolsSession):

Canonical link: <a href="https://commits.webkit.org/283440@main">https://commits.webkit.org/283440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7257a679aa7323106954cbbb03a66466c987eb04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16738 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53067 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11651 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38645 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71862 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10083 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14381 "Found 1 new test failure: http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60383 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-scale.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-skew.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60676 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1960 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41309 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->