### PR TITLE
Deploy more smart pointers for member variables in Source/WebKit

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -441,7 +441,7 @@ private:
     RefPtr<WebCore::VideoFrame> m_videoFrameForCurrentTime;
     bool m_shouldCheckHardwareSupport { false };
 #if !RELEASE_LOG_DISABLED
-    const Logger& m_logger;
+    Ref<const Logger> m_logger;
 #endif
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -38,6 +38,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WeakRef.h>
 
 OBJC_CLASS CALayer;
 
@@ -153,7 +154,7 @@ public:
     bool supportsPartialRepaint() const;
     bool drawingRequiresClearedPixels() const;
 
-    PlatformCALayerRemote& layer() const { return m_layer; }
+    PlatformCALayerRemote& layer() const;
 
     void encode(IPC::Encoder&) const;
 
@@ -200,7 +201,7 @@ protected:
 
     WebCore::IntRect layerBounds() const;
 
-    PlatformCALayerRemote& m_layer;
+    WeakRef<PlatformCALayerRemote> m_layer;
 
     Parameters m_parameters;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -125,7 +125,7 @@ RemoteLayerBackingStore::~RemoteLayerBackingStore()
 
 RemoteLayerBackingStoreCollection* RemoteLayerBackingStore::backingStoreCollection() const
 {
-    if (auto* context = m_layer.context())
+    if (auto* context = m_layer->context())
         return &context->backingStoreCollection();
 
     return nullptr;
@@ -183,7 +183,7 @@ void RemoteLayerBackingStore::encode(IPC::Encoder& encoder) const
     // It would be nice to ASSERT(handle && hasValue(*handle)) here, but when we hit the timeout in RemoteImageBufferProxy::ensureBackendCreated(), we don't have a handle.
 #if !LOG_DISABLED
     if (!(handle && hasValue(*handle)))
-        LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " encode - no buffer handle; did ensureBackendCreated() time out?");
+        LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " encode - no buffer handle; did ensureBackendCreated() time out?");
 #endif
 
     encoder << WTFMove(handle);
@@ -304,7 +304,12 @@ bool RemoteLayerBackingStore::supportsPartialRepaint() const
 
 bool RemoteLayerBackingStore::drawingRequiresClearedPixels() const
 {
-    return !m_parameters.isOpaque && !m_layer.owner()->platformCALayerShouldPaintUsingCompositeCopy();
+    return !m_parameters.isOpaque && !m_layer->owner()->platformCALayerShouldPaintUsingCompositeCopy();
+}
+
+PlatformCALayerRemote& RemoteLayerBackingStore::layer() const
+{
+    return m_layer;
 }
 
 void RemoteLayerBackingStore::setDelegatedContents(const PlatformCALayerRemoteDelegatedContents& contents)
@@ -328,8 +333,8 @@ bool RemoteLayerBackingStore::needsDisplay() const
         return false;
     }
 
-    if (m_layer.owner()->platformCALayerDelegatesDisplay(&m_layer)) {
-        LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " needsDisplay() - delegates display");
+    if (m_layer->owner()->platformCALayerDelegatesDisplay(m_layer.ptr())) {
+        LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " needsDisplay() - delegates display");
         return true;
     }
 
@@ -346,17 +351,17 @@ bool RemoteLayerBackingStore::needsDisplay() const
         return hasEmptyDirtyRegion() ? BackingStoreNeedsDisplayReason::None : BackingStoreNeedsDisplayReason::HasDirtyRegion;
     }();
 
