### PR TITLE
FetchBodyOwner should not be GCed if its FormDataConsumer is reading a blob or a file

### DIFF
--- a/LayoutTests/fast/files/blob-formdata-gc-expected.txt
+++ b/LayoutTests/fast/files/blob-formdata-gc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Validate response is taking a pending activity when reading a form data blob
+

--- a/LayoutTests/fast/files/blob-formdata-gc.html
+++ b/LayoutTests/fast/files/blob-formdata-gc.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="../../resources/gc.js"></script>
+    </head>
+    <body>
+        <script>
+let totalCounter = 0;
+let okCounter = 0;
+function textFromBlobFormData()
+{
+    const blob = new Blob(["123"], {type: "text/plain"});
+    const formData = new FormData();
+    formData.append("file", blob, "");
+    const response = new Response(formData);
+    response.text().then(() => {
+          ++okCounter;
+    }).finally(() => {
+          ++totalCounter;
+    });
+}
+
+promise_test(async () => {
+    for (let i = 0; i < 10; i++) {
+       textFromBlobFormData();
+       gc();
+    }
+
+    let i = 0;
+    while (++i < 100 && totalCounter < 10)
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert_equals(totalCounter, 10, "total counter");
+    assert_equals(okCounter, 10, "ok counter");
+}, "Validate response is taking a pending activity when reading a form data blob");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -82,6 +82,7 @@ public:
 
     void consumeOnceLoadingFinished(FetchBodyConsumer::Type, Ref<DeferredPromise>&&);
     void cleanConsumer() { m_consumer.clean(); }
+    bool hasConsumerPendingActivity() const { return m_consumer.hasPendingActivity(); }
 
     FetchBody clone();
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -66,6 +66,8 @@ public:
     RefPtr<JSC::ArrayBuffer> takeAsArrayBuffer();
     String takeAsText();
 
+    bool hasPendingActivity() const { return m_formDataConsumer ? m_formDataConsumer->hasPendingActivity() : false; }
+
     void setType(Type type) { m_type = type; }
 
     void clean();

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -424,7 +424,7 @@ std::optional<Exception> FetchBodyOwner::loadingException() const
 
 bool FetchBodyOwner::virtualHasPendingActivity() const
 {
-    return !!m_blobLoader;
+    return !!m_blobLoader || (m_body && m_body->hasConsumerPendingActivity());
 }
 
 bool FetchBodyOwner::hasLoadingError() const

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -62,8 +62,6 @@ public:
 
     void loadBlob(const Blob&, FetchBodyConsumer*);
 
-    bool isActive() const { return !!m_blobLoader; }
-
     ExceptionOr<RefPtr<ReadableStream>> readableStream(JSC::JSGlobalObject&);
     bool hasReadableStreamBody() const { return m_body && m_body->hasReadableStream(); }
     bool isReadableStreamBody() const { return m_body && m_body->isReadableStream(); }

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -50,6 +50,8 @@ public:
     void start() { read(); }
     void cancel();
 
+    bool hasPendingActivity() const { return !!m_blobLoader || m_isReadingFile; }
+
 private:
     FormDataConsumer(const FormData&, ScriptExecutionContext&, Callback&&);
 
@@ -69,6 +71,7 @@ private:
     size_t m_currentElementIndex { 0 };
     Ref<WorkQueue> m_fileQueue;
     std::unique_ptr<BlobLoader> m_blobLoader;
+    bool m_isReadingFile { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f63e77117fcade21cea2c82946e35ebd79446974
<pre>
FetchBodyOwner should not be GCed if its FormDataConsumer is reading a blob or a file
<a href="https://bugs.webkit.org/show_bug.cgi?id=279441">https://bugs.webkit.org/show_bug.cgi?id=279441</a>
<a href="https://rdar.apple.com/135355235">rdar://135355235</a>

Reviewed by Chris Dumez.

FetchResponse or FetchRequest should take a pending activity to not be GCed when doing asynchronous tasks.
We did not do that when reading blob or file items of a FormData.
To fix this, we expose hasPendingActivity in FormDataConsumer to know whether it is doing an asynchronous task.
We use this getter in FetchBodyOwner::virtualHasPendingActivity to prevent GC.

* LayoutTests/fast/files/blob-formdata-gc-expected.txt: Added.
* LayoutTests/fast/files/blob-formdata-gc.html: Added.
* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::hasConsumerPendingActivity const):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
(WebCore::FetchBodyConsumer::hasPendingActivity const):
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::virtualHasPendingActivity const):
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
(WebCore::FetchBodyOwner::isActive const): Deleted.
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::consumeFile):
* Source/WebCore/Modules/fetch/FormDataConsumer.h:
(WebCore::FormDataConsumer::hasPendingActivity const):

Canonical link: <a href="https://commits.webkit.org/283430@main">https://commits.webkit.org/283430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe7506ed4e9241722d67a0fe688aa1c51d22eff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53151 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11750 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14736 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15732 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71981 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60471 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60773 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2054 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->