### PR TITLE
Expand webpushd connection SPI to enable regression testing of notifications

### DIFF
--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -483,7 +483,8 @@ void Notification::ensureOnNotificationThread(ScriptExecutionContextIdentifier c
 
 void Notification::ensureOnNotificationThread(const NotificationData& notification, Function<void(Notification*)>&& task)
 {
-    ensureOnNotificationThread(notification.contextIdentifier, notification.notificationID, WTFMove(task));
+    RELEASE_ASSERT(notification.contextIdentifier);
+    ensureOnNotificationThread(*notification.contextIdentifier, notification.notificationID, WTFMove(task));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationData.h
+++ b/Source/WebCore/Modules/notifications/NotificationData.h
@@ -59,9 +59,9 @@ struct NotificationData {
     WebCore::NotificationDirection direction;
     String originString;
     URL serviceWorkerRegistrationURL;
-    WTF::UUID notificationID;
-    ScriptExecutionContextIdentifier contextIdentifier;
-    PAL::SessionID sourceSession;
+    WTF::UUID notificationID { WTF::UUID::createVersion4() };
+    std::optional<ScriptExecutionContextIdentifier> contextIdentifier;
+    PAL::SessionID sourceSession { PAL::SessionID::defaultSessionID() };
     MonotonicTime creationTime;
     Vector<uint8_t> data;
     std::optional<bool> silent;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1502,7 +1502,7 @@ struct WebCore::NotificationData {
     String originString;
     URL serviceWorkerRegistrationURL;
     WTF::UUID notificationID;
-    WebCore::ScriptExecutionContextIdentifier contextIdentifier;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> contextIdentifier;
     PAL::SessionID sourceSession;
     MonotonicTime creationTime;
     Vector<uint8_t> data;

--- a/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp
@@ -103,4 +103,30 @@ void WebPushDaemonConnection::getNextPendingPushMessage(CompletionHandler<void(c
 #endif
 }
 
-};
+void WebPushDaemonConnection::showNotification(const WebCore::NotificationData& notificationData, CompletionHandler<void()>&& completionHandler)
+{
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::ShowNotification { notificationData, { } }, WTFMove(completionHandler));
+#else
+    completionHandler();
+#endif
+}
+
+void WebPushDaemonConnection::getNotifications(const WTF::URL& scopeURL, const WTF::String& tag, CompletionHandler<void(const Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&)>&& completionHandler)
+{
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetNotifications { scopeURL, tag }, WTFMove(completionHandler));
+#else
+    completionHandler({ });
+#endif
+}
+
+void WebPushDaemonConnection::cancelNotification(const WTF::URL& scopeURL, const WTF::UUID& uuid)
+{
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    m_connection->sendWithoutUsingIPCConnection(Messages::PushClientConnection::CancelNotification(SecurityOriginData::fromURL(scopeURL), uuid));
+#endif
+}
+
+} // namespace API
+

--- a/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.h
+++ b/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 enum class PushPermissionState : uint8_t;
 struct ExceptionData;
+struct NotificationData;
 struct PushSubscriptionData;
 }
 
