### PR TITLE
Improve `transformed-text-fill-gradient.html` test

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2695,9 +2695,6 @@ webkit.org/b/262133 [ Release ] js/ShadowRealm-importValue.html [ Pass Timeout ]
 fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html [ Failure ]
 fast/events/cancel-mousedown-and-drag-to-frame.html [ Failure ]
 
-# SVG gradients are not bit-for-bit equivalent through a scale.
-webkit.org/b/142192 svg/transforms/transformed-text-fill-gradient.html [ ImageOnlyFailure ]
-
 # rdar://117432620 [ arm64 ] 2 tests in imported/w3c/web-platform-tests/css/css-backgrounds/background-size have constant image failure
 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-cover.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-contain.xht [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1638,8 +1638,6 @@ http/tests/webgpu/webgpu/api/validation/queue/destroyed [ Pass ]
 
 http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html [ Pass ]
 
-webkit.org/b/263920 svg/transforms/transformed-text-fill-gradient.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/264266 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html [ ImageOnlyFailure ]
 
 webkit.org/b/264306 [ Sonoma+ ] fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html [ Pass ImageOnlyFailure Timeout ]

--- a/LayoutTests/svg/transforms/transformed-text-fill-gradient-expected.html
+++ b/LayoutTests/svg/transforms/transformed-text-fill-gradient-expected.html
@@ -1,14 +1,18 @@
-<html><body><svg width="600" height="600" xmlns="http://www.w3.org/2000/svg">
- <defs>
-   <lineargradient x1="0" x2="1" id="gradient">
-     <stop stop-color="#f00" offset="0"></stop>
-     <stop stop-color="#0f0" offset="0.5"></stop>
-     <stop stop-color="#00f" offset="1"></stop>
-   </lineargradient>
- </defs>
- <g transform="scale(6)" y="50">
-   <text y="10" font-size="10" fill="url(#gradient)">Text needs to have identical gradient.</text>
- </g>
-</svg>
-</body>
+<html>
+    <body>
+        <svg width="600" height="600" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <lineargradient x1="0" x2="1" id="gradient">
+                    <stop stop-color="#0f0" offset="0"></stop>
+                    <stop stop-color="#0f0" offset="0.5"></stop>
+                    <stop stop-color="#00f" offset="0.5"></stop>
+                    <stop stop-color="#00f" offset="1"></stop>
+                </lineargradient>
+            </defs>
+            <g transform="scale(6)" y="50">
+                <text y="10" font-size="10" fill="url(#gradient)">Text needs to have</text>
+                <text y="30" font-size="10" fill="url(#gradient)">identical sharp gradient fill.</text>
+            </g>
+        </svg>
+    </body>
 </html>

--- a/LayoutTests/svg/transforms/transformed-text-fill-gradient.html
+++ b/LayoutTests/svg/transforms/transformed-text-fill-gradient.html
@@ -1,14 +1,18 @@
-<html><body><svg width="600" height="600" xmlns="http://www.w3.org/2000/svg">
- <defs>
-   <lineargradient x1="0" x2="1" id="gradient">
-     <stop stop-color="#f00" offset="0"></stop>
-     <stop stop-color="#0f0" offset="0.5"></stop>
-     <stop stop-color="#00f" offset="1"></stop>
-   </lineargradient>
- </defs>
- <g transform="scale(3)" y="50">
-   <text y="20" font-size="20" fill="url(#gradient)">Text needs to have identical gradient.</text>
- </g>
-</svg>
-</body>
+<html>
+    <body>
+        <svg width="600" height="600" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <lineargradient x1="0" x2="1" id="gradient">
+                    <stop stop-color="#0f0" offset="0"></stop>
+                    <stop stop-color="#0f0" offset="0.5"></stop>
+                    <stop stop-color="#00f" offset="0.5"></stop>
+                    <stop stop-color="#00f" offset="1"></stop>
+                </lineargradient>
+            </defs>
+            <g transform="scale(3)" y="50">
+                <text y="20" font-size="20" fill="url(#gradient)">Text needs to have</text>
+                <text y="60" font-size="20" fill="url(#gradient)">identical sharp gradient fill.</text>
+            </g>
+        </svg>
+    </body>
 </html>


### PR DESCRIPTION
#### 3c2e1a0239e91d1cdc1e6fe928b5540c91b89a6b
<pre>
Improve `transformed-text-fill-gradient.html` test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263920">https://bugs.webkit.org/show_bug.cgi?id=263920</a>
<a href="https://rdar.apple.com/117705279">rdar://117705279</a>

Reviewed by Antoine Quint.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/5eabe6b6e3c8946ca10a89e0bf5b0045d3357ff9">https://source.chromium.org/chromium/chromium/src/+/5eabe6b6e3c8946ca10a89e0bf5b0045d3357ff9</a>

The test fails due to rounding gradient color values on some platform,
leading to pixel test mismatches. This merge is to improve robustness by
clamping to sharp gradient stops.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/svg/transforms/transformed-text-fill-gradient-expected.html:
* LayoutTests/svg/transforms/transformed-text-fill-gradient.html:

Canonical link: <a href="https://commits.webkit.org/283420@main">https://commits.webkit.org/283420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9081d701ce0d93a919560d4444f3a418df5a3e2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16831 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53130 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38725 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14714 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71956 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14600 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2036 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->