### PR TITLE
[WebRTC] Support for events and stats aggregation

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2370,9 +2370,6 @@ imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-pr
 
 imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html [ Skip ]
 
-# Libwebrtc log test
-http/tests/inspector/gatherWebInspectorRTCLogs.html [ Skip ]
-
 # In these tests only one canvas frame is pushed towards the sender webrtcbin,
 # this is not enough for the receiver webrtcbin to create its video source pad,
 # because on sender side we need at least a complete GOP... So the tests time

--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -34,6 +34,7 @@
 namespace WTF {
 
 Lock loggerObserverLock;
+Lock messageHandlerLoggerObserverLock;
 
 String Logger::LogSiteIdentifier::toString() const
 {
@@ -50,6 +51,16 @@ String LogArgument<const void*>::toString(const void* argument)
 Vector<std::reference_wrapper<Logger::Observer>>& Logger::observers()
 {
     static LazyNeverDestroyed<Vector<std::reference_wrapper<Observer>>> observers;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        observers.construct();
+    });
+    return observers;
+}
+
+Vector<std::reference_wrapper<Logger::MessageHandlerObserver>>& Logger::messageHandlerObservers()
+{
+    static LazyNeverDestroyed<Vector<std::reference_wrapper<MessageHandlerObserver>>> observers;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         observers.construct();

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -123,6 +123,7 @@ struct ConsoleLogValue<Argument, false> {
 };
 
 WTF_EXPORT_PRIVATE extern Lock loggerObserverLock;
+WTF_EXPORT_PRIVATE extern Lock messageHandlerLoggerObserverLock;
 
 class Logger : public ThreadSafeRefCounted<Logger> {
     WTF_MAKE_NONCOPYABLE(Logger);
@@ -134,6 +135,12 @@ public:
         virtual ~Observer() = default;
         // Can be called on any thread.
         virtual void didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) = 0;
+    };
+
+    class MessageHandlerObserver {
+    public:
+        virtual ~MessageHandlerObserver() = default;
+        virtual void handleLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) = 0;
     };
 
     static Ref<Logger> create(const void* owner)
@@ -149,7 +156,7 @@ public:
         //  on some systems, so don't allow it.
         UNUSED_PARAM(channel);
 #else
-        if (!willLog(channel, WTFLogLevel::Always))
+        if (!willLog(channel, WTFLogLevel::Always, arguments...))
             return;
 
         log(channel, WTFLogLevel::Always, arguments...);
@@ -159,7 +166,7 @@ public:
     template<typename... Arguments>
     inline void error(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Error))
+        if (!willLog(channel, WTFLogLevel::Error, arguments...))
             return;
 
         log(channel, WTFLogLevel::Error, arguments...);
@@ -168,7 +175,7 @@ public:
     template<typename... Arguments>
     inline void warning(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Warning))
+        if (!willLog(channel, WTFLogLevel::Warning, arguments...))
             return;
 
         log(channel, WTFLogLevel::Warning, arguments...);
@@ -177,7 +184,7 @@ public:
     template<typename... Arguments>
     inline void info(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Info))
+        if (!willLog(channel, WTFLogLevel::Info, arguments...))
             return;
 
         log(channel, WTFLogLevel::Info, arguments...);
@@ -186,7 +193,7 @@ public:
     template<typename... Arguments>
     inline void debug(WTFLogChannel& channel, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Debug))
+        if (!willLog(channel, WTFLogLevel::Debug, arguments...))
             return;
 
         log(channel, WTFLogLevel::Debug, arguments...);
@@ -203,7 +210,7 @@ public:
         UNUSED_PARAM(function);
         UNUSED_PARAM(line);
 #else
-        if (!willLog(channel, WTFLogLevel::Always))
+        if (!willLog(channel, WTFLogLevel::Always, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Always, file, function, line, arguments...);
@@ -213,7 +220,7 @@ public:
     template<typename... Arguments>
     inline void errorVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Error))
+        if (!willLog(channel, WTFLogLevel::Error, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Error, file, function, line, arguments...);
@@ -222,7 +229,7 @@ public:
     template<typename... Arguments>
     inline void warningVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Warning))