@@ -54,6 +55,10 @@ public:
     void unsubscribeFromPushService(const WTF::URL&, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
     void getPushSubscription(const WTF::URL&, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&&);
     void getNextPendingPushMessage(CompletionHandler<void(const std::optional<WebKit::WebPushMessage>&)>&&);
+
+    void showNotification(const WebCore::NotificationData&, CompletionHandler<void()>&&);
+    void getNotifications(const WTF::URL&, const WTF::String& tag, CompletionHandler<void(const Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&)>&&);
+    void cancelNotification(const WTF::URL&, const WTF::UUID&);
 
 private:
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -192,7 +192,7 @@ private:
         if (!m_hasShowNotificationSelector || !m_delegate || !m_dataStore)
             return false;
 
-        RetainPtr<_WKNotificationData> notification = adoptNS([[_WKNotificationData alloc] initWithCoreData:data dataStore:m_dataStore.getAutoreleased()]);
+        RetainPtr<_WKNotificationData> notification = adoptNS([[_WKNotificationData alloc] _initWithCoreData:data]);
         [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() showNotification:notification.get()];
         return true;
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.h
@@ -30,14 +30,48 @@ typedef NS_ENUM(NSUInteger, _WKNotificationAlert) {
     _WKNotificationAlertEnabled
 };
 
+typedef NS_ENUM(NSUInteger, _WKNotificationDirection) {
+    _WKNotificationDirectionAuto,
+    _WKNotificationDirectionLTR,
+    _WKNotificationDirectionRTL
+};
+
 WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @interface _WKNotificationData : NSObject
-@property (nonatomic, readonly, copy) NSString *title;
-@property (nonatomic, readonly, copy) NSString *body;
-@property (nonatomic, readonly, copy) NSString *origin;
-@property (nonatomic, readonly, copy) NSString *identifier;
-@property (nonatomic, readonly, copy) NSDictionary *userInfo;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (nonatomic, readonly) NSString *title;
+@property (nonatomic, readonly) _WKNotificationDirection dir;
+@property (nonatomic, readonly) NSString *lang;
+@property (nonatomic, readonly) NSString *body;
+@property (nonatomic, readonly) NSString *tag;
 @property (nonatomic, readonly) _WKNotificationAlert alert;
+@property (nonatomic, readonly) NSData *data;
+
+@property (nonatomic, readonly) NSString *origin;
+@property (nonatomic, readonly) NSURL *securityOrigin;
+@property (nonatomic, readonly) NSURL *serviceWorkerRegistrationURL;
+
+@property (nonatomic, readonly) NSString *identifier;
+@property (nonatomic, readonly) NSUUID *uuid;
+@property (nonatomic, readonly, copy) NSDictionary *userInfo;
 
 - (NSDictionary *)dictionaryRepresentation;
+
+@end
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKMutableNotificationData : _WKNotificationData
+- (instancetype)init;
+
+@property (nonatomic, readwrite, copy) NSString *title;
+@property (nonatomic, readwrite) _WKNotificationDirection dir;
+@property (nonatomic, readwrite, copy) NSString *lang;
+@property (nonatomic, readwrite, copy) NSString *body;
+@property (nonatomic, readwrite, copy) NSString *tag;
+@property (nonatomic, readwrite) _WKNotificationAlert alert;
+@property (nonatomic, readwrite, copy) NSData *data;
+@property (nonatomic, readwrite, copy) NSURL *securityOrigin;
+@property (nonatomic, readwrite, copy) NSURL *serviceWorkerRegistrationURL;
+@property (nonatomic, readwrite, copy) NSUUID *uuid;
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -27,56 +27,239 @@
 #import "_WKNotificationDataInternal.h"
 
 #import <WebCore/NotificationData.h>
+#import <WebCore/NotificationDirection.h>
+#import <WebCore/SecurityOriginData.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 static NSString *iconURLKey = @"iconURL";
 static NSString *tagKey = @"tag";
 static NSString *languageKey = @"language";
 static NSString *dataKey = @"data";
 
+@interface _WKNotificationData()
+- (instancetype)_init;
+
+@property (nonatomic, readwrite) NSString *title;
+@property (nonatomic, readwrite) _WKNotificationDirection dir;
+@property (nonatomic, readwrite) NSString *lang;
+@property (nonatomic, readwrite) NSString *body;
+@property (nonatomic, readwrite) NSString *tag;
+@property (nonatomic, readwrite) _WKNotificationAlert alert;
+@property (nonatomic, readwrite) NSData *data;
+@property (nonatomic, readwrite) NSURL *serviceWorkerRegistrationURL;
+@property (nonatomic, readwrite) NSUUID *notificationUUID;
+
+@end
+
 @implementation _WKNotificationData {
 @package
-    RetainPtr<NSDictionary> _dictionaryRepresentation;
+    WebCore::NotificationData _coreData;
 }
 
-- (instancetype)initWithCoreData:(const WebCore::NotificationData&)coreData dataStore:(WKWebsiteDataStore *)dataStore
+- (instancetype)_init
 {
-    self = [super init];
-    if (!self)
+    if (!(self = [super init]))
         return nil;
 
-    _dictionaryRepresentation = coreData.dictionaryRepresentation();
+    return self;
+}
 
-    _title = [(NSString *)coreData.title retain];
-    _body = [(NSString *)coreData.body retain];
-    _origin = [(NSString *)coreData.originString retain];
-    _identifier = [(NSString *)coreData.notificationID.toString() retain];
-    _userInfo = [coreData.dictionaryRepresentation() retain];
-    if (coreData.silent == std::nullopt)
-        _alert = _WKNotificationAlertDefault;
-    else
-        _alert = *coreData.silent ? _WKNotificationAlertSilent : _WKNotificationAlertEnabled;
+- (instancetype)_initWithCoreData:(const WebCore::NotificationData&)coreData
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _coreData = coreData;
 
     return self;
+}
+
+- (const WebCore::NotificationData&)_getCoreData
+{
+    return _coreData;
+}
+
+- (void)setTitle:(NSString *)title
+{
+    _coreData.title = title;
+}
+
+- (NSString *)title
+{
+    return (NSString *)_coreData.title;
+}
+
+- (void)setDir:(_WKNotificationDirection)dir
+{
+    switch (dir) {
+    case _WKNotificationDirectionAuto:
+        _coreData.direction = WebCore::NotificationDirection::Auto;
+        break;
+    case _WKNotificationDirectionLTR:
+        _coreData.direction = WebCore::NotificationDirection::Ltr;
+        break;
+    case _WKNotificationDirectionRTL:
+        _coreData.direction = WebCore::NotificationDirection::Rtl;
+        break;
+    };
+}
+
+- (_WKNotificationDirection)dir
+{
+    switch (_coreData.direction) {
+    case WebCore::NotificationDirection::Auto:
+        return _WKNotificationDirectionAuto;
+    case WebCore::NotificationDirection::Ltr:
+        return _WKNotificationDirectionLTR;
+    case WebCore::NotificationDirection::Rtl:
+        return _WKNotificationDirectionRTL;
+    };
+}
+
+- (void)setLang:(NSString *)lang
+{
+    _coreData.language = lang;
+}
+
+- (NSString *)lang
+{
+    return (NSString *)_coreData.language;
+}
+
+- (void)setBody:(NSString *)body
+{
+    _coreData.body = body;
+}
+
+- (NSString *)body
+{
+    return (NSString *)_coreData.body;
+}
+
+- (void)setTag:(NSString *)tag
+{
+    _coreData.tag = tag;
+}
+
+- (NSString *)tag
+{
+    return (NSString *)_coreData.tag;
+}
+
+- (void)setAlert:(_WKNotificationAlert)alert
+{
+    switch (alert) {
+    case _WKNotificationAlertDefault:
+        _coreData.silent = std::nullopt;
+        break;
+    case _WKNotificationAlertSilent:
+        _coreData.silent = true;
+        break;
+    case _WKNotificationAlertEnabled:
+        _coreData.silent = false;
+        break;
+    }
+}
+
+- (_WKNotificationAlert)alert
+{
+    if (_coreData.silent == std::nullopt)
+        return _WKNotificationAlertDefault;
+    return *(_coreData.silent) ? _WKNotificationAlertSilent : _WKNotificationAlertEnabled;
+}
+
+- (void)setData:(NSData *)data
+{
+    _coreData.data = makeVector(data);
+}
+
+- (NSData *)data
+{
+    return toNSData(_coreData.data.span()).autorelease();
+}
+
+- (NSString *)origin
+{
+    return (NSString *)_coreData.originString;
+}
+
+- (void)setSecurityOrigin:(NSURL *)securityOrigin
+{
+    _coreData.originString = WebCore::SecurityOriginData::fromURL(securityOrigin).toString();
+}
+
+- (NSURL *)securityOrigin
+{
+    return (NSURL *)(URL { _coreData.originString });
+}
+
+- (void)setServiceWorkerRegistrationURL:(NSURL *)serviceWorkerRegistrationURL
+{
+    _coreData.serviceWorkerRegistrationURL = serviceWorkerRegistrationURL;
+}
+
+- (NSURL *)serviceWorkerRegistrationURL
+{
+    return (NSURL *)_coreData.serviceWorkerRegistrationURL;
+}
+
+- (NSString *)identifier
+{
+    return (NSString *)_coreData.notificationID.toString();
+}
+
+- (void)setUuid:(NSUUID *)uuid
+{
+    auto wtfUUID = WTF::UUID::fromNSUUID(uuid);
+    if (wtfUUID)
+        _coreData.notificationID = *wtfUUID;
+}
+
+- (NSUUID *)uuid
+{
+    return (NSUUID *)_coreData.notificationID;
+}
+
+- (NSDictionary *)userInfo
+{
+    return _coreData.dictionaryRepresentation();
+}
+
+- (NSDictionary *)dictionaryRepresentation
+{
+    return [self userInfo];
 }
 
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKNotificationData.class, self))
         return;
