### PR TITLE
Primitives (number, string, null, etc.) thrown from JS pass through catch_all in wasm

### DIFF
--- a/JSTests/wasm/stress/exception-thrown-from-js-to-wasm-catchall-primitive.js
+++ b/JSTests/wasm/stress/exception-thrown-from-js-to-wasm-catchall-primitive.js
@@ -1,0 +1,48 @@
+import Builder from '../Builder.js'
+import * as assert from '../assert.js'
+
+{
+    const b = new Builder();
+    b.Type().End()
+        .Import().Function("context", "callback", { params: [], ret: "void" }).End()
+        .Function().End()
+        .Exception().Signature({ params: []}).End()
+        .Export().Function("call")
+            .Exception("foo", 0)
+        .End()
+        .Code()
+            .Function("call", { params: [], ret: "i32" })
+            .Try("i32")
+                .Call(0)
+                .I32Const(1)
+            .CatchAll()
+                .I32Const(2)
+            .End()
+            .End()
+        .End()
+
+
+    const bin = b.WebAssembly().get();
+    const module = new WebAssembly.Module(bin);
+    const instance = new WebAssembly.Instance(module, { context: { callback }});
+
+    let index = 0;
+    const thrown = [
+        42,
+        true,
+        false,
+        Symbol(),
+        "Hello",
+        null,
+        undefined,
+        20n,
+    ];
+
+    function callback() {
+        throw thrown[index];
+    }
+
+    for (index = 0; index < thrown.length; ++index) {
+        assert.eq(instance.exports.call(), 2, "catch_alling an exported wasm tag thrown from JS should be possible");
+    }
+}

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -674,6 +674,8 @@ public:
                 m_wasmTag = &wasmException->tag();
             } else if (ErrorInstance* error = jsDynamicCast<ErrorInstance*>(thrownValue))
                 m_catchableFromWasm = error->isCatchableFromWasm();
+            else
+                m_catchableFromWasm = true;
         }
 #else
         UNUSED_PARAM(thrownValue);


### PR DESCRIPTION
#### 78f27049a0ff46bbe87c0fe3a74db758eaffa43a
<pre>
Primitives (number, string, null, etc.) thrown from JS pass through catch_all in wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=277546">https://bugs.webkit.org/show_bug.cgi?id=277546</a>
<a href="https://rdar.apple.com/133534600">rdar://133534600</a>

Reviewed by Yijia Huang.

Wasm catch_all should accept primitive values. We should mark
m_catchableFromWasm to true when it is not a specific type of error
object.

* JSTests/wasm/stress/exception-thrown-from-js-to-wasm-catchall-primitive.js: Added.
(import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.callback):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::UnwindFunctor::UnwindFunctor):

Canonical link: <a href="https://commits.webkit.org/283404@main">https://commits.webkit.org/283404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c2d61c607600bd1e69ee9dda9095135c6549632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70232 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16810 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17091 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/57317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38705 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15686 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59314 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60594 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/15042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71934 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65444 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10155 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10187 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/57381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8385 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87211 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41381 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/15340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->