### PR TITLE
[ webkitpy ] Differentiate between virtual and physical hardware.

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_configuration.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_configuration.py
@@ -31,15 +31,16 @@ import itertools
 
 
 class TestConfiguration(object):
-    def __init__(self, version, architecture, build_type):
+    def __init__(self, version, architecture, build_type, reality=''):
         self.version = version.lower().replace(' ', '') if version is not None else ''
         self.architecture = architecture
         self.build_type = build_type
+        self.reality = reality
 
     @classmethod
     def category_order(cls):
         """The most common human-readable order in which the configuration properties are listed."""
-        return ['version', 'architecture', 'build_type']
+        return ['version', 'architecture', 'build_type', 'reality']
 
     def items(self):
         return self.__dict__.items()
@@ -48,14 +49,14 @@ class TestConfiguration(object):
         return self.__dict__.keys()
 
     def __str__(self):
-        return ("<%(version)s, %(architecture)s, %(build_type)s>" %
+        return ("<%(version)s, %(architecture)s, %(build_type)s, %(reality)s>" %
                 self.__dict__)
 
     def __repr__(self):
-        return "TestConfig(version='%(version)s', architecture='%(architecture)s', build_type='%(build_type)s')" % self.__dict__
+        return "TestConfig(version='%(version)s', architecture='%(architecture)s', build_type='%(build_type)s', reality='%(reality)s')" % self.__dict__
 
     def __hash__(self):
-        return hash(self.version + self.architecture + self.build_type)
+        return hash(self.version + self.architecture + self.build_type + self.reality)
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -46,6 +46,8 @@ class ApplePort(Port):
     ARCHITECTURES = []
     _crash_logs_to_skip_for_host = {}
 
+    REALITIES = ['physical', 'virtual']
+
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):
         options = options or {}
@@ -110,7 +112,8 @@ class ApplePort(Port):
                     for table in [PUBLIC_TABLE, INTERNAL_TABLE]:
                         version_name = VersionNameMap.map(self.host.platform).to_name(version, platform=self.port_name.split('-')[0], table=table)
                         if version_name:
-                            configurations.append(TestConfiguration(version=version_name, architecture=architecture, build_type=build_type))
+                            for reality in self.REALITIES:
+                                configurations.append(TestConfiguration(version=version_name, architecture=architecture, build_type=build_type, reality=reality))
         return configurations
 
     def all_baseline_search_paths(self, device_type=None):

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -166,6 +166,10 @@ class Port(object):
     def is_simulator(self):
         return False
 
+    @property
+    def reality(self):
+        return ''
+
     def architecture(self):
         return self.get_option('architecture') or self.DEFAULT_ARCHITECTURE
 
@@ -967,7 +971,7 @@ class Port(object):
                 style = 'asan'
             else:
                 style = self._options.configuration.lower()
-            self._test_configuration = TestConfiguration(self.version_name(), self.architecture(), style)
+            self._test_configuration = TestConfiguration(self.version_name(), self.architecture(), style, self.reality)
         return self._test_configuration
 
     # FIXME: Belongs on a Platform object.

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -275,3 +275,22 @@ class DarwinPort(ApplePort):
         # Suppress log message from <rdar://56920527>
         worthless_patterns.append((re.compile('.*nil host used in call to allows.+HTTPSCertificateForHost.*\n'), ''))
         return worthless_patterns
+
+    @property
+    @memoized
+    def hw_model(self) -> str:
+        '''
+        The model of the device running tests.
+
+        This passes through the simulator and gets the model of the host Mac.
+        '''
+
+        try:
+            return self._executive.run_command(['/usr/sbin/sysctl', '-n', 'hw.model']).rstrip()
+        except ScriptError:
+            return ''
+
+    @property
+    @memoized
+    def reality(self) -> str:
+        return 'virtual' if self.hw_model.lower().find('virtual') > -1 else 'physical'

--- a/Tools/Scripts/webkitpy/port/device_port.py
+++ b/Tools/Scripts/webkitpy/port/device_port.py
@@ -62,7 +62,8 @@ class DevicePort(DarwinPort):
         configurations = []
         for build_type in self.ALL_BUILD_TYPES:
             for architecture in self.ARCHITECTURES:
-                configurations.append(TestConfiguration(version=self.version_name(), architecture=architecture, build_type=build_type))
+                for reality in self.REALITIES:
+                    configurations.append(TestConfiguration(version=self.version_name(), architecture=architecture, build_type=build_type, reality=reality))
         return configurations
 
     def child_processes(self):
