### PR TITLE
WebAssembly.Table prototype functions need to do subtype checks

### DIFF
--- a/JSTests/wasm/function-references/ref_types.js
+++ b/JSTests/wasm/function-references/ref_types.js
@@ -351,7 +351,7 @@ async function testRefTypesInTables() {
   assert.throws(
     () => wasmTableFuncref.set(0, console.log),
     TypeError,
-    "WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function"
+    "Argument value did not match the reference type"
   );
 
   const wasmTableExternref = new WebAssembly.Table({ initial: 1, maximum: 1, element: "externref" });

--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -700,17 +700,17 @@ function testArrayTable() {
     assert.throws(
       () => m.exports.t.set(0, "foo"),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.t.set(0, 3),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.t.set(0, m2.exports.makeStruct()),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     const arr = m.exports.makeArray();
     m.exports.t.set(0, arr);

--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -295,17 +295,17 @@ function testI31Table() {
     assert.throws(
       () => m.exports.t.set(0, "foo"),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.t.set(0, m2.exports.makeArray()),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.t.set(0, 8e99),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     m.exports.t.set(0, 3);
     assert.eq(m.exports.t.get(0), 3);

--- a/JSTests/wasm/gc/js-api.js
+++ b/JSTests/wasm/gc/js-api.js
@@ -564,7 +564,7 @@ function testTable() {
     assert.throws(
       () => m1.exports.t.set(0, 5),
       TypeError,
-      "WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function"
+      "Argument value did not match the reference type"
     )
   }
 

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -1268,17 +1268,17 @@ function testStructTable() {
     assert.throws(
       () => m.exports.t.set(0, "foo"),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.t.set(0, 3),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.t.set(0, m2.exports.makeArray()),
       TypeError,
-      "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"
+      "Argument value did not match the reference type"
     );
     const str = m.exports.makeStruct();
     m.exports.t.set(0, str);

--- a/JSTests/wasm/references/table_js_api.js
+++ b/JSTests/wasm/references/table_js_api.js
@@ -24,7 +24,7 @@ function testTableGrowForExternrefTables() {
 async function testTableGrowForFuncrefTables() {
   const table = new WebAssembly.Table({initial:1, maximum:10, element: "funcref"});
   const calories = 100;
-  assert.throws(() => table.grow(3, new Pelmen(calories)), Error, "WebAssembly.Table.prototype.grow expects the second argument to be null or an instance of WebAssembly.Function");
+  assert.throws(() => table.grow(3, new Pelmen(calories)), Error, "Argument value did not match the reference type");
 
   table.grow(3, null);
   assert.eq(table.get(1), null);
@@ -75,7 +75,7 @@ async function testTableSetForFuncrefTables() {
   table.set(0, instance.exports.foo);
   assert.eq(table.get(0), instance.exports.foo);
 
-  assert.throws(() => table.set(0, {}), TypeError, "WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function");
+  assert.throws(() => table.set(0, {}), TypeError, "Argument value did not match the reference type");
 }
 
 testTableGrowForExternrefTables();

--- a/JSTests/wasm/regress/js-table-bad-set-type.js
+++ b/JSTests/wasm/regress/js-table-bad-set-type.js
@@ -1,0 +1,34 @@
+import * as assert from "../assert.js";
+
+async function test() {
+    const wat = `
+        (module
+            (type $sig_l (func (result i64)))
+            (type $sig_l_l (func (param i64) (result i64)))
+            (func (export "c_l") (type $sig_l) (i64.const 0))
+            (func (export "id_l") (type $sig_l_l) (local.get 0))
+            (table (export "table") 1 2 (ref null $sig_l))
+        )
+    `;
+
+    let buffer = new Uint8Array([0,97,115,109,1,0,0,0,1,10,2,96,1,126,1,126,96,0,1,126,3,3,2,0,1,4,6,1,99,1,1,1,2,7,22,3,5,116,97,98,108,101,1,0,4,105,100,95,108,0,0,3,99,95,108,0,1,10,11,2,4,0,32,0,11,4,0,66,0,11,0,19,4,110,97,109,101,1,12,2,0,4,105,100,95,108,1,3,99,95,108]);
+    let instance = await WebAssembly.instantiate(buffer);
+    let { table, id_l, c_l } = instance.instance.exports;
+
+    assert.throws(
+      () => table.set(0, id_l),
+      TypeError,
+      "Argument value did not match the reference type"
+    );
+
+    assert.throws(
+      () => table.grow(1, id_l),
+      TypeError,
+      "Argument value did not match the reference type"
+    );
+
+    table.set(0, c_l);
+    table.grow(1, c_l);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/v8/js-api.js
+++ b/JSTests/wasm/v8/js-api.js
@@ -716,19 +716,19 @@ assertThrows(
   /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, 0, undefined), TypeError,
-    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
+    /Argument value did not match the reference type/);
 assertThrows(
     () => set.call(tbl1, undefined, undefined), TypeError,
     /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, 0, {}), TypeError,
-    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
+    /Argument value did not match the reference type/);
 assertThrows(
     () => set.call(tbl1, 0, function() {}), TypeError,
-    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
+    /Argument value did not match the reference type/);
 assertThrows(
     () => set.call(tbl1, 0, Math.sin), TypeError,
-    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
+    /Argument value did not match the reference type/);
 assertThrows(
     () => set.call(tbl1, {valueOf() { throw Error('hai') }}, null), Error,
     'hai');

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -561,24 +561,10 @@ inline bool tableSet(JSWebAssemblyInstance* instance, unsigned tableIndex, uint3
         return false;
 
     JSValue value = JSValue::decode(encValue);
-    if (instance->table(tableIndex)->type() == Wasm::TableElementType::Externref)
+    if (value.isNull())
+        instance->table(tableIndex)->clear(index);
+    else
         instance->table(tableIndex)->set(index, value);
-    else if (instance->table(tableIndex)->type() == Wasm::TableElementType::Funcref) {
-        WebAssemblyFunction* wasmFunction;
-        WebAssemblyWrapperFunction* wasmWrapperFunction;
-
-        if (isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction)) {
-            ASSERT(!!wasmFunction || !!wasmWrapperFunction);
-            if (wasmFunction)
-                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmFunction->importableFunction(), wasmFunction->instance());
-            else
-                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmWrapperFunction->importableFunction(), wasmWrapperFunction->instance());
-        } else if (value.isNull())
-            instance->table(tableIndex)->clear(index);
-        else
-            ASSERT_NOT_REACHED();
-    } else
-        ASSERT_NOT_REACHED();
 
     return true;
 }

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -137,7 +137,7 @@ public:
         static constexpr ptrdiff_t offsetOfValue() { return OBJECT_OFFSETOF(Function, m_value); }
     };
 
-    void setFunction(uint32_t, JSObject*, WasmToWasmImportableFunction, JSWebAssemblyInstance*);
+    void setFunction(uint32_t, WebAssemblyFunctionBase*);
     const Function& function(uint32_t) const;
     void copyFunction(const FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -58,10 +58,10 @@ public:
     std::optional<uint32_t> maximum() const { return m_table->maximum(); }
     uint32_t length() const { return m_table->length(); }
     uint32_t allocatedLength() const { return m_table->allocatedLength(length()); }
-    bool grow(uint32_t delta, JSValue defaultValue) WARN_UNUSED_RETURN;
+    std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue) WARN_UNUSED_RETURN;
     JSValue get(uint32_t);
-    void set(uint32_t, WebAssemblyFunctionBase*);
     void set(uint32_t, JSValue);
+    void set(JSGlobalObject*, uint32_t, JSValue);
     void clear(uint32_t);
     JSObject* type(JSGlobalObject*);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -70,7 +70,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     // Any GC'd values in here will be marked by the MarkedArugementBuffer until stored in the Exception.
     FixedVector<uint64_t> payload(values.size());
     for (unsigned i = 0; i < values.size(); ++i) {
-        payload[i] = fromJSValue(globalObject, tagFunctionType.argumentType(i), values.at(i));
+        payload[i] = toWebAssemblyValue(globalObject, tagFunctionType.argumentType(i), values.at(i));
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -85,7 +85,7 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
 
     for (unsigned argIndex = 0; argIndex < signature.argumentCount(); ++argIndex) {
         auto argType = signature.argumentType(argIndex);
-        uint64_t value = fromJSValue(globalObject, argType, callFrame->argument(argIndex));
+        uint64_t value = toWebAssemblyValue(globalObject, argType, callFrame->argument(argIndex));
         if (UNLIKELY(argType.isRef()))
             keepAliveArgs.append(callFrame->argument(argIndex));
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -47,6 +47,7 @@ public:
     JSWebAssemblyInstance* instance() const { return m_instance.get(); }
 
     Wasm::TypeIndex typeIndex() const { return m_importableFunction.typeIndex; }
+    Wasm::Type type() const { return { Wasm::TypeKind::Ref, typeIndex() }; }
     WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation() const { return m_importableFunction.entrypointLoadLocation; }
     const uintptr_t* boxedWasmCalleeLoadLocation() const { return m_importableFunction.boxedWasmCalleeLoadLocation; }
     WasmToWasmImportableFunction importableFunction() const { return m_importableFunction; }


### PR DESCRIPTION
#### d612721aa438aac866eb2a46fd95bf866dc5bdb8
<pre>
WebAssembly.Table prototype functions need to do subtype checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=279444">https://bugs.webkit.org/show_bug.cgi?id=279444</a>
<a href="https://rdar.apple.com/134785807">rdar://134785807</a>

Reviewed by Yusuke Suzuki.

Table.prototype.set/grow don&apos;t check that the value they are inserting into the table is actually a subtype of the
funcref table&apos;s actual type. This patch fixes that. I also moved some of the verification logic into the table itself
rather than in the prototype function. This seems like a better abstraction since the checks are now done by the table
instead of any caller.

Also, convert a bunch of the RELEASE_ASSERTs into ASSERTs since they&apos;re unlikely be hit in practice at this point and
some of them e.g. isSubtype, could be reasonably expensive to do at runtime.

* JSTests/wasm/function-references/ref_types.js:
(async testRefTypesInTables):
* JSTests/wasm/gc/arrays.js:
* JSTests/wasm/gc/i31.js:
(testI31Table):
* JSTests/wasm/gc/js-api.js:
* JSTests/wasm/gc/structs.js:
* JSTests/wasm/references/table_js_api.js:
(async testTableGrowForFuncrefTables):
(async testTableSetForFuncrefTables):
* JSTests/wasm/regress/js-table-bad-set-type.js: Added.
(async test):
* JSTests/wasm/v8/js-api.js:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::tableSet):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::copy):
(JSC::Wasm::Table::clear):
(JSC::Wasm::Table::set):
(JSC::Wasm::Table::get const):
(JSC::Wasm::FuncRefTable::setFunction):
(JSC::Wasm::FuncRefTable::copyFunction):
(JSC::Wasm::FuncRefTable::clear):
(JSC::Wasm::FuncRefTable::set):
* Source/JavaScriptCore/wasm/WasmTable.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::toWebAssemblyValue):
(JSC::fromJSValue): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::grow):
(JSC::JSWebAssemblyTable::get):
(JSC::JSWebAssemblyTable::set):
(JSC::JSWebAssemblyTable::clear):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h:
(JSC::WebAssemblyFunctionBase::type const):
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/283434@main">https://commits.webkit.org/283434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1b6dde9b11a259ac569ad66ee9e5d24198a2143

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66276 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17167 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57383 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15762 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59390 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72011 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65520 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14494 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8445 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87287 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15348 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->