+        if (!willLog(channel, WTFLogLevel::Warning, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Warning, file, function, line, arguments...);
@@ -231,7 +238,7 @@ public:
     template<typename... Arguments>
     inline void infoVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Info))
+        if (!willLog(channel, WTFLogLevel::Info, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Info, file, function, line, arguments...);
@@ -240,14 +247,24 @@ public:
     template<typename... Arguments>
     inline void debugVerbose(WTFLogChannel& channel, const char* file, const char* function, int line, const Arguments&... arguments) const
     {
-        if (!willLog(channel, WTFLogLevel::Debug))
+        if (!willLog(channel, WTFLogLevel::Debug, arguments...))
             return;
 
         logVerbose(channel, WTFLogLevel::Debug, file, function, line, arguments...);
     }
 
-    inline bool willLog(const WTFLogChannel& channel, WTFLogLevel level) const
+    template<typename... Argument>
+    inline bool willLog(const WTFLogChannel& channel, WTFLogLevel level, const Argument&... arguments) const
     {
+        {
+            if (!messageHandlerObserverLock().tryLock())
+                return false;
+
+            Locker locker { AdoptLock, messageHandlerObserverLock() };
+            for (MessageHandlerObserver& observer : messageHandlerObservers())
+                observer.handleLogMessage(channel, level, { ConsoleLogValue<Argument>::toValue(arguments)... });
+        }
+
         if (!m_enabled)
             return false;
 
@@ -303,6 +320,19 @@ public:
     {
         Locker locker { observerLock() };
         observers().removeFirstMatching([&observer](auto anObserver) {
+            return &anObserver.get() == &observer;
+        });
+    }
+
+    static inline void addMessageHandlerObserver(MessageHandlerObserver& observer)
+    {
+        Locker locker { messageHandlerObserverLock() };
+        messageHandlerObservers().append(observer);
+    }
+    static inline void removeMessageHandlerObserver(MessageHandlerObserver& observer)
+    {
+        Locker locker { messageHandlerObserverLock() };
+        messageHandlerObservers().removeFirstMatching([&observer](auto anObserver) {
             return &anObserver.get() == &observer;
         });
     }
@@ -380,6 +410,12 @@ private:
         return loggerObserverLock;
     }
 
+    WTF_EXPORT_PRIVATE static Vector<std::reference_wrapper<MessageHandlerObserver>>& messageHandlerObservers() WTF_REQUIRES_LOCK(messageHandlerObserverLock());
+
+    static Lock& messageHandlerObserverLock() WTF_RETURNS_LOCK(messageHandlerLoggerObserverLock)
+    {
+        return messageHandlerLoggerObserverLock;
+    }
 
     bool m_enabled { true };
     const void* m_owner;

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -39,7 +39,6 @@
 #include "JSRTCCertificate.h"
 #include "Logging.h"
 #include "Page.h"
-#include "RTCDataChannelEvent.h"
 #include "RTCDtlsTransport.h"
 #include "RTCIceCandidate.h"
 #include "RTCPeerConnection.h"
@@ -50,7 +49,9 @@
 #include "RTCTrackEvent.h"
 #include "WebRTCProvider.h"
 #include <wtf/EnumTraits.h>
+#include <wtf/FilePrintStream.h>
 #include <wtf/UUID.h>
+#include <wtf/text/Base64.h>
 #include <wtf/text/StringBuilder.h>
 
 #if USE(GSTREAMER_WEBRTC)
@@ -104,6 +105,53 @@ std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(Scri
 }
 #endif // USE(LIBWEBRTC) || USE(GSTREAMER_WEBRTC)
 
+#if PLATFORM(WPE) || PLATFORM(GTK)
+class JSONFileHandler {
+public:
+    JSONFileHandler(const String& path)
+        : m_logFile(FilePrintStream::open(path.utf8().data(), "w"))
+    {
+        // Prefer unbuffered output, so that we get a full log upon crash or deadlock.
+        setvbuf(m_logFile->file(), nullptr, _IONBF, 0);
+    }
+
+    void log(String&& event)
+    {
+        m_logFile->println(WTFMove(event));
+    }
+
+    void addClient(uint64_t identifier)
+    {
+        Locker lock(m_clientsLock);
+        m_clients.append(identifier);
+    }
+
+    void removeClient(uint64_t identifier)
+    {
+        Locker lock(m_clientsLock);
+        if (!m_clients.contains(identifier))
+            return;
+
+        m_clients.remove(identifier);
+        if (m_clients.isEmpty())
+            m_logFile = nullptr;
+    }
+
+private:
+    std::unique_ptr<FilePrintStream> m_logFile;
+    Lock m_clientsLock;
+    Vector<uint64_t> m_clients WTF_GUARDED_BY_LOCK(m_clientsLock);
+};
+
+JSONFileHandler& jsonFileHandler()
+{
+    auto path = String::fromUTF8(getenv("WEBKIT_WEBRTC_JSON_EVENTS_FILE"));
+    ASSERT(!path.isEmpty());
+    static NeverDestroyed<JSONFileHandler> sharedInstance(path);
+    return sharedInstance;
+}
+#endif
+
 PeerConnectionBackend::PeerConnectionBackend(RTCPeerConnection& peerConnection)
     : m_peerConnection(peerConnection)
 #if !RELEASE_LOG_DISABLED
@@ -116,9 +164,73 @@ PeerConnectionBackend::PeerConnectionBackend(RTCPeerConnection& peerConnection)
     if (auto* page = document ? document->page() : nullptr)
         m_shouldFilterICECandidates = page->webRTCProvider().isSupportingMDNS();
 #endif
+
+#if !RELEASE_LOG_DISABLED && (PLATFORM(WPE) || PLATFORM(GTK))
+    m_jsonFilePath = String::fromUTF8(getenv("WEBKIT_WEBRTC_JSON_EVENTS_FILE"));
+    if (!m_jsonFilePath.isEmpty())
+        jsonFileHandler().addClient(m_logIdentifier);
+
+    m_logger->addMessageHandlerObserver(*this);
+    ALWAYS_LOG(LOGIDENTIFIER, "PeerConnection created"_s);
+#endif
 }
 
