### PR TITLE
[Skia] Use CoordinatedPlatformLayerBufferNativeImage in ImageBufferSkiaAcceleratedBackend

### DIFF
--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -56,13 +56,8 @@ private:
 
 #if USE(COORDINATED_GRAPHICS)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const final;
-    bool swapBuffersIfNeeded();
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
-    struct {
-        RefPtr<BitmapTexture> back;
-        RefPtr<BitmapTexture> front;
-    } m_texture;
 #endif
 };
 


### PR DESCRIPTION
#### 0e217502a1853b522ad445233d600bbe18bc86bf
<pre>
[Skia] Use CoordinatedPlatformLayerBufferNativeImage in ImageBufferSkiaAcceleratedBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=279437">https://bugs.webkit.org/show_bug.cgi?id=279437</a>

Reviewed by Miguel Gomez.

It simplifies the code and avoids the context switch to copy the texture.

* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
(ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend):
(ImageBufferSkiaAcceleratedBackend::copyNativeImage):
(ImageBufferSkiaAcceleratedBackend::createNativeImageReference):
(ImageBufferSkiaAcceleratedBackend::layerContentsDisplayDelegate const):
(WebCore::ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend): Deleted.
(WebCore::flushSurfaceIfNeeded): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::copyNativeImage): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::createNativeImageReference): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::layerContentsDisplayDelegate const): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:

Canonical link: <a href="https://commits.webkit.org/283460@main">https://commits.webkit.org/283460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd84627a516ad3973db49cb75896523b2b60f3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53134 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11732 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60456 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60757 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8407 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->