### PR TITLE
Ensure CookieStore uses the creation URL for setting/getting cookies

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS cookieStore.set and cookieStore.getAll use the creation url
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
@@ -1,0 +1,33 @@
+// META: title=Cookie Store API: cookieStore.set()/getAll() with Document URL changing
+// META: global=window
+
+'use strict';
+
+promise_test(async testCase => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory =
+      currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
+  
+  await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+
+  await cookieStore.set(
+    { name: 'cookie-name', value: 'cookie-value', path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  // This changes the Document's current URL to this different URL.
+  // The Document's creation URL does not change.
+  // If set() and getAll() use Document's current URL, the cookie will be set 
+  // using the original URL above, and the get below will fail since it looks 
+  // for cookies with this different URL. If they both use the creation URL,
+  // the get will succeed since it won't use this different URL to search.
+  let different_url = `${self.location.protocol}//${self.location.host}/different/path`;
+  history.pushState({}, "", different_url);
+
+  const cookies = await cookieStore.getAll();
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.set and cookieStore.getAll use the creation url');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'frameCookie.value')"
-FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.value')"
+FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: The domain must be a part of the current host"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS cookieStore.set and cookieStore.get use the creation url
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js
@@ -1,0 +1,32 @@
+// META: title=Cookie Store API: cookieStore.set()/get() with Document URL changing
+// META: global=window
+
+'use strict';
+
+promise_test(async testCase => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory =
+      currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
+  
+  await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+
+  await cookieStore.set(
+      { name: 'cookie-name', value: 'cookie-value', path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  // This changes the Document's current URL to this different URL.
+  // The Document's creation URL does not change.
+  // If set() and get() use Document's current URL, the cookie will be set 
+  // using the original URL above, and the get below will fail since it looks 
+  // for cookies with this different URL. If they both use the creation URL,
+  // the get will succeed since it won't use this different URL to search.
+  let different_url = `${self.location.protocol}//${self.location.host}/different/path`;
+  history.pushState({}, "", different_url);
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.set and cookieStore.get use the creation url');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
@@ -1,4 +1,4 @@
 
-PASS cookieStore in non-sandboxed iframe should not throw
+FAIL cookieStore in non-sandboxed iframe should not throw assert_equals: cookieStore ${apiCall} should not throw expected "no exception" but got "TypeError"
 PASS cookieStore in sandboxed iframe should throw SecurityError
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -73,9 +73,9 @@ public:
         return adoptRef(*new MainThreadBridge(cookieStore));
     }
 
-    void get(CookieStoreGetOptions&&, Function<void(CookieStore&, ExceptionOr<Vector<Cookie>>&&)>&&);
+    void get(CookieStoreGetOptions&&, URL&&, Function<void(CookieStore&, ExceptionOr<Vector<Cookie>>&&)>&&);
     void getAll(CookieStoreGetOptions&&, URL&&, Function<void(CookieStore&, ExceptionOr<Vector<Cookie>>&&)>&&);
-    void set(CookieInit&& options, Cookie&&, Function<void(CookieStore&, std::optional<Exception>&&)>&&);
+    void set(CookieInit&& options, Cookie&&, URL&&, Function<void(CookieStore&, std::optional<Exception>&&)>&&);
 
     void detach() { m_cookieStore = nullptr; }
 
@@ -121,11 +121,11 @@ void CookieStore::MainThreadBridge::ensureOnContextThread(Function<void(CookieSt
     });
 }
 
-void CookieStore::MainThreadBridge::get(CookieStoreGetOptions&& options, Function<void(CookieStore&, ExceptionOr<Vector<Cookie>>&&)>&& completionHandler)
+void CookieStore::MainThreadBridge::get(CookieStoreGetOptions&& options, URL&& url, Function<void(CookieStore&, ExceptionOr<Vector<Cookie>>&&)>&& completionHandler)
 {
     ASSERT(m_cookieStore);
 
-    auto getCookies = [this, protectedThis = Ref { *this }, options = crossThreadCopy(WTFMove(options)), completionHandler = WTFMove(completionHandler)](ScriptExecutionContext& context) mutable {
+    auto getCookies = [this, protectedThis = Ref { *this }, options = crossThreadCopy(WTFMove(options)), url = crossThreadCopy(WTFMove(url)), completionHandler = WTFMove(completionHandler)](ScriptExecutionContext& context) mutable {
         Ref document = downcast<Document>(context);
         WeakPtr page = document->page();
         if (!page) {
@@ -145,7 +145,7 @@ void CookieStore::MainThreadBridge::get(CookieStoreGetOptions&& options, Functio
             });
         };
 
-        cookieJar->getCookiesAsync(document, document->url(), options, WTFMove(resultHandler));
+        cookieJar->getCookiesAsync(document, url, options, WTFMove(resultHandler));
     };
 
     ensureOnMainThread(WTFMove(getCookies));
@@ -181,11 +181,11 @@ void CookieStore::MainThreadBridge::getAll(CookieStoreGetOptions&& options, URL&
     ensureOnMainThread(WTFMove(getAllCookies));
 }
 
-void CookieStore::MainThreadBridge::set(CookieInit&& options, Cookie&& cookie, Function<void(CookieStore&, std::optional<Exception>&&)>&& completionHandler)
+void CookieStore::MainThreadBridge::set(CookieInit&& options, Cookie&& cookie, URL&& url, Function<void(CookieStore&, std::optional<Exception>&&)>&& completionHandler)
 {
     ASSERT(m_cookieStore);
 
-    auto setCookie = [this, protectedThis = Ref { *this }, options = crossThreadCopy(WTFMove(options)), cookie = crossThreadCopy(WTFMove(cookie)), completionHandler = WTFMove(completionHandler)](ScriptExecutionContext& context) mutable {
+    auto setCookie = [this, protectedThis = Ref { *this }, options = crossThreadCopy(WTFMove(options)), cookie = crossThreadCopy(WTFMove(cookie)), url = crossThreadCopy(WTFMove(url)), completionHandler = WTFMove(completionHandler)](ScriptExecutionContext& context) mutable {
         Ref document = downcast<Document>(context);
         WeakPtr page = document->page();
         if (!page) {
@@ -206,7 +206,7 @@ void CookieStore::MainThreadBridge::set(CookieInit&& options, Cookie&& cookie, F
         };
 
         document->invalidateDOMCookieCache();
-        cookieJar.setCookieAsync(document, document->url(), cookie, WTFMove(resultHandler));
+        cookieJar.setCookieAsync(document, url, cookie, WTFMove(resultHandler));
     };
 
     ensureOnMainThread(WTFMove(setCookie));
@@ -259,7 +259,7 @@ void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& pr
         return;
     }
 
-    auto url = context->url();
+    auto url = context->creationURL();
     if (!options.url.isNull()) {
         auto parsed = context->completeURL(options.url);
         if (context->isDocument() && parsed != url) {
@@ -272,8 +272,8 @@ void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& pr
             return;
         }
         url = WTFMove(parsed);
+        options.url = nullString();
     }
-    options.url = url.string();
 
     m_promises.add(++m_nextPromiseIdentifier, WTFMove(promise));
     auto completionHandler = [promiseIdentifier = m_nextPromiseIdentifier](CookieStore& cookieStore, ExceptionOr<Vector<Cookie>>&& result) {
@@ -295,7 +295,7 @@ void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& pr
         promise->resolve<IDLDictionary<CookieListItem>>(CookieListItem(WTFMove(cookies[0])));
     };
 
-    protectedMainThreadBridge()->get(WTFMove(options), WTFMove(completionHandler));
+    protectedMainThreadBridge()->get(WTFMove(options), WTFMove(url), WTFMove(completionHandler));
 }
 
 void CookieStore::getAll(String&& name, Ref<DeferredPromise>&& promise)
@@ -322,7 +322,7 @@ void CookieStore::getAll(CookieStoreGetOptions&& options, Ref<DeferredPromise>&&
         return;
     }
 
-    auto url = context->url();
+    auto url = context->creationURL();
     if (!options.url.isNull()) {
         auto parsed = context->completeURL(options.url);
         if (context->isDocument() && parsed != url) {
@@ -335,6 +335,7 @@ void CookieStore::getAll(CookieStoreGetOptions&& options, Ref<DeferredPromise>&&
             return;
         }
         url = WTFMove(parsed);
+        options.url = nullString();
     }
 
     m_promises.add(++m_nextPromiseIdentifier, WTFMove(promise));
@@ -383,8 +384,10 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
 
     // The maximum attribute value size is specified at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
     static constexpr auto maximumAttributeValueSize = 1024;
+
+    auto url = context->creationURL();
+    auto host = url.host();
     auto domain = origin->domain();
-    auto host = origin->host();
 
     Cookie cookie;
     cookie.name = WTFMove(options.name);
@@ -398,7 +401,7 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
             return;
         }
 
-        if (!host.endsWith(cookie.domain) || (host.length() > cookie.domain.length() && !StringView(host).substring(0, host.length() - cookie.domain.length()).endsWith('.'))) {
+        if (!host.endsWith(cookie.domain) || (host.length() > cookie.domain.length() && !host.substring(0, host.length() - cookie.domain.length()).endsWith('.'))) {
             promise->reject(Exception { ExceptionCode::TypeError, "The domain must be a part of the current host"_s });
             return;
         }
@@ -454,7 +457,7 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
             promise->resolve();
     };
 
-    protectedMainThreadBridge()->set(WTFMove(options), WTFMove(cookie), WTFMove(completionHandler));
+    protectedMainThreadBridge()->set(WTFMove(options), WTFMove(cookie), WTFMove(url), WTFMove(completionHandler));
 }
 
 void CookieStore::remove(String&& name, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -839,7 +839,7 @@ public:
 
     URL adjustedURL() const;
 
-    const URL& creationURL() const { return m_creationURL; }
+    const URL& creationURL() const final { return m_creationURL; }
 
     // To understand how these concepts relate to one another, please see the
     // comments surrounding their declaration.

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -55,6 +55,7 @@ public:
         return *m_eventLoopTaskGroup;
     }
     const URL& url() const final { return m_url; }
+    const URL& creationURL() const final { return url(); }
     URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final { return { }; };
     String userAgent(const URL&) const final { return emptyString(); }
     ReferrerPolicy referrerPolicy() const final { return ReferrerPolicy::EmptyString; }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -130,6 +130,8 @@ public:
     enum class ForceUTF8 : bool { No, Yes };
     virtual URL completeURL(const String& url, ForceUTF8 = ForceUTF8::No) const = 0;
 
+    virtual const URL& creationURL() const = 0;
+
     virtual String userAgent(const URL&) const = 0;
 
     virtual const Settings::Values& settingsValues() const = 0;

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -89,6 +89,7 @@ public:
     virtual Type type() const = 0;
 
     const URL& url() const final { return m_url; }
+    const URL& creationURL() const final { return url(); }
     const URL& ownerURL() const { return m_ownerURL; }
     String origin() const;
     const String& inspectorIdentifier() const { return m_inspectorIdentifier; }

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -66,6 +66,7 @@ public:
     MessagePortChannelProvider& messagePortChannelProvider();
 
     const URL& url() const final { return m_url; }
+    const URL& creationURL() const final { return url(); }
 
     void evaluate();
 


### PR DESCRIPTION
#### 8a2b852c5d38ea4ecae01783031902f7a99d3a8b
<pre>
Ensure CookieStore uses the creation URL for setting/getting cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=279454">https://bugs.webkit.org/show_bug.cgi?id=279454</a>
<a href="https://rdar.apple.com/135730639">rdar://135730639</a>

Reviewed by Brady Eidson.

Per the Cookie Store API spec, (<a href="https://wicg.github.io/cookie-store/)">https://wicg.github.io/cookie-store/)</a>, when setting or
getting cookies, the CookieStore should use the url passed in or setting&apos;s creation url.
Up till now, we were using setting&apos;s current url. This is a problem because the current
url can change--meaning that if the current url changes, then requests to get cookies
set using the preivous url will fail. The current WPT tests don&apos;t test this scenario.

This patch updates set(), get(), and getAll() to use the url passed in or the creation url.
We also add two layout tests to test the case where a cookie is set, the document&apos;s
current URL changes, and then there is a request to get the cookies. These tests fail
without the changes to set(), get(), and getAll().

There will be a future patch to the WPT repository to add the tests there.

Since the CookieStoreGetOptions passed into get() and getAll() are still sent over IPC
but their `url` field is not used, we set this field to a null string so that we are not
sending data unnecessarily. We still want to send the options because this object may
change in the future, so it&apos;s better practice to have the code sending it already.

Note that this causes the layout test cookieStore_opaque_origin.https.html to fail. This
test attempts to set a cookie from an iframe. Before this change, this succeeded because
CookieStore::get() was incorrectly using the host obtained from the iframe&apos;s security
origin. Since the iframe didn&apos;t have it&apos;s own security origin, it was given the security
origin of it&apos;s parent--so the test was able to obtain the correct host. But this is the
wrong method of obtaining the host. As per the spec, the host should be obtained from the
url. Now that we use the creation URL (which is about:srcdoc for this iframe), the host
is null, and the test fails.

This breakage in iframe (also occurring in cookieStore_get_set_across_frames.https.html)
will be fixed in the next patch that will travel up the parent tree until a valid creation
url is found. I didn&apos;t do this in this patch so that this patch could be small and focus
on switching set(), get(), and getAll() to using the creation url.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js: Added.
(promise_test.async testCase.async let):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js: Added.
(promise_test.async testCase.async let):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::get):
(WebCore::CookieStore::MainThreadBridge::set):
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::set):
* Source/WebCore/dom/Document.h:
(WebCore::Document::creationURL const): Deleted.
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/283530@main">https://commits.webkit.org/283530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e4a8bccfda182579878434ca757612490fd2ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53334 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33997 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72278 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60657 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60980 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2261 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10089 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->