-    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " size " << size() << " needsDisplay() - needs display reason: " << needsDisplayReason);
+    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " size " << size() << " needsDisplay() - needs display reason: " << needsDisplayReason);
     return needsDisplayReason != BackingStoreNeedsDisplayReason::None;
 }
 
 bool RemoteLayerBackingStore::performDelegatedLayerDisplay()
 {
-    auto& layerOwner = *m_layer.owner();
-    if (layerOwner.platformCALayerDelegatesDisplay(&m_layer)) {
+    auto& layerOwner = *m_layer->owner();
+    if (layerOwner.platformCALayerDelegatesDisplay(m_layer.ptr())) {
         // This can call back to setContents(), setting m_contentsBufferHandle.
-        layerOwner.platformCALayerLayerDisplay(&m_layer);
-        layerOwner.platformCALayerLayerDidDisplay(&m_layer);
+        layerOwner.platformCALayerLayerDisplay(m_layer.ptr());
+        layerOwner.platformCALayerLayerDidDisplay(m_layer.ptr());
         return true;
     }
     
@@ -365,7 +370,7 @@ bool RemoteLayerBackingStore::performDelegatedLayerDisplay()
 
 void RemoteLayerBackingStore::dirtyRepaintCounterIfNecessary()
 {
-    if (m_layer.owner()->platformCALayerShowRepaintCounter(&m_layer)) {
+    if (m_layer->owner()->platformCALayerShowRepaintCounter(m_layer.ptr())) {
         IntRect indicatorRect(0, 0, 52, 27);
         m_dirtyRegion.unite(indicatorRect);
     }
@@ -373,8 +378,8 @@ void RemoteLayerBackingStore::dirtyRepaintCounterIfNecessary()
 
 void RemoteLayerBackingStore::paintContents()
 {
-    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " paintContents() - has dirty region " << !hasEmptyDirtyRegion());
-    if (m_layer.owner()->platformCALayerDelegatesDisplay(&m_layer))
+    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " paintContents() - has dirty region " << !hasEmptyDirtyRegion());
+    if (m_layer->owner()->platformCALayerDelegatesDisplay(m_layer.ptr()))
         return;
 
     if (hasEmptyDirtyRegion()) {
@@ -418,18 +423,18 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
 #endif
 
     OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
-    if (m_layer.context() && m_layer.context()->nextRenderingUpdateRequiresSynchronousImageDecoding())
+    if (auto* context = m_layer->context(); context && context->nextRenderingUpdateRequiresSynchronousImageDecoding())
         paintBehavior.add(GraphicsLayerPaintBehavior::ForceSynchronousImageDecode);
     
     // FIXME: This should be moved to PlatformCALayerRemote for better layering.
-    switch (m_layer.layerType()) {
+    switch (m_layer->layerType()) {
     case PlatformCALayer::LayerType::LayerTypeSimpleLayer:
     case PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer:
-        m_layer.owner()->platformCALayerPaintContents(&m_layer, context, dirtyBounds, paintBehavior);
+        m_layer->owner()->platformCALayerPaintContents(m_layer.ptr(), context, dirtyBounds, paintBehavior);
         break;
     case PlatformCALayer::LayerType::LayerTypeWebLayer:
     case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
-        PlatformCALayer::drawLayerContents(context, &m_layer, m_paintingRects, paintBehavior);
+        PlatformCALayer::drawLayerContents(context, m_layer.ptr(), m_paintingRects, paintBehavior);
         break;
     case PlatformCALayer::LayerType::LayerTypeLayer:
     case PlatformCALayer::LayerType::LayerTypeTransformLayer:
@@ -454,7 +459,7 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
     m_dirtyRegion = { };
     m_paintingRects.clear();
 
-    m_layer.owner()->platformCALayerLayerDidDisplay(&m_layer);
+    m_layer->owner()->platformCALayerLayerDidDisplay(m_layer.ptr());
 
     m_previouslyPaintedRect = dirtyBounds;
     if (auto flusher = createFlusher())

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -94,7 +94,7 @@ public:
 
     virtual void gpuProcessConnectionWasDestroyed();
 
-    RemoteLayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
+    RemoteLayerTreeContext& layerTreeContext() const;
 
 protected:
 
@@ -124,7 +124,7 @@ protected:
     static constexpr auto volatileBackingStoreAgeThreshold = 1_s;
     static constexpr auto volatileSecondaryBackingStoreAgeThreshold = 200_ms;
 
-    RemoteLayerTreeContext& m_layerTreeContext;
+    WeakRef<RemoteLayerTreeContext> m_layerTreeContext;
 
     WeakHashSet<RemoteLayerBackingStore> m_liveBackingStore;
     WeakHashSet<RemoteLayerBackingStore> m_unparentedBackingStore;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -471,12 +471,17 @@ bool RemoteLayerBackingStoreCollection::collectAllRemoteRenderingBufferIdentifie
 
 void RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&& identifiers, CompletionHandler<void(bool)>&& completionHandler, bool forcePurge)
 {
-    auto& remoteRenderingBackend = m_layerTreeContext.ensureRemoteRenderingBackendProxy();
+    auto& remoteRenderingBackend = m_layerTreeContext->ensureRemoteRenderingBackendProxy();
 
     remoteRenderingBackend.markSurfacesVolatile(WTFMove(identifiers), [completionHandler = WTFMove(completionHandler)](bool markedAllVolatile) mutable {
         LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile: marked all volatile " << markedAllVolatile);
         completionHandler(markedAllVolatile);
     }, forcePurge);
+}
+
+RemoteLayerTreeContext& RemoteLayerBackingStoreCollection::layerTreeContext() const
+{
+    return m_layerTreeContext.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -107,7 +107,7 @@ DynamicContentScalingResourceCache RemoteLayerWithInProcessRenderingBackingStore
 void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents()
 {
     if (!m_frontBuffer.imageBuffer) {
-        ASSERT(m_layer.owner()->platformCALayerDelegatesDisplay(&m_layer));
+        ASSERT(m_layer->owner()->platformCALayerDelegatesDisplay(m_layer.ptr()));
         return;
     }
 
@@ -198,7 +198,7 @@ SwapBuffersDisplayRequirement RemoteLayerWithInProcessRenderingBackingStore::pre
     if (!hasFrontBuffer() || result == SetNonVolatileResult::Empty)
         displayRequirement = SwapBuffersDisplayRequirement::NeedsFullDisplay;
 
-    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " prepareBuffers() - " << displayRequirement);
+    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " prepareBuffers() - " << displayRequirement);
     return displayRequirement;
 }
 
@@ -266,7 +266,7 @@ static RefPtr<ImageBuffer> allocateBufferInternal(RemoteLayerBackingStore::Type 
 
 RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer()
 {
-    auto purpose = m_layer.containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
+    auto purpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
     ImageBufferCreationContext creationContext;
     creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPool();
 
@@ -299,7 +299,7 @@ void RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay()
         return;
     }
 
-    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " prepareToDisplay()");
+    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " prepareToDisplay()");
 
     if (performDelegatedLayerDisplay())
         return;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -112,7 +112,7 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
     m_parameters = parameters;
     clearBackingStore();
     if (m_bufferSet)
-        m_bufferSet->setConfiguration(size(), scale(), colorSpace(), pixelFormat(), type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated, m_layer.containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking);
+        m_bufferSet->setConfiguration(size(), scale(), colorSpace(), pixelFormat(), type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated, m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking);
 }
 
 void RemoteLayerWithRemoteRenderingBackingStore::encodeBufferAndBackendInfos(IPC::Encoder& encoder) const

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -466,42 +466,42 @@ WebPageProxy::Internals::~Internals() = default;
 
 IPC::Connection* WebPageProxy::Internals::paymentCoordinatorConnection(const WebPaymentCoordinatorProxy&)
 {
-    return &page.legacyMainFrameProcess().connection();
+    return &page->legacyMainFrameProcess().connection();
 }
 
 const String& WebPageProxy::Internals::paymentCoordinatorBoundInterfaceIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    return page.websiteDataStore().configuration().boundInterfaceIdentifier();
+    return page->websiteDataStore().configuration().boundInterfaceIdentifier();
 }
 
 void WebPageProxy::Internals::getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    completionHandler(page.userAgent());
+    completionHandler(page->userAgent());
 }
 
 CocoaWindow *WebPageProxy::Internals::paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) const
 {
-    return page.pageClient().platformWindow();
+    return page->pageClient().platformWindow();
 }
 
 const String& WebPageProxy::Internals::paymentCoordinatorSourceApplicationBundleIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    return page.websiteDataStore().configuration().sourceApplicationBundleIdentifier();
+    return page->websiteDataStore().configuration().sourceApplicationBundleIdentifier();
 }
 
 const String& WebPageProxy::Internals::paymentCoordinatorSourceApplicationSecondaryIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    return page.websiteDataStore().configuration().sourceApplicationSecondaryIdentifier();
+    return page->websiteDataStore().configuration().sourceApplicationSecondaryIdentifier();
 }
 
 void WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName receiverName, IPC::MessageReceiver& messageReceiver)
 {
-    page.legacyMainFrameProcess().addMessageReceiver(receiverName, webPageID, messageReceiver);
+    protectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(receiverName, webPageID, messageReceiver);
 }
 
 void WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName receiverName)
 {
-    page.legacyMainFrameProcess().removeMessageReceiver(receiverName, webPageID);
+    protectedPage()->protectedLegacyMainFrameProcess()->removeMessageReceiver(receiverName, webPageID);
 }
 
 #endif // ENABLE(APPLE_PAY)
