### PR TITLE
Handle empty URL passed to history.replaceState according to spec

### DIFF
--- a/LayoutTests/fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange-expected.txt
@@ -31,9 +31,8 @@ State popped with event null (type object) and last path component pushstate-wit
 Hash change fired and last path component is pushstate-with-fragment-urls-and-hashchange.html#otherhash
 State popped with event null (type object) and last path component pushstate-with-fragment-urls-and-hashchange.html#hash
 Hash change fired and last path component is pushstate-with-fragment-urls-and-hashchange.html#hash
-State popped with event null (type object) and last path component pushstate-with-fragment-urls-and-hashchange.html
-Hash change fired and last path component is pushstate-with-fragment-urls-and-hashchange.html
 State popped with event null (type object) and last path component pushstate-with-fragment-urls-and-hashchange.html#
 Hash change fired and last path component is pushstate-with-fragment-urls-and-hashchange.html#
+State popped with event null (type object) and last path component pushstate-with-fragment-urls-and-hashchange.html#
 State popped with event OriginalEntry (type string) and last path component pushstate-with-fragment-urls-and-hashchange.html
 

--- a/LayoutTests/http/tests/history/replacestate-no-url-expected.txt
+++ b/LayoutTests/http/tests/history/replacestate-no-url-expected.txt
@@ -1,4 +1,4 @@
-Tests that ReplaceState should not change document URL if URL argument is null.
+Tests that ReplaceState should not change document URL if URL argument is null or empty.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -11,7 +11,7 @@ PASS document.location.href is "http://127.0.0.1:8000/one"
 Replace item one with empty url
 Push item two
 Going back to item one
-PASS document.location.href is "http://127.0.0.1:8000/"
+PASS document.location.href is "http://127.0.0.1:8000/one"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/history/replacestate-no-url.html
+++ b/LayoutTests/http/tests/history/replacestate-no-url.html
@@ -5,7 +5,7 @@
   <script src="/js-test-resources/js-test.js"></script>
   <script>
   jsTestIsAsync = true;
-  description('Tests that ReplaceState should not change document URL if URL argument is null.');
+  description('Tests that ReplaceState should not change document URL if URL argument is null or empty.');
 
   function testNullUrl() {
     debug('Push item one');
@@ -32,7 +32,7 @@
       shouldBeEqualToString('document.location.href', 'http://127.0.0.1:8000/one');
       setTimeout(testEmptyUrl, 0);
     } else {
-      shouldBeEqualToString('document.location.href', 'http://127.0.0.1:8000/');
+      shouldBeEqualToString('document.location.href', 'http://127.0.0.1:8000/one');
       finishJSTest();
     }
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base-expected.txt
@@ -1,0 +1,3 @@
+
+PASS history.pushState() with an empty string URL and base URL different from document's URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>history.pushState() with an empty string URL and base URL different from document's URL</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9343">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<base href="/the-base">
+
+<script>
+"use strict";
+
+test(() => {
+  const before = location.pathname;
+
+  history.pushState(null, null, "");
+  assert_equals(location.pathname, before);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-expected.txt
@@ -1,0 +1,3 @@
+
+PASS history.pushState() with an empty string URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace-expected.txt
@@ -1,0 +1,3 @@
+
+PASS history.pushState() with a whitespace URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>history.pushState() with a whitespace URL</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9343">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  location.hash = "test";
+
+  const before = location.pathname;
+
+  history.pushState(null, null, " ");
+  assert_equals(location.pathname, before, "pathname");
+  assert_equals(location.hash, "", "hash");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>history.pushState() with an empty string URL</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9343">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  location.hash = "test";
+
+  history.pushState(null, null, "");
+  assert_equals(location.hash, "#test");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base-expected.txt
@@ -1,0 +1,3 @@
+
+PASS history.replaceState() with an empty string URL and base URL different from document's URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>history.replaceState() with an empty string URL and base URL different from document's URL</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9343">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<base href="/the-base">
+
+<script>
+"use strict";
+
+test(() => {
+  const before = location.pathname;
+
+  history.replaceState(null, null, "");
+  assert_equals(location.pathname, before);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-expected.txt
@@ -1,0 +1,3 @@
+
+PASS history.replaceState() with an empty string URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace-expected.txt
@@ -1,0 +1,3 @@
+
+PASS history.replaceState() with a whitespace URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>history.replaceState() with a whitespace URL</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9343">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  location.hash = "test";
+
+  const before = location.pathname;
+
+  history.replaceState(null, null, " ");
+  assert_equals(location.pathname, before, "pathname");
+  assert_equals(location.hash, "", "hash");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>history.replaceState() with an empty string URL</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9343">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  location.hash = "test";
+
+  history.replaceState(null, null, "");
+  assert_equals(location.hash, "#test");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate.html

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -75,9 +75,8 @@ private:
     explicit History(LocalDOMWindow&);
 
     ExceptionOr<void> stateObjectAdded(RefPtr<SerializedScriptValue>&&, const String& url, NavigationHistoryBehavior);
+    ExceptionOr<void> updateAndCheckStateObjectQuota(const URL&, SerializedScriptValue*, NavigationHistoryBehavior);
     bool stateChanged() const;
-
-    URL urlForState(const String& url);
 
     SerializedScriptValue* stateInternal() const;
     uint32_t totalStateObjectPayloadLimit() const;


### PR DESCRIPTION
#### ba51e8eae852a32250944ac0785c3561d749e0f9
<pre>
Handle empty URL passed to history.replaceState according to spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=263635">https://bugs.webkit.org/show_bug.cgi?id=263635</a>

Reviewed by Alex Christensen.

<a href="https://html.spec.whatwg.org/#shared-history-push/replace-state-steps">https://html.spec.whatwg.org/#shared-history-push/replace-state-steps</a> Step 6 states:

&gt; If url is not null or the empty string, then:

So this moves that logic into a conditional for a non-empty URL.

It also does some refactoring to move the quota checks for state object
changes into its own method.

* LayoutTests/http/tests/history/replacestate-no-url.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-base.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate-whitespace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/pushstate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-base.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate-whitespace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/replacestate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/pushstate-replacestate-empty-string/w3c-import.log: Added.
* Source/WebCore/page/History.cpp:
(WebCore::History::updateAndCheckStateObjectQuota):
(WebCore::History::stateObjectAdded):
(WebCore::History::urlForState): Deleted.
* Source/WebCore/page/History.h:

Canonical link: <a href="https://commits.webkit.org/283565@main">https://commits.webkit.org/283565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cd97c610a25cbb141c48d934d4333cae15052f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53157 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33799 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60781 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2063 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41440 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->