### PR TITLE
[Site Isolation] Take process assertions for iframe processes

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -447,6 +447,7 @@ UIProcess/WebPageProxyTesting.cpp
 UIProcess/WebPasteboardProxy.cpp
 UIProcess/WebPermissionControllerProxy.cpp
 UIProcess/WebPreferences.cpp
+UIProcess/WebProcessActivityState.cpp
 UIProcess/WebProcessCache.cpp
 UIProcess/WebProcessPool.cpp
 UIProcess/WebProcessProxy.cpp

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -41,6 +41,7 @@
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcessActivityState.h"
 #include "WebProcessMessages.h"
 #include "WebProcessProxy.h"
 #include <WebCore/RemoteUserInputEventData.h>
@@ -55,6 +56,7 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
     , m_process(process)
     , m_page(page)
     , m_site(site)
+    , m_processActivityState(makeUniqueRef<WebProcessActivityState>(*this))
 {
     if (registrationToTransfer)
         m_messageReceiverRegistration.transferMessageReceivingFrom(*registrationToTransfer, *this);
@@ -233,6 +235,11 @@ RefPtr<WebPageProxy> RemotePageProxy::protectedPage() const
 WebPageProxy* RemotePageProxy::page() const
 {
     return m_page.get();
+}
+
+WebProcessActivityState& RemotePageProxy::processActivityState()
+{
+    return m_processActivityState;
 }
 
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -71,6 +71,7 @@ class RemotePageVisitedLinkStoreRegistration;
 class UserData;
 class WebFrameProxy;
 class WebPageProxy;
+class WebProcessActivityState;
 class WebProcessProxy;
 
 struct FrameInfoData;
@@ -98,6 +99,8 @@ public:
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return m_webPageID; }
     const Site& site() const { return m_site; }
 