@@ -534,17 +534,20 @@ void WebPageProxy::Internals::didResumeSpeaking(WebCore::PlatformSpeechSynthesis
 
 void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
 {
-    page.legacyMainFrameProcess().send(Messages::WebPage::SpeakingErrorOccurred(), page.webPageIDInMainFrameProcess());
+    Ref protectedPage = page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::SpeakingErrorOccurred(), protectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
 {
-    page.legacyMainFrameProcess().send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), page.webPageIDInMainFrameProcess());
+    Ref protectedPage = page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), protectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::voicesDidChange()
 {
-    page.legacyMainFrameProcess().send(Messages::WebPage::VoicesDidChange(), page.webPageIDInMainFrameProcess());
+    Ref protectedPage = page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::VoicesDidChange(), protectedPage->webPageIDInMainFrameProcess());
 }
 
 #endif // ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebKit/UIProcess/TextCheckerCompletion.cpp
+++ b/Source/WebKit/UIProcess/TextCheckerCompletion.cpp
@@ -31,16 +31,21 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<TextCheckerCompletion> TextCheckerCompletion::create(TextCheckerRequestID requestID, const TextCheckingRequestData& requestData, WebPageProxy* page)
+Ref<TextCheckerCompletion> TextCheckerCompletion::create(TextCheckerRequestID requestID, const TextCheckingRequestData& requestData, WebPageProxy& page)
 {
     return adoptRef(*new TextCheckerCompletion(requestID, requestData, page));
 }
 
-TextCheckerCompletion::TextCheckerCompletion(TextCheckerRequestID requestID, const TextCheckingRequestData& requestData, WebPageProxy* page)
+TextCheckerCompletion::TextCheckerCompletion(TextCheckerRequestID requestID, const TextCheckingRequestData& requestData, WebPageProxy& page)
     : m_requestID(requestID)
     , m_requestData(requestData)
     , m_page(page)
 {
+}
+
+Ref<WebPageProxy> TextCheckerCompletion::protectedPage() const
+{
+    return m_page.get();
 }
 
 const TextCheckingRequestData& TextCheckerCompletion::textCheckingRequestData() const
@@ -50,7 +55,7 @@ const TextCheckingRequestData& TextCheckerCompletion::textCheckingRequestData() 
 
 int64_t TextCheckerCompletion::spellDocumentTag()
 {
-    return m_page->spellDocumentTag();
+    return protectedPage()->spellDocumentTag();
 }
 
 void TextCheckerCompletion::didFinishCheckingText(const Vector<TextCheckingResult>& result) const