-PeerConnectionBackend::~PeerConnectionBackend() = default;
+PeerConnectionBackend::~PeerConnectionBackend()
+{
+#if !RELEASE_LOG_DISABLED && (PLATFORM(WPE) || PLATFORM(GTK))
+    ALWAYS_LOG(LOGIDENTIFIER, "Disposing PeerConnection"_s);
+    m_logger->removeMessageHandlerObserver(*this);
+
+    if (isJSONLogStreamingEnabled())
+        jsonFileHandler().removeClient(m_logIdentifier);
+#endif
+}
+
+#if !RELEASE_LOG_DISABLED && (PLATFORM(WPE) || PLATFORM(GTK))
+void PeerConnectionBackend::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel, Vector<JSONLogValue>&& values)
+{
+    auto name = StringView::fromLatin1(channel.name);
+    if (name != "WebRTC"_s)
+        return;
+
+    // Ignore logs containing only the call site information or JSON logs.
+    if (values.size() < 2 || values[1].type == JSONLogValue::Type::JSON)
+        return;
+
+    if (!isJSONLogStreamingEnabled())
+        return;
+
+    // Parse "foo::bar(hexidentifier) "
+    auto& callSite = values[0].value;
+    auto leftParenthesisIndex = callSite.reverseFind('(');
+    if (leftParenthesisIndex == notFound)
+        return;
+
+    auto rightParenthesisIndex = callSite.reverseFind(')');
+    if (rightParenthesisIndex == notFound)
+        return;
+
+    if (!m_logIdentifierString)
+        m_logIdentifierString = makeString(hex(m_logIdentifier));
+
+    auto identifier = callSite.substring(leftParenthesisIndex + 1, rightParenthesisIndex - leftParenthesisIndex - 1);
+    if (identifier != m_logIdentifierString)
+        return;
+
+    String event;
+
+    // Check if the third message is a multi-lines string, concatenating such message would look ugly in log events.
+    if (values.size() >= 3 && values[2].value.find("\r\n"_s) != notFound)
+        event = generateJSONLogEvent(MessageLogEvent { values[1].value, { values[2].value.span8() } }, false);
+    else {
+        StringBuilder builder;
+        for (auto& value : values.subvector(1))
+            builder.append(WTF::makeStringByReplacingAll(value.value, '\"', '\''));
+        event = generateJSONLogEvent(MessageLogEvent { builder.toString(), { } }, false);
+    }
+    emitJSONLogEvent(WTFMove(event));
+}
+#endif // !RELEASE_LOG_DISABLED && (PLATFORM(WPE) || PLATFORM(GTK))
 
 void PeerConnectionBackend::createOffer(RTCOfferOptions&& options, CreateCallback&& callback)
 {
@@ -242,7 +354,7 @@ static void processRemoteTracks(RTCRtpTransceiver& transceiver, PeerConnectionBa
 void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<DescriptionStates>&& descriptionStates, std::optional<TransceiverStates>&& transceiverStates, std::unique_ptr<RTCSctpTransportBackend>&& sctpBackend, std::optional<double> maxMessageSize)
 {
     ASSERT(isMainThread());
-    ALWAYS_LOG(LOGIDENTIFIER);
+    ALWAYS_LOG(LOGIDENTIFIER, "Set local description succeeded");
     if (transceiverStates)
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
@@ -420,6 +532,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             DEBUG_LOG(LOGIDENTIFIER, "Dispatching ", trackEventList.size(), " track events");
             for (auto& event : trackEventList) {
                 RefPtr track = event->track();
+                ALWAYS_LOG(LOGIDENTIFIER, "Dispatching track event for track ", track->id());
                 peerConnection->dispatchEvent(event);
                 if (peerConnection->isClosed()) {
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while dispatching track events");
@@ -568,6 +681,7 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
 
         ASSERT(!m_shouldFilterICECandidates || sdp.contains(".local"_s) || sdp.contains(" srflx "_s) || sdp.contains(" relay "_s));
         auto candidate = RTCIceCandidate::create(WTFMove(sdp), WTFMove(mid), sdpMLineIndex);
+        ALWAYS_LOG(logSiteIdentifier, "Dispatching ICE event for SDP ", candidate->candidate());
         peerConnection->dispatchEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, WTFMove(candidate), WTFMove(serverURL)));
     });
 }
