### PR TITLE
[bmalloc] Cache T instead of doing two atomic loads in getSlowCase

### DIFF
--- a/Source/bmalloc/bmalloc/StaticPerProcess.h
+++ b/Source/bmalloc/bmalloc/StaticPerProcess.h
@@ -81,11 +81,12 @@ private:
     {
         using Storage = typename StaticPerProcessStorageTraits<T>::Storage;
         LockHolder lock(Storage::s_mutex);
-        if (!Storage::s_object.load(std::memory_order_consume)) {
-            T* t = new (&Storage::s_memory) T(lock);
+        T* t = Storage::s_object.load(std::memory_order_consume);
+        if (!t) {
+            t = new (&Storage::s_memory) T(lock);
             Storage::s_object.store(t, std::memory_order_release);
         }
-        return Storage::s_object.load(std::memory_order_consume);
+        return t;
     }
 };
 


### PR DESCRIPTION
#### efbdd3a54283af188fa9b4ffb7fb31fc26822763
<pre>
[bmalloc] Cache T instead of doing two atomic loads in getSlowCase
<a href="https://bugs.webkit.org/show_bug.cgi?id=266970">https://bugs.webkit.org/show_bug.cgi?id=266970</a>

Reviewed by Mark Lam.

* Source/bmalloc/bmalloc/StaticPerProcess.h:
  (bmalloc::StaticPerProcess::getSlowCase):
  Cache T instead of doing two atomic loads.

Canonical link: <a href="https://commits.webkit.org/283469@main">https://commits.webkit.org/283469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f186150e085574f8ac94c394d783e4dac7738dfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16784 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53107 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11696 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15660 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59288 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71908 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65418 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60430 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1999 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87185 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41355 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15339 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->