@@ -58,12 +63,12 @@ void TextCheckerCompletion::didFinishCheckingText(const Vector<TextCheckingResul
     if (result.isEmpty())
         didCancelCheckingText();
 
-    m_page->didFinishCheckingText(m_requestID, result);
+    protectedPage()->didFinishCheckingText(m_requestID, result);
 }
 
 void TextCheckerCompletion::didCancelCheckingText() const
 {
-    m_page->didCancelCheckingText(m_requestID);
+    protectedPage()->didCancelCheckingText(m_requestID);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/TextCheckerCompletion.h
+++ b/Source/WebKit/UIProcess/TextCheckerCompletion.h
@@ -28,6 +28,7 @@
 #include "IdentifierTypes.h"
 #include <WebCore/TextChecking.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ class WebPageProxy;
 
 class TextCheckerCompletion : public RefCounted<TextCheckerCompletion> {
 public:
-    static Ref<TextCheckerCompletion> create(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, WebPageProxy*);
+    static Ref<TextCheckerCompletion> create(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, WebPageProxy&);
 
     const WebCore::TextCheckingRequestData& textCheckingRequestData() const;
     SpellDocumentTag spellDocumentTag();
@@ -45,11 +46,13 @@ public:
     void didCancelCheckingText() const;
 
 private:
-    TextCheckerCompletion(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, WebPageProxy*);
+    TextCheckerCompletion(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, WebPageProxy&);
+
+    Ref<WebPageProxy> protectedPage() const;
 
     const TextCheckerRequestID m_requestID;
     const WebCore::TextCheckingRequestData m_requestData;
-    WebPageProxy* m_page;
+    WeakRef<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -107,9 +107,10 @@ class WebBackForwardListItem;
 class WebPageProxy;
 class WebProcessProxy;
 
-class ViewGestureController : public IPC::MessageReceiver {
+class ViewGestureController final : public IPC::MessageReceiver, public CanMakeCheckedPtr<ViewGestureController> {
     WTF_MAKE_TZONE_ALLOCATED(ViewGestureController);
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ViewGestureController);
 public:
 
     static constexpr double defaultMinMagnification { 1 };
@@ -223,6 +224,8 @@ private:
 
     static ViewGestureController* controllerForGesture(WebPageProxyIdentifier, GestureID);
 
+    Ref<WebPageProxy> protectedWebPageProxy() const;
+
     static GestureID takeNextGestureID();
     void willBeginGesture(ViewGestureType);
     void didEndGesture();
@@ -330,6 +333,9 @@ private:
         void setShouldIgnorePinnedState(bool ignore) { m_shouldIgnorePinnedState = ignore; }
 
     private:
+        CheckedRef<ViewGestureController> checkedViewGestureController() const;
+        Ref<WebPageProxy> protectedWebPageProxy() const;
+
         bool tryToStartSwipe(PlatformScrollEvent);
         bool scrollEventCanBecomeSwipe(PlatformScrollEvent, SwipeDirection&);
 
@@ -351,8 +357,8 @@ private:
 
         bool m_shouldIgnorePinnedState { false };
 
-        ViewGestureController& m_viewGestureController;
-        WebPageProxy& m_webPageProxy;
+        WeakRef<ViewGestureController> m_viewGestureController;
+        WeakRef<WebPageProxy> m_webPageProxy;
     };
 #endif
 
@@ -360,7 +366,7 @@ private:
     GRefPtr<GtkStyleContext> createStyleContext(const char*);
 #endif
 
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
     ViewGestureType m_activeGestureType { ViewGestureType::None };
 
     bool m_swipeGestureEnabled { true };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -528,7 +528,7 @@ inline static Vector<AuthenticatorTransport> toTransports(NSArray<ASAuthorizatio
 void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestData &&requestData, RequestCompletionHandler &&handler)
 {
 #if HAVE(UNIFIED_ASC_AUTH_UI)
-    if (!m_webPageProxy.preferences().webAuthenticationASEnabled()) {
+    if (!protectedWebPageProxy()->protectedPreferences()->webAuthenticationASEnabled()) {
         auto context = contextForRequest(WTFMove(requestData));
         if (context.get() == nullptr) {
             handler({ }, (AuthenticatorAttachment)0, ExceptionData { ExceptionCode::NotAllowedError, "The origin of the document is not the same as its ancestors."_s });
@@ -1117,12 +1117,12 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
     }
 #endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    requestContext.get().windowSceneIdentifier = m_webPageProxy.pageClient().sceneID();
+    requestContext.get().windowSceneIdentifier = m_webPageProxy->pageClient().sceneID();
 
     [m_proxy performAuthorizationRequestsForContext:requestContext.get() withCompletionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, handler = WTFMove(handler)](id<ASCCredentialProtocol> credential, NSError *error) mutable {
         callOnMainRunLoop([weakThis, handler = WTFMove(handler), credential = retainPtr(credential), error = retainPtr(error)] () mutable {
 #elif PLATFORM(MAC)
-    RetainPtr<NSWindow> window = m_webPageProxy.platformWindow();
+    RetainPtr<NSWindow> window = m_webPageProxy->platformWindow();
     [m_proxy performAuthorizationRequestsForContext:requestContext.get() withClearanceHandler:makeBlockPtr([weakThis = WeakPtr { *this }, handler = WTFMove(handler), window = WTFMove(window)](NSXPCListenerEndpoint *daemonEndpoint, NSError *error) mutable {
         callOnMainRunLoop([weakThis, handler = WTFMove(handler), window = WTFMove(window), daemonEndpoint = retainPtr(daemonEndpoint), error = retainPtr(error)] () mutable {
             if (!weakThis || !daemonEndpoint) {

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -100,6 +100,8 @@ public:
 private:
     using QueryCompletionHandler = CompletionHandler<void(bool)>;
 
+    Ref<WebPageProxy> protectedWebPageProxy() const;
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -113,7 +115,7 @@ private:
 
     void handleRequest(WebAuthenticationRequestData&&, RequestCompletionHandler&&);
 
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
 
 #if HAVE(UNIFIED_ASC_AUTH_UI) || HAVE(WEB_AUTHN_AS_MODERN)
     bool isASCAvailable();

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -41,8 +41,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebBackForwardCache);
 
-WebBackForwardCache::WebBackForwardCache(WebProcessPool& processPool)
-    : m_processPool(processPool)
+WebBackForwardCache::WebBackForwardCache()
 {
 }
 
@@ -58,7 +57,7 @@ inline void WebBackForwardCache::removeOldestEntry()
         item->setBackForwardCacheEntry(nullptr);
 }
 
-void WebBackForwardCache::setCapacity(unsigned capacity)
+void WebBackForwardCache::setCapacity(WebProcessPool& pool, unsigned capacity)
 {
     if (m_capacity == capacity)
         return;
@@ -67,7 +66,7 @@ void WebBackForwardCache::setCapacity(unsigned capacity)
     while (size() > capacity)
         removeOldestEntry();
 
-    m_processPool.sendToAllProcesses(Messages::WebProcess::SetBackForwardCacheCapacity(m_capacity));
+    pool.sendToAllProcesses(Messages::WebProcess::SetBackForwardCacheCapacity(m_capacity));
 }
 
 void WebBackForwardCache::addEntry(WebBackForwardListItem& item, std::unique_ptr<WebBackForwardCacheEntry>&& backForwardCacheEntry)

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -45,10 +45,10 @@ class WebBackForwardCache final : public CanMakeCheckedPtr<WebBackForwardCache> 
     WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCache);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebBackForwardCache);
 public:
-    explicit WebBackForwardCache(WebProcessPool&);
+    explicit WebBackForwardCache();
     ~WebBackForwardCache();
 
-    void setCapacity(unsigned);
+    void setCapacity(WebProcessPool&, unsigned);
     unsigned capacity() const { return m_capacity; }
     unsigned size() const { return m_itemsWithCachedPage.computeSize(); }
 
@@ -66,11 +66,12 @@ public:
     std::unique_ptr<SuspendedPageProxy> takeSuspendedPage(WebBackForwardListItem&);
 
 private:
+    Ref<WebProcessPool> protectedProcessPool() const;
+
     void removeOldestEntry();
     void removeEntriesMatching(const Function<bool(WebBackForwardListItem&)>&);
     void addEntry(WebBackForwardListItem&, std::unique_ptr<WebBackForwardCacheEntry>&&);
 
-    WebProcessPool& m_processPool;
     unsigned m_capacity { 0 };
     WeakListHashSet<WebBackForwardListItem> m_itemsWithCachedPage;
 };

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -65,38 +65,48 @@ WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFull
     , m_logIdentifier(page.logIdentifier())
 #endif
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
+    Ref webPageProxy = m_page.get();
+    webPageProxy->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), webPageProxy->webPageIDInMainFrameProcess(), *this);
 }
 
 WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 {
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), webPageProxy->webPageIDInMainFrameProcess());
     m_client.closeFullScreenManager();
     callCloseCompletionHandlers();
 }
 
+Ref<WebPageProxy> WebFullScreenManagerProxy::protectedPage() const
+{
+    return m_page.get();
+}
+
 const SharedPreferencesForWebProcess& WebFullScreenManagerProxy::sharedPreferencesForWebProcess() const
 {
-    return m_page.legacyMainFrameProcess().sharedPreferencesForWebProcess();
+    return protectedPage()->protectedLegacyMainFrameProcess()->sharedPreferencesForWebProcess();
 }
 
 void WebFullScreenManagerProxy::willEnterFullScreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::EnteringFullscreen;
-    m_page.fullscreenClient().willEnterFullscreen(&m_page);
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::WillEnterFullScreen(mode), m_page.webPageIDInMainFrameProcess());
+
+    Ref webPageProxy = m_page.get();
+    webPageProxy->fullscreenClient().willEnterFullscreen(webPageProxy.ptr());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::WillEnterFullScreen(mode), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::didEnterFullScreen()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::InFullscreen;
-    m_page.fullscreenClient().didEnterFullscreen(&m_page);
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::DidEnterFullScreen(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->fullscreenClient().didEnterFullscreen(webPageProxy.ptr());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::DidEnterFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
 
-    if (m_page.isControlledByAutomation()) {
-        if (WebAutomationSession* automationSession = m_page.configuration().processPool().automationSession())
+    if (webPageProxy->isControlledByAutomation()) {
+        if (auto* automationSession = webPageProxy->configuration().processPool().automationSession())
             automationSession->didEnterFullScreenForPage(m_page);
     }
 }
@@ -105,8 +115,9 @@ void WebFullScreenManagerProxy::willExitFullScreen()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::ExitingFullscreen;
-    m_page.fullscreenClient().willExitFullscreen(&m_page);
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::WillExitFullScreen(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->fullscreenClient().willExitFullscreen(webPageProxy.ptr());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::WillExitFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::callCloseCompletionHandlers()
@@ -126,11 +137,12 @@ void WebFullScreenManagerProxy::didExitFullScreen()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::NotInFullscreen;
-    m_page.fullscreenClient().didExitFullscreen(&m_page);
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::DidExitFullScreen(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->fullscreenClient().didExitFullscreen(webPageProxy.ptr());
+    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::DidExitFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
     
-    if (m_page.isControlledByAutomation()) {
-        if (WebAutomationSession* automationSession = m_page.configuration().processPool().automationSession())
+    if (webPageProxy->isControlledByAutomation()) {
+        if (auto* automationSession = webPageProxy->protectedConfiguration()->processPool().automationSession())
             automationSession->didExitFullScreenForPage(m_page);
     }
     callCloseCompletionHandlers();
@@ -138,19 +150,22 @@ void WebFullScreenManagerProxy::didExitFullScreen()
 
 void WebFullScreenManagerProxy::setAnimatingFullScreen(bool animating)
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetAnimatingFullScreen(animating), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::SetAnimatingFullScreen(animating), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::requestRestoreFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page.legacyMainFrameProcess().sendWithAsyncReply(Messages::WebFullScreenManager::RequestRestoreFullScreen(), WTFMove(completionHandler), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebFullScreenManager::RequestRestoreFullScreen(), WTFMove(completionHandler), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::requestExitFullScreen()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::RequestExitFullScreen(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::RequestExitFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::supportsFullScreen(bool withKeyboard, CompletionHandler<void(bool)>&& completionHandler)
@@ -164,22 +179,26 @@ void WebFullScreenManagerProxy::supportsFullScreen(bool withKeyboard, Completion
 
 void WebFullScreenManagerProxy::saveScrollPosition()
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SaveScrollPosition(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::SaveScrollPosition(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::restoreScrollPosition()
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::RestoreScrollPosition(), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::RestoreScrollPosition(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenInsets(insets), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenInsets(insets), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
 {
-    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration), m_page.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_page.get();
+    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::close()
@@ -254,7 +273,7 @@ void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(
 
 void WebFullScreenManagerProxy::beganEnterFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)
 {
-    m_page.callAfterNextPresentationUpdate([weakThis = WeakPtr { *this }, initialFrame = initialFrame, finalFrame = finalFrame] {
+    protectedPage()->callAfterNextPresentationUpdate([weakThis = WeakPtr { *this }, initialFrame = initialFrame, finalFrame = finalFrame] {
         if (weakThis)
             weakThis->m_client.beganEnterFullScreen(initialFrame, finalFrame);
     });

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -120,6 +120,8 @@ public:
     void unlockFullscreenOrientation();
 
 private:
+    Ref<WebPageProxy> protectedPage() const;
+
     void supportsFullScreen(bool withKeyboard, CompletionHandler<void(bool)>&&);
     void enterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&);
     void exitFullScreen();
@@ -137,7 +139,7 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    WebPageProxy& m_page;
+    WeakRef<WebPageProxy> m_page;
     WebFullScreenManagerProxyClient& m_client;
     FullscreenState m_fullscreenState { FullscreenState::NotInFullscreen };
     bool m_blocksReturnToFullscreenFromPictureInPicture { false };

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -219,7 +219,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 public:
     virtual ~Internals();
 
-    WebPageProxy& page;
+    WeakRef<WebPageProxy> page;
     OptionSet<WebCore::ActivityState> activityState;
     RunLoop::Timer audibleActivityTimer;
     std::optional<WebCore::Color> backgroundColor;
@@ -383,6 +383,8 @@ public:
 
     explicit Internals(WebPageProxy&);
 
+    Ref<WebPageProxy> protectedPage() const;
+
     SpeechSynthesisData& speechSynthesisData();
 
     // WebPopupMenuProxy::Client
@@ -445,7 +447,7 @@ public:
     void externalOutputDeviceAvailableDidChange(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void setShouldPlayToPlaybackTarget(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void playbackTargetPickerWasDismissed(WebCore::PlaybackTargetClientContextIdentifier) final;
-    bool alwaysOnLoggingAllowed() const final { return page.sessionID().isAlwaysOnLoggingAllowed(); }
+    bool alwaysOnLoggingAllowed() const final { return protectedPage()->sessionID().isAlwaysOnLoggingAllowed(); }
     RetainPtr<PlatformView> platformView() const final;
 #endif
 };

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -244,7 +244,7 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
 #endif
     , m_foregroundWebProcessCounter([this](RefCounterEvent) { updateProcessAssertions(); })
     , m_backgroundWebProcessCounter([this](RefCounterEvent) { updateProcessAssertions(); })
-    , m_backForwardCache(makeUniqueRef<WebBackForwardCache>(*this))
+    , m_backForwardCache(makeUniqueRef<WebBackForwardCache>())
     , m_webProcessCache(makeUniqueRef<WebProcessCache>(*this))
     , m_webProcessWithAudibleMediaCounter([this](RefCounterEvent) { updateAudibleMediaAssertions(); })
     , m_audibleActivityTimer(RunLoop::main(), this, &WebProcessPool::clearAudibleActivity)
@@ -1503,7 +1503,7 @@ void WebProcessPool::updateBackForwardCacheCapacity()
     unsigned backForwardCacheCapacity = 0;
     calculateMemoryCacheSizes(LegacyGlobalSettings::singleton().cacheModel(), dummy, dummy, dummy, dummyInterval, backForwardCacheCapacity);
 
-    checkedBackForwardCache()->setCapacity(backForwardCacheCapacity);
+    checkedBackForwardCache()->setCapacity(*this, backForwardCacheCapacity);
 }
 
 void WebProcessPool::setCacheModel(CacheModel cacheModel)

--- a/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
+++ b/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
@@ -60,17 +60,20 @@ void WebPageProxy::Internals::didResumeSpeaking(WebCore::PlatformSpeechSynthesis
 
 void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
 {
-    page.legacyMainFrameProcess().send(Messages::WebPage::SpeakingErrorOccurred(), page.webPageIDInMainFrameProcess());
+    Ref protectedPage = page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::SpeakingErrorOccurred(), protectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
 {
-    page.legacyMainFrameProcess().send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), page.webPageIDInMainFrameProcess());
+    Ref protectedPage = page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), protectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::voicesDidChange()
 {
-    page.legacyMainFrameProcess().send(Messages::WebPage::VoicesDidChange(), page.webPageIDInMainFrameProcess());
+    Ref protectedPage = page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::VoicesDidChange(), protectedPage->webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1295,12 +1295,12 @@ UIViewController *WebPageProxy::Internals::paymentCoordinatorPresentingViewContr
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    return page.uiClient().presentingViewController();
+    return page->uiClient().presentingViewController();
 }
 
 const String& WebPageProxy::Internals::paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&)
 {
-    return page.websiteDataStore().configuration().dataConnectionServiceType();
+    return page->websiteDataStore().configuration().dataConnectionServiceType();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -113,7 +113,8 @@ void ViewGestureController::gestureEventWasNotHandledByWebCore(NSEvent *event, F
 
 void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, FloatPoint origin)
 {
-    origin.setY(origin.y() - m_webPageProxy.topContentInset());
+    Ref webPageProxy = m_webPageProxy.get();
+    origin.setY(origin.y() - webPageProxy->topContentInset());
 
     ASSERT(m_activeGestureType == ViewGestureType::None || m_activeGestureType == ViewGestureType::Magnification);
 
@@ -133,8 +134,8 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
 
     willBeginGesture(ViewGestureType::Magnification);
 
-    auto minMagnification = m_webPageProxy.minPageZoomFactor();
-    auto maxMagnification = m_webPageProxy.maxPageZoomFactor();
+    auto minMagnification = webPageProxy->minPageZoomFactor();
+    auto maxMagnification = webPageProxy->maxPageZoomFactor();
 
     double scale = event.magnification;
     double scaleWithResistance = resistanceForDelta(scale, m_magnification, minMagnification, maxMagnification) * scale;
@@ -162,7 +163,8 @@ void ViewGestureController::handleSmartMagnificationGesture(FloatPoint gestureLo
 
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleSmartMagnificationGesture - gesture location " << gestureLocationInViewCoordinates);
 
-    m_webPageProxy.legacyMainFrameProcess().send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), m_webPageProxy.webPageIDInMainFrameProcess());
+    Ref webPageProxy = m_webPageProxy.get();
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 static float maximumRectangleComponentDelta(FloatRect a, FloatRect b)
@@ -172,7 +174,8 @@ static float maximumRectangleComponentDelta(FloatRect a, FloatRect b)
 
 void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(FloatPoint gestureLocationInViewCoordinates, FloatRect absoluteTargetRect, FloatRect visibleContentRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale)
 {
-    double currentScaleFactor = m_webPageProxy.pageScaleFactor();
+    Ref webPageProxy = m_webPageProxy.get();
+    double currentScaleFactor = webPageProxy->pageScaleFactor();
 
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::didCollectGeometryForSmartMagnificationGesture - gesture location " << gestureLocationInViewCoordinates << " absoluteTargetRect " << absoluteTargetRect);
 
@@ -203,8 +206,8 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
     if (fitEntireRect)
         targetMagnification = std::min(targetMagnification, static_cast<double>(visibleContentRect.height() / viewportConstrainedUnscaledTargetRect.height()));
 
-    auto minMagnification = m_webPageProxy.minPageZoomFactor();
-    auto maxMagnification = m_webPageProxy.maxPageZoomFactor();
+    auto minMagnification = webPageProxy->minPageZoomFactor();
+    auto maxMagnification = webPageProxy->maxPageZoomFactor();
     targetMagnification = std::min(std::max(targetMagnification, minMagnification), maxMagnification);
 
     // Allow panning between elements via double-tap while magnified, unless the target rect is
@@ -224,12 +227,12 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
     auto targetCenter = targetRect.center();
     targetOrigin.moveBy(-targetCenter);
 
-    m_initialMagnification = m_webPageProxy.pageScaleFactor();
+    m_initialMagnification = webPageProxy->pageScaleFactor();
     m_initialMagnificationOrigin = { };
 
-    auto pageScaleFactor = m_webPageProxy.pageScaleFactor();
-    m_webPageProxy.drawingArea()->adjustTransientZoom(pageScaleFactor, scaledMagnificationOrigin(FloatPoint(), pageScaleFactor));
-    m_webPageProxy.drawingArea()->commitTransientZoom(targetMagnification, targetOrigin);
+    auto pageScaleFactor = webPageProxy->pageScaleFactor();
+    webPageProxy->drawingArea()->adjustTransientZoom(pageScaleFactor, scaledMagnificationOrigin(FloatPoint(), pageScaleFactor));
+    webPageProxy->drawingArea()->commitTransientZoom(targetMagnification, targetOrigin);
 
     m_lastSmartMagnificationUnscaledTargetRect = unscaledTargetRect;
     m_lastSmartMagnificationOrigin = gestureLocationInViewCoordinates;
@@ -383,11 +386,12 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 {
     ASSERT(m_currentSwipeLiveLayers.isEmpty());
 
-    m_webPageProxy.navigationGestureDidBegin();
+    Ref webPageProxy = m_webPageProxy.get();
+    webPageProxy->navigationGestureDidBegin();
 
     willBeginGesture(ViewGestureType::Swipe);
 
-    CALayer *rootContentLayer = m_webPageProxy.acceleratedCompositingRootLayer();
+    CALayer *rootContentLayer = webPageProxy->acceleratedCompositingRootLayer();
 
     m_swipeLayer = adoptNS([[CALayer alloc] init]);
     m_swipeSnapshotLayer = adoptNS([[CALayer alloc] init]);
@@ -406,8 +410,8 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
             m_currentSwipeLiveLayers.append(layer);
         }
     } else {
-        swipeArea = [rootContentLayer convertRect:CGRectMake(0, 0, m_webPageProxy.viewSize().width(), m_webPageProxy.viewSize().height()) toLayer:nil];
-        topContentInset = m_webPageProxy.topContentInset();
+        swipeArea = [rootContentLayer convertRect:CGRectMake(0, 0, webPageProxy->viewSize().width(), webPageProxy->viewSize().height()) toLayer:nil];
+        topContentInset = webPageProxy->topContentInset();
         m_currentSwipeLiveLayers.append(rootContentLayer);
     }
 
@@ -432,7 +436,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     [m_swipeLayer setGeometryFlipped:geometryIsFlippedToRoot];
     [m_swipeLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
 
-    float deviceScaleFactor = m_webPageProxy.deviceScaleFactor();
+    float deviceScaleFactor = webPageProxy->deviceScaleFactor();
     [m_swipeSnapshotLayer setContentsGravity:kCAGravityTopLeft];
     [m_swipeSnapshotLayer setContentsScale:deviceScaleFactor];
     [m_swipeSnapshotLayer setAnchorPoint:CGPointZero];
@@ -442,7 +446,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
     [m_swipeLayer addSublayer:m_swipeSnapshotLayer.get()];
 
-    if (m_webPageProxy.preferences().viewGestureDebuggingEnabled())
+    if (webPageProxy->preferences().viewGestureDebuggingEnabled())
         applyDebuggingPropertiesToSwipeViews();
 
     m_didCallEndSwipeGesture = false;
@@ -457,7 +461,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
     // We don't know enough about the custom views' hierarchy to apply a shadow.
     if (m_customSwipeViews.isEmpty()) {
-        FloatRect dimmingRect(FloatPoint(), m_webPageProxy.viewSize());
+        FloatRect dimmingRect(FloatPoint(), webPageProxy->viewSize());
         m_swipeDimmingLayer = adoptNS([[CALayer alloc] init]);
         [m_swipeDimmingLayer setName:@"Gesture Swipe Dimming Layer"];
         [m_swipeDimmingLayer setBackgroundColor:[NSColor blackColor].CGColor];
@@ -467,7 +471,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
         [m_swipeDimmingLayer setGeometryFlipped:geometryIsFlippedToRoot];
         [m_swipeDimmingLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
 
-        FloatRect shadowRect(-swipeOverlayShadowWidth, topContentInset, swipeOverlayShadowWidth, m_webPageProxy.viewSize().height() - topContentInset);
+        FloatRect shadowRect(-swipeOverlayShadowWidth, topContentInset, swipeOverlayShadowWidth, webPageProxy->viewSize().height() - topContentInset);
         m_swipeShadowLayer = adoptNS([[CAGradientLayer alloc] init]);
         [m_swipeShadowLayer setName:@"Gesture Swipe Shadow Layer"];
         [m_swipeShadowLayer setColors:@[
@@ -527,7 +531,7 @@ void ViewGestureController::handleSwipeGesture(WebBackForwardListItem* targetIte
 {
     ASSERT(m_activeGestureType == ViewGestureType::Swipe);
 
-    if (!m_webPageProxy.drawingArea())
+    if (!m_webPageProxy->drawingArea())
         return;
 
     bool swipingLeft = isPhysicallySwipingLeft(direction);
@@ -536,7 +540,7 @@ void ViewGestureController::handleSwipeGesture(WebBackForwardListItem* targetIte
     if (!m_customSwipeViews.isEmpty())
         width = m_currentSwipeCustomViewBounds.width();
     else
-        width = m_webPageProxy.drawingArea()->size().width();
+        width = m_webPageProxy->drawingArea()->size().width();
 
     double swipingLayerOffset = floor(width * progress);
 
@@ -568,7 +572,7 @@ void ViewGestureController::didMoveSwipeSnapshotLayer()
     if (!m_didMoveSwipeSnapshotCallback)
         return;
 
-    m_didMoveSwipeSnapshotCallback(m_webPageProxy.boundsOfLayerInLayerBackedWindowCoordinates(m_swipeLayer.get()));
+    m_didMoveSwipeSnapshotCallback(m_webPageProxy->boundsOfLayerInLayerBackedWindowCoordinates(m_swipeLayer.get()));
 }
 
 void ViewGestureController::removeSwipeSnapshot()
@@ -615,7 +619,7 @@ void ViewGestureController::resetState()
 
     m_currentSwipeLiveLayers.clear();
 
-    m_webPageProxy.navigationGestureSnapshotWasRemoved();
+    m_webPageProxy->navigationGestureSnapshotWasRemoved();
 
     m_backgroundColorForCurrentSnapshot = Color();
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -631,7 +631,7 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteA
 
 RetainPtr<NSView> WebPageProxy::Internals::platformView() const
 {
-    return [page.protectedPageClient()->platformWindow() contentView];
+    return [page->protectedPageClient()->platformWindow() contentView];
 }
 
 #if ENABLE(PDF_PLUGIN)


### PR DESCRIPTION
#### 5b3959949338a3eac3345c7e84010cd877a0dd6c
<pre>
Deploy more smart pointers for member variables in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=279427">https://bugs.webkit.org/show_bug.cgi?id=279427</a>

Reviewed by Chris Dumez.

Deployed more smart pointer for member variables in Source/WebKit as warned by clang static analyzer.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
(WebKit::RemoteLayerBackingStore::layer const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::backingStoreCollection const):
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStore::drawingRequiresClearedPixels const):
(WebKit::RemoteLayerBackingStore::layer const):
(WebKit::RemoteLayerBackingStore::needsDisplay const):
(WebKit::RemoteLayerBackingStore::performDelegatedLayerDisplay):
(WebKit::RemoteLayerBackingStore::dirtyRepaintCounterIfNecessary):
(WebKit::RemoteLayerBackingStore::paintContents):
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
(WebKit::RemoteLayerBackingStoreCollection::layerTreeContext const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile):
(WebKit::RemoteLayerBackingStoreCollection::layerTreeContext const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareBuffers):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::Internals::paymentCoordinatorConnection):
(WebKit::WebPageProxy::Internals::paymentCoordinatorBoundInterfaceIdentifier):
(WebKit::WebPageProxy::Internals::getPaymentCoordinatorEmbeddingUserAgent):
(WebKit::WebPageProxy::Internals::paymentCoordinatorPresentingWindow const):
(WebKit::WebPageProxy::Internals::paymentCoordinatorSourceApplicationBundleIdentifier):
(WebKit::WebPageProxy::Internals::paymentCoordinatorSourceApplicationSecondaryIdentifier):
(WebKit::WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver):
(WebKit::WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver):
(WebKit::WebPageProxy::Internals::speakingErrorOccurred):
(WebKit::WebPageProxy::Internals::boundaryEventOccurred):
(WebKit::WebPageProxy::Internals::voicesDidChange):
* Source/WebKit/UIProcess/TextCheckerCompletion.cpp:
(WebKit::TextCheckerCompletion::create):
(WebKit::TextCheckerCompletion::TextCheckerCompletion):
(WebKit::TextCheckerCompletion::protectedPage const):
(WebKit::TextCheckerCompletion::spellDocumentTag):
(WebKit::TextCheckerCompletion::didFinishCheckingText const):
(WebKit::TextCheckerCompletion::didCancelCheckingText const):
* Source/WebKit/UIProcess/TextCheckerCompletion.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::~ViewGestureController):
(WebKit::ViewGestureController::protectedWebPageProxy const):
(WebKit::ViewGestureController::disconnectFromProcess):
(WebKit::ViewGestureController::connectToProcess):
(WebKit::ViewGestureController::willBeginGesture):
(WebKit::ViewGestureController::didEndGesture):
(WebKit::ViewGestureController::canSwipeInDirection const):
(WebKit::ViewGestureController::checkForActiveLoads):
(WebKit::ViewGestureController::PendingSwipeTracker::checkedViewGestureController const):
(WebKit::ViewGestureController::PendingSwipeTracker::protectedWebPageProxy const):
(WebKit::ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe):
(WebKit::ViewGestureController::PendingSwipeTracker::handleEvent):
(WebKit::ViewGestureController::PendingSwipeTracker::tryToStartSwipe):
(WebKit::ViewGestureController::startSwipeGesture):
(WebKit::ViewGestureController::isPhysicallySwipingLeft const):
(WebKit::ViewGestureController::shouldUseSnapshotForSize):
(WebKit::ViewGestureController::forceRepaintIfNeeded):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
(WebKit::ViewGestureController::requestRenderTreeSizeNotificationIfNeeded):
(WebKit::ViewGestureController::didCollectGeometryForMagnificationGesture):
(WebKit::ViewGestureController::prepareMagnificationGesture):
(WebKit::ViewGestureController::applyMagnification):
(WebKit::ViewGestureController::endMagnificationGesture):
(WebKit::ViewGestureController::magnification const):
* Source/WebKit/UIProcess/ViewGestureController.h:
(WebKit::ViewGestureController::wheelEventWasNotHandledByWebCore): Deleted.
(WebKit::ViewGestureController::shouldIgnorePinnedState): Deleted.
(WebKit::ViewGestureController::setShouldIgnorePinnedState): Deleted.
(WebKit::ViewGestureController::hasActiveMagnificationGesture const): Deleted.
(WebKit::ViewGestureController::setCustomSwipeViews): Deleted.
(WebKit::ViewGestureController::setCustomSwipeViewsTopContentInset): Deleted.
(WebKit::ViewGestureController::setDidMoveSwipeSnapshotCallback): Deleted.
(WebKit::ViewGestureController::backgroundColorForCurrentSnapshot const): Deleted.
(WebKit::ViewGestureController::didFinishNavigation): Deleted.
(WebKit::ViewGestureController::didFailNavigation): Deleted.
(WebKit::ViewGestureController::setSwipeGestureEnabled): Deleted.
(WebKit::ViewGestureController::isSwipeGestureEnabled): Deleted.
(WebKit::ViewGestureController::SnapshotRemovalTracker::pause): Deleted.
(WebKit::ViewGestureController::SnapshotRemovalTracker::isPaused const): Deleted.
(WebKit::ViewGestureController::SnapshotRemovalTracker::hasRemovalCallback const): Deleted.
(WebKit::ViewGestureController::SnapshotRemovalTracker::renderTreeSizeThreshold const): Deleted.
(WebKit::ViewGestureController::SnapshotRemovalTracker::setRenderTreeSizeThreshold): Deleted.
(WebKit::ViewGestureController::PendingSwipeTracker::shouldIgnorePinnedState): Deleted.
(WebKit::ViewGestureController::PendingSwipeTracker::setShouldIgnorePinnedState): Deleted.
(WebKit::ViewGestureController::SwipeProgressTracker::progress const): Deleted.
(WebKit::ViewGestureController::SwipeProgressTracker::direction const): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
(WebKit::WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::protectedWebPageProxy const):
(WebKit::WebAuthenticatorCoordinatorProxy::sharedPreferencesForWebProcess const):
(WebKit::WebAuthenticatorCoordinatorProxy::makeCredential):
(WebKit::WebAuthenticatorCoordinatorProxy::getAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::handleRequest):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::WebBackForwardCache):
(WebKit::WebBackForwardCache::setCapacity):
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::~WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::protectedPage const):
(WebKit::WebFullScreenManagerProxy::sharedPreferencesForWebProcess const):
(WebKit::WebFullScreenManagerProxy::willEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::didEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::willExitFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen):
(WebKit::WebFullScreenManagerProxy::setAnimatingFullScreen):
(WebKit::WebFullScreenManagerProxy::requestRestoreFullScreen):
(WebKit::WebFullScreenManagerProxy::requestExitFullScreen):
(WebKit::WebFullScreenManagerProxy::saveScrollPosition):
(WebKit::WebFullScreenManagerProxy::restoreScrollPosition):
(WebKit::WebFullScreenManagerProxy::setFullscreenInsets):
(WebKit::WebFullScreenManagerProxy::setFullscreenAutoHideDuration):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::Internals::protectedPage const):
(WebKit::WebPageProxy::Internals::didChooseColor):
(WebKit::WebPageProxy::Internals::didEndColorPicker):
(WebKit::WebPageProxy::Internals::valueChangedForPopupMenu):
(WebKit::WebPageProxy::Internals::setTextFromItemForPopupMenu):
(WebKit::WebPageProxy::Internals::failedToShowPopupMenu):
(WebKit::WebPageProxy::requestCheckingOfString):
(WebKit::WebPageProxy::Internals::setPlaybackTarget):
(WebKit::WebPageProxy::Internals::externalOutputDeviceAvailableDidChange):
(WebKit::WebPageProxy::Internals::setShouldPlayToPlaybackTarget):
(WebKit::WebPageProxy::Internals::playbackTargetPickerWasDismissed):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::updateBackForwardCacheCapacity):
* Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp:
(WebKit::WebPageProxy::Internals::speakingErrorOccurred):
(WebKit::WebPageProxy::Internals::boundaryEventOccurred):
(WebKit::WebPageProxy::Internals::voicesDidChange):
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::handleSwipeGesture):
(WebKit::ViewGestureController::snapshot):
(WebKit::ViewGestureController::draw):
(WebKit::ViewGestureController::removeSwipeSnapshot):
(WebKit::ViewGestureController::setMagnification):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::Internals::paymentCoordinatorPresentingViewController):
(WebKit::WebPageProxy::Internals::paymentCoordinatorCTDataConnectionServiceType):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
(WebKit::ViewGestureController::handleSmartMagnificationGesture):
(WebKit::ViewGestureController::didCollectGeometryForSmartMagnificationGesture):
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::handleSwipeGesture):
(WebKit::ViewGestureController::didMoveSwipeSnapshotLayer):
(WebKit::ViewGestureController::resetState):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::Internals::platformView const):

Canonical link: <a href="https://commits.webkit.org/283489@main">https://commits.webkit.org/283489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193d49056b03a7c31d647436a95fd16314d0a89d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70415 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16993 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53239 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38852 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60564 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60878 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2146 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10065 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->