@@ -575,14 +689,7 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
 void PeerConnectionBackend::newDataChannel(UniqueRef<RTCDataChannelHandler>&& channelHandler, String&& label, RTCDataChannelInit&& channelInit)
 {
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [peerConnection, label = WTFMove(label), channelHandler = WTFMove(channelHandler), channelInit = WTFMove(channelInit)]() mutable {
-        if (peerConnection->isClosed())
-            return;
-
-        auto channel = RTCDataChannel::create(*peerConnection->document(), channelHandler.moveToUniquePtr(), WTFMove(label), WTFMove(channelInit), RTCDataChannelState::Open);
-        peerConnection->dispatchEvent(RTCDataChannelEvent::create(eventNames().datachannelEvent, Event::CanBubble::No, Event::IsCancelable::No, Ref { channel }));
-        channel->fireOpenEventIfNeeded();
-    });
+    peerConnection->dispatchDataChannelEvent(WTFMove(channelHandler), WTFMove(label), WTFMove(channelInit));
 }
 
 void PeerConnectionBackend::doneGatheringCandidates()
@@ -705,6 +812,48 @@ void PeerConnectionBackend::ref() const
 void PeerConnectionBackend::deref() const
 {
     m_peerConnection->deref();
+}
+
+String PeerConnectionBackend::generateJSONLogEvent(LogEvent&& logEvent, bool isForGatherLogs)
+{
+    ASCIILiteral type;
+    String event;
+    WTF::switchOn(WTFMove(logEvent), [&](MessageLogEvent&& logEvent) {
+        type = "event"_s;
+        StringBuilder builder;
+        auto strippedMessage = logEvent.message.removeCharacters([](auto character) {
+            return character == '\n';
+        });
+        builder.append("{\"message\":\""_s, strippedMessage, "\",\"payload\":\""_s);
+        if (logEvent.payload)
+            builder.append(WTF::base64EncodeToString(*logEvent.payload));
+        builder.append("\"}"_s);
+        event = builder.toString();
+    }, [&](StatsLogEvent&& logEvent) {
+        type = "stats"_s;
+        event = WTFMove(logEvent);
+    });
+
+    if (isForGatherLogs) {
+        UNUSED_VARIABLE(type);
+        return event;
+    }
+
+    auto timestamp = WTF::WallTime::now().secondsSinceEpoch().microseconds();
+    return makeString("{\"peer-connection\":\""_s, m_logIdentifierString, "\",\"timestamp\":"_s, timestamp, ",\"type\":\""_s, type, "\",\"event\":"_s, event, '}');
+}
+
+void PeerConnectionBackend::emitJSONLogEvent(String&& event)
+{
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    if (!isJSONLogStreamingEnabled())
+        return;
+
+    auto& handler = jsonFileHandler();
+    handler.log(WTFMove(event));
+#else
+    UNUSED_PARAM(event);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -89,6 +89,9 @@ class PeerConnectionBackend
     : public CanMakeWeakPtr<PeerConnectionBackend>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    , public Logger::MessageHandlerObserver
+#endif
 #endif
 {
 public:
@@ -168,6 +171,9 @@ public:
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const override { return "PeerConnectionBackend"_s; }
     WTFLogChannel& logChannel() const final;
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    void handleLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
+#endif
 #endif
 
     virtual bool isLocalDescriptionSet() const = 0;
@@ -240,6 +246,20 @@ protected:
 
     void validateSDP(const String&) const;
 
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    bool isJSONLogStreamingEnabled() const { return !m_jsonFilePath.isEmpty(); }
+#endif
+
+    struct MessageLogEvent {
+        String message;
+        std::optional<std::span<const uint8_t>> payload;
+    };
+    using StatsLogEvent = String;
+
+    using LogEvent = std::variant<MessageLogEvent, StatsLogEvent>;
+    String generateJSONLogEvent(LogEvent&&, bool isForGatherLogs);
+    void emitJSONLogEvent(String&&);
+
 private:
     virtual void doCreateOffer(RTCOfferOptions&&) = 0;
     virtual void doCreateAnswer(RTCAnswerOptions&&) = 0;
@@ -261,9 +281,14 @@ private:
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
+    String m_logIdentifierString;
 #endif
     bool m_finishedGatheringCandidates { false };
     bool m_isProcessingLocalDescriptionAnswer { false };
+
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    String m_jsonFilePath;
+#endif
 };
 
 inline PeerConnectionBackend::DescriptionStates PeerConnectionBackend::DescriptionStates::isolatedCopy() &&

--- a/Source/WebCore/Modules/mediastream/RTCController.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCController.cpp
@@ -37,6 +37,10 @@
 #include "LibWebRTCUtils.h"
 #endif
 
+#if USE(GSTREAMER_WEBRTC)
+#include "GStreamerWebRTCLogSink.h"
+#endif
+
 #endif
 
 namespace WebCore {
@@ -191,6 +195,18 @@ void RTCController::startGatheringLogs(Document& document, LogCallback&& callbac
         m_logSink->start();
     }
 #endif
+
+#if USE(GSTREAMER_WEBRTC)
+    if (!m_logSink) {
+        m_logSink = makeUnique<GStreamerWebRTCLogSink>([weakThis = WeakPtr { *this }](const auto& logLevel, const auto& logMessage) {
+            ensureOnMainThread([weakThis, logMessage = logMessage.isolatedCopy(), logLevel = logLevel.isolatedCopy()]() mutable {
+                if (auto protectedThis = weakThis.get())
+                    protectedThis->m_callback("backend-logs"_s, WTFMove(logMessage), WTFMove(logLevel), nullptr);
+            });
+        });
+        m_logSink->start();
+    }
+#endif
 }
 
 void RTCController::stopGatheringLogs()
@@ -203,7 +219,7 @@ void RTCController::stopGatheringLogs()
     for (Ref connection : m_peerConnections)
         connection->stopGatheringStatLogs();
 
-    stopLoggingLibWebRTCLogs();
+    stopLoggingWebRTCLogs();
 }
 
 void RTCController::startGatheringStatLogs(RTCPeerConnection& connection)
