### PR TITLE
Changing the overflow bounds of a compositing layer doesn't recompute overlap for siblings.

### DIFF
--- a/LayoutTests/compositing/overflow/overflow-change-recomputes-overlap-expected.html
+++ b/LayoutTests/compositing/overflow/overflow-change-recomputes-overlap-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+     <style>
+         div {
+           width: 200px;
+           height: 400px;
+           background: green;
+         }
+     </style>
+ </head>
+ <body>
+     <div></div>
+ </body>
+

--- a/LayoutTests/compositing/overflow/overflow-change-recomputes-overlap.html
+++ b/LayoutTests/compositing/overflow/overflow-change-recomputes-overlap.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+ <html class="reftest-wait">
+ <head>
+     <style>
+         .composited {
+           width: 200px;
+           height: 200px;
+           background: green;
+           position: relative;
+           transform: translateZ(0px);
+           display: flow-root;
+         }
+
+         .overflow {
+           width: 100px;
+           height: 100px;
+           background: red;
+         }
+
+        .overlap-overflow {
+           width: 200px;
+           height: 200px;
+           background: green;
+           position: relative;
+         }
+
+     </style>
+ </head>
+
+ <script>
+     function waitAndResizeContainers() {
+         requestAnimationFrame(() => requestAnimationFrame(() => {
+             overflow.style.marginTop = "200px";
+             document.documentElement.classList.remove("reftest-wait");
+         }));
+     }
+ </script>
+ <body onload="waitAndResizeContainers()">
+
+     <div class="composited">
+         <div id="overflow" class="overflow"></div>
+     </div>
+     <div class="overlap-overflow"></div>
+ </body>
+

--- a/LayoutTests/css3/filters/effect-blur.html
+++ b/LayoutTests/css3/filters/effect-blur.html
@@ -3,12 +3,6 @@
 <head>
     <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-5000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <img src="resources/reference.png" style="filter: blur(0)">

--- a/LayoutTests/css3/filters/effect-brightness.html
+++ b/LayoutTests/css3/filters/effect-brightness.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-12300">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-combined.html
+++ b/LayoutTests/css3/filters/effect-combined.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-600" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-contrast.html
+++ b/LayoutTests/css3/filters/effect-contrast.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-5000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-grayscale.html
+++ b/LayoutTests/css3/filters/effect-grayscale.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-59700">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-hue-rotate.html
+++ b/LayoutTests/css3/filters/effect-hue-rotate.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-invert.html
+++ b/LayoutTests/css3/filters/effect-invert.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-10000" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-opacity.html
+++ b/LayoutTests/css3/filters/effect-opacity.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-saturate.html
+++ b/LayoutTests/css3/filters/effect-saturate.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/effect-sepia.html
+++ b/LayoutTests/css3/filters/effect-sepia.html
@@ -4,12 +4,6 @@
     <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-66700">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/css3/filters/null-effect-check.html
+++ b/LayoutTests/css3/filters/null-effect-check.html
@@ -1,9 +1,3 @@
-<script>
-if (window.internals) {
-    // Force software rendering mode.
-    window.internals.settings.setAcceleratedCompositingEnabled(false);
-}
-</script>
 <style>
 div {
     float:left;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4012,6 +4012,11 @@ imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-dyna
 imported/w3c/web-platform-tests/css/filter-effects/effect-reference-rename-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-function-to-url.html [ ImageOnlyFailure ]
 webkit.org/b/180134 webanimations/opacity-animation-no-longer-composited-upon-completion.html [ Failure ]
+css3/filters/effect-blur.html [ ImageOnlyFailure ]
+css3/filters/effect-combined.html [ ImageOnlyFailure ]
+css3/filters/effect-drop-shadow-clip-abspos.html [ ImageOnlyFailure ]
+css3/filters/effect-hue-rotate.html [ ImageOnlyFailure ]
+css3/filters/effect-saturate.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/element-stops-grouping-after-animation.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1020,6 +1020,7 @@ void RenderLayerBacking::updateAfterLayout(bool needsClippingUpdate, bool needsF
         m_owningLayer.setNeedsCompositingGeometryUpdate();
         // This layer's geometry affects those of its children.
         m_owningLayer.setChildrenNeedCompositingGeometryUpdate();
+        m_owningLayer.setSubsequentLayersNeedCompositingRequirementsTraversal();
     } else if (needsClippingUpdate) {
         m_owningLayer.setNeedsCompositingConfigurationUpdate();
         m_owningLayer.setNeedsCompositingGeometryUpdate();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -432,8 +432,6 @@ auto RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLaye
     }
 
     auto& providerLayer = *candidate.providerLayer;
-
-    LOG_WITH_STREAM(Compositing, stream << "Provider: composited scroll(" << providerLayer.canUseCompositedScrolling() << ") scrollableArea(" << providerLayer.scrollableArea() << ") horizontalOverflow(" << (providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableHorizontalOverflow()) << ") verticalOverflow(" << (providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableVerticalOverflow()) << ")");
     LayoutRect overlapBounds = candidate.absoluteBounds;
     if (providerLayer.canUseCompositedScrolling() && providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableHorizontalOverflow() != providerLayer.scrollableArea()->hasScrollableVerticalOverflow()) {
         // If the provider uses composited scrolling but only supports scrolling
@@ -450,11 +448,14 @@ auto RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLaye
         }
     }
 
