### PR TITLE
[GStreamer] Build fails with GST_DISABLE_GST_DEBUG and -Werror=unused

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -347,8 +347,7 @@ void GStreamerDataChannelHandler::bufferedAmountChanged()
 
 void GStreamerDataChannelHandler::onMessageData(GBytes* bytes)
 {
-    auto size = g_bytes_get_size(bytes);
-    DC_DEBUG("Incoming data of size: %zu", size);
+    DC_DEBUG("Incoming data of size: %zu", g_bytes_get_size(bytes));
     Locker locker { m_clientLock };
 
     if (!m_client) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -51,6 +51,7 @@ GST_DEBUG_CATEGORY(webkit_webrtc_pc_backend_debug);
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebRTCLogObserver);
 
+#ifndef GST_DISABLE_GST_DEBUG
 class WebRTCLogObserver : public WebCoreLogObserver {
 public:
     GstDebugCategory* debugCategory() const final
@@ -68,6 +69,7 @@ WebRTCLogObserver& webrtcLogObserverSingleton()
     static NeverDestroyed<WebRTCLogObserver> sharedInstance;
     return sharedInstance;
 }
+#endif // GST_DISABLE_GST_DEBUG
 
 static std::unique_ptr<PeerConnectionBackend> createGStreamerPeerConnectionBackend(RTCPeerConnection& peerConnection)
 {
@@ -91,6 +93,7 @@ GStreamerPeerConnectionBackend::GStreamerPeerConnectionBackend(RTCPeerConnection
 {
     disableICECandidateFiltering();
 
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
     // PeerConnectionBackend relies on the Document logger, so to prevent duplicate messages in case
     // more than one PeerConnection is created, we register a single observer.
     auto& logObserver = webrtcLogObserverSingleton();
@@ -98,12 +101,15 @@ GStreamerPeerConnectionBackend::GStreamerPeerConnectionBackend(RTCPeerConnection
 
     auto logIdentifier = makeString(hex(reinterpret_cast<uintptr_t>(this->logIdentifier())));
     GST_INFO_OBJECT(m_endpoint->pipeline(), "WebCore logs identifier for this pipeline is: %s", logIdentifier.ascii().data());
+#endif
 }
 
 GStreamerPeerConnectionBackend::~GStreamerPeerConnectionBackend()
 {
+#if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)
     auto& logObserver = webrtcLogObserverSingleton();
     logObserver.removeWatch(logger());
+#endif
 }
 
 void GStreamerPeerConnectionBackend::suspend()

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -276,7 +276,7 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
     });
 }
 