@@ -253,7 +254,12 @@ class DevicePort(DarwinPort):
         device_type = host.device_type if host else self.DEVICE_TYPE
         model = device_type.hardware_family
         if model and device_type.hardware_type:
-            model += u' {}'.format(device_type.hardware_type)
+            model += f' {device_type.hardware_type}'
+            if self.is_simulator():
+                # FIXME: rdar://135638815
+                # While this is the easiest way to implement this, it reduces our long-term options for sorting/grouping results in resultsdbpy.
+                # We should add a is_virtual_machine parameter to resultsdbpy, akin to is_simulator.
+                model += f' on {self.hw_model}'
 
         version = self.device_version()
         for table in [INTERNAL_TABLE, PUBLIC_TABLE]:

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -335,10 +335,7 @@ class MacPort(DarwinPort):
 
         # --model should override the detected model
         if not configuration.get('model'):
-            output = host.executive.run_command(['/usr/sbin/sysctl', 'hw.model']).rstrip()
-            match = re.match(r'hw.model: (?P<model>.*)', output)
-            if match:
-                configuration['model'] = match.group('model')
+            configuration['model'] = self.hw_model
 
         return configuration
 


### PR DESCRIPTION
#### b5f01d7e22dc22dc6c3e393297d01f4c0a5dc86d
<pre>
[ webkitpy ] Differentiate between virtual and physical hardware.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279409">https://bugs.webkit.org/show_bug.cgi?id=279409</a>
<a href="https://rdar.apple.com/132862697">rdar://132862697</a>

Reviewed by NOBODY (OOPS!).

In order to support running tests in macOS VMs (including iOS simulator tests), webkitpy
should understand the difference between virtual and physical devices. This is because
we want to:
- Be able to set test expectations with virtual/physical device specificity (config mod)
- Report the VM status coherently to resultsdbpy (i.e., easily human/machine readable)

To achieve this, this PR adds a new &quot;reality&quot; parameter to the TestConfiguration class
that can be either &quot;virtual&quot; or &quot;physical&quot; depending on the type of device &quot;hardware&quot;.
We determine whether or not a device is virtual or physical by checking if the output
of `/usr/sbin/sysctl -n hw.model` contains &quot;virtual&quot;. This is fragile, but it works by
current naming conventions.

Lastly, this abstraction preserves the ability of non-Apple ports to incorporate the
checks for physical/virtual into their workflows if so desired in the future.

Changes:

Add/define reality and hw_model:
* Tools/Scripts/webkitpy/layout_tests/models/test_configuration.py: Add reality parameter.
* Tools/Scripts/webkitpy/port/darwin.py: Define hw_model and reality properties.

Add logic for reality to the associated port files:
* Tools/Scripts/webkitpy/port/apple.py
* Tools/Scripts/webkitpy/port/base.py
* Tools/Scripts/webkitpy/port/device_port.py: Add virtual device model to reported model.

Refactor to use new hw_model parameter instead of calling the same command separately:
* Tools/Scripts/webkitpy/port/mac.py
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f01d7e22dc22dc6c3e393297d01f4c0a5dc86d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53158 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11757 "Found 60 new test failures: accessibility/accessibility-node-memory-management.html accessibility/ax-thread-text-apis/character-offset-from-upstream-position.html accessibility/ax-thread-text-apis/character-offset-visible-position-conversion-hang.html accessibility/ax-thread-text-apis/content-editable-attributed-string.html accessibility/ax-thread-text-apis/crash-in-element-for-text-marker.html accessibility/ax-thread-text-apis/crash-invalid-text-marker-node.html accessibility/ax-thread-text-apis/display-contents-end-text-marker.html accessibility/ax-thread-text-apis/dynamic-text-line-wrapping.html accessibility/ax-thread-text-apis/element-for-text-marker.html accessibility/ax-thread-text-apis/index-for-zero-offset-text-marker.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33800 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/65769 "Found 13 webkitpy test failures: webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationConverterTest.test_converter_macro_collapsing, webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationConverterTest.test_to_specifier_lists, webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationTest.test_items, webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationTest.test_keys, webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationTest.test_repr, webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationTest.test_str, webkitpy.layout_tests.models.test_configuration_unittest.TestConfigurationTest.test_values, webkitpy.layout_tests.models.test_expectations_unittest.TestExpectationSerializationTests.test_parsed_to_string, webkitpy.layout_tests.models.test_expectations_unittest.TestExpectationSerializationTests.test_reconstitute_only_these, webkitpy.layout_tests.models.test_run_results_unittest.SummarizedResultsTest.test_summarized_run_metadata ...") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14752 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60477 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60779 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2067 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41439 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->