### PR TITLE
[Site Isolation] Cross-site iframes nested within same-site iframes cannot receive mouse events

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/iframe-within-srcdoc-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/iframe-within-srcdoc-expected.txt
@@ -1,0 +1,12 @@
+Verifies that an isolated iframe created within the srcdoc of another iframe can receive mouse events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS events[0] is 'mousemove'
+PASS events[1] is 'mousedown'
+PASS events[2] is 'mouseup'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/iframe-within-srcdoc.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/iframe-within-srcdoc.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that an isolated iframe created within the srcdoc of another iframe can receive mouse events.");
+jsTestIsAsync = true;
+
+var events = [];
+addEventListener("message", (event) => {
+    events.push(event.data);
+    if (event.data == "mouseup") {
+        shouldBe("events[0]", "'mousemove'");
+        shouldBe("events[1]", "'mousedown'");
+        shouldBe("events[2]", "'mouseup'");
+        finishJSTest();
+    }
+});
+
+async function runTest() {
+    await eventSender.asyncMouseMoveTo(100, 100);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
+}
+</script>
+<iframe onload="runTest()" srcdoc="<iframe src='http://localhost:8000/site-isolation/mouse-events/resources/message-top-mouse-event-type.html'></iframe>"></iframe>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/message-top-mouse-event-type.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/message-top-mouse-event-type.html
@@ -1,0 +1,7 @@
+<script>
+for (const event of ["mousemove", "mousedown", "mouseup"]) {
+    addEventListener(event, () => {
+        window.top.postMessage(event, "*");
+    });
+}
+</script>

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -480,9 +480,9 @@ private:
     
     bool mouseMovementExceedsThreshold(const FloatPoint&, int pointsThreshold) const;
 
-    bool passMousePressEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&);
-    bool passMouseMoveEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&, HitTestResult* = nullptr);
-    bool passMouseReleaseEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&);
+    HandleUserInputEventResult passMousePressEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&);
+    HandleUserInputEventResult passMouseMoveEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&, HitTestResult* = nullptr);
+    HandleUserInputEventResult passMouseReleaseEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&);
 
     bool passSubframeEventToSubframe(MouseEventWithHitTestResults&, LocalFrame&, HitTestResult* = nullptr);
 

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -552,7 +552,7 @@ void EventHandler::dispatchSyntheticMouseMove(const PlatformMouseEvent& platform
     mouseMoved(platformMouseEvent);
 }
 
-bool EventHandler::passMousePressEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
+HandleUserInputEventResult EventHandler::passMousePressEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
 {
     // WebKit1 code path.
     if (frameHasPlatformWidget(m_frame))
@@ -563,7 +563,7 @@ bool EventHandler::passMousePressEventToSubframe(MouseEventWithHitTestResults& m
     return true;
 }
 
-bool EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe, HitTestResult* hitTestResult)
+HandleUserInputEventResult EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe, HitTestResult* hitTestResult)
 {
     // WebKit1 code path.
     if (frameHasPlatformWidget(m_frame))
@@ -573,7 +573,7 @@ bool EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mo
     return true;
 }
 
-bool EventHandler::passMouseReleaseEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
+HandleUserInputEventResult EventHandler::passMouseReleaseEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
 {
     // WebKit1 code path.
     if (frameHasPlatformWidget(m_frame))

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -693,18 +693,19 @@ static bool frameHasPlatformWidget(const LocalFrame& frame)
     return false;
 }
 
-bool EventHandler::passMousePressEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
+HandleUserInputEventResult EventHandler::passMousePressEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
 {
     // WebKit1 code path.
     if (frameHasPlatformWidget(m_frame))
         return passSubframeEventToSubframe(mouseEventAndResult, subframe);
 
     // WebKit2 code path.
-    subframe.eventHandler().handleMousePressEvent(mouseEventAndResult.event());
+    if (auto remoteMouseEventData = subframe.eventHandler().handleMousePressEvent(mouseEventAndResult.event()).remoteUserInputEventData())
+        return *remoteMouseEventData;
     return true;
 }
 
-bool EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe, HitTestResult* hitTestResult)
+HandleUserInputEventResult EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe, HitTestResult* hitTestResult)
 {
     // WebKit1 code path.
     if (frameHasPlatformWidget(m_frame))
@@ -716,18 +717,20 @@ bool EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mo
         return false;
 #endif
 
-    subframe.eventHandler().handleMouseMoveEvent(mouseEventAndResult.event(), hitTestResult);
+    if (auto remoteMouseEventData = subframe.eventHandler().handleMouseMoveEvent(mouseEventAndResult.event(), hitTestResult).remoteUserInputEventData())
+        return *remoteMouseEventData;
     return true;
 }
 
-bool EventHandler::passMouseReleaseEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
+HandleUserInputEventResult EventHandler::passMouseReleaseEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe)
 {
     // WebKit1 code path.
     if (frameHasPlatformWidget(m_frame))
         return passSubframeEventToSubframe(mouseEventAndResult, subframe);
 
     // WebKit2 code path.
-    subframe.eventHandler().handleMouseReleaseEvent(mouseEventAndResult.event());
+    if (auto remoteMouseEventData = subframe.eventHandler().handleMouseReleaseEvent(mouseEventAndResult.event()).remoteUserInputEventData())
+        return *remoteMouseEventData;
     return true;
 }
 

--- a/Source/WebCore/page/win/EventHandlerWin.cpp
+++ b/Source/WebCore/page/win/EventHandlerWin.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-bool EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe, HitTestResult* hitTestResult)
+HandleUserInputEventResult EventHandler::passMouseMoveEventToSubframe(MouseEventWithHitTestResults& mouseEventAndResult, LocalFrame& subframe, HitTestResult* hitTestResult)
 {
 #if ENABLE(DRAG_SUPPORT)
     if (m_mouseDownMayStartDrag && !m_mouseDownWasInSubframe)


### PR DESCRIPTION
#### 1656a6f556cdfa06e6f2e159be2465b1a934f0ad
<pre>
[Site Isolation] Cross-site iframes nested within same-site iframes cannot receive mouse events
<a href="https://bugs.webkit.org/show_bug.cgi?id=279398">https://bugs.webkit.org/show_bug.cgi?id=279398</a>
<a href="https://rdar.apple.com/135438488">rdar://135438488</a>

Reviewed by Alex Christensen.

The `passMouseXEventToSubframe()` function is used to send mouse events to local iframes, but it may
later hit test an out-of-process iframe. In such cases, the function must return a
`HandleUserInputEventResult` so we can tell the UI process to forward the event.

* LayoutTests/http/tests/site-isolation/mouse-events/iframe-within-srcdoc-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/iframe-within-srcdoc.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/resources/message-top-mouse-event-type.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::passMousePressEventToSubframe):
(WebCore::EventHandler::passMouseReleaseEventToSubframe):
(WebCore::EventHandler::passMouseMoveEventToSubframe):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::passMousePressEventToSubframe):
(WebCore::EventHandler::passMouseMoveEventToSubframe):
(WebCore::EventHandler::passMouseReleaseEventToSubframe):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passMousePressEventToSubframe):
(WebCore::EventHandler::passMouseMoveEventToSubframe):
(WebCore::EventHandler::passMouseReleaseEventToSubframe):
* Source/WebCore/page/win/EventHandlerWin.cpp:
(WebCore::EventHandler::passMouseMoveEventToSubframe):

Canonical link: <a href="https://commits.webkit.org/283389@main">https://commits.webkit.org/283389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/505696db71d3a72aa0fb9400961ede280a56d133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53075 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14635 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71871 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10092 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60394 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60685 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1969 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41318 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->