-Ref<AudioDecoder::DecodePromise> GStreamerInternalAudioDecoder::decode(std::span<const uint8_t> frameData, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration)
+Ref<AudioDecoder::DecodePromise> GStreamerInternalAudioDecoder::decode(std::span<const uint8_t> frameData, [[maybe_unused]] bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration)
 {
     GST_DEBUG_OBJECT(m_harness->element(), "Decoding%s frame", isKeyFrame ? " key" : "");
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -270,6 +270,9 @@ void AudioDestinationGStreamer::notifyStartupResult(bool success)
         notifyIsPlaying(true);
 
     callOnMainThreadAndWait([this, completionHandler = WTFMove(m_startupCompletionHandler), success]() mutable {
+#ifdef GST_DISABLE_GST_DEBUG
+        UNUSED_VARIABLE(this);
+#endif
         GST_DEBUG_OBJECT(m_pipeline.get(), "Has start completion handler: %s", boolForPrinting(!!completionHandler));
         if (completionHandler)
             completionHandler(success);
@@ -282,6 +285,9 @@ void AudioDestinationGStreamer::notifyStopResult(bool success)
         notifyIsPlaying(false);
 
     callOnMainThreadAndWait([this, completionHandler = WTFMove(m_stopCompletionHandler), success]() mutable {
+#ifdef GST_DISABLE_GST_DEBUG
+        UNUSED_VARIABLE(this);
+#endif
         GST_DEBUG_OBJECT(m_pipeline.get(), "Has stop completion handler: %s", boolForPrinting(!!completionHandler));
         if (completionHandler)
             completionHandler(success);

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -189,13 +189,15 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
 {
     auto& self = *reinterpret_cast<PlatformRawAudioDataGStreamer*>(this);
 
-    auto [sourceFormat, sourceLayout] = convertAudioSampleFormatToGStreamerFormat(self.format());
+    [[maybe_unused]] auto [sourceFormat, sourceLayout] = convertAudioSampleFormatToGStreamerFormat(self.format());
     auto [destinationFormat, destinationLayout] = convertAudioSampleFormatToGStreamerFormat(format);
-
     auto sourceOffset = frameOffset.value_or(0);
-    const char* destinationFormatDescription = gst_audio_format_to_string(destinationFormat);
 
+#ifndef GST_DISABLE_GST_DEBUG
+    const char* destinationFormatDescription = gst_audio_format_to_string(destinationFormat);
     GST_TRACE("Copying %s data at planeIndex %zu, destination format is %s, source offset: %zu", gst_audio_format_to_string(sourceFormat), planeIndex, destinationFormatDescription, sourceOffset);
+#endif
+
     GST_TRACE("Input caps: %" GST_PTR_FORMAT, gst_sample_get_caps(self.sample()));
 
     GstMappedAudioBuffer mappedBuffer(self.sample(), GST_MAP_READ);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -916,9 +916,14 @@ bool webkitGstSetElementStateSynchronously(GstElement* pipeline, GstState target
 
     auto cleanup = makeScopeExit([bus = GRefPtr<GstBus>(bus), pipeline, targetState] {
         gst_bus_disable_sync_message_emission(bus.get());
+#ifdef GST_DISABLE_GST_DEBUG
+        UNUSED_VARIABLE(pipeline);
+        UNUSED_VARIABLE(targetState);
+#else
         GstState currentState;
         auto result = gst_element_get_state(pipeline, &currentState, nullptr, 0);
         GST_DEBUG_OBJECT(pipeline, "Task finished, result: %s, target state reached: %s", gst_element_state_change_return_get_name(result), boolForPrinting(currentState == targetState));
+#endif
     });
 
     result = gst_element_set_state(pipeline, targetState);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -765,8 +765,10 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isCodecSup
         }
     }
 
-    const char* configLogString = configurationNameForLogging(configuration);
-    GST_LOG("Checked %s %s codec \"%s\" supported %s", shouldCheckForHardwareUse ? "hardware" : "software", configLogString, codecName.utf8().data(), boolForPrinting(result.isSupported));
+#ifndef GST_DISABLE_GST_DEBUG
+    ASCIILiteral configLogString = configurationNameForLogging(configuration);
+    GST_LOG("Checked %s %s codec \"%s\" supported %s", shouldCheckForHardwareUse ? "hardware" : "software", configLogString.characters(), codecName.utf8().data(), boolForPrinting(result.isSupported));
+#endif
     return result;
 }
 
@@ -960,33 +962,33 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isAVC1Code
     return areCapsSupported(configuration, h264Caps, shouldCheckForHardwareUse);
 }
 
-const char* GStreamerRegistryScanner::configurationNameForLogging(Configuration configuration) const
+ASCIILiteral GStreamerRegistryScanner::configurationNameForLogging(Configuration configuration) const
 {
-    const char* configLogString = "";
-
     switch (configuration) {
     case Configuration::Encoding:
-        configLogString = "encoding";
-        break;
+        return "encoding"_s;
     case Configuration::Decoding:
-        configLogString = "decoding";
-        break;
+        return "decoding"_s;
     }
-    return configLogString;
+    return ""_s;
 }
 
 GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfigurationSupported(Configuration configuration, const MediaConfiguration& mediaConfiguration) const
 {
     bool isSupported = false;
     bool isUsingHardware = false;
-    const char* configLogString = configurationNameForLogging(configuration);
+#ifndef GST_DISABLE_GST_DEBUG
+    ASCIILiteral configLogString = configurationNameForLogging(configuration);
+#endif
 
     if (mediaConfiguration.video) {
         auto& videoConfiguration = mediaConfiguration.video.value();
-        GST_DEBUG("Checking %s support for video configuration: \"%s\" size: %ux%u bitrate: %" G_GUINT64_FORMAT " framerate: %f", configLogString,
+#ifndef GST_DISABLE_GST_DEBUG
+        GST_DEBUG("Checking %s support for video configuration: \"%s\" size: %ux%u bitrate: %" G_GUINT64_FORMAT " framerate: %f", configLogString.characters(),
             videoConfiguration.contentType.utf8().data(),
             videoConfiguration.width, videoConfiguration.height,
             videoConfiguration.bitrate, videoConfiguration.framerate);
+#endif
 
         auto contentType = ContentType(videoConfiguration.contentType);
         isSupported = isContainerTypeSupported(configuration, contentType.containerType());
@@ -997,9 +999,11 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
 
     if (mediaConfiguration.audio) {
         auto& audioConfiguration = mediaConfiguration.audio.value();
-        GST_DEBUG("Checking %s support for audio configuration: \"%s\" %s channels, bitrate: %" G_GUINT64_FORMAT " samplerate: %u", configLogString,
+#ifndef GST_DISABLE_GST_DEBUG
+        GST_DEBUG("Checking %s support for audio configuration: \"%s\" %s channels, bitrate: %" G_GUINT64_FORMAT " samplerate: %u", configLogString.characters(),
             audioConfiguration.contentType.utf8().data(), audioConfiguration.channels.utf8().data(),
             audioConfiguration.bitrate.value_or(0), audioConfiguration.samplerate.value_or(0));
+#endif
         auto contentType = ContentType(audioConfiguration.contentType);
         isSupported = isContainerTypeSupported(configuration, contentType.containerType());
     }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -173,7 +173,7 @@ private:
     CodecLookupResult isAVC1CodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
     CodecLookupResult isHEVCCodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
 
-    const char* configurationNameForLogging(Configuration) const;
+    ASCIILiteral configurationNameForLogging(Configuration) const;
     bool supportsFeatures(const String& features) const;
 
 #if USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -268,7 +268,7 @@ private:
             GRefPtr<GstCaps> caps = adoptGRef(gst_pad_get_current_caps(pad));
             GST_DEBUG_OBJECT(pad, "Sending stored pad caps to appsink: %" GST_PTR_FORMAT, caps.get());
             // This will cause a recursive call to appsinkWorkaroundProbe() which will also set `needsResendCaps` to false.
-            bool wereCapsSent = gst_pad_send_event(pad, gst_event_new_caps(caps.get()));
+            [[maybe_unused]] bool wereCapsSent = gst_pad_send_event(pad, gst_event_new_caps(caps.get()));
             GST_DEBUG_OBJECT(pad, "wereCapsSent = %s. Returning from the probe so that the buffer is sent: %" GST_PTR_FORMAT, boolForPrinting(wereCapsSent), info->data);
         }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -44,7 +44,7 @@ public:
         delete static_cast<WebKitVideoSinkProbe*>(userData);
     }
 
-    static GstPadProbeReturn doProbe(GstPad* pad, GstPadProbeInfo* info, gpointer userData)
+    static GstPadProbeReturn doProbe([[maybe_unused]] GstPad* pad, GstPadProbeInfo* info, gpointer userData)
     {
         auto* self = static_cast<WebKitVideoSinkProbe*>(userData);
         auto* player = self->m_player;
@@ -142,15 +142,19 @@ void webKitVideoSinkSetMediaPlayerPrivate(GstElement* appSink, MediaPlayerPrivat
 
     g_signal_connect(appSink, "new-sample", G_CALLBACK(+[](GstElement* sink, MediaPlayerPrivateGStreamer* player) -> GstFlowReturn {
         GRefPtr<GstSample> sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
+#ifndef GST_DISABLE_GST_DEBUG
         GstBuffer* buffer = gst_sample_get_buffer(sample.get());
         GST_TRACE_OBJECT(sink, "new-sample with PTS=%" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(buffer)));
+#endif
         player->triggerRepaint(WTFMove(sample));
         return GST_FLOW_OK;
     }), player);
     g_signal_connect(appSink, "new-preroll", G_CALLBACK(+[](GstElement* sink, MediaPlayerPrivateGStreamer* player) -> GstFlowReturn {
         GRefPtr<GstSample> sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
+#ifndef GST_DISABLE_GST_DEBUG
         GstBuffer* buffer = gst_sample_get_buffer(sample.get());
         GST_DEBUG_OBJECT(sink, "new-preroll with PTS=%" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(buffer)));
+#endif
         player->triggerRepaint(WTFMove(sample));
         return GST_FLOW_OK;
     }), player);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -180,8 +180,10 @@ static std::optional<unsigned> retrieveTemporalIndex(const GRefPtr<GstSample>& s
         GST_TRACE("Looking-up layer id in %" GST_PTR_FORMAT, metaStructure);
         return gstStructureGet<unsigned>(metaStructure, "layer-id"_s);
     }
+#ifndef GST_DISABLE_GST_DEBUG
     auto name = gstStructureGetName(structure);
     GST_TRACE("Retrieval of temporal index from encoded format %s is not yet supported.", reinterpret_cast<const char*>(name.rawCharacters()));
+#endif
 #endif
     return { };
 }

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -261,7 +261,7 @@ enum class ResetType {
     Hard
 };
 
-static void webkitWebSrcReset(WebKitWebSrc* src, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>& members, ResetType resetType)
+static void webkitWebSrcReset([[maybe_unused]] WebKitWebSrc* src, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>& members, ResetType resetType)
 {
     GST_DEBUG_OBJECT(src, "Resetting internal state");
     gst_adapter_clear(members->adapter.get());
@@ -419,7 +419,7 @@ static void restartLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSr
 }
 
 
-static void stopLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>& members)
+static void stopLoaderIfNeeded([[maybe_unused]] WebKitWebSrc* src, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>& members)
 {
     ASSERT(isMainThread());
 
@@ -1164,9 +1164,11 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
     // sending time from the receiving time, it is better to ignore it.
     if (!members->downloadStartTime.isNaN()) {
         members->totalDownloadedBytes += data.size();
+#ifndef GST_DISABLE_GST_DEBUG
         double timeSinceStart = (WallTime::now() - members->downloadStartTime).seconds();
         GST_TRACE_OBJECT(src.get(), "R%u: downloaded %" G_GUINT64_FORMAT " bytes in %f seconds =~ %1.0f bytes/second", m_requestNumber, members->totalDownloadedBytes, timeSinceStart
             , timeSinceStart ? members->totalDownloadedBytes / timeSinceStart : 0);
+#endif
     } else {
         members->downloadStartTime = WallTime::now();
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -257,7 +257,7 @@ void AppendPipeline::handleErrorConditionFromStreamingThread()
     });
 }
 
-void AppendPipeline::handleErrorSyncMessage(GstMessage* message)
+void AppendPipeline::handleErrorSyncMessage([[maybe_unused]] GstMessage* message)
 {
     ASSERT(!isMainThread());
     GST_WARNING_OBJECT(pipeline(), "Demuxing error: %" GST_PTR_FORMAT, message);
@@ -557,7 +557,7 @@ void AppendPipeline::consumeAppsinksAvailableSamples()
     ASSERT(isMainThread());
 
     GRefPtr<GstSample> sample;
-    int batchedSampleCount = 0;
+    [[maybe_unused]] int batchedSampleCount = 0;
     for (std::unique_ptr<Track>& track : m_tracks) {
         while ((sample = adoptGRef(gst_app_sink_try_pull_sample(GST_APP_SINK(track->appsink.get()), 0)))) {
             appsinkNewSample(*track, WTFMove(sample));
@@ -684,7 +684,7 @@ void AppendPipeline::handleAppsinkNewSampleFromStreamingThread(GstElement*)
     }
 }
 
-GRefPtr<GstElement> createOptionalParserForFormat(GstBin* bin, const AtomString& trackStringId, const GstCaps* caps)
+GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, const AtomString& trackStringId, const GstCaps* caps)
 {
     // Parser elements have either or both of two functions:
     //
@@ -1069,7 +1069,7 @@ static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad* pad, Gst
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-static GstPadProbeReturn appendPipelineAppsinkPadEventProbe(GstPad* pad, GstPadProbeInfo* info, struct PadProbeInformation *padProbeInformation)
+static GstPadProbeReturn appendPipelineAppsinkPadEventProbe([[maybe_unused]] GstPad* pad, GstPadProbeInfo* info, struct PadProbeInformation *padProbeInformation)
 {
     ASSERT(GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM);
     GstEvent* event = gst_pad_probe_info_get_event(info);
@@ -1089,11 +1089,13 @@ static GstPadProbeReturn appendPipelineAppsinkPadEventProbe(GstPad* pad, GstPadP
 }
 #endif
 
-static GstPadProbeReturn appendPipelineDemuxerBlackHolePadProbe(GstPad* pad, GstPadProbeInfo* info, gpointer)
+static GstPadProbeReturn appendPipelineDemuxerBlackHolePadProbe([[maybe_unused]] GstPad* pad, [[maybe_unused]] GstPadProbeInfo* info, gpointer)
 {
     ASSERT(GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER);
+#ifndef GST_DISABLE_GST_DEBUG
     GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
     GST_TRACE_OBJECT(pad, "buffer of size %" G_GSIZE_FORMAT " ignored", gst_buffer_get_size(buffer));
+#endif
     return GST_PAD_PROBE_DROP;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -59,6 +59,7 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+#ifndef GST_DISABLE_GST_DEBUG
 static const char* dumpReadyState(WebCore::MediaPlayer::ReadyState readyState)
 {
     switch (readyState) {
@@ -70,6 +71,7 @@ static const char* dumpReadyState(WebCore::MediaPlayer::ReadyState readyState)
     default: return "(unknown)";
     }
 }
+#endif // GST_DISABLE_GST_DEBUG
 
 GST_DEBUG_CATEGORY(webkit_mse_debug);
 #define GST_CAT_DEFAULT webkit_mse_debug
@@ -199,7 +201,7 @@ void MediaPlayerPrivateGStreamerMSE::checkPlayingConsistency()
     }
 }
 
-#ifndef GST_DISABLE_DEBUG
+#ifndef GST_DISABLE_GST_DEBUG
 void MediaPlayerPrivateGStreamerMSE::setShouldDisableSleep(bool shouldDisableSleep)
 {
     // This method is useful only for logging purpose. The actual sleep disabler is managed by HTMLMediaElement.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -91,7 +91,7 @@ public:
 #endif
 
     void checkPlayingConsistency() final;
-#ifndef GST_DISABLE_DEBUG
+#ifndef GST_DISABLE_GST_DEBUG
     void setShouldDisableSleep(bool) final;
 #endif
 

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -115,7 +115,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
 
     if (hasSometimesSrcPad) {
         GST_DEBUG_OBJECT(m_element.get(), "Expecting output buffers on sometimes src pad(s).");
-        g_signal_connect(m_element.get(), "pad-added", reinterpret_cast<GCallback>(+[](GstElement* element, GstPad* pad, gpointer userData) {
+        g_signal_connect(m_element.get(), "pad-added", reinterpret_cast<GCallback>(+[]([[maybe_unused]] GstElement* element, GstPad* pad, gpointer userData) {
             GST_DEBUG_OBJECT(element, "Pad added: %" GST_PTR_FORMAT, pad);
             auto& harness = *reinterpret_cast<GStreamerElementHarness*>(userData);
             RefPtr<GStreamerElementHarness> downstreamHarness;
@@ -132,7 +132,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
             harness.dumpGraph("pad-added"_s);
         }), this);
 
-        g_signal_connect(m_element.get(), "pad-removed", reinterpret_cast<GCallback>(+[](GstElement* element, GstPad* pad, gpointer userData) {
+        g_signal_connect(m_element.get(), "pad-removed", reinterpret_cast<GCallback>(+[]([[maybe_unused]] GstElement* element, GstPad* pad, gpointer userData) {
             GST_DEBUG_OBJECT(element, "Pad removed: %" GST_PTR_FORMAT, pad);
             auto& harness = *reinterpret_cast<GStreamerElementHarness*>(userData);
             harness.m_outputStreams.removeAllMatching([pad = GRefPtr<GstPad>(pad)](auto& item) -> bool {

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -459,7 +459,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     return true;
 }
 
-EncoderId videoEncoderFindForFormat(WebKitVideoEncoder* self, const GRefPtr<GstCaps>& caps)
+EncoderId videoEncoderFindForFormat([[maybe_unused]] WebKitVideoEncoder* self, const GRefPtr<GstCaps>& caps)
 {
     if (!caps)
         return None;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -372,7 +372,7 @@ bool MediaRecorderPrivateBackend::preparePipeline()
     }), this);
 
     m_signalAdapter = adoptGRef(gst_transcoder_get_sync_signal_adapter(m_transcoder.get()));
-    g_signal_connect(m_signalAdapter.get(), "warning", G_CALLBACK(+[](GstTranscoder*, GError* error, GstStructure* details) {
+    g_signal_connect(m_signalAdapter.get(), "warning", G_CALLBACK(+[](GstTranscoder*, [[maybe_unused]] GError* error, [[maybe_unused]] GstStructure* details) {
         GST_WARNING("%s details: %" GST_PTR_FORMAT, error->message, details);
     }), nullptr);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -330,7 +330,7 @@ public:
         trackEnded(m_track);
     }
 
-    void pushSample(GRefPtr<GstSample>&& sample, const ASCIILiteral logMessage)
+    void pushSample(GRefPtr<GstSample>&& sample, [[maybe_unused]] const ASCIILiteral logMessage)
     {
         ASSERT(m_src);
         if (!m_src || !m_isObserving)
@@ -962,7 +962,7 @@ WEBKIT_DEFINE_ASYNC_DATA_STRUCT(ProbeData);
 static GstPadProbeReturn webkitMediaStreamSrcPadProbeCb(GstPad* pad, GstPadProbeInfo* info, ProbeData* data)
 {
     GstEvent* event = GST_PAD_PROBE_INFO_EVENT(info);
-    WebKitMediaStreamSrc* self = WEBKIT_MEDIA_STREAM_SRC_CAST(data->element.get());
+    [[maybe_unused]] WebKitMediaStreamSrc* self = WEBKIT_MEDIA_STREAM_SRC_CAST(data->element.get());
 
     GST_DEBUG_OBJECT(self, "Event %" GST_PTR_FORMAT, event);
     switch (GST_EVENT_TYPE(event)) {
@@ -1078,7 +1078,7 @@ void webkitMediaStreamSrcSignalEndOfStream(WebKitMediaStreamSrc* self)
     self->priv->sources.clear();
 }
 
-void webkitMediaStreamSrcCharacteristicsChanged(WebKitMediaStreamSrc* self)
+void webkitMediaStreamSrcCharacteristicsChanged([[maybe_unused]] WebKitMediaStreamSrc* self)
 {
     GST_DEBUG_OBJECT(self, "MediaStream characteristics changed");
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -38,7 +38,7 @@ GST_DEBUG_CATEGORY_STATIC(webkitGstMockDeviceDebug);
 #define webkit_mock_device_provider_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(GStreamerMockDevice, webkit_mock_device, GST_TYPE_DEVICE, GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceDebug, "webkitmockdevice", 0, "Mock Device"))
 
-static GstElement* webkitMockDeviceCreateElement(GstDevice* device, const char* name)
+static GstElement* webkitMockDeviceCreateElement([[maybe_unused]] GstDevice* device, const char* name)
 {
     GST_INFO_OBJECT(device, "Creating source element for device %s", name);
     auto* element = makeGStreamerElement("appsrc", name);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -38,7 +38,7 @@ GST_DEBUG_CATEGORY_STATIC(webkitGstMockDeviceProviderDebug);
 #define webkit_mock_device_provider_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(GStreamerMockDeviceProvider, webkit_mock_device_provider, GST_TYPE_DEVICE_PROVIDER, GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceProviderDebug, "webkitmockdeviceprovider", 0, "Mock Device Provider"))
 
-static GList* webkitMockDeviceProviderProbe(GstDeviceProvider* provider)
+static GList* webkitMockDeviceProviderProbe([[maybe_unused]] GstDeviceProvider* provider)
 {
     if (!MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled()) {
         GST_INFO_OBJECT(provider, "Mock capture sources are disabled, returning empty device list");


### PR DESCRIPTION
#### f5cd6dd027cac497f6bb2035a093b66f6234a257
<pre>
[GStreamer] Build fails with GST_DISABLE_GST_DEBUG and -Werror=unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=279435">https://bugs.webkit.org/show_bug.cgi?id=279435</a>

Reviewed by Philippe Normand.

Add [[maybe_unused]]&apos;s and #ifndef guards where missing.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::onMessageData):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::GStreamerPeerConnectionBackend):
(WebCore::GStreamerPeerConnectionBackend::~GStreamerPeerConnectionBackend):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioDecoder::decode):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::notifyStartupResult):
(WebCore::AudioDestinationGStreamer::notifyStopResult):
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
(WebCore::PlatformRawAudioData::copyTo):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::webkitGstSetElementStateSynchronously):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isCodecSupported const):
(WebCore::GStreamerRegistryScanner::configurationNameForLogging const):
(WebCore::GStreamerRegistryScanner::isConfigurationSupported const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
(WebCore::AppSinkFlushCapsWorkaroundProbe::probe):
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
(WebKitVideoSinkProbe::doProbe):
(webKitVideoSinkSetMediaPlayerPrivate):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::mediaPlayerWillBeDestroyed):
(WebCore::MediaPlayerPrivateGStreamer::updateTracks):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::attemptToDecryptWithInstance):
(WebCore::MediaPlayerPrivateGStreamer::attemptToDecryptWithLocalInstance):
(WebCore::MediaPlayerPrivateGStreamer::supportsKeySystem):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::retrieveTemporalIndex):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webkitWebSrcReset):
(stopLoaderIfNeeded):
(CachedResourceStreamingClient::dataReceived):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::handleErrorSyncMessage):
(WebCore::AppendPipeline::consumeAppsinksAvailableSamples):
(WebCore::createOptionalParserForFormat):
(WebCore::appendPipelineAppsinkPadEventProbe):
(WebCore::appendPipelineDemuxerBlackHolePadProbe):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(dumpPipeline):
(webKitMediaSrcActivateMode):
(webKitMediaSrcLoop):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderFindForFormat):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::preparePipeline):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcPadProbeCb):
(webkitMediaStreamSrcCharacteristicsChanged):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
(webkitMockDeviceCreateElement):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
(webkitMockDeviceProviderProbe):

Canonical link: <a href="https://commits.webkit.org/283413@main">https://commits.webkit.org/283413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbe51d74c49150b2bf9eb44b855799ba0aece10a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16830 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53128 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11726 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14712 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60451 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60751 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2034 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41401 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->