### PR TITLE
[css-transitions] WPT test css/css-transitions/starting-style-cascade.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
@@ -4,5 +4,5 @@ PASS @starting-style with higher specificity
 PASS Starting style does not inherit from parent starting style
 PASS Starting style inheriting from parent's after-change style
 PASS Starting style inheriting from parent's after-change style while parent transitioning
-FAIL Starting style inheriting from parent's after-change style while ancestor is transitioning assert_equals: Transition started from parent's after-change style color, inherited from ancestors after-change color expected "rgb(0, 192, 0)" but got "rgb(0, 160, 0)"
+PASS Starting style inheriting from parent's after-change style while ancestor is transitioning
 

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -408,6 +408,8 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
         siblingRules.append({ ruleData });
     if (ruleData.containsUncommonAttributeSelector())
         uncommonAttributeRules.append({ ruleData });
+    if (ruleData.isStartingStyle() == IsStartingStyle::Yes)
+        hasStartingStyleRules = true;
 
     auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {
         for (auto& entry : entries) {
@@ -505,6 +507,7 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
 
     usesFirstLineRules = usesFirstLineRules || other.usesFirstLineRules;
     usesFirstLetterRules = usesFirstLetterRules || other.usesFirstLetterRules;
+    hasStartingStyleRules = hasStartingStyleRules || other.hasStartingStyleRules;
 }
 
 void RuleFeatureSet::registerContentAttribute(const AtomString& attributeName)
@@ -535,6 +538,7 @@ void RuleFeatureSet::clear()
     pseudoClasses.clear();
     usesFirstLineRules = false;
     usesFirstLetterRules = false;
+    hasStartingStyleRules = false;
 }
 
 void RuleFeatureSet::shrinkToFit()

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -130,6 +130,7 @@ struct RuleFeatureSet {
 
     bool usesFirstLineRules { false };
     bool usesFirstLetterRules { false };
+    bool hasStartingStyleRules { false };
 
 private:
     struct SelectorFeatures {

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -147,7 +147,8 @@ public:
 
     bool usesFirstLineRules() const { return m_ruleSets.features().usesFirstLineRules; }
     bool usesFirstLetterRules() const { return m_ruleSets.features().usesFirstLetterRules; }
-    
+    bool usesStartingStyleRules() const { return m_ruleSets.features().hasStartingStyleRules; }
+
     void invalidateMatchedDeclarationsCache();
     void clearCachedDeclarationsAffectedByViewportUnits();
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AnchorPositionEvaluator.h"
+#include "PropertyCascade.h"
 #include "SelectorChecker.h"
 #include "SelectorMatchingState.h"
 #include "StyleChange.h"
@@ -82,6 +83,10 @@ private:
 
     ElementUpdate createAnimatedElementUpdate(ResolvedStyle&&, const Styleable&, Change, const ResolutionContext&, IsInDisplayNoneTree = IsInDisplayNoneTree::No);
     std::unique_ptr<RenderStyle> resolveStartingStyle(const ResolvedStyle&, const Styleable&, const ResolutionContext&) const;
+    std::unique_ptr<RenderStyle> resolveAfterChangeStyleForNonAnimated(const ResolvedStyle&, const Styleable&, const ResolutionContext&) const;
+    std::unique_ptr<RenderStyle> resolveAgainWithParentStyle(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, const ResolutionContext&) const;
+    const RenderStyle& parentAfterChangeStyle(const Styleable&, const ResolutionContext&) const;
+
     HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
     std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree);


### PR DESCRIPTION
#### 826e5996a267a9dbe9ddc4bf97e329e777460b8a
<pre>
[css-transitions] WPT test css/css-transitions/starting-style-cascade.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=276664">https://bugs.webkit.org/show_bug.cgi?id=276664</a>
<a href="https://rdar.apple.com/131515890">rdar://131515890</a>

Reviewed by Sam Weinig.

Inherit after-change style from after-change style of the parent also in case where the element has no animations.

&quot;Likewise, define the after-change style as... and inheriting from the after-change style of the parent&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::clear):
* Source/WebCore/style/RuleFeature.h:

Track if we are using @starting-style rules so we don&apos;t need to do extra work of computing after-change styles otherwise.

* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::Resolver::usesStartingStyleRules const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Resolve the after change style if needed and shove it into lastStyleChangeEventStyle.

(WebCore::Style::TreeResolver::resolveStartingStyle const):
(WebCore::Style::TreeResolver::resolveAfterChangeStyleForNonAnimated const):

Re-resolve style inheriting from parent after change style.
Only compute this if we have @starting-style rules and the parent has lastStyleChangeEventStyle.

(WebCore::Style::TreeResolver::resolveAgainWithParentStyle const):

Factor into function.

(WebCore::Style::TreeResolver::parentAfterChangeStyle const):

Factor into function.

(WebCore::Style::TreeResolver::popParent):

Clear lastStyleChangeEventStyle after if there are no animations on the element.
It only affects descendant resolution.

* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/283423@main">https://commits.webkit.org/283423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8382f27e89cb348ee5a530d063ff4ae930516c51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53121 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11712 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14699 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15689 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71937 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2021 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41384 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->