-
-    [_title release];
-    [_body release];
-    [_origin release];
-    [_identifier release];
-    [_userInfo release];
-
     [super dealloc];
 }
 
-- (NSDictionary *)dictionaryRepresentation
+@end
+
+@implementation _WKMutableNotificationData
+
+@dynamic title;
+@dynamic dir;
+@dynamic lang;
+@dynamic body;
+@dynamic tag;
+@dynamic alert;
+@dynamic data;
+@dynamic securityOrigin;
+@dynamic serviceWorkerRegistrationURL;
+@dynamic uuid;
+
+- (instancetype)init
 {
-    return _dictionaryRepresentation.get();
+    if (!(self = [super _init]))
+        return nil;
+
+    return self;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationDataInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationDataInternal.h
@@ -32,5 +32,6 @@ struct NotificationData;
 };
 
 @interface _WKNotificationData ()
--(instancetype)initWithCoreData:(const WebCore::NotificationData&)coreData dataStore:(WKWebsiteDataStore *)dataStore;
+-(instancetype)_initWithCoreData:(const WebCore::NotificationData&)coreData;
+-(const WebCore::NotificationData&)_getCoreData;
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(NSInteger, _WKWebPushPermissionState) {
     _WKWebPushPermissionStatePrompt,
 };
 