@@ -214,9 +230,9 @@ void RTCController::startGatheringStatLogs(RTCPeerConnection& connection)
     });
 }
 
-void RTCController::stopLoggingLibWebRTCLogs()
+void RTCController::stopLoggingWebRTCLogs()
 {
-#if USE(LIBWEBRTC)
+#if USE(LIBWEBRTC) || USE(GSTREAMER_WEBRTC)
     if (!m_logSink)
         return;
 

--- a/Source/WebCore/Modules/mediastream/RTCController.h
+++ b/Source/WebCore/Modules/mediastream/RTCController.h
@@ -44,6 +44,10 @@ class WeakPtrImplWithEventTargetData;
 class LibWebRTCLogSink;
 #endif
 
+#if USE(GSTREAMER_WEBRTC)
+class GStreamerWebRTCLogSink;
+#endif
+
 class RTCController : public RefCounted<RTCController>, public CanMakeWeakPtr<RTCController> {
 public:
     static Ref<RTCController> create() { return adoptRef(*new RTCController); }
@@ -72,7 +76,7 @@ private:
     void startGatheringStatLogs(RTCPeerConnection&);
     bool shouldDisableICECandidateFiltering(Document&);
 
-    void stopLoggingLibWebRTCLogs();
+    void stopLoggingWebRTCLogs();
 
     struct PeerConnectionOrigin {
         Ref<SecurityOrigin> topOrigin;
@@ -86,6 +90,9 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_gatheringLogsDocument;
 #if USE(LIBWEBRTC)
     std::unique_ptr<LibWebRTCLogSink> m_logSink;
+#endif
+#if USE(GSTREAMER_WEBRTC)
+    std::unique_ptr<GStreamerWebRTCLogSink> m_logSink;
 #endif
 #endif // ENABLE(WEB_RTC)
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -201,6 +201,8 @@ public:
     // EventTarget implementation.
     void dispatchEvent(Event&) final;
 
+    void dispatchDataChannelEvent(UniqueRef<RTCDataChannelHandler>&&, String&& label, RTCDataChannelInit&&);
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     uint64_t logIdentifier() const final { return m_logIdentifier; }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -117,9 +117,12 @@ public:
 
     void connectIncomingTrack(WebRTCTrackData&);
 
+    void startRTCLogs();
+    void stopRTCLogs();
+
 protected:
 #if !RELEASE_LOG_DISABLED
-    void onStatsDelivered(GUniquePtr<GstStructure>&&);
+    void onStatsDelivered(const GstStructure*);
 #endif
 
 private:
@@ -215,6 +218,8 @@ private:
     Vector<RefPtr<MediaStreamTrackPrivate>> m_pendingIncomingTracks;
 
     Vector<RefPtr<RealtimeOutgoingMediaSourceGStreamer>> m_unlinkedOutgoingSources;
+
+    bool m_isGatheringRTCLogs { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -30,6 +30,7 @@
 #include "GStreamerRtpTransceiverBackend.h"
 #include "IceCandidate.h"
 #include "JSRTCStatsReport.h"
+#include "Logging.h"
 #include "MediaEndpointConfiguration.h"
 #include "NotImplemented.h"
 #include "RTCIceCandidate.h"
@@ -388,6 +389,27 @@ void GStreamerPeerConnectionBackend::tearDown()
         auto& backend = backendFromRTPTransceiver(*transceiver);
         backend.tearDown();
     }
+}
+
+void GStreamerPeerConnectionBackend::startGatheringStatLogs(Function<void(String&&)>&& callback)
+{
+    if (!m_rtcStatsLogCallback)
+        m_endpoint->startRTCLogs();
+    m_rtcStatsLogCallback = WTFMove(callback);
+}
+
+void GStreamerPeerConnectionBackend::stopGatheringStatLogs()
+{
+    if (m_rtcStatsLogCallback) {
+        m_endpoint->stopRTCLogs();
+        m_rtcStatsLogCallback = { };
+    }
+}
+
+void GStreamerPeerConnectionBackend::provideStatLogs(String&& stats)
+{
+    if (m_rtcStatsLogCallback)
+        m_rtcStatsLogCallback(WTFMove(stats));
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -92,6 +92,11 @@ private:
 
     std::optional<bool> canTrickleIceCandidates() const final;
 
+    void startGatheringStatLogs(Function<void(String&&)>&&) final;
+    void stopGatheringStatLogs() final;
+    void provideStatLogs(String&&);
+    friend class RtcEventLogOutput;
+
     friend class GStreamerMediaEndpoint;
     friend class GStreamerRtpSenderBackend;
     RTCPeerConnection& connection();
@@ -131,6 +136,8 @@ private:
     bool m_isRemoteDescriptionSet { false };
 
     bool m_isReconfiguring { false };
+
+    Function<void(String&&)> m_rtcStatsLogCallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -139,6 +139,7 @@ platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
 platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
 platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
 platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
 platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
 platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
 platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#if USE(GSTREAMER_WEBRTC)
+#include "GStreamerWebRTCLogSink.h"
+
+namespace WebCore {
+
+GStreamerWebRTCLogSink::GStreamerWebRTCLogSink(LogCallback&& callback)
+    : m_callback(WTFMove(callback))
+    , m_isGstDebugActive(gst_debug_is_active())
+{
+}
+
+GStreamerWebRTCLogSink::~GStreamerWebRTCLogSink() = default;
+
+static String toWebRTCLogLevel(GstDebugLevel level)
+{
+    switch (level) {
+    case GST_LEVEL_NONE:
+        return "none"_s;
+    case GST_LEVEL_ERROR:
+        return "error"_s;
+    case GST_LEVEL_WARNING:
+        return "warning"_s;
+    case GST_LEVEL_FIXME:
+        return "fixme"_s;
+    case GST_LEVEL_INFO:
+        return "info"_s;
+    case GST_LEVEL_DEBUG:
+        return "debug"_s;
+    case GST_LEVEL_LOG:
+        return "log"_s;
+    case GST_LEVEL_TRACE:
+        return "trace"_s;
+    case GST_LEVEL_MEMDUMP:
+        return "memdump"_s;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return ""_s;
+}
+
+void GStreamerWebRTCLogSink::start()
+{
+#ifdef GST_DISABLE_GST_DEBUG
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        WTFLogAlways("GST_DEBUG is disabled in this build. gatherLogs() will report only WebRTC stats logs.");
+    });
+#else
+    if (!m_isGstDebugActive)
+        gst_debug_remove_log_function(gst_debug_log_default);
+    gst_debug_add_log_function(static_cast<GstLogFunction>(+[](GstDebugCategory*, GstDebugLevel level, const char*, const char*, int, GObject*, GstDebugMessage* message, gpointer userData) G_GNUC_NO_INSTRUMENT {
+        auto self = reinterpret_cast<GStreamerWebRTCLogSink*>(userData);
+        self->m_callback(toWebRTCLogLevel(level), String::fromUTF8(gst_debug_message_get(message)));
+    }), this, nullptr);
+
+    // Do not include webrtcstats in the list, because stats are logged using a different code path by the endpoint.
+    gst_debug_set_threshold_from_string("webrtcbin:5,webrtcdatachannel:5,webrtctransport*:5,webrtcsctp*:5,nice*:6", FALSE);
+#endif
+}
+
+void GStreamerWebRTCLogSink::stop()
+{
+#ifndef GST_DISABLE_GST_DEBUG
+    gst_debug_remove_log_function_by_data(this);
+    if (!m_isGstDebugActive)
+        gst_debug_add_log_function(gst_debug_log_default, nullptr, nullptr);
+#endif
+}
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if USE(GSTREAMER_WEBRTC)
+
+#include <gst/gstinfo.h>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class GStreamerWebRTCLogSink {
+    WTF_MAKE_TZONE_ALLOCATED(GStreamerWebRTCLogSink);
+
+public:
+    using LogCallback = Function<void(const String&, const String&)>;
+    explicit GStreamerWebRTCLogSink(LogCallback&&);
+
+    ~GStreamerWebRTCLogSink();
+
+    void start();
+    void stop();
+
+private:
+    LogCallback m_callback;
+    bool m_isGstDebugActive { false };
+};
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER_WEBRTC)


### PR DESCRIPTION
#### b36717dc42b180575f2a695f04703b2765c1d28e
<pre>
[WebRTC] Support for events and stats aggregation
<a href="https://bugs.webkit.org/show_bug.cgi?id=279433">https://bugs.webkit.org/show_bug.cgi?id=279433</a>
&lt;<a href="https://rdar.apple.com/problem/136139817">rdar://problem/136139817</a>&gt;

Reviewed by Eric Carlson.

This patch instruments the LibWebRTC and GstWebRTC backends with additional logging that can be
gathered and processed by the PeerConnectionBackend. In this first version, for WPE and GTK ports,
the collected logs are written to a JSON file, if the WEBKIT_WEBRTC_JSON_EVENTS_FILE environment
variable is set.

gatherLogs is also now supported by the GStreamer backend, by using a custom GST_DEBUG log handler.

Future versions could send the JSON stream to the WebInspector or a custom URI protocol handler in
the UIProcess, for live graphing purposes.

* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/wtf/Logger.h:
(WTF::Logger::Observer::handleLogMessage):
(WTF::Logger::logAlways const):
(WTF::Logger::error const):
(WTF::Logger::warning const):
(WTF::Logger::info const):
(WTF::Logger::debug const):
(WTF::Logger::logAlwaysVerbose const):
(WTF::Logger::errorVerbose const):
(WTF::Logger::warningVerbose const):
(WTF::Logger::infoVerbose const):
(WTF::Logger::debugVerbose const):
(WTF::Logger::willLog const):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::PeerConnectionBackend):
(WebCore::PeerConnectionBackend::~PeerConnectionBackend):
(WebCore::PeerConnectionBackend::handleLogMessage):
(WebCore::PeerConnectionBackend::createOfferSucceeded):
(WebCore::PeerConnectionBackend::createOfferFailed):
(WebCore::PeerConnectionBackend::createAnswerSucceeded):
(WebCore::PeerConnectionBackend::createAnswerFailed):
(WebCore::PeerConnectionBackend::setLocalDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setLocalDescriptionFailed):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setRemoteDescriptionFailed):
(WebCore::PeerConnectionBackend::newICECandidate):
(WebCore::PeerConnectionBackend::newDataChannel):
(WebCore::PeerConnectionBackend::generateJSONLogEvent):
(WebCore::PeerConnectionBackend::emitJSONLogEvent):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
(WebCore::PeerConnectionBackend::isJSONLogStreamingEnabled const):
(WebCore::PeerConnectionBackend::setJSONLogStreamingEnabled):
* Source/WebCore/Modules/mediastream/RTCController.cpp:
(WebCore::RTCController::startGatheringLogs):
(WebCore::RTCController::stopGatheringLogs):
(WebCore::RTCController::stopLoggingWebRTCLogs):
(WebCore::RTCController::stopLoggingLibWebRTCLogs): Deleted.
* Source/WebCore/Modules/mediastream/RTCController.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::setLocalDescription):
(WebCore::RTCPeerConnection::setRemoteDescription):
(WebCore::RTCPeerConnection::addIceCandidate):
(WebCore::RTCPeerConnection::dispatchEvent):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::GStreamerMediaEndpoint):
(WebCore::RTCStatsLogger::toJSONString const):
(WebCore::GStreamerMediaEndpoint::processStatsItem):
(WebCore::GStreamerMediaEndpoint::statsLogInterval const):
(WebCore::GStreamerMediaEndpoint::startRTCLogs):
(WebCore::GStreamerMediaEndpoint::stopRTCLogs):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::startGatheringStatLogs):
(WebCore::GStreamerPeerConnectionBackend::stopGatheringStatLogs):
(WebCore::GStreamerPeerConnectionBackend::provideStatLogs):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::LibWebRTCMediaEndpoint):
(WebCore::LibWebRTCMediaEndpoint::OnStatsDelivered):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::setLogger):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp: Added.
(WebCore::GStreamerWebRTCLogSink::GStreamerWebRTCLogSink):
(WebCore::toWebRTCLogLevel):
(WebCore::GStreamerWebRTCLogSink::start):
(WebCore::GStreamerWebRTCLogSink::stop):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.h: Added.

Canonical link: <a href="https://commits.webkit.org/287090@main">https://commits.webkit.org/287090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d85dfb91c46b329f79866379f8dbf478c49852e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5628 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/19244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81368 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68576 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/41640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24974 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27904 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71448 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84327 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77541 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3830 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67267 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11111 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5615 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21811 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->