### PR TITLE
[GStreamer][WebRTC] Refactor additional stats support into the endpoint

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -139,7 +139,7 @@ public:
 #if USE(LIBWEBRTC)
         InboundRtpStreamStats(const webrtc::RTCInboundRtpStreamStats&);
 #elif USE(GSTREAMER_WEBRTC)
-        InboundRtpStreamStats(const GstStructure*, const GstStructure* additionalStats);
+        InboundRtpStreamStats(const GstStructure*);
 #endif
 
         String trackIdentifier;
@@ -240,7 +240,7 @@ public:
 #if USE(LIBWEBRTC)
         OutboundRtpStreamStats(const webrtc::RTCOutboundRtpStreamStats&);
 #elif USE(GSTREAMER_WEBRTC)
-        OutboundRtpStreamStats(const GstStructure*, const GstStructure* additionalStats);
+        OutboundRtpStreamStats(const GstStructure*);
 #endif
 
         String mid;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -66,7 +66,7 @@ public:
     void doCreateOffer(const RTCOfferOptions&);
     void doCreateAnswer();
 
-    void getStats(GstPad*, const GstStructure*, Ref<DeferredPromise>&&);
+    void getStats(const GRefPtr<GstPad>&, Ref<DeferredPromise>&&);
     void getStats(RTCRtpReceiver&, Ref<DeferredPromise>&&);
 
     std::unique_ptr<RTCDataChannelHandler> createDataChannel(const String&, const RTCDataChannelInit&);
@@ -110,15 +110,16 @@ public:
     GstElement* webrtcBin() const { return m_webrtcBin.get(); }
     bool handleMessage(GstMessage*);
 
+    GUniquePtr<GstStructure> preprocessStats(const GRefPtr<GstPad>&, const GstStructure*);
 #if !RELEASE_LOG_DISABLED
-    void processStats(const GValue*);
+    void processStatsItem(const GValue*);
 #endif
 
     void connectIncomingTrack(WebRTCTrackData&);
 
 protected:
 #if !RELEASE_LOG_DISABLED
-    void onStatsDelivered(const GstStructure*);
+    void onStatsDelivered(GUniquePtr<GstStructure>&&);
 #endif
 
 private:

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -65,6 +65,9 @@ public:
     explicit GStreamerPeerConnectionBackend(RTCPeerConnection&);
     ~GStreamerPeerConnectionBackend();
 
+    GStreamerRtpSenderBackend& backendFromRTPSender(RTCRtpSender&);
+    RefPtr<RTCRtpSender> findExistingSender(const Vector<RefPtr<RTCRtpTransceiver>>&, GStreamerRtpSenderBackend&);
+
 private:
     void close() final;
     void doCreateOffer(RTCOfferOptions&&) final;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
@@ -37,7 +37,8 @@ public:
     static Ref<GStreamerStatsCollector> create() { return adoptRef(*new GStreamerStatsCollector()); }
 
     void setElement(GstElement* element) { m_webrtcBin = element; }
-    void getStats(CollectorCallback&&, GstPad*, const GstStructure*);
+    using PreprocessCallback = Function<GUniquePtr<GstStructure>(const GRefPtr<GstPad>&, const GstStructure*)>;
+    void getStats(CollectorCallback&&, const GRefPtr<GstPad>&, PreprocessCallback&&);
 
 private:
     GRefPtr<GstElement> m_webrtcBin;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -38,7 +38,7 @@ public:
     ~GStreamerIncomingTrackProcessor() = default;
 
     void configure(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&&, GRefPtr<GstPad>&&);
-    GstPad* pad() const { return m_pad.get(); }
+    const GRefPtr<GstPad>& pad() const { return m_pad; }
 
     GstElement* bin() const { return m_bin.get(); }
 


### PR DESCRIPTION
#### 0a9e652443883b72766dfb016c886e188a86dd9f
<pre>
[GStreamer][WebRTC] Refactor additional stats support into the endpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=279429">https://bugs.webkit.org/show_bug.cgi?id=279429</a>

Reviewed by Xabier Rodriguez-Calvar.

By keeping additional stats aggregation in the endpoint we can reuse this for future additional
internal stats reporting.

* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::getStats):
(WebCore::GStreamerMediaEndpoint::gatherStatsForLogging):
(WebCore::GStreamerMediaEndpoint::preprocessStats):
(WebCore::GStreamerMediaEndpoint::processStatsItem):
(WebCore::GStreamerMediaEndpoint::onStatsDelivered):
(WebCore::GStreamerMediaEndpoint::processStats): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::backendFromRTPSender):
(WebCore::GStreamerPeerConnectionBackend::getStats):
(WebCore::GStreamerPeerConnectionBackend::findExistingSender):
(WebCore::backendFromRTPSender): Deleted.
(WebCore::findExistingSender): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats):
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats):
(WebCore::ReportHolder::ReportHolder):
(WebCore::fillReportCallback):
(WebCore::GStreamerStatsCollector::getStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:
(WebCore::GStreamerIncomingTrackProcessor::pad const):

Canonical link: <a href="https://commits.webkit.org/283474@main">https://commits.webkit.org/283474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75ba464a6d00395d0ace6cbbfa32350490010565

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53124 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71945 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60446 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2027 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41392 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->