+@class WKSecurityOrigin;
+@class _WKNotificationData;
 @class _WKWebPushMessage;
 @class _WKWebPushSubscriptionData;
 
@@ -61,6 +63,9 @@ WK_EXTERN
 - (void)unsubscribeFromPushServiceForScope:(NSURL *)scopeURL completionHandler:(void (^)(BOOL unsubscribed, NSError *))completionHandler;
 - (void)getSubscriptionForScope:(NSURL *)scopeURL completionHandler:(void (^)(_WKWebPushSubscriptionData *, NSError *))completionHandler;
 - (void)getNextPendingPushMessage:(void (^)(_WKWebPushMessage *))completionHandler;
+- (void)showNotification:(_WKNotificationData *)notificationData completionHandler:(void (^)())completionHandler;
+- (void)getNotifications:(NSURL *)scopeURL tag:(NSString *)tag completionHandler:(void (^)(NSArray<_WKNotificationData *> *, NSError *))completionHandler;
+- (void)cancelNotification:(NSURL *)securityOriginURL uuid:(NSUUID *)notificationIdentifier;
 
 @end
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -211,7 +211,8 @@ bool WebNotificationManager::show(NotificationData&& notification, RefPtr<Notifi
 
     if (!notification.isPersistent()) {
         ASSERT(!m_nonPersistentNotificationsContexts.contains(notificationID));
-        m_nonPersistentNotificationsContexts.add(notificationID, notification.contextIdentifier);
+        RELEASE_ASSERT(notification.contextIdentifier);
+        m_nonPersistentNotificationsContexts.add(notificationID, *notification.contextIdentifier);
     }
     return true;
 #else

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -997,7 +997,7 @@ void WebPushDaemon::getNotifications(PushClientConnection& connection, const URL
                     continue;
                 }
 
-                if (notificationData->tag != tag || notificationData->serviceWorkerRegistrationURL != registrationURL)
+                if ((!tag.isEmpty() && notificationData->tag != tag) || notificationData->serviceWorkerRegistrationURL != registrationURL)
                     continue;
 
                 notificationDatas.append(*notificationData);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -234,7 +234,6 @@ TEST(PushAPI, firePushEvent)
 
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore getDisplayedNotificationsForWorkerOrigin:(WKSecurityOrigin *)workerOrigin completionHandler:(void (^)(NSArray<NSDictionary *> *))completionHandler
 {
-
     NSMutableArray *notifications = [NSMutableArray new];
     for (id notification in _displayedNotifications)
         [notifications addObject:[notification dictionaryRepresentation]];


### PR DESCRIPTION
#### 8f9f5a32d4cee9eceba7c5fe2bb6ffda454b329d
<pre>
Expand webpushd connection SPI to enable regression testing of notifications
<a href="https://rdar.apple.com/135722662">rdar://135722662</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279447">https://bugs.webkit.org/show_bug.cgi?id=279447</a>

Reviewed by Sihui Liu.

Also includes a drive-by fix of tag processing in webpushd, which was easy to test
because of this change!

* Source/WebCore/Modules/notifications/NotificationData.h:

* Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp:
(API::WebPushDaemonConnection::showNotification):
(API::WebPushDaemonConnection::getNotifications):
(API::WebPushDaemonConnection::cancelNotification):
* Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.h:

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:

* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm:
(-[_WKNotificationData _init]):
(-[_WKNotificationData _initWithCoreData:]):
(-[_WKNotificationData _getCoreData]):
(-[_WKNotificationData setTitle:]):
(-[_WKNotificationData title]):
(-[_WKNotificationData setDir:]):
(-[_WKNotificationData dir]):
(-[_WKNotificationData setLang:]):
(-[_WKNotificationData lang]):
(-[_WKNotificationData setBody:]):
(-[_WKNotificationData body]):
(-[_WKNotificationData setTag:]):
(-[_WKNotificationData tag]):
(-[_WKNotificationData setAlert:]):
(-[_WKNotificationData alert]):
(-[_WKNotificationData setData:]):
(-[_WKNotificationData data]):
(-[_WKNotificationData origin]):
(-[_WKNotificationData setSecurityOrigin:]):
(-[_WKNotificationData securityOrigin]):
(-[_WKNotificationData setServiceWorkerRegistrationURL:]):
(-[_WKNotificationData serviceWorkerRegistrationURL]):
(-[_WKNotificationData identifier]):
(-[_WKNotificationData setUuid:]):
(-[_WKNotificationData uuid]):
(-[_WKNotificationData userInfo]):
(-[_WKNotificationData dealloc]):
(-[_WKMutableNotificationData init]):
(-[_WKNotificationData initWithCoreData:dataStore:]): Deleted.
(-[_WKNotificationData dictionaryRepresentation]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationDataInternal.h:

* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnection showNotification:completionHandler:]):
(-[_WKWebPushDaemonConnection getNotifications:tag:completionHandler:]):
(-[_WKWebPushDaemonConnection cancelNotification:uuid:]):

* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::getNotifications):

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate createBrowserWindowController:]): Unfortunately, because Obj-C is
  what it is, and `tag` is a common selector, do gnarly Obj-C tricks here.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::(WebPushD, WKWebPushDaemonConnectionPushNotifications)):
(TestWebKitAPI::(WebPushD, WKWebPushDaemonConnectionPushSubscription)): Deleted.

Canonical link: <a href="https://commits.webkit.org/283493@main">https://commits.webkit.org/283493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5adee9c782be7a7cfa827c0c91648cb473e9754

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70465 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/17565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53281 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/17565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72168 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14646 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8574 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->