+    LOG_WITH_STREAM(Compositing, stream << "Provider: composited scroll(" << providerLayer.canUseCompositedScrolling() << ") scrollableArea(" << providerLayer.scrollableArea() << ") horizontalOverflow(" << (providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableHorizontalOverflow()) << ") verticalOverflow(" << (providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableVerticalOverflow()) << ")" << " overlapBounds(" << overlapBounds << ")");
+
     // Check if any of the other candidates that are in front of the selected provider will
     // overlap the bounds of the layer to be added.
     for (auto& provider : m_backingProviderCandidates.subspan(candidateIndex + 1)) {
+        LOG_WITH_STREAM(Compositing, stream << "Considering " << provider.providerLayer  << " with bounds " << provider.absoluteBounds);
         if (overlapBounds.intersects(provider.absoluteBounds)) {
-            LOG_WITH_STREAM(Compositing, stream << "Aborting due to " << overlapBounds << " intersecting with " << provider.providerLayer << " " << provider.absoluteBounds);
+            LOG_WITH_STREAM(Compositing, stream << "Aborting due to overlap");
             return nullptr;
         }
     }


### PR DESCRIPTION
#### dd230e7c1bc5f58ba34f7008ac279bb9bff087dd
<pre>
Changing the overflow bounds of a compositing layer doesn&apos;t recompute overlap for siblings.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279422">https://bugs.webkit.org/show_bug.cgi?id=279422</a>
&lt;<a href="https://rdar.apple.com/135587131">rdar://135587131</a>&gt;

Reviewed by Simon Fraser.

Changing the overflow of a composited layer (and thus the compositing bounds)
should trigger a requirements traversal for siblings, since their overlap may
have changed.

Improves the logging for backing store providers slightly to show all the bounds
rects being compared (whether they intersect or not).

Removed the attempt to disable accelerated compositing from some css filters
tests, since this isn&apos;t supported with UI-side compositing (and the tests still
cover non-accelerated filter rendering without this).

* LayoutTests/compositing/overflow/overflow-change-recomputes-overlap-expected.html: Added.
* LayoutTests/compositing/overflow/overflow-change-recomputes-overlap.html: Added.
* LayoutTests/css3/filters/effect-blur.html:
* LayoutTests/css3/filters/effect-brightness.html:
* LayoutTests/css3/filters/effect-combined.html:
* LayoutTests/css3/filters/effect-contrast.html:
* LayoutTests/css3/filters/effect-grayscale.html:
* LayoutTests/css3/filters/effect-hue-rotate.html:
* LayoutTests/css3/filters/effect-invert.html:
* LayoutTests/css3/filters/effect-opacity.html:
* LayoutTests/css3/filters/effect-saturate.html:
* LayoutTests/css3/filters/effect-sepia.html:
* LayoutTests/css3/filters/null-effect-check.html:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAfterLayout):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):

Canonical link: <a href="https://commits.webkit.org/283514@main">https://commits.webkit.org/283514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/410d503ff288540c5c1c3126258570176844af93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17437 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69611 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33991 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/38962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14968 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16031 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72280 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65789 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/10501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/10533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14685 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42546 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->