+    WebProcessActivityState& processActivityState();
+
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
@@ -117,6 +120,7 @@ private:
     std::unique_ptr<RemotePageDrawingAreaProxy> m_drawingArea;
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
+    UniqueRef<WebProcessActivityState> m_processActivityState;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "config.h"
+#include "WebProcessActivityState.h"
+
+#include "RemotePageProxy.h"
+#include "WebPageProxy.h"
+#include "WebProcessProxy.h"
+
+namespace WebKit {
+
+WebProcessActivityState::WebProcessActivityState(WebPageProxy& page)
+    : m_page(page)
+#if PLATFORM(MAC)
+    , m_wasRecentlyVisibleActivity(makeUniqueRef<ProcessThrottlerTimedActivity>(8_min))
+#endif
+{
+}
+
+WebProcessActivityState::WebProcessActivityState(RemotePageProxy& page)
+    : m_page(page)
+#if PLATFORM(MAC)
+    , m_wasRecentlyVisibleActivity(makeUniqueRef<ProcessThrottlerTimedActivity>(8_min))
+#endif
+{
+}
+
+void WebProcessActivityState::takeVisibleActivity()
+{
+    m_isVisibleActivity = process().throttler().foregroundActivity("View is visible"_s).moveToUniquePtr();
+#if PLATFORM(MAC)
+    *m_wasRecentlyVisibleActivity = nullptr;
+#endif
+}
+
+void WebProcessActivityState::takeAudibleActivity()
+{
+    m_isAudibleActivity = process().throttler().foregroundActivity("View is playing audio"_s).moveToUniquePtr();
+}
+
+void WebProcessActivityState::takeCapturingActivity()
+{
+    m_isCapturingActivity = process().throttler().foregroundActivity("View is capturing media"_s).moveToUniquePtr();
+}
+
+void WebProcessActivityState::takeMutedCaptureAssertion()
+{
+    m_isMutedCaptureAssertion = ProcessAssertion::create(protectedProcess(), "WebKit Muted Media Capture"_s, ProcessAssertionType::Background);
+
+    auto page = std::visit([](auto&& weakPageRef) -> std::variant<WeakPtr<WebPageProxy>, WeakPtr<RemotePageProxy>> {
+        return weakPageRef.get();
+    }, m_page);
+
+    m_isMutedCaptureAssertion->setInvalidationHandler([weakPage = page] {
+        auto invalidateCaptureAssertion = [](auto&& weakPage) {
+            if (auto* page = weakPage.get()) {
+                RELEASE_LOG(ProcessSuspension, "Muted capture assertion is invalidated");
+                page->processActivityState().m_isMutedCaptureAssertion = nullptr;
+            }
+        };
+        std::visit(invalidateCaptureAssertion, weakPage);
+    });
+}
+
+void WebProcessActivityState::reset()
+{
+    m_isVisibleActivity = nullptr;
+#if PLATFORM(MAC)
+    *m_wasRecentlyVisibleActivity = nullptr;
+#endif
+    m_isAudibleActivity = nullptr;
+    m_isCapturingActivity = nullptr;
+    m_isMutedCaptureAssertion = nullptr;
+#if PLATFORM(IOS_FAMILY)
+    m_openingAppLinkActivity = nullptr;
+#endif
+}
+
+void WebProcessActivityState::dropVisibleActivity()
+{
+#if PLATFORM(MAC)
+    if (WTF::numberOfProcessorCores() > 4)
+        *m_wasRecentlyVisibleActivity = process().throttler().backgroundActivity("View was recently visible"_s);
+    else
+        *m_wasRecentlyVisibleActivity = process().throttler().foregroundActivity("View was recently visible"_s);
+#endif
+    m_isVisibleActivity = nullptr;
+}
+
+void WebProcessActivityState::dropAudibleActivity()
+{
+    m_isAudibleActivity = nullptr;
+}
+
+void WebProcessActivityState::dropCapturingActivity()
+{
+    m_isCapturingActivity = nullptr;
+}
+
+void WebProcessActivityState::dropMutedCaptureAssertion()
+{
+    m_isMutedCaptureAssertion = nullptr;
+}
+
+bool WebProcessActivityState::hasValidVisibleActivity() const
+{
+    return m_isVisibleActivity && m_isVisibleActivity->isValid();
+}
+
+bool WebProcessActivityState::hasValidAudibleActivity() const
+{
+    return m_isAudibleActivity && m_isAudibleActivity->isValid();
+}
+
+bool WebProcessActivityState::hasValidCapturingActivity() const
+{
+    return m_isCapturingActivity && m_isCapturingActivity->isValid();
+}
+
+bool WebProcessActivityState::hasValidMutedCaptureAssertion() const
+{
+    return m_isMutedCaptureAssertion;
+}
+
+#if PLATFORM(IOS_FAMILY)
+void WebProcessActivityState::takeOpeningAppLinkActivity()
+{
+    m_openingAppLinkActivity = process().throttler().backgroundActivity("Opening AppLink"_s).moveToUniquePtr();
+}
+
+void WebProcessActivityState::dropOpeningAppLinkActivity()
+{
+    m_openingAppLinkActivity = nullptr;
+}
+
+bool WebProcessActivityState::hasValidOpeningAppLinkActivity() const
+{
+    return m_openingAppLinkActivity && m_openingAppLinkActivity->isValid();
+}
+#endif
+
+WebProcessProxy& WebProcessActivityState::process() const
+{
+    return std::visit([](auto& page) -> WebProcessProxy& {
+        using T = std::decay_t<decltype(page)>;
+        if constexpr (std::is_same_v<T, WeakRef<WebPageProxy>>)
+            return page->legacyMainFrameProcess();
+        else if constexpr (std::is_same_v<T, WeakRef<RemotePageProxy>>)
+            return page->process();
+        else
+            static_assert(std::is_same_v<T, std::false_type>, "Unhandled page type in WebProcessActivityState::process");
+    }, m_page);
+}
+
+Ref<WebProcessProxy> WebProcessActivityState::protectedProcess() const
+{
+    return process();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/WeakRef.h>
+
+namespace WebKit {
+
+class ProcessAssertion;
+class ProcessThrottlerActivity;
+class RemotePageProxy;
+class WebPageProxy;
+class WebProcessProxy;
+
+class WebProcessActivityState {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit WebProcessActivityState(WebPageProxy&);
+    explicit WebProcessActivityState(RemotePageProxy&);
+
+    void takeVisibleActivity();
+    void takeAudibleActivity();
+    void takeCapturingActivity();
+    void takeMutedCaptureAssertion();
+
+    void reset();
+    void dropVisibleActivity();
+    void dropAudibleActivity();
+    void dropCapturingActivity();
+    void dropMutedCaptureAssertion();
+
+    bool hasValidVisibleActivity() const;
+    bool hasValidAudibleActivity() const;
+    bool hasValidCapturingActivity() const;
+    bool hasValidMutedCaptureAssertion() const;
+
+#if PLATFORM(IOS_FAMILY)
+    void takeOpeningAppLinkActivity();
+    void dropOpeningAppLinkActivity();
+    bool hasValidOpeningAppLinkActivity() const;
+#endif
+
+private:
+    WebProcessProxy& process() const;
+    Ref<WebProcessProxy> protectedProcess() const;
+
+    std::variant<WeakRef<WebPageProxy>, WeakRef<RemotePageProxy>> m_page;
+
+    std::unique_ptr<ProcessThrottlerActivity> m_isVisibleActivity;
+#if PLATFORM(MAC)
+    UniqueRef<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
+#endif
+    std::unique_ptr<ProcessThrottlerActivity> m_isAudibleActivity;
+    std::unique_ptr<ProcessThrottlerActivity> m_isCapturingActivity;
+    RefPtr<ProcessAssertion> m_isMutedCaptureAssertion;
+#if PLATFORM(IOS_FAMILY)
+    std::unique_ptr<ProcessThrottlerActivity> m_openingAppLinkActivity;
+#endif
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "GPUProcessProxy.h"
 #include "MessageSenderInlines.h"
 #include "PlatformXRSystemMessages.h"
 #include "PlatformXRSystemProxyMessages.h"

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1502,17 +1502,17 @@ void WebPageProxy::setScreenIsBeingCaptured(bool captured)
 
 void WebPageProxy::willOpenAppLink()
 {
-    if (m_legacyMainFrameProcessActivityState.hasValidOpeningAppLinkActivity())
+    if (hasValidOpeningAppLinkActivity())
         return;
 
     // We take a background activity for 25 seconds when switching to another app via an app link in case the WebPage
     // needs to run script to pass information to the native app.
     // We chose 25 seconds because the system only gives us 30 seconds and we don't want to get too close to that limit
     // to avoid assertion invalidation (or even termination).
-    m_legacyMainFrameProcessActivityState.takeOpeningAppLinkActivity();
+    takeOpeningAppLinkActivity();
     WorkQueue::main().dispatchAfter(25_s, [weakThis = WeakPtr { *this }] {
-        if (weakThis)
-            weakThis->m_legacyMainFrameProcessActivityState.dropOpeningAppLinkActivity();
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->dropOpeningAppLinkActivity();
     });
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
 		02660A7C2C4099370074EDC5 /* WebExtensionAPISidebarActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		02660A7E2C4099B50074EDC5 /* WebExtensionAPISidePanelCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		0269BED42C8FDDEA00DC2FEC /* WebProcessActivityState.h in Headers */ = {isa = PBXBuildFile; fileRef = 0269BED32C8FDDCB00DC2FEC /* WebProcessActivityState.h */; };
 		028648C62C3F5A3A00E474D4 /* WebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 028648C52C3F5A2E00E474D4 /* WebExtensionAPISidePanel.h */; };
 		028D30772C616E8A004F4FC6 /* WebExtensionSidebar.h in Headers */ = {isa = PBXBuildFile; fileRef = 028D30762C616E8A004F4FC6 /* WebExtensionSidebar.h */; };
 		028D30882C63DEE1004F4FC6 /* _WKWebExtensionSidebar.h in Headers */ = {isa = PBXBuildFile; fileRef = 028D30862C62FA8A004F4FC6 /* _WKWebExtensionSidebar.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3098,6 +3099,8 @@
 		0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindStringCallbackAggregator.h; sourceTree = "<group>"; };
 		02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPISidebarActionCocoa.mm; sourceTree = "<group>"; };
 		02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPISidePanelCocoa.mm; sourceTree = "<group>"; };
+		0269BED22C8FDDC600DC2FEC /* WebProcessActivityState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebProcessActivityState.cpp; sourceTree = "<group>"; };
+		0269BED32C8FDDCB00DC2FEC /* WebProcessActivityState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebProcessActivityState.h; sourceTree = "<group>"; };
 		02789EF628D3FC3200F77E40 /* WebGPUBufferBindingLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUBufferBindingLayout.serialization.in; sourceTree = "<group>"; };
 		02789EF728D3FF4800F77E40 /* WebGPUCanvasConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUCanvasConfiguration.serialization.in; sourceTree = "<group>"; };
 		02789EF828D4026000F77E40 /* WebGPUColor.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUColor.serialization.in; sourceTree = "<group>"; };
@@ -14196,6 +14199,8 @@
 				BC574E611267D080006F0F12 /* WebPopupMenuProxy.h */,
 				BCD597FE112B57BE00EC8C23 /* WebPreferences.cpp */,
 				BCD597FD112B57BE00EC8C23 /* WebPreferences.h */,
+				0269BED22C8FDDC600DC2FEC /* WebProcessActivityState.cpp */,
+				0269BED32C8FDDCB00DC2FEC /* WebProcessActivityState.h */,
 				83397C6622124BD100B62388 /* WebProcessCache.cpp */,
 				83397C6722124BD100B62388 /* WebProcessCache.h */,
 				7CE4D2171A4914A300C7F152 /* WebProcessPool.cpp */,
@@ -17174,6 +17179,7 @@
 				A1C512C9190656E500448914 /* WebPreviewLoaderClient.h in Headers */,
 				F4648E92296E81FA00744170 /* WebPrivacyHelpers.h in Headers */,
 				BC032D9710F437AF0058C15A /* WebProcess.h in Headers */,
+				0269BED42C8FDDEA00DC2FEC /* WebProcessActivityState.h in Headers */,
 				BC306824125A6B9400E71278 /* WebProcessCreationParameters.h in Headers */,
 				467E43E82243FF7D00B13924 /* WebProcessDataStoreParameters.h in Headers */,
 				BC3066BF125A442100E71278 /* WebProcessMessages.h in Headers */,


### PR DESCRIPTION
#### 3cb2304105dcdab874f0212055e3aac6da982499
<pre>
[Site Isolation] Take process assertions for iframe processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=279410">https://bugs.webkit.org/show_bug.cgi?id=279410</a>
<a href="https://rdar.apple.com/135639905">rdar://135639905</a>

Reviewed by Alex Christensen.

This relands the process assertion fix (282064@main) that was reverted. The original change was wrong
because I moved where we were holding process activity state to `WebProcessProxy`. Since multiple pages
can share a web process, this caused an issue where one page could release an assertion on a process
that was still in use by another page. This patch keeps the process activity state on `WebPageProxy` but
also adds it to RemotePageProxy to take assertions for web processes that are not hosting the main frame.

In the future, we may only want to take assertions for certain processes on a page, but for now, this
should match the behavior with site isolation disabled.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::processActivityState):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeVisibleActivity):
(WebKit::WebPageProxy::takeAudibleActivity):
(WebKit::WebPageProxy::takeCapturingActivity):
(WebKit::WebPageProxy::takeMutedCaptureAssertion):
(WebKit::WebPageProxy::resetActivityState):
(WebKit::WebPageProxy::dropVisibleActivity):
(WebKit::WebPageProxy::dropAudibleActivity):
(WebKit::WebPageProxy::dropCapturingActivity):
(WebKit::WebPageProxy::dropMutedCaptureAssertion):
(WebKit::WebPageProxy::hasValidVisibleActivity const):
(WebKit::WebPageProxy::hasValidAudibleActivity const):
(WebKit::WebPageProxy::hasValidCapturingActivity const):
(WebKit::WebPageProxy::hasValidMutedCaptureAssertion const):
(WebKit::WebPageProxy::takeOpeningAppLinkActivity):
(WebKit::WebPageProxy::dropOpeningAppLinkActivity):
(WebKit::WebPageProxy::hasValidOpeningAppLinkActivity const):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::updateThrottleState):
(WebKit::WebPageProxy::clearAudibleActivity):
(WebKit::WebPageProxy::waitForDidUpdateActivityState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::processActivityState):
(WebKit::WebPageProxy::ProcessActivityState::ProcessActivityState): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::takeVisibleActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::takeAudibleActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::takeCapturingActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::takeMutedCaptureAssertion): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::reset): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropVisibleActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropAudibleActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropCapturingActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropMutedCaptureAssertion): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::hasValidVisibleActivity const): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::hasValidAudibleActivity const): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::hasValidCapturingActivity const): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::hasValidMutedCaptureAssertion const): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::takeOpeningAppLinkActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropOpeningAppLinkActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::hasValidOpeningAppLinkActivity const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp: Added.
(WebKit::WebProcessActivityState::WebProcessActivityState):
(WebKit::WebProcessActivityState::takeVisibleActivity):
(WebKit::WebProcessActivityState::takeAudibleActivity):
(WebKit::WebProcessActivityState::takeCapturingActivity):
(WebKit::WebProcessActivityState::takeMutedCaptureAssertion):
(WebKit::WebProcessActivityState::reset):
(WebKit::WebProcessActivityState::dropVisibleActivity):
(WebKit::WebProcessActivityState::dropAudibleActivity):
(WebKit::WebProcessActivityState::dropCapturingActivity):
(WebKit::WebProcessActivityState::dropMutedCaptureAssertion):
(WebKit::WebProcessActivityState::hasValidVisibleActivity const):
(WebKit::WebProcessActivityState::hasValidAudibleActivity const):
(WebKit::WebProcessActivityState::hasValidCapturingActivity const):
(WebKit::WebProcessActivityState::hasValidMutedCaptureAssertion const):
(WebKit::WebProcessActivityState::takeOpeningAppLinkActivity):
(WebKit::WebProcessActivityState::dropOpeningAppLinkActivity):
(WebKit::WebProcessActivityState::hasValidOpeningAppLinkActivity const):
(WebKit::WebProcessActivityState::process const):
(WebKit::WebProcessActivityState::protectedProcess const):
* Source/WebKit/UIProcess/WebProcessActivityState.h: Added.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willOpenAppLink):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/283432@main">https://commits.webkit.org/283432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc33305a69da926b6aa51723516154d99b3261e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16796 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53106 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38691 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71920 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2005 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10039 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41367 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->