### PR TITLE
[WebGPU] executeBundles may attempt to encode commands on invalid encoder

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279453-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279453-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279453.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279453.html
@@ -1,0 +1,31401 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAARhtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAABLKAGuYQTmZeVIu8RbaTYlLT6M37Azp2RAe3IEIV023n83eXSVUMBx7Y2iB8wAu3zfquCloEP/+/JCmDAPfYZQ6IAABA7GhAAJuF0QAAAAJgIB0HgoHi8ghf1U50bda3ZQlpx6HFJAXQEZAAP2AAv4AB9wAENAAAAAIgIB4PCQPIPL0ghVUsCXBQwADOgAI2AAQkAAroABXwJKA64AAAAjAgHgeJh6HoPD0whVUsCWiBgADvgAKiAAacAAy4ABmQKKBEwAAAAjAgHhaNB6DwHr0whVUsCWiBgADvgAKiAAacAAy4ABmQKKBEwAAAQ8bW9vdgAAAGxtdmhkAAAAAOLnqjHi56oxAAACWAAAC7gAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAA8h0cmFrAAAAXHRraGQAAAAP4ueqMeLnqjEAAAABAAAAAAAAC7gAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAQAAAAEAAAAAAABEdGFwdAAAABRjbGVmAAAAAAEAAAABAAAAAAAAFHByb2YAAAAAAQAAAAEAAAAAAAAUZW5vZgAAAAABAAAAAQAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAC7gAAAAAAAEAAAAAAvxtZGlhAAAAIG1kaGQAAAAA4ueqMeLnqjEAAAJYAAALuFXEAAAAAAAxaGRscgAAAABtaGxydmlkZWFwcGwAAAAAAAAAABBDb3JlIE1lZGlhIFZpZGVvAAACo21pbmYAAAAUdm1oZAAAAAEAQIAAgACAAAAAADhoZGxyAAAAAGRobHJhbGlzYXBwbAAAAAAAAAAAF0NvcmUgTWVkaWEgRGF0YSBIYW5kbGVyAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAABAAAADGFsaXMAAAABAAACK3N0YmwAAADpc3RzZAAAAAAAAAABAAAA2Wh2YzEAAAAAAAAAAQAAAAAAAAAAAAACAAAAAgABAAEAAEgAAABIAAAAAAAAAAEESEVWQwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY//8AAABtaHZjQwEECAAAAL3IAAAAAFrwAPz8+PgAAAsDoAABABdAAQwB//8ECAAAAwC9yAAAAwAAWhXAkKEAAQAhQgEBBAgAAAMAvcgAAAMAAFrAICAQFiBXuRZVNwEHBwCAogABAAdEAcAsvBTJAAAAEmNvbHJuY2xjAAEABwAHAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAHIAAAAqAAAAJgAAACcAAAAnAAAAJHN0Y28AAAAAAAAABQAAACQAAACWAAAAwAAAAOYAAAEN`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAeJtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAADFKAGvMIOXEB0FUaFg6msTf+CC/0/D/q8LIgSkpn/xRPS6tIBUkQfmLSq+FKe+AjZI3DPkmDAqe84kr8Qr3WlvT/qcZsAKtkVtV81+h174Kfq/LdRAbcBN0GoPgAASocj7cqF8CRftAl4QEQ/W2xxBLE53uVtLJH3RdhxD/zwsgC0ZDqAZSBr4xY1ICQOXJIG7MxRoFbldtdaakXI//uhZuCQ17t5m67XINY+M5AgFuRKLHq4gtUIjBzX0AA84QErAACNkgyIAAABQAgHQeCgeL5BBhBAx4Qgo93QqBQyTeADNgAAAFTAATkSaRapy2A6uGZjvabgbd8SMJ0ofPKdigTPRIGs/optRIRZX5YSDR0AACqgAJmAAYEAAAAA2AgHg8JA8g8vpBBCIm8hgkoT0AApIABvwBkTtXkvGjgHW78t2neSdYgYUk12ydoAA0IAB+wMuAAAAJgIB4HiYeh6Dw+mENJREwJIH+AANuAAj4ANSzfMIAhoYAV0CRgOqAAAAMgIB4WjQeg8B6+mEEIiLiGCSB/gADbgAI+AAVUA2lMHBnz5RRfIgCrRExMgAaEABlwKCAAAEPm1vb3YAAABsbXZoZAAAAADi56x24uesdgAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAPKdHJhawAAAFx0a2hkAAAAD+LnrHbi56x2AAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAAL+bWRpYQAAACBtZGhkAAAAAOLnrHbi56x2AAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAqVtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAi1zdGJsAAAA63N0c2QAAAAAAAAAAQAAANtodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAb2h2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALA6AAAQAYQAEMAf//AWAAAAMAsAAAAwAAAwBaFcCQoQABACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUGEgEAgogABAAdEAcAsvBTJAAAAEmNvbHJuY2xjAAYAEgABAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAOwAAABUAAAAOgAAACoAAAA2AAAAJHN0Y28AAAAAAAAABQAAACQAAAEQAAABZAAAAZ4AAAHI`,
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {label: '\u0159\u3a8d\u{1fdce}\uf03f\u{1f72b}\u0e7e\u{1ff75}\u09bb\uf963\uc999'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxStorageBuffersPerShaderStage: 8,
+    maxTextureArrayLayers: 256,
+    maxUniformBufferBindingSize: 94971194,
+    maxStorageBufferBindingSize: 142040007,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let texture0 = device0.createTexture({
+  label: '\u0287\u0732',
+  size: {width: 192, height: 80, depthOrArrayLayers: 6},
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler0 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.46,
+  maxAnisotropy: 8,
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1ffc5}\u0485\u6894\ub50b\u46fe',
+  entries: [
+    {
+      binding: 89,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 173});
+let texture1 = device0.createTexture({
+  size: [24],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture2 = device0.createTexture({
+  label: '\u{1fe99}\u0ddf\u2132',
+  size: [96, 40, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture2.createView({label: '\u0eef\u01f8\u{1f74e}\uf4c2\u{1f644}', dimension: '2d-array'});
+let sampler1 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 67.52,
+  lodMaxClamp: 83.37,
+  maxAnisotropy: 1,
+});
+let buffer0 = device0.createBuffer({
+  label: '\u71cd\u0a78',
+  size: 9388,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  label: '\u{1fc25}\u{1ff34}\u{1f6a1}\uaf07\u48ad\u9fd4\u{1fb7f}',
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+let buffer1 = device0.createBuffer({size: 7193, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder1 = device0.createCommandEncoder();
+let textureView1 = texture1.createView({});
+let computePassEncoder1 = commandEncoder1.beginComputePass();
+try {
+computePassEncoder0.pushDebugGroup('\u{1f62e}');
+} catch {}
+let textureView2 = texture3.createView({dimension: '2d', mipLevelCount: 1});
+let textureView3 = texture2.createView({label: '\u{1fcd7}\u{1f71c}\u6880\u26ef', dimension: '2d-array'});
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1944, new Int16Array(4210), 277, 300);
+} catch {}
+let imageData0 = new ImageData(28, 8);
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 202,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture4 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer2 = device0.createBuffer({
+  label: '\uf0b8\u84e1\u2fa8\u{1f716}\u{1f682}\u6824\u{1fe86}\u{1f789}\u2d53',
+  size: 1888,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+let textureView4 = texture2.createView({});
+let texture5 = device0.createTexture({
+  label: '\uf187\u00a9\u{1f7a6}\ub2a4\u367f\u{1f63a}\u9224',
+  size: [16, 16, 12],
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let texture6 = device0.createTexture({
+  size: [96, 40, 13],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView5 = texture6.createView({aspect: 'all', baseArrayLayer: 2, arrayLayerCount: 2});
+let textureView6 = texture6.createView({dimension: '2d', mipLevelCount: 1});
+let texture7 = device0.createTexture({
+  label: '\u08a9\uc201\uc64a\u9cde\u4cef\udcd0\u02b2\u{1fcf4}\u{1ffcc}\u{1fe1e}\uae4a',
+  size: [48],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView7 = texture2.createView({dimension: '2d-array'});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+adapter0.label = '\uf3f3\u{1f8a8}\u0747\ub0b4\u64c6';
+} catch {}
+let textureView8 = texture4.createView({});
+let sampler2 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.27,
+  lodMaxClamp: 89.36,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(99).fill(146), /* required buffer size: 99 */
+{offset: 99}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise0;
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 243, resource: {buffer: buffer0, offset: 768, size: 4508}},
+    {binding: 202, resource: textureView2},
+    {binding: 52, resource: textureView6},
+    {binding: 999, resource: textureView8},
+  ],
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView9 = texture5.createView({mipLevelCount: 1, arrayLayerCount: 2});
+let sampler3 = device0.createSampler({
+  label: '\ue862\u23df\u{1f919}\u1484\u73ea\u0208\u{1f96b}\u0f84\ue682\u6aa2',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.980,
+  lodMaxClamp: 51.28,
+  maxAnisotropy: 3,
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 407,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let sampler4 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.29,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(259), 28, 0);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let buffer3 = device0.createBuffer({
+  size: 10628,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  size: [96, 40, 36],
+  mipLevelCount: 2,
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView10 = texture5.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder3 = commandEncoder2.beginComputePass({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 1.414,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer0, 908, 3388);
+} catch {}
+let texture9 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 2},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView11 = texture6.createView({aspect: 'all', baseArrayLayer: 5, arrayLayerCount: 1});
+let computePassEncoder4 = commandEncoder3.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(142), 16, 0);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: atomic<u32>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: array<T0, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T2 {
+  @align(1) f0: array<array<atomic<i32>, 1>>,
+}
+/* target size: 4 max align: 4 */
+struct T3 {
+  f0: array<T1, 1>,
+}
+@group(0) @binding(36) var<uniform> buffer4: vec2h;
+@group(0) @binding(407) var tex0: texture_2d_array<f32>;
+@group(0) @binding(19) var tex1: texture_1d<f32>;
+struct VertexOutput0 {
+  @location(14) f0: vec2f,
+  @builtin(position) f1: vec4f,
+  @location(3) @interpolate(flat) f2: i32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec4i {
+  var out: vec4i;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let computePassEncoder5 = commandEncoder4.beginComputePass({});
+try {
+computePassEncoder5.pushDebugGroup('\udc45');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 3},
+  aspect: 'all',
+}, new Uint8Array(17_851).fill(202), /* required buffer size: 17_851 */
+{offset: 211, bytesPerRow: 63, rowsPerImage: 70}, {width: 15, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule0, constants: {}, targets: [{format: 'rgba32sint'}]},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: false},
+});
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 52, resource: textureView6},
+    {binding: 202, resource: textureView2},
+    {binding: 243, resource: {buffer: buffer0, offset: 0, size: 100}},
+    {binding: 999, resource: textureView4},
+  ],
+});
+let texture10 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView12 = texture1.createView({});
+let sampler6 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.08,
+  lodMaxClamp: 54.51,
+  maxAnisotropy: 18,
+});
+let promise2 = device0.queue.onSubmittedWorkDone();
+let commandEncoder5 = device0.createCommandEncoder({});
+let textureView13 = texture8.createView({
+  label: '\u0db4\ub974\u0a55\u0e0e\uae9d',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+let computePassEncoder6 = commandEncoder5.beginComputePass({});
+try {
+texture10.label = '\u0515\uea97\u538e\u4ad0\uf57e\u{1fa87}\u{1f612}\ua147';
+} catch {}
+try {
+computePassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 700, new BigUint64Array(12266), 990, 0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 52, resource: textureView6},
+    {binding: 999, resource: textureView8},
+    {binding: 202, resource: textureView2},
+    {binding: 243, resource: {buffer: buffer0, offset: 1280}},
+  ],
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u2996\u8e21',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer5 = device0.createBuffer({
+  label: '\u0aae\ubc3a',
+  size: 1697,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder4.pushDebugGroup('\u4bd5');
+} catch {}
+let texture11 = device0.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], sampleCount: 1, depthReadOnly: false, stencilReadOnly: true});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+texture10.destroy();
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u8ee0');
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(615), 193, 0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(1, buffer3, 0);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange();
+try {
+  await promise4;
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'jedecP22Phosphors', transfer: 'smpte170m'} });
+let commandEncoder6 = device0.createCommandEncoder();
+let textureView14 = texture8.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(925), 208, 0);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer3, 'uint16', 1_966, 4_351);
+} catch {}
+await gc();
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint']});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup1, new Uint32Array(1861), 164, 0);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let buffer6 = device0.createBuffer({
+  size: 514,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder7 = commandEncoder6.beginComputePass();
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.76,
+  lodMaxClamp: 70.47,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(3161), 464, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer3, 'uint16', 144, 1_670);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(0, buffer3, 0);
+} catch {}
+let imageData1 = new ImageData(20, 4);
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 262});
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(3, buffer6, 12);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 692});
+let textureView15 = texture6.createView({label: '\u6e09\uf164\u04b8\ue0a6\u4b3f\u{1fafd}\u09b9\u0260', dimension: '2d', baseArrayLayer: 1});
+let texture12 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(586), 151, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(2115), 189, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer3, 'uint32', 1_172, 670);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 64);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder7.beginComputePass({});
+let sampler8 = device0.createSampler({
+  label: '\u0fd0\u1a9a\u0d92\u{1fe5e}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 42.40,
+  lodMaxClamp: 59.78,
+});
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(1427), 140, 0);
+} catch {}
+try {
+computePassEncoder4.popDebugGroup();
+} catch {}
+let buffer7 = device0.createBuffer({
+  size: 16162,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder8 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  size: [48, 20, 87],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(2238), 193, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer3, 'uint32', 444, 1_291);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(385).fill(235), /* required buffer size: 385 */
+{offset: 70, bytesPerRow: 105}, {width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u{1f701}\ud35e\u{1fd78}\ub415\ud2ce',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 41, resource: textureView2},
+    {binding: 5, resource: textureView2},
+    {binding: 89, resource: textureView1},
+  ],
+});
+let commandBuffer0 = commandEncoder8.finish({});
+let textureView16 = texture3.createView({mipLevelCount: 1});
+let textureView17 = texture4.createView({baseArrayLayer: 0});
+try {
+renderBundleEncoder1.setPipeline(pipeline0);
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  label: '\ufac5\u{1ff0d}\ud7a6\ud90e\uca93\u4707',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 407, resource: textureView17},
+    {binding: 36, resource: {buffer: buffer5, offset: 0, size: 224}},
+    {binding: 19, resource: textureView2},
+  ],
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let sampler9 = device0.createSampler({
+  label: '\ua123\u0548\uaa20\uaaad\u8ad9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.34,
+  maxAnisotropy: 1,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+  await promise3;
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u307b\u0818\u{1f856}\u{1f6d2}\u{1fca4}\ue936\u8a4b\u63a3\u{1fdd8}\u{1f808}',
+  entries: [
+    {
+      binding: 300,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder10 = device0.createCommandEncoder({});
+let renderBundle1 = renderBundleEncoder1.finish({label: '\u9568\u80da\u04a6\u{1f62c}\u4392\u3324\ua32d\u04de'});
+try {
+externalTexture0.label = '\u0ce9\u4503\u3693\u{1f67c}\ufd1b\ud2c0\u0f9c\u{1f8da}';
+} catch {}
+let textureView18 = texture9.createView({dimension: '2d', arrayLayerCount: 1});
+let computePassEncoder9 = commandEncoder9.beginComputePass();
+let renderPassEncoder0 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView18,
+  clearValue: { r: 519.5, g: -468.4, b: 523.5, a: -949.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(1489), 139, 0);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(1, buffer3, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(74).fill(131), /* required buffer size: 74 */
+{offset: 74}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer8 = device0.createBuffer({size: 2620, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder11 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup4, new Uint32Array(512), 20, 0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -775.4, g: -598.5, b: -891.0, a: 390.2, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 228, 653);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder10 = commandEncoder11.beginComputePass();
+let renderBundle2 = renderBundleEncoder2.finish({});
+let sampler10 = device0.createSampler({
+  label: '\u4fd9\ub288\ua959\u{1fb6f}\u{1f9e6}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.36,
+  lodMaxClamp: 76.62,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer3, 116, 4_342);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+window.someLabel = computePassEncoder9.label;
+} catch {}
+let buffer9 = device0.createBuffer({size: 3585, usage: GPUBufferUsage.VERTEX});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u2115\u{1f7fa}\ue701\u{1fa9f}\u{1fdca}\u{1f93e}\u20c0\uad2e\u0f15'});
+let textureView19 = texture11.createView({label: '\u{1fd6f}\u08d4\ub4a7\u53f6\u0cb6\u6573\ua5eb\ue5a8\u{1f84a}', baseArrayLayer: 0});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+let imageData2 = new ImageData(180, 16);
+try {
+//  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer6, offset: 0, size: 30}}],
+});
+let commandEncoder13 = device0.createCommandEncoder();
+let renderPassEncoder1 = commandEncoder12.beginRenderPass({
+  label: '\u7a54\u232b\u0748\ufb1e\u35b0\u0353\u9fc4\u759b\u08a6\u3191\u{1fb3c}',
+  colorAttachments: [{view: textureView18, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+});
+let sampler11 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', magFilter: 'nearest', lodMinClamp: 17.94});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 2},
+  aspect: 'all',
+}, new Uint8Array(32_375).fill(115), /* required buffer size: 32_375 */
+{offset: 7, bytesPerRow: 476, rowsPerImage: 4}, {width: 88, height: 0, depthOrArrayLayers: 18});
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer6, offset: 256, size: 5}}],
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let buffer10 = device0.createBuffer({size: 9250, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture14 = device0.createTexture({
+  size: [48],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture15 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder11 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(1, bindGroup1, new Uint32Array(4324), 2_648, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer7);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder();
+let texture16 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+sampler3.label = '\ud891\u7835\u7521\u0b1d\u057f\u{1f96a}\ucf5f\u0a94';
+} catch {}
+let textureView20 = texture16.createView({dimension: '3d', mipLevelCount: 1});
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.29,
+  lodMaxClamp: 89.28,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(3, bindGroup4, new Uint32Array(370), 67, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer7, 6_980, 2_511);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\ufecd');
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 122,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 3, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 963,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 366,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 3},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture18 = device0.createTexture({size: [48, 20, 87], dimension: '3d', format: 'r16float', usage: GPUTextureUsage.COPY_DST});
+let textureView21 = texture15.createView({label: '\u217c\u0d02\u{1fea5}\ub61f\u0267\u8e3c\u800b\ucfbb\u030e', mipLevelCount: 1});
+let sampler13 = device0.createSampler({
+  label: '\u{1f8c1}\u50c1\ue4ce\u0397',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.22,
+  lodMaxClamp: 94.53,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer3, 0);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder12 = commandEncoder15.beginComputePass({label: '\uf414\u{1fb11}\u{1f611}\u301c\ufb70\u734b'});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(959), 116, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer7);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet2, 209, 38, buffer5, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture20 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler14 = device0.createSampler({
+  label: '\ud900\ue722\uaad7\uaaf7\uac8a\u43aa',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.78,
+  lodMaxClamp: 95.41,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(3, bindGroup5, new Uint32Array(3042), 5, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(2, 2, 0, 0);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer0, 756, buffer2, 56, 396);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+await gc();
+let imageData3 = new ImageData(88, 16);
+let texture21 = device0.createTexture({
+  size: [192, 80, 215],
+  mipLevelCount: 2,
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture22 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 23},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder13 = commandEncoder14.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.setViewport(4.34591098575214, 6.763648455195831, 4.274906219328906, 1.0688487740395227, 0.24231102540485805, 0.9441730389307519);
+} catch {}
+let texture23 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView22 = texture8.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 4});
+let computePassEncoder14 = commandEncoder16.beginComputePass();
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(184, 16);
+try {
+commandEncoder17.copyBufferToBuffer(buffer0, 952, buffer2, 904, 40);
+} catch {}
+await gc();
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer3, offset: 3584, size: 698}}],
+});
+let buffer11 = device0.createBuffer({size: 19650, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 139},
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder2 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView18,
+  clearValue: { r: 737.0, g: 89.54, b: 44.65, a: 307.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 104},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1184 */
+  offset: 1184,
+  bytesPerRow: 0,
+  rowsPerImage: 0,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 23});
+} catch {}
+let textureView23 = texture20.createView({label: '\u46f8\u510f\u09da\u{1fc36}\u0917\u024b'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], stencilReadOnly: true});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.setViewport(12.935995780856018, 6.252941946547381, 9.060438381171672, 0.7809480118709001, 0.1100367008374109, 0.9235997618760754);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint16', 158, 1_078);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup6, new Uint32Array(331), 8, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer3, 'uint16', 556, 2_605);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 384 */
+  offset: 384,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(78).fill(217), /* required buffer size: 78 */
+{offset: 78}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 36, resource: {buffer: buffer6, offset: 0, size: 24}},
+    {binding: 407, resource: textureView8},
+    {binding: 19, resource: textureView16},
+  ],
+});
+let texture25 = device0.createTexture({
+  size: [24],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture26 = device0.createTexture({
+  size: [24, 10, 43],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture6.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder18.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(2344), 24, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer11);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer7, 2_160);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let texture27 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture28 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 11_228, 940);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let texture29 = device0.createTexture({
+  size: [80, 110, 1],
+  mipLevelCount: 4,
+  format: 'astc-10x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture30 = device0.createTexture({size: [24, 10, 43], dimension: '3d', format: 'r16float', usage: GPUTextureUsage.COPY_SRC});
+let textureView25 = texture29.createView({
+  label: '\u0212\u0acd\u5af2\u2e0b\u{1ff4a}\u1e95\u0e37\u2b80\u08e9\u2b70',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let sampler15 = device0.createSampler({
+  label: '\ub212\ue399',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 32.70,
+  lodMaxClamp: 79.00,
+});
+let externalTexture3 = device0.importExternalTexture({
+  label: '\u9fd1\u{1fad7}\u{1ffef}\u0723\u0470\u5857\u{1fd53}\u4583\uc6fb\u0285',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, undefined);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer6, 164);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({label: '\ub522\u9d02\ud92c\u0681\u{1f8b1}\u6fe4\u129e\ub9fc'});
+let texture31 = device0.createTexture({
+  size: [192, 80, 349],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture32 = device0.createTexture({
+  label: '\u4ca6\ue250',
+  size: [24, 10, 43],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder16 = commandEncoder19.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+let textureView26 = texture15.createView({label: '\u{1f9f4}\u0f48\u05cd\u08f7\u8839\u0844', mipLevelCount: 1});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler16 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 60.87,
+  lodMaxClamp: 68.38,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup5, new Uint32Array(2133), 139, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 88, y: 36, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+//let promise7 = adapter0.requestAdapterInfo();
+let buffer12 = device0.createBuffer({
+  size: 9376,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView27 = texture32.createView({});
+let texture33 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 2},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(1895), 159, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(44);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  label: '\u{1fcfc}\u61f0\u03a1',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 89, resource: textureView12},
+    {binding: 5, resource: textureView2},
+    {binding: 41, resource: textureView2},
+  ],
+});
+let buffer13 = device0.createBuffer({size: 1613, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture34 = device0.createTexture({
+  size: {width: 8, height: 6, depthOrArrayLayers: 30},
+  mipLevelCount: 1,
+  format: 'astc-8x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView28 = texture17.createView({arrayLayerCount: 1});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup7, new Uint32Array(536), 109, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint32', 264, 4_073);
+} catch {}
+let buffer14 = device0.createBuffer({size: 662, usage: GPUBufferUsage.VERTEX});
+let commandEncoder20 = device0.createCommandEncoder({});
+let textureView29 = texture19.createView({});
+let renderPassEncoder3 = commandEncoder20.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 32,
+  clearValue: { r: 155.7, g: 297.1, b: 18.81, a: 994.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer12, 620);
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u702c\u5ff9\u4228',
+  size: 34690,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture35 = device0.createTexture({
+  size: [1104, 30, 1],
+  mipLevelCount: 3,
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture36 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView30 = texture11.createView({baseMipLevel: 0});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup3, new Uint32Array(59), 5, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData1,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 42, y: 4, z: 38},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteSt4281', transfer: 'gamma28curve'} });
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 125,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 348,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 115, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder();
+let textureView31 = texture20.createView({});
+let sampler17 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.07,
+  maxAnisotropy: 18,
+});
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 80 */
+  offset: 80,
+  buffer: buffer10,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet1, 46, 26, buffer5, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 0, new DataView(new ArrayBuffer(19561)), 17186, 16);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 127,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture37 = device0.createTexture({
+  label: '\u0318\u09d3\u9292\u48b5\u0546\u06a1',
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler18 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.44,
+  lodMaxClamp: 96.36,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup3, new Uint32Array(1109), 17, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let textureView32 = texture21.createView({mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 102});
+let renderPassEncoder4 = commandEncoder21.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 22,
+  clearValue: { r: 548.9, g: -284.5, b: -390.6, a: 142.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer12, 'uint32', 3_564, 1_486);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer11, 0, 5_284);
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData1);
+let buffer16 = device0.createBuffer({
+  size: 3296,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder22 = device0.createCommandEncoder();
+let textureView33 = texture37.createView({});
+let computePassEncoder17 = commandEncoder22.beginComputePass();
+let sampler19 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.99,
+  lodMaxClamp: 96.29,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup6, new Uint32Array(532), 119, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(68, 620, 61, 26_869_237, 1_013_919_499);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+let video0 = await videoWithData(97);
+let textureView34 = texture15.createView({baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 31.46,
+  lodMaxClamp: 50.13,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup6, new Uint32Array(830), 64, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer13, 'uint16', 80, 56);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer9);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u7384\u56fc\u{1f7b9}\u0a88\u{1f8a3}'});
+let texture38 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture39 = device0.createTexture({
+  size: [48, 20, 5],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView35 = texture4.createView({dimension: '2d-array'});
+let computePassEncoder18 = commandEncoder23.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 240);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer6, 244);
+} catch {}
+let texture40 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup9, new Uint32Array(164), 70, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 1_512);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer6, 4);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer15, 'uint16', 13_674, 5_481);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer11, 11_036);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let textureView36 = texture10.createView({dimension: '2d-array'});
+try {
+renderPassEncoder2.drawIndexed(158, 153, 160, -1_022_552_193, 390_580_179);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 828);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer6, 20);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 36,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 376,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture41 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 30},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture42 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture4 = device0.importExternalTexture({label: '\u044f\u03f2\u0460', source: videoFrame0});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(1064), 260, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup1, new Uint32Array(3368), 248, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(6.6710598238708325, 1.6667456714245943, 14.49549038822768, 5.48444995605258, 0.4823071703254951, 0.7797731761016642);
+} catch {}
+try {
+renderPassEncoder2.draw(70, 256, 2_567_810_386, 580_814_599);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 130, 23, 232_133_232, 62_339_046);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer5, 92);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 224);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView37 = texture40.createView({
+  label: '\u{1f628}\ufbd0\u2f8b\u69f0\u{1f8ef}\uce02\u85e1\u68ad\uf675\u55ba\u{1fa18}',
+  dimension: '2d',
+});
+let textureView38 = texture29.createView({format: 'astc-10x10-unorm-srgb', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder2.draw(643, 0, 404_658_650, 1_188_699_992);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 396);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer3, 0, 116);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 4568);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder();
+let texture43 = device0.createTexture({
+  size: [360, 360, 1],
+  mipLevelCount: 2,
+  format: 'astc-10x6-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView39 = texture32.createView({mipLevelCount: 1});
+let computePassEncoder19 = commandEncoder24.beginComputePass({label: '\u0abb\u0a1e\u0859\ucc3f\u89ee\u9f75\u8012'});
+try {
+renderPassEncoder2.draw(137, 94, 576_366_466, 468_132_509);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(69, 56, 55, 75_957_346, 606_037_319);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 308);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 116);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 888, new Int16Array(4771), 116, 356);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  label: '\u{1f744}\ud8c4\u6925',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 89, resource: textureView12},
+    {binding: 5, resource: textureView2},
+    {binding: 41, resource: textureView2},
+  ],
+});
+let texture44 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 29},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder5 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView18,
+  clearValue: { r: 187.9, g: 694.0, b: -558.8, a: -976.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle2, renderBundle1, renderBundle0, renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.draw(86, 14, 323_524_936, 510_128_117);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer5, 476);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+adapter0.label = '\u3606\u{1f61e}\u6555\u85e6';
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u{1fc5f}\u4482\u105f\u0808\uafbc\ua3c9', bindGroupLayouts: []});
+let commandEncoder26 = device0.createCommandEncoder({});
+let textureView40 = texture41.createView({
+  label: '\u00d1\u0de0\u2d8d\u3218\u8ddd\u00a4\u35cc\ue888\u0fdc\u8379\u528f',
+  dimension: '2d',
+  baseArrayLayer: 5,
+});
+let texture45 = device0.createTexture({
+  label: '\u8f11\u{1f6d6}\u033f\ue6ea\u0df6\u09fd\u{1ffb5}\u{1fbfc}\ucec8\u0ea4',
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder6 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{view: textureView39, depthSlice: 31, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 7239155,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup3, new Uint32Array(1043), 592, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 1_828);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange(64, 84);
+let img0 = await imageWithData(41, 14, '#10101010', '#20202020');
+let buffer17 = device0.createBuffer({
+  size: 6900,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let texture46 = device0.createTexture({
+  size: [2700, 6, 1],
+  mipLevelCount: 2,
+  format: 'astc-10x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture47 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView41 = texture4.createView({aspect: 'all', arrayLayerCount: 1});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u8bc6\u3909',
+  colorFormats: ['rgba32sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler21 = device0.createSampler({
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.79,
+  lodMaxClamp: 99.81,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(2369), 39, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(7, 80, 122, 440_379_657, 1_869_011_213);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer7, 836);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer16, 228, 522);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+await gc();
+let canvas0 = document.createElement('canvas');
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let buffer18 = device0.createBuffer({
+  size: 4743,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture48 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture49 = device0.createTexture({
+  size: [24, 10, 43],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler22 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.85,
+  lodMaxClamp: 99.24,
+  compare: 'not-equal',
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup5, new Uint32Array(356), 53, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(122, 33, 89, -1_527_129_379, 1_865_160_505);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer16, 'uint32', 1_072, 186);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let buffer19 = device0.createBuffer({
+  label: '\u{1fe99}\ud5f2\ud786\u0e11\u74ce',
+  size: 460,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView42 = texture38.createView({label: '\uc7ba\u077a\u09fa\u6a4d', format: 'rgba8uint'});
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.draw(27, 116, 198_747_449, 861_036_440);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(118, 132, 20, 498_153_685, 356_086_522);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 1_104);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 108);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer7, 'uint16', 8_468, 465);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData4 = new ImageData(8, 32);
+let buffer20 = device0.createBuffer({
+  size: 17463,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture50 = device0.createTexture({
+  size: [48, 20, 79],
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5, new Uint32Array(199), 23, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint32', 4_832, 35);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup9, new Uint32Array(1459), 30, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 2344, new BigUint64Array(46956), 13547, 236);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture51 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 28},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture52 = device0.createTexture({
+  label: '\uc132\u858a\u7e08\u{1ff13}',
+  size: [24],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView43 = texture14.createView({format: 'rg32uint', baseMipLevel: 0});
+try {
+renderPassEncoder2.drawIndexed(1, 837, 0, 336_168_213, 342_874_100);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup7, new Uint32Array(1263), 287, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer19, 'uint32', 16, 49);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer18, 0, 1_621);
+} catch {}
+let texture53 = device0.createTexture({
+  size: {width: 4110, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'astc-10x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle4 = renderBundleEncoder4.finish({});
+let sampler23 = device0.createSampler({
+  label: '\u3b7c\u{1fe7f}\u8819\u778c\u0f10\u{1fdec}\u39cb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 37.68,
+  lodMaxClamp: 76.76,
+});
+try {
+renderPassEncoder2.drawIndexed(2, 15, 0, 141_938_610, 717_753_596);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer6, 56);
+} catch {}
+let arrayBuffer3 = buffer10.getMappedRange(784, 32);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture55 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder20 = commandEncoder27.beginComputePass({});
+let sampler24 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 44.35,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup7, new Uint32Array(850), 54, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 82, 1, -896_965_562, 59_801_100);
+} catch {}
+let arrayBuffer4 = buffer17.getMappedRange();
+let texture56 = device0.createTexture({
+  label: '\ub544\uc362\u609a\u3d66',
+  size: {width: 230, height: 8, depthOrArrayLayers: 23},
+  format: 'astc-10x8-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture57 = device0.createTexture({
+  label: '\u7279\u484e\u{1fd65}\ue7ab\u352e\ub7f3\u551e\u0357',
+  size: [192, 80, 128],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 90.96,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 1_408);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer21 = device0.createBuffer({size: 1232, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder28 = device0.createCommandEncoder({label: '\u0e6d\u5864\u{1f6ce}'});
+let texture58 = device0.createTexture({
+  label: '\u7c8b\u2f7d\u{1fcf4}\u09e7\u787e\u718b',
+  size: {width: 1356, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'astc-12x12-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.draw(31, 44, 105_300_218, 504_598_653);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer15, 'uint16', 3_714, 22_010);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture59 = device0.createTexture({
+  size: {width: 510, height: 152, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'astc-10x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture60 = device0.createTexture({
+  size: [48, 20, 87],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView44 = texture13.createView({aspect: 'all'});
+let externalTexture5 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup10, new Uint32Array(5706), 63, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 248, 0, -2_002_496_790, 1_500_824_876);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 24);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let texture61 = device0.createTexture({
+  size: [192, 80, 11],
+  dimension: '2d',
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture62 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView45 = texture48.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder2.draw(4, 298, 1_079_432_010, 440_257_493);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 136);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint16', 304, 2_448);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer14, 0, 95);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer22 = device0.createBuffer({
+  size: 7799,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture63 = device0.createTexture({
+  label: '\u7ea3\u8141\u7b9a\u65ef\u03e6',
+  size: [192, 80, 142],
+  mipLevelCount: 3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder7 = commandEncoder29.beginRenderPass({colorAttachments: [{view: textureView26, depthSlice: 281, loadOp: 'load', storeOp: 'discard'}]});
+let sampler26 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 8.805,
+  lodMaxClamp: 12.98,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup7, new Uint32Array(694), 34, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1120 */
+  offset: 1120,
+  buffer: buffer11,
+}, {width: 96, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'unspecified', transfer: 'iec6196624'} });
+let bindGroup11 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView42}]});
+let texture64 = device0.createTexture({
+  size: [320, 132, 1],
+  mipLevelCount: 7,
+  format: 'astc-10x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture65 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView46 = texture26.createView({label: '\u9f87\u0d23\ucc4f\uc033\uce5d\u0c72', aspect: 'all', format: 'rgba32sint'});
+let computePassEncoder21 = commandEncoder28.beginComputePass({});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup5, new Uint32Array(402), 41, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3, renderBundle4]);
+} catch {}
+try {
+computePassEncoder17.pushDebugGroup('\u0561');
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture66 = device0.createTexture({
+  size: [16, 16, 12],
+  format: 'astc-4x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView47 = texture47.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder22 = commandEncoder30.beginComputePass({label: '\u82d7\udb97\u4670\u095d\u8039\u09de\u2e2a'});
+try {
+renderPassEncoder2.draw(131, 102, 217_147_496, 1_533_386_665);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 916);
+} catch {}
+let texture67 = device0.createTexture({
+  size: [924, 24, 1],
+  mipLevelCount: 3,
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.draw(47, 732, 549_698_063, 571_558_449);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 372);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer12, 'uint16', 326, 34);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 19, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(24).fill(194), /* required buffer size: 24 */
+{offset: 24}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer23 = device0.createBuffer({
+  size: 11969,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let commandBuffer1 = commandEncoder31.finish({});
+let texture68 = device0.createTexture({
+  size: [96, 40, 1],
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(43, 156, 49, -1_985_972_425, 221_151_648);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 4_740);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer6, 64);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer22, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, colorSpace: 'display-p3'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(400).fill(4), /* required buffer size: 400 */
+{offset: 400}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView48 = texture66.createView({label: '\ua36c\udc84', dimension: 'cube', baseArrayLayer: 1});
+try {
+renderPassEncoder2.drawIndexed(96, 22, 255, 289_940_664, 515_416_111);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 324);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 3, y: 6, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.draw(110, 0, 223_802_518, 102_588_341);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer20, 968);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer15);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let sampler28 = device0.createSampler({
+  label: '\u{1f8a0}\u05fe\u061b\u{1f8fb}\u4b24\u{1f985}\u{1f912}\u7fce\u30d5\u{1f88a}\u5066',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 70.18,
+  lodMaxClamp: 98.78,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup4, new Uint32Array(801), 209, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(256, 117, 184_141_252, 296_062_854);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(55, 145, 59, 220_155_619, 862_532_453);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 90, y: 48, z: 0},
+  aspect: 'all',
+}, new Uint8Array(78).fill(118), /* required buffer size: 78 */
+{offset: 78}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder21.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(62, 18, 113, 401_298_410, 287_030_219);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer18, 'uint16', 420, 243);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let texture69 = device0.createTexture({
+  label: '\u050a\u0c71\u0def\u0d86\u{1fd4a}\u0ae5\ud303\ubfda',
+  size: [192, 80, 1],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler29 = device0.createSampler({
+  label: '\ud6f8\u32b9\ucd8d\u{1fe1d}\u19d3\u0507\u0a48',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.89,
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup6, new Uint32Array(1120), 78, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 3_040);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer9, 0, 3_352);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let imageData5 = new ImageData(64, 8);
+let buffer24 = device0.createBuffer({size: 669, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder32 = device0.createCommandEncoder({});
+let renderPassEncoder8 = commandEncoder32.beginRenderPass({
+  label: '\u0e3c\u5120\u9882',
+  colorAttachments: [{
+  view: textureView34,
+  depthSlice: 78,
+  clearValue: { r: -503.2, g: 652.2, b: 53.86, a: -812.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 664163177,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(29, 3, 0, 142_634_122, 2_051_110_816);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer20, 1_056);
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 8, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let texture70 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 240);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 140);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer20, 'uint16', 232, 1_028);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer22, 0, 3_458);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder23 = commandEncoder33.beginComputePass({});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup4, new Uint32Array(88), 22, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(106);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.draw(2, 172, 1_630_581_500, 158_516_715);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(13, 5, 14, 776_453_362, 407_489_366);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer20, 'uint16', 134, 766);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture71 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup5, new Uint32Array(1081), 23, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(65, 17, 11, 78_616_567, 91_517_467);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 236);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer6, 240);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer22, 0, 322);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 1096, new BigUint64Array(8129), 938, 0);
+} catch {}
+document.body.append(video0);
+let commandEncoder34 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder34.finish({});
+let texture72 = device0.createTexture({
+  size: [24, 10, 1],
+  mipLevelCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView49 = texture44.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 1});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup1, new Uint32Array(1040), 346, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(126, 89, 89_710_137, 1_614_403_328);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 84);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 632);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer7, 'uint16', 10_412, 2_292);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\u0efb\u{1ff53}\u2249\u095c\u{1f7fd}',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 125, resource: {buffer: buffer12, offset: 1536}},
+    {binding: 129, resource: {buffer: buffer7, offset: 256, size: 4888}},
+    {binding: 115, resource: sampler23},
+    {binding: 71, resource: textureView33},
+    {binding: 348, resource: textureView37},
+  ],
+});
+let texture73 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 17},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.drawIndexed(8, 143, 34, 317_276_873, 149_103_890);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer23, 4_336);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 632);
+} catch {}
+let arrayBuffer5 = buffer12.getMappedRange(4560, 100);
+try {
+buffer20.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer25 = device0.createBuffer({
+  size: 560,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture74 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler30 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 47.64,
+  lodMaxClamp: 53.85,
+});
+let externalTexture6 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer6, 8);
+} catch {}
+let buffer26 = device0.createBuffer({
+  label: '\u{1f8a7}\u6a47\u{1fe9f}\ufed6',
+  size: 18088,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder35 = device0.createCommandEncoder({label: '\u{1feb0}\u{1fc28}\u66b2\u0abc\ueba8\u33c6'});
+let texture75 = device0.createTexture({
+  size: {width: 1185, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle2, renderBundle2, renderBundle1, renderBundle4, renderBundle1, renderBundle4, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer3, 'uint16', 36, 152);
+} catch {}
+let computePassEncoder24 = commandEncoder33.beginComputePass({});
+let renderPassEncoder9 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 135,
+  clearValue: { r: -570.0, g: -512.9, b: 819.2, a: -37.81, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 4_704, 2_999);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer6 = buffer16.getMappedRange(1400);
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(396).fill(100), /* required buffer size: 396 */
+{offset: 44, bytesPerRow: 24, rowsPerImage: 3}, {width: 2, height: 3, depthOrArrayLayers: 5});
+} catch {}
+document.body.prepend(video0);
+try {
+computePassEncoder16.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup9, new Uint32Array(242), 18, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.draw(147, 303, 609_811_290, 992_407_811);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer17, 504);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer7, 'uint32', 4_240, 3_101);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer18, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1220, new Int16Array(14050), 529, 112);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let texture76 = device0.createTexture({
+  size: [48],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler31 = device0.createSampler({
+  label: '\ub7bf\uba25\u0291\u6713\ua220\uf9ae\u0522\u093b\u48fa\u9c74\u0b8f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 48.57,
+  lodMaxClamp: 56.02,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup6, new Uint32Array(377), 7, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(img0);
+let textureView50 = texture17.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\uc5f8\u6f00\ucea9\u{1fdcc}\u01ef\u6fa2\u05e5\u7b88\u610f\u1b63\udfd3',
+  colorFormats: ['rgba32sint'],
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(1, bindGroup7, new Uint32Array(1818), 209, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(207, 77, 336_514_621, 25_019_180);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer13, 'uint16', 78, 59);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer7, 0, 4_762);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer15, 'uint32', 4_656, 5_426);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(5, buffer7);
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker('\u{1fdbc}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 25, y: 5, z: 61},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup13 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 8, resource: {buffer: buffer12, offset: 1024}}]});
+let commandEncoder36 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder10 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 6,
+  clearValue: { r: -753.7, g: -533.1, b: -477.0, a: -140.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 57727096,
+});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup6, new Uint32Array(662), 8, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(610), 203, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(30, 93, 605_988_755, 636_815_052);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 2_316);
+} catch {}
+let video1 = await videoWithData(58);
+let imageData6 = new ImageData(56, 12);
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 261,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView42}]});
+let texture78 = device0.createTexture({
+  size: [48],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.96,
+  lodMaxClamp: 47.60,
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup6);
+} catch {}
+let textureView51 = texture77.createView({label: '\u49aa\u4b41\u44e3\u7f36\u{1f720}\u013c\ud415\u0288\u01fd', dimension: '3d'});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(387);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(20, 125, 2, 216_249_797, 548_567_923);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 196);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 328);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 115, resource: sampler31},
+    {binding: 129, resource: {buffer: buffer5, offset: 0, size: 464}},
+    {binding: 125, resource: {buffer: buffer7, offset: 7424, size: 296}},
+    {binding: 71, resource: textureView33},
+    {binding: 348, resource: textureView37},
+  ],
+});
+let commandEncoder37 = device0.createCommandEncoder();
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 654});
+let texture79 = device0.createTexture({
+  label: '\ub8c4\u04b7\u0f50',
+  size: [192, 80, 1],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder25 = commandEncoder37.beginComputePass({});
+let sampler33 = device0.createSampler({magFilter: 'nearest', lodMinClamp: 45.67, lodMaxClamp: 80.95});
+let externalTexture7 = device0.importExternalTexture({label: '\u84b2\u08d0\uc0e3\u06ac\u05f4\ubd32\u1dd7\u595a\u60f3\u8779', source: videoFrame4});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(1709), 309, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(629, 46, 1_875_703_044, 1_423_520_652);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+video0.height = 7;
+await gc();
+let bindGroup16 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 8, resource: {buffer: buffer6, offset: 0, size: 156}}]});
+let renderPassEncoder11 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 3,
+  clearValue: { r: -647.3, g: 93.14, b: -109.5, a: -213.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup8, new Uint32Array(3889), 324, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(7.149552370025362, 7.7662886316043185, 3.724981216328184, 1.5458016920028201, 0.10937976838234875, 0.8538846290735143);
+} catch {}
+try {
+renderPassEncoder2.draw(338, 310, 801_162_648, 29_170_379);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(54, 163, 29, 166_341_105, 2_822_408_643);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer19, 68);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let texture80 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 5},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint32', 764, 1_530);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 52, resource: textureView45},
+    {binding: 999, resource: textureView47},
+    {binding: 243, resource: {buffer: buffer0, offset: 256, size: 3344}},
+    {binding: 202, resource: textureView2},
+  ],
+});
+let texture81 = device0.createTexture({
+  size: [16, 16, 12],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture82 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle0, renderBundle0, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(17, 321, 3, 7_530_654, 161_101_934);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 5_036);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(3, 56, 3, 403_754_755, 1_378_117_375);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 32);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 1_908);
+} catch {}
+try {
+  await promise9;
+} catch {}
+let imageData7 = new ImageData(36, 36);
+try {
+computePassEncoder22.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(1033);
+} catch {}
+try {
+renderPassEncoder2.draw(45, 44, 85_291_131, 618_083_818);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 1_000, 52, -1_819_814_386, 44_650_910);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 3_640);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer14, 76, 89);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let querySet4 = device0.createQuerySet({label: '\u2145\u4888\u9d6f', type: 'occlusion', count: 182});
+let textureView52 = texture41.createView({dimension: '2d'});
+let sampler34 = device0.createSampler({
+  label: '\u{1fdd2}\u80b3\u02ab\u{1ff71}\u{1f7b0}\u9bc9\u0a9e\u70b0',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.767,
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup7, new Uint32Array(1369), 263, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(12.373479818582013, 5.620571382015448, 0.16010280807814928, 3.041515596855049, 0.1266067849265735, 0.559655281024197);
+} catch {}
+try {
+renderPassEncoder2.draw(102, 126, 169_406_744, 168_679_002);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 88);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 2},
+  aspect: 'all',
+}, new Uint8Array(892).fill(102), /* required buffer size: 892 */
+{offset: 199, bytesPerRow: 99, rowsPerImage: 7}, {width: 9, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let commandEncoder38 = device0.createCommandEncoder();
+let commandBuffer3 = commandEncoder38.finish({});
+let texture83 = device0.createTexture({
+  size: [192, 80, 349],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(13, 167, 15, 413_359_720, 873_402_050);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 3_376);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer7, 'uint16', 2_894, 976);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer14, 0, 128);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 18},
+  aspect: 'all',
+}, new Uint8Array(528).fill(25), /* required buffer size: 528 */
+{offset: 173, bytesPerRow: 71, rowsPerImage: 1}, {width: 6, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 36, resource: {buffer: buffer17, offset: 0}},
+    {binding: 407, resource: textureView47},
+    {binding: 19, resource: textureView2},
+  ],
+});
+let buffer27 = device0.createBuffer({
+  size: 10064,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder39 = device0.createCommandEncoder();
+let textureView53 = texture1.createView({baseMipLevel: 0, mipLevelCount: 1});
+let texture84 = device0.createTexture({
+  size: [96, 40, 1],
+  mipLevelCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView54 = texture41.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+let computePassEncoder26 = commandEncoder39.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(39, 303, 20, 585_875_846, 255_870_845);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer19, 'uint32', 20, 23);
+} catch {}
+let buffer28 = device0.createBuffer({
+  size: 18707,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\u{1fa6b}\udab2\u1611\u{1f9b7}\u{1ff07}\u07e3\uc50e\u2b65'});
+let texture85 = device0.createTexture({
+  size: {width: 40, height: 5, depthOrArrayLayers: 48},
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView55 = texture65.createView({format: 'r16float'});
+let computePassEncoder27 = commandEncoder40.beginComputePass({});
+let sampler35 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 35.82,
+  lodMaxClamp: 52.49,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 60, 0, 1_586_017_498, 26_240_250);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 1_968);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer17, 2_632);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint32', 3_472, 525);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, undefined, 365_696_803, 118_692_444);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+try {
+computePassEncoder25.setBindGroup(2, bindGroup16, new Uint32Array(1080), 166, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer23, 0, 720);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 28}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt709', transfer: 'linear'} });
+let bindGroup19 = device0.createBindGroup({
+  label: '\u095e\ud64c\u{1ff2d}\u8d9b',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 125, resource: {buffer: buffer6, offset: 0, size: 100}},
+    {binding: 129, resource: {buffer: buffer0, offset: 1280}},
+    {binding: 115, resource: sampler24},
+    {binding: 348, resource: textureView37},
+    {binding: 71, resource: textureView33},
+  ],
+});
+try {
+renderPassEncoder2.draw(62, 2, 134_170_991, 970_972_647);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 127, 28, 531_261_277, 1_676_045_566);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 84);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder();
+let textureView56 = texture54.createView({
+  label: '\u{1fa9e}\u0382\u{1fb6b}\u1967\u9b3a\u{1fecb}\u6a57\u9a62\u0233\ube35\u{1fde1}',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder2.draw(71, 4, 318_206_311, 68_147_163);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer27, 88);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 5_612);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\ufac8');
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 1220, new Int16Array(3), 0, 0);
+} catch {}
+let bindGroup20 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 300, resource: {buffer: buffer16, offset: 512}}]});
+let buffer29 = device0.createBuffer({
+  size: 3625,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture86 = device0.createTexture({
+  size: [24, 10, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.draw(85, 103, 966_817_369, 271_881_291);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(6, 29, 9, -1_477_290_629, 683_045_782);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video1);
+let commandEncoder42 = device0.createCommandEncoder({});
+let computePassEncoder28 = commandEncoder41.beginComputePass({});
+let renderPassEncoder12 = commandEncoder42.beginRenderPass({
+  label: '\uf4af\ufb21\ubd23\u92a0\u4746',
+  colorAttachments: [{view: textureView18, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 2405035,
+});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup3, new Uint32Array(97), 34, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 52, 48, 640_509_558, 260_781_443);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 3_180);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 112, new Float32Array(23618), 1370, 64);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture87 = device0.createTexture({
+  label: '\ueebb\u131f',
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView57 = texture76.createView({label: '\u29ca\u472b\u0371\u{1fa30}\ua433\u3667', dimension: '1d', aspect: 'all'});
+let sampler36 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 22.99,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(2, bindGroup5, new Uint32Array(2319), 342, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup4, new Uint32Array(1420), 49, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(32);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(16, 6, 7, -1_712_042_662, 1_720_902_382);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline1);
+} catch {}
+let video2 = await videoWithData(33);
+let textureView58 = texture78.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(215), 35, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder2.draw(543, 61, 524_296_366, 362_107_777);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(18, 511, 8, 391_956_627, 115_182_053);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer3, 'uint32', 640, 1_407);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder43.beginRenderPass({
+  colorAttachments: [{view: textureView27, depthSlice: 5, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 316177684,
+});
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.draw(164, 656, 2_172_455_148, 805_064_579);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 380);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer22, 3_928);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer16);
+} catch {}
+try {
+renderPassEncoder8.pushDebugGroup('\u{1f91b}');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+video2.width = 4;
+let sampler37 = device0.createSampler({
+  label: '\u703c\u00e4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.08,
+  lodMaxClamp: 90.74,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 1_408);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer3);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\u{1fd25}\u8990\u5329\u58fa\u0a88\uff30\uac05\u3e90\u{1fb8d}\u{1f7e8}\u{1fae5}',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: atomic<i32>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @size(4) f0: f16,
+}
+@group(0) @binding(19) var tex3: texture_depth_cube_array;
+@group(0) @binding(407) var tex2: texture_cube<u32>;
+@group(0) @binding(36) var<uniform> buffer30: T1;
+struct S0 {
+  @location(7) @interpolate(perspective, sample) f0: f32
+}
+struct S1 {
+  @location(8) @interpolate(flat, center) f0: vec2u,
+  @location(4) f1: i32,
+  @location(14) @interpolate(flat, sample) f2: vec4h,
+  @location(6) @interpolate(flat, center) f3: i32,
+  @location(3) f4: u32,
+  @location(9) f5: vec4i,
+  @location(11) f6: vec4i
+}
+struct VertexOutput1 {
+  @location(4) f3: f32,
+  @builtin(position) f4: vec4f,
+  @location(12) @interpolate(flat, centroid) f5: i32
+}
+
+@vertex
+fn vertex0(@location(0) @interpolate(perspective) a0: vec4h, @location(13) a1: f16, a2: S0, a3: S1) -> VertexOutput1 {
+  var out: VertexOutput1;
+  _ = a1;
+  _ = a3.f0;
+  return out;
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec2i,
+  @location(0) @interpolate(flat) f1: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.50,
+  lodMaxClamp: 96.97,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup5, new Uint32Array(4687), 34, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(356, 362, 1_042_632_685, 666_125_778);
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 44, resource: textureView23},
+    {binding: 114, resource: {buffer: buffer13, offset: 0, size: 29}},
+    {binding: 963, resource: textureView48},
+    {binding: 3, resource: sampler22},
+    {binding: 366, resource: {buffer: buffer28, offset: 0, size: 7360}},
+    {binding: 178, resource: textureView29},
+    {binding: 122, resource: textureView16},
+  ],
+});
+let buffer31 = device0.createBuffer({
+  size: 31199,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder44 = device0.createCommandEncoder();
+let texture88 = device0.createTexture({
+  size: [24, 10, 158],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder29 = commandEncoder44.beginComputePass({});
+let sampler39 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 74.60,
+  lodMaxClamp: 89.11,
+});
+let bindGroup22 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView38}]});
+let commandEncoder45 = device0.createCommandEncoder({});
+let texture89 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder30 = commandEncoder45.beginComputePass({label: '\u{1f94b}\ucaf6\u07fe\uaabd\u0440\u{1fdd3}\u0941'});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(167);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 22, 43, 143_514_208, 52_234_918);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer7, 44);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer11, 596);
+} catch {}
+try {
+renderPassEncoder8.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+renderPassEncoder2.drawIndexed(5, 350, 9, 296_096_758, 450_722_694);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer20, 1_944);
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let texture90 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder31 = commandEncoder46.beginComputePass({});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup21, new Uint32Array(507), 22, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(2, 16, 13, 94_378_916, 242_788_557);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 3_260);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint32', 816, 207);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer14, 0, 27);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u048d');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(250).fill(177), /* required buffer size: 250 */
+{offset: 250, rowsPerImage: 39}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture91 = device0.createTexture({
+  label: '\udd06\u0b2f\ue401\uf9e4\uf33a\u22e2\u54f4',
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture92 = device0.createTexture({
+  label: '\u04f4\u{1fe2a}\u068c',
+  size: [96],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView59 = texture38.createView({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({label: '\ubf70\u3ff3\u3c82\u02aa\u304a\u8c3a\u0557\u4790\u{1fc16}\u{1fdf5}'});
+let texture93 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler40 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.95,
+  lodMaxClamp: 93.10,
+});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer32 = device0.createBuffer({size: 10713, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder1.draw(47, 147, 1_418_557_664, 39_673_121);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(60, 267, 4, 234_106_400, 454_057_109);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer19, 132, 18);
+} catch {}
+let renderPassEncoder14 = commandEncoder47.beginRenderPass({
+  label: '\u0771\uf3d0\u3049\ub1f8\u{1fbd5}\u70c3\u2b47\u1000\u05b4',
+  colorAttachments: [{view: textureView39, depthSlice: 40, loadOp: 'clear', storeOp: 'discard'}],
+});
+let bindGroup23 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 19, resource: textureView16},
+    {binding: 407, resource: textureView17},
+    {binding: 36, resource: {buffer: buffer18, offset: 256, size: 1764}},
+  ],
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let textureView60 = texture1.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 744);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 636, new Int16Array(1446), 196, 136);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u{1fc0c}\u096a\uf14e\u{1f8bc}\u{1fdf9}\u0b9b\ud654';
+} catch {}
+let buffer33 = device0.createBuffer({
+  label: '\uc006\u6191\u07c6\u0143\u{1feef}\u0661\u30f8\u5218',
+  size: 7501,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder48.finish();
+let computePassEncoder32 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup8, new Uint32Array(1124), 199, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer18, 160);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let textureView61 = texture33.createView({dimension: '2d'});
+let sampler41 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.16,
+  lodMaxClamp: 64.88,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup3, new Uint32Array(419), 94, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder2.draw(101, 142, 1_062_090_949, 776_310_093);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer29, 484);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData6,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 5, resource: textureView2},
+    {binding: 89, resource: textureView60},
+    {binding: 41, resource: textureView2},
+  ],
+});
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture94 = device0.createTexture({
+  size: [96, 40, 20],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder15 = commandEncoder50.beginRenderPass({colorAttachments: [{view: textureView27, depthSlice: 31, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder1.drawIndexed(0, 35, 0, 34_710_751, 736_067_043);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u0adf');
+} catch {}
+let buffer34 = device0.createBuffer({
+  size: 27651,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup10, new Uint32Array(1670), 338, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder13.setViewport(15.076589496250943, 4.497159091294634, 5.467988144544742, 1.8782278100763437, 0.5542663357270142, 0.7608080240300892);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer22, 3_732);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer12, 'uint16', 1_962, 2_012);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer26, 1_540, 862);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let texture95 = device0.createTexture({
+  size: [96],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture96 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle6 = renderBundleEncoder6.finish({});
+let sampler42 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.03,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(49);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 196);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer29, 96);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer19, 'uint32', 20, 8);
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 88,
+      visibility: 0,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let textureView62 = texture95.createView({});
+let sampler43 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.86,
+  lodMaxClamp: 99.40,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.draw(57, 110, 58_254_052, 44_560_388);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer28, 'uint16', 4_258, 453);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer16, 0, 361);
+} catch {}
+let bindGroup25 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView49}]});
+let commandEncoder51 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({
+  size: {width: 96},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder33 = commandEncoder51.beginComputePass({});
+try {
+renderPassEncoder2.draw(102, 102, 388_463_617, 1_216_425_854);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer29, 152);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer34, 336);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup26 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView59}]});
+let commandEncoder52 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder16 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: 889.0, g: -267.7, b: 988.4, a: 938.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+let sampler44 = device0.createSampler({
+  label: '\u4285\u152a\u69fb\u{1f816}\u62c9\u0730\u1e86\u020a\u{1f865}',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.27,
+  lodMaxClamp: 93.69,
+});
+try {
+renderPassEncoder10.beginOcclusionQuery(11);
+} catch {}
+try {
+renderPassEncoder1.draw(210, 5, 680_507_079, 157_985_577);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 148);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 56, new DataView(new ArrayBuffer(5217)), 163, 68);
+} catch {}
+let textureView63 = texture98.createView({});
+let texture99 = device0.createTexture({
+  size: [96, 40, 1],
+  mipLevelCount: 4,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 256);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule1, entryPoint: 'fragment0', targets: [{format: 'r16sint'}]},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+renderPassEncoder4.setViewport(3.4982036769197604, 6.772480551364351, 4.199792841916261, 0.7888335709653141, 0.9878193847839855, 0.988779940205179);
+} catch {}
+try {
+renderPassEncoder1.draw(6, 537, 1_442_444_475, 620_658_255);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(12, 205, 13, 74_889_106, 926_248_810);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer27, 2_776);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer12, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let bindGroup27 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 129, resource: {buffer: buffer13, offset: 256, size: 96}},
+    {binding: 125, resource: {buffer: buffer26, offset: 3584}},
+    {binding: 71, resource: textureView33},
+    {binding: 115, resource: sampler8},
+    {binding: 348, resource: textureView37},
+  ],
+});
+let textureView64 = texture37.createView({baseArrayLayer: 0});
+let textureView65 = texture14.createView({
+  label: '\uc56a\u1e1f\u3f1b\uddd9\u{1ff84}\ufe52\ueefa\u{1ffbe}\ua680\u0704\uaae7',
+  format: 'rg32uint',
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup25, new Uint32Array(1128), 200, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 2_420);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(32_957).fill(192), /* required buffer size: 32_957 */
+{offset: 120, bytesPerRow: 33, rowsPerImage: 142}, {width: 1, height: 2, depthOrArrayLayers: 8});
+} catch {}
+let textureView66 = texture58.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(0, bindGroup14, new Uint32Array(2125), 269, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 3_144);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer3, 0);
+} catch {}
+try {
+computePassEncoder4.pushDebugGroup('\u224f');
+} catch {}
+let bindGroup28 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView38}]});
+let textureView67 = texture92.createView({});
+try {
+renderPassEncoder1.drawIndirect(buffer23, 9_384);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer27, 'uint16', 1_154, 1_550);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let texture100 = device0.createTexture({
+  label: '\u0f9c\ua962\u214c\u{1fa6c}\u{1f8eb}\uc10b\ud4f9\uf478\u{1fcd7}\u{1fdb9}\u00e0',
+  size: [16, 16, 12],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup6, new Uint32Array(1268), 234, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 1_980);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer16, 72);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  label: '\u0b8b\ue73f\u13bd\u08fa\u0d6f\u{1fee2}\u3786',
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer34, offset: 10240, size: 664}}],
+});
+let commandEncoder53 = device0.createCommandEncoder({label: '\u9b53\ud4c9\u6e2d\u{1fff2}\uf5bf\u0d2a\u4891\u06ab'});
+let computePassEncoder34 = commandEncoder53.beginComputePass({});
+let sampler45 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 78.70,
+  lodMaxClamp: 85.00,
+});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(0, bindGroup8, new Uint32Array(15), 2, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(14, 128, 6, 379_637_224, 1_183_323_415);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 384);
+} catch {}
+try {
+computePassEncoder34.insertDebugMarker('\uf75c');
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video1);
+let bindGroup30 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView51}]});
+let buffer35 = device0.createBuffer({
+  size: 6176,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup29, new Uint32Array(970), 4, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder1.draw(51, 66, 979_345_861, 900_655_670);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer32, 1_100);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer7, 'uint32', 3_496, 541);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let sampler46 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.39,
+  lodMaxClamp: 68.08,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup15, new Uint32Array(2359), 153, 0);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -191.5, g: -618.1, b: -720.4, a: -294.0, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(2.33227101321744, 4.5298367630226455, 17.66001404919373, 4.859680789975956, 0.019204984048504792, 0.939847163838836);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(16, 84, 13, 228_016_503, 1_251_353_780);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer22, 532);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer18, 'uint32', 488, 133);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer16, 80, 226);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 708, new DataView(new ArrayBuffer(7648)), 2403, 604);
+} catch {}
+let textureView68 = texture5.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0, new Uint32Array(1087), 11, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(6, 90, 12, 308_857_853, 1_678_589_432);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer18, 296);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer23, 4_064);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+let texture101 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle6, renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer17, 32);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer7, 7_112);
+} catch {}
+let arrayBuffer7 = buffer35.getMappedRange(0, 3016);
+let commandEncoder54 = device0.createCommandEncoder();
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], sampleCount: 1});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.89,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup26, new Uint32Array(449), 86, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer15, 2_844);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer7, 0);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData8 = new ImageData(64, 8);
+let buffer36 = device0.createBuffer({
+  size: 16984,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let computePassEncoder35 = commandEncoder54.beginComputePass();
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup10, new Uint32Array(1233), 259, 0);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -776.8, g: -694.0, b: -764.5, a: -766.5, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(15, 131, 4, -1_454_660_322, 532_144_862);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer18, 60);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4, buffer18, 0, 3_512);
+} catch {}
+try {
+computePassEncoder4.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 202, resource: textureView2},
+    {binding: 52, resource: textureView6},
+    {binding: 999, resource: textureView8},
+    {binding: 243, resource: {buffer: buffer0, offset: 1792}},
+  ],
+});
+let buffer37 = device0.createBuffer({
+  label: '\ue6ae\u2b3f\u16da\u74f0\u09a4\u0e46\u0e66\u{1fffb}',
+  size: 23502,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 579});
+let texture102 = device0.createTexture({
+  label: '\uf8b8\u4c71\u0594\u{1f7fd}',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView69 = texture31.createView({});
+let renderPassEncoder17 = commandEncoder55.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 199,
+  clearValue: { r: -844.9, g: -56.25, b: -475.8, a: -740.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup6, new Uint32Array(928), 1, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer18, 'uint32', 388, 732);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer32, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer37, 'uint16', 7_864, 589);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 44, new BigUint64Array(6993), 1501, 0);
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let textureView70 = texture33.createView({format: 'rgba32sint', arrayLayerCount: 1});
+let renderPassEncoder18 = commandEncoder56.beginRenderPass({
+  label: '\uc204\u1d00\ua689\uf99f\u8ea7',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 246,
+  clearValue: { r: 164.2, g: -405.6, b: -797.0, a: -322.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 82365922,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(84);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer19, 132);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer31, 'uint32', 752, 5_329);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 144, new BigUint64Array(193), 17, 48);
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 1280, size: 2440}}],
+});
+let buffer38 = device0.createBuffer({size: 2200, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder57 = device0.createCommandEncoder();
+let computePassEncoder36 = commandEncoder57.beginComputePass({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+try {
+renderPassEncoder2.setViewport(1.0888839824322138, 8.82144157886723, 19.844351048742745, 0.9225836321183851, 0.9081627700895403, 0.9899714838519624);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer19, 'uint32', 0, 60);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 4624, new DataView(new ArrayBuffer(546)), 50, 124);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(81), /* required buffer size: 19 */
+{offset: 19, bytesPerRow: 128}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame0);
+let textureView71 = texture70.createView({aspect: 'all', format: 'rgba32sint', baseArrayLayer: 0});
+let sampler48 = device0.createSampler({
+  label: '\u0e88\u0105\u{1fd47}\u4bbd\u05e1\u01be\u2f3d\u0852',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 41.63,
+  lodMaxClamp: 99.22,
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup5, new Uint32Array(953), 112, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup23, new Uint32Array(1673), 317, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(82, 155, 304_634_619, 670_241_809);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer36, 4_664);
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+  label: '\u7909\ude2b\u088d\u0fda\u1d0d\uc814\u{1fb93}\u9dba\ufa84\u0028\u{1f9c8}',
+  layout: bindGroupLayout9,
+  entries: [{binding: 261, resource: textureView38}],
+});
+let texture103 = device0.createTexture({
+  size: [96, 40, 33],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -988.0, g: -312.2, b: -217.1, a: 913.2, });
+} catch {}
+try {
+renderPassEncoder5.draw(292, 46, 609_718_469, 110_817_715);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(90, 597, 36, 59_614_010, 949_512_111);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData2,
+  origin: { x: 35, y: 0 },
+  flipY: true,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder37 = commandEncoder58.beginComputePass({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.85,
+  lodMaxClamp: 71.06,
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup17, new Uint32Array(1570), 100, 0);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(68);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle1, renderBundle1, renderBundle5]);
+} catch {}
+let arrayBuffer8 = buffer36.getMappedRange(0, 556);
+try {
+computePassEncoder27.pushDebugGroup('\u{1f947}');
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer3, offset: 256, size: 1213}}],
+});
+let buffer39 = device0.createBuffer({
+  size: 1663,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup1, new Uint32Array(1745), 51, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(347, 379, 547_918_650, 221_869_924);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(5, 37, 13, 331_599_743, 82_046_931);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer3, 'uint16', 4_280, 90);
+} catch {}
+document.body.append(video2);
+try {
+computePassEncoder4.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 915.0, g: 554.2, b: -91.61, a: 169.9, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 60);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer27, 108);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer20, 'uint16', 2_618, 3_405);
+} catch {}
+let texture105 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 18},
+  mipLevelCount: 6,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView72 = texture56.createView({dimension: '2d', format: 'astc-10x8-unorm', baseArrayLayer: 11});
+try {
+renderPassEncoder15.executeBundles([renderBundle7, renderBundle6, renderBundle7, renderBundle7, renderBundle6, renderBundle6]);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData9 = new ImageData(72, 104);
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u05d3\u0be6\u03b1\u{1f768}\ud09f\u0d5c\u{1f93b}\uc98b',
+  entries: [{binding: 408, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }}],
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let textureView73 = texture27.createView({dimension: '2d-array', baseMipLevel: 0});
+let renderPassEncoder19 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 52,
+  clearValue: { r: 735.8, g: -848.5, b: -937.8, a: -118.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 12583217,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\ud8d4\u0e22\u{1fe53}\udcc3',
+  colorFormats: ['rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder7.setViewport(72.13937120531281, 49.45767928134884, 11.644855391616654, 10.518371076071013, 0.5735912237759192, 0.7762111930930526);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(362, 428, 96, 188_088_057, 488_259_643);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer17, 3_416);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder27.popDebugGroup();
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'film', transfer: 'bt2020_10bit'} });
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 122, resource: textureView16},
+    {binding: 3, resource: sampler12},
+    {binding: 366, resource: {buffer: buffer34, offset: 5376, size: 1364}},
+    {binding: 114, resource: {buffer: buffer3, offset: 512}},
+    {binding: 178, resource: textureView29},
+    {binding: 963, resource: textureView48},
+    {binding: 44, resource: textureView23},
+  ],
+});
+let buffer40 = device0.createBuffer({
+  size: 7868,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder60 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder60.beginComputePass();
+let sampler50 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 19.43,
+  lodMaxClamp: 94.41,
+});
+try {
+renderPassEncoder18.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 820);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint16', 1_176, 4_917);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup34, new Uint32Array(116), 39, 0);
+} catch {}
+document.body.append(canvas0);
+let buffer41 = device0.createBuffer({
+  label: '\uac11\u0f76\u{1fda9}\u0504\u0c27\u896e\uf67f',
+  size: 8980,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView74 = texture59.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup26, new Uint32Array(293), 6, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(83, 161, 806_754_756, 134_393_659);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+await gc();
+let buffer42 = device0.createBuffer({
+  size: 6324,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let sampler51 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMinClamp: 25.45, lodMaxClamp: 48.22});
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer19, 48);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer36, 3_364);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer3, 'uint32', 1_256, 2_368);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer27, 0);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({label: '\u431b\u0585\u493e\u040f\ueeb3\u{1fd3b}\u0958\u9c1e\u4f4a\u{1fefe}', bindGroupLayouts: []});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup26, new Uint32Array(2122), 508, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(231, 474, 483_534_959, 170_839_447);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer29, 28);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer27);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 89, resource: textureView60},
+    {binding: 41, resource: textureView16},
+    {binding: 5, resource: textureView16},
+  ],
+});
+let commandEncoder61 = device0.createCommandEncoder({label: '\u7aa3\ua20d\uc13f'});
+let commandBuffer5 = commandEncoder6.finish();
+let texture106 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder20 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 12,
+  clearValue: { r: -920.4, g: 953.6, b: 149.0, a: 589.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 290564014,
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup9, new Uint32Array(5692), 71, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup8, new Uint32Array(2975), 522, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(673, 18, 814_347_666, 157_960_827);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(274, 375, 134, 1_048_652_359, 101_545_365);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer5, 300);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer24, 20);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer28, 'uint32', 1_696, 4_652);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer11, 0);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder();
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(86, 71, 372, 635_627_749, 74_011_513);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer42, 1_732);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer20, 1_196);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer27, 'uint16', 1_974, 858);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let buffer43 = device0.createBuffer({
+  size: 15583,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder39 = commandEncoder62.beginComputePass({label: '\u927d\u{1fccb}\u0c4a\u652f\u1a7d\ub4cd\ua312\u07be\u71ac\ufbab\ub216'});
+let renderBundle8 = renderBundleEncoder8.finish();
+try {
+computePassEncoder17.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup15, new Uint32Array(4488), 783, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7, renderBundle7, renderBundle6, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder1.draw(28, 66, 382_026_451, 1_331_750_604);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(393, 148, 433, 258_413_310, 176_193_895);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer37, 18_508);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer34, 2_948);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 72, y: 18, z: 0},
+  aspect: 'all',
+}, new Uint8Array(140).fill(17), /* required buffer size: 140 */
+{offset: 140, rowsPerImage: 22}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'smpteSt4281'} });
+let querySet6 = device0.createQuerySet({label: '\ua3fa\u6b64\u{1f82d}\u{1ff57}\u0a3f', type: 'occlusion', count: 231});
+let textureView75 = texture31.createView({label: '\u01c3\u093d', mipLevelCount: 1});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup10, new Uint32Array(906), 26, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle7, renderBundle7, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(123, 49, 10, 88_360_995, 180_206_020);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer23, 92);
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup36, new Uint32Array(6727), 92, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(235), 68, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(1_021, 11, 2, 74_089_766, 3_660_750_396);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer7, 2_368);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer29, 68);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet2, 36, 60, buffer23, 512);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u56e4');
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 36, resource: textureView40}, {binding: 376, resource: {buffer: buffer36, offset: 4096}}],
+});
+let texture107 = device0.createTexture({
+  size: [48, 20, 15],
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView76 = texture59.createView({format: 'astc-10x8-unorm', mipLevelCount: 1});
+let computePassEncoder40 = commandEncoder63.beginComputePass();
+try {
+computePassEncoder37.setBindGroup(3, bindGroup28, new Uint32Array(8027), 1_310, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(26, 19, 21, 39_690_367, 589_393_236);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer20, 1_132);
+} catch {}
+let arrayBuffer9 = buffer42.getMappedRange(0, 820);
+let imageData10 = new ImageData(92, 16);
+let texture108 = device0.createTexture({
+  size: [16, 16, 33],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup29, new Uint32Array(1158), 329, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup33, new Uint32Array(127), 8, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer34, 816);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer32, 0, 4_588);
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 88, resource: textureView63},
+    {binding: 126, resource: sampler12},
+    {binding: 78, resource: textureView24},
+  ],
+});
+let texture109 = device0.createTexture({
+  size: [24, 10, 43],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup8, new Uint32Array(334), 13, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(196);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(131, 11, 107, 96_166_026, 275_617_345);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer42, 732);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 244);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer27, 0, 114);
+} catch {}
+let buffer44 = device0.createBuffer({
+  size: 15488,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let texture110 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+try {
+renderPassEncoder1.drawIndexed(834, 72, 34, 403_477_659, 912_595_452);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer42, 432);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer20, 'uint16', 1_564, 3_618);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup6, new Uint32Array(291), 225, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer19, 0, 32);
+} catch {}
+let renderBundle9 = renderBundleEncoder9.finish({label: '\u09db\u8bcd\u0019\u01ad\u7b53\uf10d'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup21, new Uint32Array(710), 369, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(416, 13, 80, 289_624_588, 1_477_927_541);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 320);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer7, 'uint16', 1_018, 1_186);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+ // await adapter0.requestAdapterInfo();
+} catch {}
+let textureView77 = texture57.createView({baseMipLevel: 0, baseArrayLayer: 18, arrayLayerCount: 2});
+let textureView78 = texture37.createView({});
+let computePassEncoder41 = commandEncoder64.beginComputePass({label: '\u{1ffc9}\u3821\u8ce1\u0f07\u9f65\u{1fe6f}\u76a9\u5d7e'});
+let sampler52 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.33,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.draw(106, 2, 2_040_505_010, 464_099_179);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(27, 361, 305, 515_137_615, 606_183_816);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer22, 3_936);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 16, new Int16Array(4597), 1821, 36);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteSt4281', transfer: 'gamma22curve'} });
+let sampler53 = device0.createSampler({
+  label: '\uac3d\ua0f3\u055b\u0901\u521a\u0802\ubd3f\u4efe\u8933\u0aee\u6cd1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.24,
+  lodMaxClamp: 82.72,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup22, new Uint32Array(2633), 758, 0);
+} catch {}
+let texture111 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 18},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup5, new Uint32Array(924), 551, 0);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(75);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer7, 5_104);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 232);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer18, 0, 511);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let buffer45 = device0.createBuffer({
+  size: 2308,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView79 = texture11.createView({baseMipLevel: 0});
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 93.20,
+  lodMaxClamp: 94.72,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup23, new Uint32Array(1160), 205, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(11, 308, 992_004_843, 855_508_120);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 4724, new DataView(new ArrayBuffer(8115)), 87, 520);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let sampler55 = device0.createSampler({
+  label: '\u8cad\u220d\u0186\u{1fb03}\ucc61\u3def\ub922\u1234\ubffe\u7448',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup38, new Uint32Array(41), 1, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer23, 9_596);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(1793);
+} catch {}
+try {
+renderPassEncoder1.draw(8, 749, 1_224_864_932, 15_600_257);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(37, 101, 293, 189_350_225, 444_731_773);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer32, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(583).fill(238), /* required buffer size: 583 */
+{offset: 583}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture112 = device0.createTexture({
+  size: [96, 40, 174],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder42 = commandEncoder65.beginComputePass({});
+let sampler56 = device0.createSampler({
+  label: '\u0148\ude22\ud058\u7f49\u16af\u{1ffe5}\u83de\u0aee\u{1fe5c}\u00ce\u{1f7ad}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 18.92,
+  lodMaxClamp: 59.28,
+});
+try {
+renderPassEncoder7.executeBundles([renderBundle3, renderBundle0, renderBundle8, renderBundle4, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(946, 103, 19, 238_975_977, 61_740_613);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer19, 40);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer40, 'uint16', 1_134, 839);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer22);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  label: '\u2811\u0738\u9ffc\u0342\ud75e\u088e\ubcbd\u0a41\ua19a\u{1fe52}',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 963, resource: textureView48},
+    {binding: 44, resource: textureView23},
+    {binding: 114, resource: {buffer: buffer23, offset: 512, size: 254}},
+    {binding: 178, resource: textureView29},
+    {binding: 366, resource: {buffer: buffer28, offset: 0, size: 5360}},
+    {binding: 122, resource: textureView16},
+    {binding: 3, resource: sampler35},
+  ],
+});
+let texture113 = device0.createTexture({
+  size: [48, 20, 19],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup36, new Uint32Array(1002), 87, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(108, 44, 808_321_646, 146_815_685);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1_332, 9, 0, 102_449_261, 467_811_860);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 720);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer40, 'uint16', 68, 1_311);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(0).fill(195), /* required buffer size: 0 */
+{offset: 0, bytesPerRow: 96, rowsPerImage: 63}, {width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData11 = new ImageData(20, 40);
+let bindGroup40 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView59}]});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder11.draw(376, 87, 22_157_560, 663_715_557);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(209, 179, 152, 353_392_125, 1_213_953_741);
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup('\u33ca');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({label: '\uc76a\u32b1\ub796\u0bfe\ua798\u004e\u3308\u2042\ub648', bindGroupLayouts: []});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], depthReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup8, new Uint32Array(4944), 224, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(85, 39, 480_727_447, 2_367_346_257);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(254, 92, 27, 331_035_044, 3_516_497_459);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer39);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let buffer46 = device0.createBuffer({
+  label: '\u{1fac1}\u04d5\uf4c8\udd66\u0b0a\u079d\ua83d\ua222\u{1fc91}',
+  size: 5740,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder66 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder66.finish({});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2, renderBundle8, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(188, 165, 434, 151_534_053, 542_643_610);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer18, 212);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer32, 0, 2_479);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 37, y: 24, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(250), /* required buffer size: 21 */
+{offset: 21, bytesPerRow: 768}, {width: 188, height: 48, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 280,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder2.draw(189, 91, 399_739_926, 572_462_397);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer19, 4);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer40, 'uint32', 768, 1_499);
+} catch {}
+try {
+texture87.destroy();
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder();
+let textureView80 = texture100.createView({dimension: '2d'});
+let computePassEncoder43 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(1, bindGroup29, new Uint32Array(806), 35, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(408, 26, 148_708_211, 797_555_498);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(25, 67, 109, 29_184_438, 1_244_386_629);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer13, 'uint32', 568, 446);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  label: '\ue6a5\uff4a',
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer25, offset: 256, size: 13}}],
+});
+let texture114 = device0.createTexture({
+  size: [96, 40, 1],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView81 = texture70.createView({});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder11.draw(186, 33, 279_140_017, 601_913_878);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer5, 408);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer43, 2_464);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(137_027).fill(241), /* required buffer size: 137_027 */
+{offset: 36, bytesPerRow: 217, rowsPerImage: 15}, {width: 4, height: 2, depthOrArrayLayers: 43});
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  label: '\uad9f\u0da4\ud559\u0ed2\uf238',
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView59}],
+});
+let buffer47 = device0.createBuffer({
+  size: 1656,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture115 = device0.createTexture({
+  label: '\u{1f912}\ud593',
+  size: {width: 48, height: 20, depthOrArrayLayers: 8},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture116 = device0.createTexture({
+  size: [16, 16, 295],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.81,
+  lodMaxClamp: 66.89,
+});
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer16, 36);
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({});
+let textureView82 = texture76.createView({label: '\u{1ff47}\uee2b\u{1fb67}\u0da1\u76bc\ud39f\u008f\ud318', mipLevelCount: 1});
+let renderPassEncoder21 = commandEncoder68.beginRenderPass({colorAttachments: [{view: textureView34, depthSlice: 68, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+renderPassEncoder11.draw(313, 346, 1_251_506_246, 1_198_215_830);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 528);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+computePassEncoder37.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  label: '\u{1fcce}\ue454\u7d22\u072d\u{1ffe4}\u134b\u6703',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 5, resource: textureView2},
+    {binding: 41, resource: textureView2},
+    {binding: 89, resource: textureView1},
+  ],
+});
+let texture117 = device0.createTexture({
+  label: '\uc63f\u{1fb3e}\u0b47',
+  size: [192, 80, 30],
+  mipLevelCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.541,
+  lodMaxClamp: 53.20,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder1.draw(77, 66, 128_166_950, 393_026_765);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 16);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer19, 28);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer12, 0, 1_044);
+} catch {}
+let texture118 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(156, 23, 531, 443_190_050, 57_960_563);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 4, new Int16Array(13886), 225, 16);
+} catch {}
+let buffer48 = device0.createBuffer({
+  label: '\u06bb\ub569\uf88f',
+  size: 27288,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView83 = texture109.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(6, 0, 1, 3);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 3_200);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer37, 'uint16', 2_540, 992);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let computePassEncoder44 = commandEncoder69.beginComputePass();
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: false, stencilReadOnly: false});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup39, new Uint32Array(3936), 95, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup18, new Uint32Array(1755), 695, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 1_820);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer22, 588);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup18, new Uint32Array(1663), 253, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 576, new DataView(new ArrayBuffer(17452)), 3659, 396);
+} catch {}
+try {
+renderPassEncoder5.draw(54, 127, 209_317_671, 758_791_629);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer32, 4_200, 481);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 2344, new Float32Array(660), 278, 68);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture119 = device0.createTexture({size: [24, 10, 1], mipLevelCount: 2, format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler59 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 39.89,
+  lodMaxClamp: 72.84,
+  compare: 'always',
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(20, 371, 231, 459_969_831, 806_978_182);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas0);
+let videoFrame9 = new VideoFrame(videoFrame7, {timestamp: 0});
+let commandEncoder70 = device0.createCommandEncoder({label: '\u{1f710}\u4258\u{1f852}\u1b9a\u53b6\u99e9'});
+let textureView84 = texture113.createView({arrayLayerCount: 2});
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup7, new Uint32Array(3057), 1_367, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint16', 374, 1_320);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let buffer49 = device0.createBuffer({
+  label: '\u9e7b\u{1fc58}',
+  size: 9352,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let renderPassEncoder22 = commandEncoder70.beginRenderPass({
+  label: '\u04a3\u3ee0\u5eeb\u8d62\u6edd',
+  colorAttachments: [{
+  view: textureView80,
+  clearValue: { r: -164.3, g: 970.8, b: -658.6, a: -249.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 660, new DataView(new ArrayBuffer(2558)), 30, 880);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 85,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let textureView85 = texture64.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder45 = commandEncoder53.beginComputePass({label: '\u{1f8b2}\u0d0b\u0651\u0b16\u024b\u2f42\u07f2\u{1f70e}'});
+let renderPassEncoder23 = commandEncoder71.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 149,
+  clearValue: { r: -145.4, g: 690.0, b: 755.2, a: -900.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder2.draw(6, 55, 305_263_735, 1_480_629_047);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(22, 565, 196, -2_009_741_872, 515_025_823);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(7, buffer18);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, buffer3, 2_876, 478);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let texture120 = device0.createTexture({
+  size: [24, 10, 46],
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder22.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1307);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer7, 24);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer22, 1_540);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer27, 'uint32', 3_160, 166);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup36, new Uint32Array(650), 36, 0);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(201, 29, 11, 99_500_224, 482_950_191);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer48, 'uint32', 3_028, 2_660);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 79}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 14, y: 11, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup44 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView59}]});
+let textureView86 = texture102.createView({});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(28, 78, 41, 94_132_176, 27_960_126);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 88);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer17, 4_016);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer34, 4_024);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer48, 'uint16', 5_358, 2_038);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 126, resource: sampler22},
+    {binding: 78, resource: textureView5},
+    {binding: 88, resource: textureView63},
+  ],
+});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 4096});
+let sampler60 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 27.51,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder5.draw(17, 0, 836_550_042, 85_746_871);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(214, 69, 366, 48_340_490, 431_581_082);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer42, 1_756);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer11);
+} catch {}
+try {
+for (let i = 0; i < 1e6; ++i) renderBundleEncoder11.draw(0);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(19, 159, 92, -1_315_479_107, 938_762_485);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer0, 1_328);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder72.beginComputePass({label: '\u00e8\u{1fdd5}\ub356\ucce1\u01c3\u{1fd88}\ue703'});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup0, new Uint32Array(427), 113, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder11.draw(92, 86, 16_096_607, 34_467_824);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer34, 192);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer22, 344);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer19, 'uint16', 114, 97);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer21.mapAsync(GPUMapMode.READ, 96, 112);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 1372, new Float32Array(892), 154, 288);
+} catch {}
+document.body.prepend(img0);
+let renderBundle11 = renderBundleEncoder11.finish();
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(42, 215, 202, 28_803_138, 313_580_606);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(105).fill(197), /* required buffer size: 105 */
+{offset: 105}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+device0.queue.label = '\ua7ec\u{1fcff}\u0805\u0c2e\u5c8d\u04f6\u{1fce1}\ud53e\u{1f608}\u{1f948}';
+} catch {}
+let texture121 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture9 = device0.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.draw(101, 307, 84_566_179, 1_091_576_735);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(151, 5, 75, 1_510_564_081, 45_837_212);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 4_380);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({label: '\ue7ca\u0957\u02a6\u0c8d\u0986\u0e00\u{1fc62}\u047a\ucccf'});
+let textureView87 = texture38.createView({baseMipLevel: 0});
+let texture122 = gpuCanvasContext0.getCurrentTexture();
+let sampler61 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 33.40,
+  lodMaxClamp: 68.50,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup44, new Uint32Array(5379), 243, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(653, 342, 768_238_318, 464_916_882);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer22, 600);
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(buffer12, 3912, buffer48, 5400, 44);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3856 */
+  offset: 3856,
+  rowsPerImage: 238,
+  buffer: buffer40,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 22},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer50 = device0.createBuffer({
+  size: 55,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture123 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 75},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler62 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.95,
+  lodMaxClamp: 91.45,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup33, new Uint32Array(682), 116, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder11.draw(170, 290, 110_004_808, 523_060_559);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer16, 152);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6496 */
+  offset: 6496,
+  bytesPerRow: 512,
+  buffer: buffer28,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet6, 27, 19, buffer41, 0);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let buffer51 = device0.createBuffer({size: 6192, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture124 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView88 = texture23.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder47 = commandEncoder73.beginComputePass();
+try {
+renderPassEncoder5.drawIndexed(6, 145, 8, 887_258_079, 130_753_397);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer19, 72);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 884);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+computePassEncoder40.setBindGroup(3, bindGroup38, new Uint32Array(2393), 893, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(44, 77, 217, 740_744_435, 1_128_348_700);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 18, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView89 = texture26.createView({label: '\u3903\u{1ffee}\ue6b6\uff7d\uce43\ude6f\u41bc\u{1ff43}', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+let promise12 = shaderModule1.getCompilationInfo();
+let buffer52 = device0.createBuffer({size: 4011, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder74 = device0.createCommandEncoder({});
+let textureView90 = texture60.createView({label: '\u8bdc\u077a\u{1f6bf}\u3510\uc244\ubbe3\u0347', mipLevelCount: 1});
+let computePassEncoder48 = commandEncoder74.beginComputePass();
+try {
+renderPassEncoder5.draw(72, 23, 148_723_644, 1_301_726);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer24, 204);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer39, 'uint32', 220, 262);
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule1, constants: {}}});
+await gc();
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 41, resource: textureView16},
+    {binding: 89, resource: textureView1},
+    {binding: 5, resource: textureView2},
+  ],
+});
+let buffer53 = device0.createBuffer({size: 7548, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let commandEncoder75 = device0.createCommandEncoder({});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMaxClamp: 87.79,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup14, new Uint32Array(873), 165, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer36, 2_232);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer19, 8);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer12);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: img0,
+  origin: { x: 13, y: 2 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 24},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder49 = commandEncoder75.beginComputePass({});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup10, new Uint32Array(2030), 743, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup6, new Uint32Array(69), 2, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(15, 124, 42, 152_830_191, 214_272_941);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer23, 28);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 40, new Int16Array(2649), 63, 16);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture125 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView91 = texture77.createView({label: '\u3a22\ue370\u652f\u0756'});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup6, new Uint32Array(673), 100, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(40, 104, 0, 149_231_806, 1_343_590_548);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer42, 2_460);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer29, 372);
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder({});
+let renderPassEncoder24 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{view: textureView39, depthSlice: 29, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 754210783,
+});
+let externalTexture10 = device0.importExternalTexture({label: '\u0644\u5ff9', source: videoFrame3});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup17, []);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(1, bindGroup38, new Uint32Array(2670), 466, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(12, 50, 1, 85_479_243, 138_709_153);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer44, 'uint32', 420, 1_299);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer54 = device0.createBuffer({
+  size: 10248,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder77 = device0.createCommandEncoder({});
+let textureView92 = texture97.createView({format: 'r32float'});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer7, 2_704);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer12, 'uint16', 288, 713);
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 14},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 368 */
+  offset: 368,
+  bytesPerRow: 0,
+  rowsPerImage: 84,
+  buffer: buffer31,
+}, {width: 0, height: 3, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 16, y: 1, z: 4},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer55 = device0.createBuffer({
+  size: 588,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let computePassEncoder50 = commandEncoder77.beginComputePass();
+let renderPassEncoder25 = commandEncoder78.beginRenderPass({
+  colorAttachments: [{view: textureView26, depthSlice: 130, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 291755361,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup7, new Uint32Array(444), 36, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder11.draw(5, 31, 766_490_591, 20_960_709);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(7, 108, 224, 397_885_260, 135_393_907);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer42, 2_088);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer39, 0, 44);
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  label: '\u{1faa7}\u7181\u092c\u{1f74d}\u{1fa08}\udbd5\ube99\u5e21\u{1f64f}\udba3\u8497',
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer42, offset: 768, size: 1998}}],
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup44, new Uint32Array(1798), 525, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer22, 1_424); };
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer31, 'uint32', 6_432, 857);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView93 = texture38.createView({format: 'rgba8uint', mipLevelCount: 1});
+let sampler64 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.20,
+  lodMaxClamp: 50.95,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup9, new Uint32Array(1259), 41, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer36, 3_588); };
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.pushDebugGroup('\uc4d4');
+} catch {}
+document.body.append(canvas0);
+let texture126 = device0.createTexture({
+  size: [192],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup41, new Uint32Array(788), 158, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup24, new Uint32Array(2088), 1_536, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle11, renderBundle11, renderBundle11, renderBundle2, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder11.draw(98, 95, 99_215_385, 407_688_578);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer42, 152);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer18);
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture127 = device0.createTexture({
+  size: [192, 80, 349],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 280, resource: {buffer: buffer34, offset: 4096, size: 4804}}],
+});
+let computePassEncoder51 = commandEncoder79.beginComputePass({label: '\ufeb3\u66d2\u0350\uf13d\u0581\u0557\u6766'});
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(2, 66, 16, -1_666_555_418, 12_654_236);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer24, 48);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer40, 'uint32', 1_816, 1_072);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer50, 4, 16);
+} catch {}
+try {
+renderPassEncoder22.popDebugGroup();
+} catch {}
+let imageData12 = new ImageData(28, 12);
+let bindGroup49 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 376, resource: {buffer: buffer31, offset: 2560, size: 5528}},
+    {binding: 36, resource: textureView52},
+  ],
+});
+let commandEncoder80 = device0.createCommandEncoder();
+let commandBuffer7 = commandEncoder80.finish();
+try {
+renderPassEncoder24.setBlendConstant({ r: 20.13, g: 614.6, b: -984.4, a: -714.2, });
+} catch {}
+try {
+renderPassEncoder2.draw(208, 294, 1_070_448_653, 174_638_929);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(6, 234, 1, 34_651_964, 315_635_150);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer12, 620);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer17, 48);
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({label: '\u7cba\u{1fafa}'});
+let renderPassEncoder26 = commandEncoder81.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 122,
+  clearValue: { r: 57.13, g: -969.2, b: 933.2, a: -249.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler65 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.57,
+  lodMaxClamp: 55.86,
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer22, 0, 2_293);
+} catch {}
+let arrayBuffer10 = buffer26.getMappedRange(0, 1740);
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'hlg'} });
+try {
+externalTexture10.label = '\u98f2\u0075\u0bde\u{1fd28}\ub764\u349b\u3d15';
+} catch {}
+let bindGroup50 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 8, resource: {buffer: buffer13, offset: 0, size: 76}}]});
+let commandEncoder82 = device0.createCommandEncoder();
+let texture128 = device0.createTexture({
+  label: '\u528a\u{1fadc}\ud09d\u0ed2',
+  size: [192, 80, 8],
+  mipLevelCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder82.beginComputePass();
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.draw(220, 6, 668_390_813, 197_368_401);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer34, 2_144);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 1_472);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer15, 'uint16', 4_976, 1_885);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer19, 0, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer7, offset: 2048, size: 2456}}],
+});
+let buffer56 = device0.createBuffer({
+  size: 8912,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder2.draw(70, 1, 351_418_180, 398_888_429);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(25, 192, 155, 78_817_869, 494_783_814);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer3, 'uint32', 4_308, 352);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer32, 0, 99);
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte432', transfer: 'iec61966-2-1'} });
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 36, resource: {buffer: buffer37, offset: 11520, size: 1176}},
+    {binding: 407, resource: textureView4},
+    {binding: 19, resource: textureView2},
+  ],
+});
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup8, new Uint32Array(942), 90, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer19, 28);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer42, 1_456);
+} catch {}
+let arrayBuffer11 = buffer35.getMappedRange(4016, 136);
+try {
+  await promise13;
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  label: '\uefc8\u2721',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 36, resource: textureView40},
+    {binding: 376, resource: {buffer: buffer13, offset: 0, size: 25}},
+  ],
+});
+let buffer57 = device0.createBuffer({size: 482, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(11, 102, 4, 27_607_076, 1_223_154_586);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer7, 3_584);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer42, 'uint32', 1_452, 451);
+} catch {}
+let buffer58 = device0.createBuffer({size: 5739, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder83 = device0.createCommandEncoder({});
+let textureView94 = texture28.createView({});
+let computePassEncoder53 = commandEncoder83.beginComputePass({});
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder5.draw(567, 154, 1_036_794_447, 456_885_238);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(2, 102, 13, 693_221_431, 731_124_877);
+} catch {}
+try {
+computePassEncoder6.pushDebugGroup('\u{1fe85}');
+} catch {}
+try {
+computePassEncoder43.insertDebugMarker('\u{1f999}');
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'r8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: ['stencil8']});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+ // await adapter0.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder25.setBindGroup(0, bindGroup10, new Uint32Array(344), 29, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup40, new Uint32Array(2443), 70, 0);
+} catch {}
+try {
+renderPassEncoder23.draw(137, 48, 39_499_502, 174_571_883);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder6.popDebugGroup();
+} catch {}
+let imageData13 = new ImageData(12, 36);
+let buffer59 = device0.createBuffer({size: 4730, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup3, new Uint32Array(3095), 162, 0);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle9, renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder11.draw(292, 383, 786_394_503, 1_596_833_245);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer16, 352);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(848, 139);
+try {
+externalTexture8.label = '\u{1f81e}\u01ae\u02db\u{1fe13}\u0791\u87b0\u04b6\u{1fe1d}\u0fd6\u8bd5\ua0e9';
+} catch {}
+let textureView95 = texture66.createView({dimension: 'cube'});
+let texture129 = device0.createTexture({
+  label: '\ue7c7\u0a9f\ud5b6\u0de9\u0d97\u4277\u311c\u07ca\u0483',
+  size: [16, 16, 12],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup49, new Uint32Array(685), 40, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup1, new Uint32Array(672), 227, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(4);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer44, 1_364);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer9, 1_152);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 80, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(78).fill(131), /* required buffer size: 78 */
+{offset: 78, bytesPerRow: 682}, {width: 42, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+document.body.append(video1);
+let texture130 = device0.createTexture({size: [96], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer23, 2_464); };
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.draw(62, 259, 205_515_336, 754_924_178);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer12, 'uint32', 2_932, 976);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 28}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 33, y: 9 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 29, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  label: '\u{1fd4d}\u882b\u{1fa69}\u7921',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 89, resource: textureView53},
+    {binding: 5, resource: textureView16},
+    {binding: 41, resource: textureView16},
+  ],
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+let computePassEncoder54 = commandEncoder84.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(3, bindGroup30, new Uint32Array(2067), 500, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(30);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(14, 14, 52, 91_344_251, 2_136_202_742);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer56, 1_968);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer43, 388, 1_397);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder9.dispatchWorkgroups(1, 4);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(223, 173);
+try {
+externalTexture9.label = '\u{1ff31}\ufd2d\uca4e\u0959\ufe77\u1fd5\u0d52\u87c8\u{1fa36}\ud7ea';
+} catch {}
+let buffer60 = device0.createBuffer({size: 26056, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let textureView96 = texture38.createView({dimension: '3d', baseArrayLayer: 0});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(3, 260, 15, -1_643_773_131, 776_907_222);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer24, 128);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer31, 'uint16', 3_360, 702);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer19, 0, 109);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let texture131 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup33, []);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(1, bindGroup49, new Uint32Array(1358), 23, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 1_632);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer44, 'uint32', 5_144, 65);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer54, 240, 1_131);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(6_409).fill(199), /* required buffer size: 6_409 */
+{offset: 1, bytesPerRow: 267, rowsPerImage: 12}, {width: 25, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView97 = texture51.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup49, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.draw(63, 150, 963_001_136, 917_799_844);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(10, 19, 23, 566_004_320, 141_045_686);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer43, 1_220);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer37, 'uint32', 5_164, 9_618);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+computePassEncoder25.label = '\ua2d3\ub73f\u6fe1\ue023\u11e7\u0641\u{1feb2}\u7afe';
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer5, 448);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer54, 2_364);
+} catch {}
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({label: '\uad18\udea1\u0679\u609b', colorFormats: ['r16sint'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let sampler66 = device0.createSampler({
+  label: '\u{1ffa0}\u0a56\u7fc9\u0e5c',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 39.55,
+  lodMaxClamp: 97.15,
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup10, new Uint32Array(39), 15, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(94, 153, 135_127_134, 111_307_869);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(16, 135, 19, -672_456_606, 528_797_360);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer43, 2_148);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer27, 1_628);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+document.body.append(video2);
+let imageData14 = new ImageData(48, 4);
+let buffer61 = device0.createBuffer({
+  size: 4028,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let commandEncoder85 = device0.createCommandEncoder();
+let texture132 = device0.createTexture({
+  size: {width: 24},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView98 = texture130.createView({format: 'r16sint'});
+let computePassEncoder55 = commandEncoder85.beginComputePass();
+try {
+computePassEncoder46.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(39, 1, 10, 1);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer50, 'uint32', 0, 6);
+} catch {}
+let promise15 = shaderModule0.getCompilationInfo();
+let bindGroup55 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 300, resource: {buffer: buffer36, offset: 512}}]});
+let texture133 = device0.createTexture({
+  label: '\ueebe\u{1fff8}\u141c\u0f36',
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+offscreenCanvas1.getContext('webgpu');
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let computePassEncoder56 = commandEncoder86.beginComputePass({});
+let sampler67 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.46,
+  lodMaxClamp: 94.36,
+});
+try {
+computePassEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder5.draw(62, 378, 1_253_070_001, 37_249_416);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(13, 50, 9, 648_219_834, 2_793_205_293);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer31, 'uint16', 25_162, 1_766);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise15;
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup56 = device0.createBindGroup({
+  label: '\ub82e\u01b0\u8bf4\u6c6c\u397f',
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView96}],
+});
+let textureView99 = texture13.createView({aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer42, 124);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer43, 8_356);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer7, 0, 1_975);
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt2020', transfer: 'iec61966-2-1'} });
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 44, resource: textureView23},
+    {binding: 178, resource: textureView29},
+    {binding: 114, resource: {buffer: buffer3, offset: 1280, size: 1667}},
+    {binding: 3, resource: sampler64},
+    {binding: 366, resource: {buffer: buffer45, offset: 256}},
+    {binding: 963, resource: textureView95},
+    {binding: 122, resource: textureView2},
+  ],
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup54, new Uint32Array(1597), 73, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(70, 875, 58, 78_915_322, 47_491_850);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 552);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let bindGroup58 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 8, resource: {buffer: buffer49, offset: 512}}]});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 41});
+let textureView100 = texture62.createView({mipLevelCount: 1});
+let computePassEncoder57 = commandEncoder87.beginComputePass({label: '\ue494\u63e3\u5051\u5221\u32e0\u4d2c\u8349\u01da\u9189'});
+try {
+computePassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup54);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 28);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer7, 'uint32', 1_488, 5_340);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+computePassEncoder17.label = '\u{1fb0f}\u{1ff1c}\ub915\u0bf9\ub36a\u376d';
+} catch {}
+let buffer62 = device0.createBuffer({
+  label: '\u0e18\u0b3e\u{1f749}\u990e\uc68a\u{1fbb1}\u2800',
+  size: 7576,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder88 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 161});
+let textureView101 = texture17.createView({arrayLayerCount: 1});
+let computePassEncoder58 = commandEncoder88.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle5, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(80, 113, 33, 357_430_182, 235_415_712);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 1188, new Float32Array(2972), 47, 48);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(video1);
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u0ea5\ue21b\u2d53\u777a', bindGroupLayouts: []});
+let texture134 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView102 = texture106.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({label: '\u529a\u018d\u{1fb02}\u011a\u00cb', colorFormats: ['r16float'], depthReadOnly: true});
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.57,
+  lodMaxClamp: 91.93,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder11.drawIndirect(buffer56, 376);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup54, new Uint32Array(64), 4, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 188, new Int16Array(4612), 831, 140);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder89 = device0.createCommandEncoder();
+let sampler69 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 39.29,
+  lodMaxClamp: 48.76,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup3, new Uint32Array(3768), 637, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer61, 'uint16', 252, 261);
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer39, 168, buffer57, 156, 48);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({});
+let texture135 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let textureView103 = texture59.createView({mipLevelCount: 1});
+let renderPassEncoder27 = commandEncoder90.beginRenderPass({
+  colorAttachments: [{
+  view: textureView80,
+  clearValue: { r: 685.5, g: 703.6, b: -151.5, a: -829.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 46489447,
+});
+let renderBundle13 = renderBundleEncoder13.finish({});
+let sampler70 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 92.68,
+  lodMaxClamp: 94.98,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder23.draw(88, 79, 1_218_776_947, 627_772_068);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(11, 34, 59, 1_252_448_624, 270_798_072);
+} catch {}
+let videoFrame13 = videoFrame1.clone();
+try {
+sampler9.label = '\u{1f9c9}\u{1f7a9}\u525f\uff5e';
+} catch {}
+let bindGroup59 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView62}]});
+let buffer63 = device0.createBuffer({
+  size: 944,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder59 = commandEncoder89.beginComputePass({});
+let externalTexture11 = device0.importExternalTexture({label: '\ud6c5\u0811\u4d25\u{1f67c}\u3601\u{1fdd0}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(33, 179, 35, 331_909_849, 161_059_967);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder();
+let textureView104 = texture41.createView({arrayLayerCount: 8});
+let textureView105 = texture92.createView({});
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 67.95,
+  lodMaxClamp: 85.47,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup16, new Uint32Array(1052), 136, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(0, 93, 11, 25_804_555, 674_441_711);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer23, 224);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer24, 20);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 79}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 52},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup60 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 300, resource: {buffer: buffer16, offset: 0}}]});
+let commandEncoder92 = device0.createCommandEncoder({label: '\u4c75\u0bd2\uc9e7\u9aa6\u08e3'});
+let texture136 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder60 = commandEncoder92.beginComputePass({label: '\u06fc\u0d1c\u01dc\u2fbb\u8508\ub61f\u{1fadb}'});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 4, 15, -1_936_430_889, 80_744_673);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer39, 260);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer40, 'uint32', 2_816, 35);
+} catch {}
+try {
+commandEncoder91.resolveQuerySet(querySet1, 33, 32, buffer33, 2816);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let computePassEncoder61 = commandEncoder93.beginComputePass({});
+let renderPassEncoder28 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 25,
+  clearValue: { r: -697.2, g: -867.4, b: 627.6, a: -451.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 28079977,
+});
+let sampler72 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.301,
+  lodMaxClamp: 67.22,
+});
+try {
+renderPassEncoder26.setStencilReference(985);
+} catch {}
+try {
+renderPassEncoder11.draw(25, 12, 858_614_464, 352_515_691);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer34, 1_224);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer14, 148);
+} catch {}
+let textureView106 = texture110.createView({});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup47, new Uint32Array(470), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer56, 568); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup36, new Uint32Array(2972), 1_073, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7, renderBundle6, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(3.6115541407256266, 1.1761282179241395, 6.818391965779242, 8.218989065132586, 0.3836633628191687, 0.6308431050335134);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer18, 1_204);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer36, 3_692);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer23, offset: 4352, size: 180}}],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], stencilReadOnly: true});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup50, new Uint32Array(2407), 173, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: -110.6, g: 985.0, b: 0.4441, a: -774.4, });
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(156, 43, 13, 153_698_873, 1_429_398_566);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer18, 1_736);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer18, 'uint32', 308, 614);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer47, 1_392, 59);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup30, new Uint32Array(129), 34, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer42, 'uint32', 1_056, 2_352);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'logSqrt'} });
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 71, resource: textureView78},
+    {binding: 129, resource: {buffer: buffer6, offset: 0, size: 84}},
+    {binding: 348, resource: textureView37},
+    {binding: 115, resource: sampler66},
+    {binding: 125, resource: {buffer: buffer34, offset: 1280, size: 380}},
+  ],
+});
+let buffer64 = device0.createBuffer({size: 2727, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup40, new Uint32Array(1177), 354, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup56);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 3_204);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let commandEncoder94 = device0.createCommandEncoder({});
+let textureView107 = texture94.createView({baseArrayLayer: 1, arrayLayerCount: 5});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+renderPassEncoder5.draw(53, 88, 328_026_631, 227_118_860);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer29, 340);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline0);
+} catch {}
+let texture137 = device0.createTexture({
+  size: [48, 20, 87],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder29 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 217,
+  clearValue: { r: -988.4, g: 298.8, b: 292.9, a: -601.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({label: '\u72cf\u9910\ud1b9\u0030', colorFormats: ['rgba32sint']});
+let sampler73 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.39,
+  lodMaxClamp: 76.30,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.draw(708, 428, 973_389_285, 79_075_817);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(24, 164, 4, 588_990_560, 1_267_364_714);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer46);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer65 = device0.createBuffer({
+  size: 13361,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView108 = texture25.createView({label: '\u{1ffa0}\u0513', mipLevelCount: 1});
+let sampler74 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.57,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder39.dispatchWorkgroups(2, 2);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(21, 42, 128, 265_262, 993_194_377);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer34, 4_508);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer12, 96);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer16, 'uint16', 876, 304);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer36);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer19, 'uint32', 12, 47);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise16;
+} catch {}
+document.body.prepend(canvas0);
+let buffer66 = device0.createBuffer({
+  size: 4313,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView109 = texture59.createView({label: '\u642f\ud550\ue4c6\u0d99\u6b91\u0c00', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.draw(58, 163, 550_997_021, 1_697_578_590);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer16, 1_100);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer14);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+document.body.prepend(img0);
+let buffer67 = device0.createBuffer({size: 12701, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView110 = texture75.createView({mipLevelCount: 1});
+try {
+computePassEncoder45.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder23.draw(0, 15, 733_610_809, 843_891_798);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer56, 1_992);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer40, 'uint16', 3_298, 776);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer55, 0, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer15, 'uint32', 11_088, 2_569);
+} catch {}
+try {
+computePassEncoder47.insertDebugMarker('\u{1fb1a}');
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'gamma28curve'} });
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView51}]});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(0, bindGroup41, new Uint32Array(5449), 495, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder11.draw(118, 116, 406_655_868, 1_715_773_639);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(1, 16, 0, -2_103_896_642, 774_049_870);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup59, new Uint32Array(440), 13, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer7, 'uint32', 1_432, 210);
+} catch {}
+await gc();
+let buffer68 = device0.createBuffer({size: 398, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder95 = device0.createCommandEncoder({});
+let textureView111 = texture19.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let renderPassEncoder30 = commandEncoder95.beginRenderPass({
+  colorAttachments: [{view: textureView39, depthSlice: 13, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 26818644,
+});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup36, new Uint32Array(4562), 221, 0);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: -857.6, g: -497.7, b: 156.6, a: -831.4, });
+} catch {}
+try {
+renderPassEncoder5.draw(67, 99, 589_806_571, 1_954_967_438);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(6, 342, 23, 304_203_649, 3_067_162_413);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer31, 'uint32', 784, 2_671);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(184), /* required buffer size: 21 */
+{offset: 21}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let buffer69 = device0.createBuffer({
+  size: 14472,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder42.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 752.2, g: 572.9, b: -682.3, a: -45.70, });
+} catch {}
+try {
+renderPassEncoder11.draw(499, 193, 494_696_678, 515_011_273);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(12, 109, 485, 354_845_934, 337_149_584);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer24, 28);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer34, 1_408);
+} catch {}
+let promise17 = shaderModule0.getCompilationInfo();
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let buffer70 = device0.createBuffer({size: 3431, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let renderBundle15 = renderBundleEncoder15.finish({});
+try {
+renderPassEncoder5.draw(135, 46, 841_643_867, 2_542_575_518);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(311, 160, 5, 351_066_432, 444_440_912);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer12, 848);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer22, 212);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer19, 'uint16', 256, 15);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer42);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 1,
+  origin: {x: 7, y: 1, z: 37},
+  aspect: 'all',
+}, new Uint8Array(7_858).fill(104), /* required buffer size: 7_858 */
+{offset: 34, bytesPerRow: 376, rowsPerImage: 4}, {width: 19, height: 1, depthOrArrayLayers: 6});
+} catch {}
+document.body.prepend(video2);
+offscreenCanvas0.height = 1143;
+try {
+computePassEncoder1.setBindGroup(0, bindGroup32, new Uint32Array(992), 43, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(3); };
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer18, 'uint32', 756, 403);
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 88, resource: textureView92},
+    {binding: 78, resource: textureView11},
+    {binding: 126, resource: sampler35},
+  ],
+});
+let buffer71 = device0.createBuffer({
+  size: 2906,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture138 = device0.createTexture({
+  label: '\u{1fa9b}\u6298\u7e7e\u0aa4',
+  size: [96, 40, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup26, new Uint32Array(665), 72, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer62, 88);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer15, 'uint32', 22_600, 356);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let buffer72 = device0.createBuffer({
+  size: 4312,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder5.drawIndexed(0, 376, 0, 108_609_188, 1_021_381_023);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer42, 1_568);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let buffer73 = device0.createBuffer({
+  size: 4821,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup15, new Uint32Array(1210), 9, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: 506.1, g: -280.7, b: 692.1, a: 404.1, });
+} catch {}
+try {
+renderPassEncoder11.draw(10, 53, 49_495_062, 778_735_926);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer36, 3_404);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer37, 860);
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder96.beginComputePass({});
+let sampler75 = device0.createSampler({
+  label: '\u0cb2\ub1b2',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 12.84,
+  lodMaxClamp: 15.29,
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer61, 44);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer23, 736);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 28}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 54, y: 2, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], stencilReadOnly: true});
+let sampler76 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 51.71,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder59.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+renderPassEncoder2.draw(36, 376, 413_405_755, 2_548_352_399);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(55, 9, 2, 212_800_912, 1_041_022_893);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 8_988);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer7, 3_660);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer61, 'uint16', 1_466, 309);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470bg', transfer: 'pq'} });
+try {
+computePassEncoder1.setBindGroup(1, bindGroup10, new Uint32Array(3331), 2_905, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer63, 60);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer39, 'uint32', 696, 46);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer72, 0, 468);
+} catch {}
+let promise19 = shaderModule0.getCompilationInfo();
+try {
+device0.queue.writeBuffer(buffer50, 8, new DataView(new ArrayBuffer(13962)), 1782, 4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+externalTexture2.label = '\u{1f832}\u02b1\u044b\ub6d9\u018a\u04b7';
+} catch {}
+try {
+computePassEncoder36.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder23.draw(3, 9, 802_453_875, 549_466_879);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(135, 217, 5, 708_273_989, 570_979_723);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer61, 152);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer14, 0, 41);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer50, 'uint16', 2, 5);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup56, new Uint32Array(3299), 152, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(3, 41, 0, -1_523_827_240, 2_140_760_379);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer7, 'uint32', 436, 78);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer16, 0, 127);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup39, new Uint32Array(318), 21, 0);
+} catch {}
+let arrayBuffer12 = buffer60.getMappedRange(1416);
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 7},
+  aspect: 'all',
+}, new Uint8Array(9_051).fill(154), /* required buffer size: 9_051 */
+{offset: 262, bytesPerRow: 39, rowsPerImage: 45}, {width: 7, height: 1, depthOrArrayLayers: 6});
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 49231,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+let computePassEncoder63 = commandEncoder97.beginComputePass({});
+let sampler77 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 57.99,
+  lodMaxClamp: 92.58,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(2, bindGroup34, new Uint32Array(1391), 241, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer65, 'uint16', 4_558, 427);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup25);
+} catch {}
+let arrayBuffer13 = buffer61.getMappedRange(1128);
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte432', transfer: 'gamma22curve'} });
+let buffer75 = device0.createBuffer({
+  size: 9688,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame13, colorSpace: 'srgb'});
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup28, new Uint32Array(1736), 117, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(248, 303, 471_556_306, 101_138_215);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer32, 2_680);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer15, 'uint16', 554, 794);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 28}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 6, y: 5, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'iec61966-2-1'} });
+let bindGroup65 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 85, resource: textureView16}]});
+let renderBundle16 = renderBundleEncoder16.finish();
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer39, 280);
+} catch {}
+try {
+  await promise19;
+} catch {}
+document.body.append(canvas0);
+let bindGroup66 = device0.createBindGroup({
+  label: '\u1218\u0b6a\u9158\ucbce\u{1fabe}\u{1fc8f}\u0cad\u{1fc1f}\u98ea\uf99a',
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView93}],
+});
+let commandEncoder98 = device0.createCommandEncoder();
+let texture139 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder19.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(0, bindGroup43, new Uint32Array(2675), 372, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer63, 684); };
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup66, []);
+} catch {}
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle5, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -763.2, g: -609.9, b: -108.5, a: 536.0, });
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer44, 2_516);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer22, 444);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer74, 'uint16', 696, 18_719);
+} catch {}
+let computePassEncoder64 = commandEncoder98.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup54, new Uint32Array(3525), 1, 0);
+} catch {}
+try {
+computePassEncoder9.dispatchWorkgroups(2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle3, renderBundle15, renderBundle1, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(71.99601704339173, 50.638564562934405, 24.692212020125503, 14.331958796530296, 0.969673257038854, 0.9977332744165444);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer14 = buffer48.getMappedRange(3520);
+let commandEncoder99 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder99.finish({});
+let texture140 = device0.createTexture({
+  label: '\uba89\ub31f',
+  size: [24, 10, 7],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder23.draw(9, 262, 315_204_713, 1_216_960_799);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer72, 204);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer43, 0);
+} catch {}
+try {
+buffer73.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+video2.height = 36;
+await gc();
+let shaderModule2 = device0.createShaderModule({
+  label: '\u023a\uf935\u39a8\u051f\uecd2\u{1f685}\u2434\u0710\u01d3\u{1febe}\u0524',
+  code: `
+enable f16;
+enable f16;
+/* target size: 2 max align: 2 */
+struct T0 {
+  f0: f16,
+}
+@group(0) @binding(36) var<uniform> buffer76: array<array<array<T0, 1>, 2>, 1>;
+@group(0) @binding(407) var tex4: texture_1d<f32>;
+@group(0) @binding(19) var tex5: texture_2d<i32>;
+struct S2 {
+  @location(6) f0: f32,
+  @location(11) @interpolate(flat, centroid) f1: vec4i,
+  @location(13) f2: vec2i,
+  @location(3) f3: vec2u
+}
+struct VertexOutput2 {
+  @builtin(position) f6: vec4f
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec3u, a1: S2, @location(10) a2: vec3i, @location(7) @interpolate(flat, sample) a3: vec2h) -> VertexOutput2 {
+  var out: VertexOutput2;
+  _ = buffer76[0][1][0];
+  _ = buffer76[0][1][0].f0;
+  _ = a1.f0;
+  _ = a1.f2;
+  _ = buffer76[0];
+  return out;
+}
+struct S3 {
+  @location(3) @interpolate(perspective) f0: vec2f
+}
+
+@vertex
+fn vertex1(@location(9) a0: vec3i, a1: S3) -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = buffer76[0];
+  _ = buffer76[0][1][0].f0;
+  _ = textureLoad(tex4, 0, 0);
+  _ = buffer76[0][1];
+  return out;
+}
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0() {
+  _ = buffer76[0][1];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder100 = device0.createCommandEncoder();
+let texture141 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder65 = commandEncoder100.beginComputePass();
+try {
+computePassEncoder38.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle4, renderBundle2]);
+} catch {}
+let bindGroup67 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 8, resource: {buffer: buffer62, offset: 512}}]});
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture142 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder66 = commandEncoder101.beginComputePass({});
+try {
+renderPassEncoder23.draw(38, 73, 205_254_007, 603_732_259);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer20, 692);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer34, 1_764);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer50, 'uint16', 6, 9);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let bindGroup68 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 408, resource: sampler71}]});
+let textureView112 = texture79.createView({format: 'r32uint'});
+let sampler78 = device0.createSampler({
+  label: '\u7f72\u{1ff87}\u{1faa1}\u4beb\u{1fd71}\ucbef\u0cce\u{1f987}\u0c1d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.70,
+  lodMaxClamp: 96.15,
+  compare: 'less-equal',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup4, new Uint32Array(936), 286, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(152, 265, 565_523_640, 165_840_389);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer13, 'uint32', 148, 170);
+} catch {}
+try {
+externalTexture9.label = '\u0b81\u{1f6e1}\u39ac';
+} catch {}
+let textureView113 = texture125.createView({baseMipLevel: 0});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup60, new Uint32Array(4691), 70, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer44, 772);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer44, 6_948);
+} catch {}
+try {
+  await promise18;
+} catch {}
+await gc();
+try {
+//  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let textureView114 = texture118.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer62, 2_228); };
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(55);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.pushDebugGroup('\u9add');
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker('\u03df');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(122).fill(139), /* required buffer size: 122 */
+{offset: 122, rowsPerImage: 40}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture143 = device0.createTexture({
+  size: [48, 20, 87],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder31 = commandEncoder102.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 12,
+  clearValue: { r: -94.80, g: 44.89, b: 568.4, a: 358.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 26384664,
+});
+let sampler79 = device0.createSampler({
+  label: '\ud31e\u{1fcb8}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 2.345,
+  lodMaxClamp: 3.061,
+});
+try {
+computePassEncoder56.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle15]);
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  label: '\u0481\u7b11\uaa4e\u338a\u0c09',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 202, resource: textureView37},
+    {binding: 52, resource: textureView45},
+    {binding: 999, resource: textureView106},
+    {binding: 243, resource: {buffer: buffer65, offset: 0, size: 5336}},
+  ],
+});
+let textureView115 = texture1.createView({aspect: 'all', format: 'rg32uint'});
+let computePassEncoder67 = commandEncoder83.beginComputePass({label: '\u0d27\uc18e\u3687\u207b\u05ae\ue7e1\uf18e'});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder66.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup65, new Uint32Array(1354), 294, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer43, 5_600);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder({});
+let texture144 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder68 = commandEncoder103.beginComputePass();
+let sampler80 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 34.24,
+  lodMaxClamp: 50.71,
+});
+try {
+computePassEncoder63.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(5, 39, 0, -1_600_902_271, 2_192_166_753);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer65, 'uint32', 1_544, 383);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+await gc();
+let texture145 = device0.createTexture({
+  size: [16],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView116 = texture100.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup3, new Uint32Array(1365), 12, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup56, []);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup29, new Uint32Array(5876), 823, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(330, 265, 1_028_300_227, 860_420_524);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 103, 5, -1_740_540_902, 1_931_627_972);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer42, 316);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer66, 'uint32', 1_672, 133);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer27, 0, 874);
+} catch {}
+let arrayBuffer15 = buffer55.getMappedRange(88, 16);
+document.body.append(video1);
+await gc();
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture146 = device0.createTexture({size: [16, 16, 12], format: 'r16float', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let textureView117 = texture96.createView({arrayLayerCount: 1});
+let renderPassEncoder32 = commandEncoder104.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: -145.8, g: -865.0, b: -272.9, a: 177.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.draw(91, 221, 391_341_742, 688_277_860);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer72, 52);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer44, 'uint16', 570, 4_464);
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'gamma22curve'} });
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer5, 88); };
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder11.draw(65, 350, 662_298_409, 417_879_247);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 30, 0, 22_471_030, 177_662_487);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer39, 184);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer61, 520);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer16 = buffer54.getMappedRange();
+let texture147 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture148 = gpuCanvasContext1.getCurrentTexture();
+let textureView118 = texture80.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 1});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle16, renderBundle8, renderBundle16, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(299);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer71, 8);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer23, 'uint32', 1_232, 2_087);
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder();
+let computePassEncoder69 = commandEncoder105.beginComputePass();
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.68,
+  lodMaxClamp: 90.18,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 60, 30, 50_309_023, 1_646_227_107);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer23, 764);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(video2);
+let commandEncoder106 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 447});
+let texture149 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler82 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 64.41,
+  lodMaxClamp: 97.65,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup48, new Uint32Array(604), 62, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.draw(390, 28, 877_358_967, 68_582_162);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(58, 17, 116, 227_926_413, 1_779_871_745);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer23, 32);
+} catch {}
+try {
+commandEncoder106.insertDebugMarker('\u{1f873}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 768, new BigUint64Array(2867), 252, 12);
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 22856,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture150 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder33 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: 479.1, g: -939.8, b: -879.5, a: -267.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let externalTexture14 = device0.importExternalTexture({source: video2});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup24, new Uint32Array(1071), 86, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(175, 704, 348_563_519, 770_409_194);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer39, 136);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder62.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer27, 764); };
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer43, 1_660);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer63, 84);
+} catch {}
+let arrayBuffer17 = buffer55.getMappedRange(248, 20);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({label: '\uc842\u{1f7f5}\u0f43\u66b9'});
+let computePassEncoder70 = commandEncoder107.beginComputePass({});
+try {
+computePassEncoder40.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer41, 'uint16', 386, 2_652);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(124).fill(144), /* required buffer size: 124 */
+{offset: 124, bytesPerRow: 810}, {width: 300, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler83 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.64,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder29.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle16, renderBundle2, renderBundle5, renderBundle15, renderBundle16, renderBundle4, renderBundle3]);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(153);
+} catch {}
+try {
+renderPassEncoder23.draw(114, 804, 4_294_967_295, 702_329_177);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer49, 'uint16', 290, 730);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer15, 19_644);
+} catch {}
+let buffer78 = device0.createBuffer({
+  size: 14712,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder108 = device0.createCommandEncoder({label: '\ua2e8\u6705\uc140\u{1ffd0}\uc4cf\u0cae'});
+let texture151 = device0.createTexture({
+  label: '\u007f\u0509\u{1fa2f}\u8bd9\u6237',
+  size: [192, 80, 349],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView119 = texture74.createView({});
+let renderPassEncoder34 = commandEncoder108.beginRenderPass({
+  label: '\uc485\u{1fdca}\u{1f6c5}\u0be9\uf915',
+  colorAttachments: [{view: textureView80, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 489583317,
+});
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder8.draw(176, 69, 40_396_011, 801_726_427);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer61, 328);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer23, 'uint32', 1_692, 1_640);
+} catch {}
+document.body.prepend(canvas0);
+let imageData15 = new ImageData(12, 20);
+let texture152 = device0.createTexture({
+  label: '\u{1fb20}\uad77\u0fb9',
+  size: [24, 10, 1],
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView120 = texture29.createView({aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let sampler84 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.81,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 309.8, g: 45.08, b: 76.84, a: -826.5, });
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer27, 500);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'bt709'} });
+let commandEncoder109 = device0.createCommandEncoder({});
+let computePassEncoder71 = commandEncoder109.beginComputePass();
+let sampler85 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.57,
+  lodMaxClamp: 51.60,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder70.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer69, 'uint16', 456, 100);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+ // await adapter0.requestAdapterInfo();
+} catch {}
+let texture153 = device0.createTexture({
+  label: '\ubbe5\u3d84\u0a06\uecaf\u03d4\u1666\u869e\u0f31\u0162',
+  size: [192, 80, 1],
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(0, bindGroup61, new Uint32Array(7169), 2_318, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup28, new Uint32Array(699), 58, 0);
+} catch {}
+try {
+renderPassEncoder31.setViewport(10.217096726289485, 0.9757486766795831, 4.179720023764602, 4.909881688052168, 0.8719094868248574, 0.9972591193309677);
+} catch {}
+try {
+renderPassEncoder8.draw(75, 70, 995_535_462, 1_084_983_335);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(3, 143, 11, 37_611_590, 643_944_782);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer54, 3_404);
+} catch {}
+try {
+buffer69.unmap();
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  label: '\u0b3b\ua11b\ud93d\u3adf\uf075\u40e7',
+  layout: bindGroupLayout9,
+  entries: [{binding: 261, resource: textureView120}],
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout7]});
+let sampler86 = device0.createSampler({
+  label: '\u{1fd49}\u7a35\ucc5e\u{1ff64}\u5295\u{1fa2b}\uc08e\u3134\u4ff3\u006e\ubc34',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.67,
+  lodMaxClamp: 76.87,
+  compare: 'less',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer40, 'uint32', 932, 472);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 71, resource: textureView78},
+    {binding: 115, resource: sampler63},
+    {binding: 129, resource: {buffer: buffer32, offset: 768, size: 1372}},
+    {binding: 348, resource: textureView37},
+    {binding: 125, resource: {buffer: buffer75, offset: 4352, size: 472}},
+  ],
+});
+let texture154 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler87 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 9.529,
+  lodMaxClamp: 37.30,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup8, new Uint32Array(750), 2, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup34, new Uint32Array(1888), 10, 0);
+} catch {}
+try {
+renderPassEncoder34.setViewport(15.516051411213573, 12.186917650324466, 0.2547277028191982, 2.0513505906955203, 0.3700317279266493, 0.793957569257361);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer19, 32);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer11, 0, 5_827);
+} catch {}
+let textureView121 = texture150.createView({format: 'rgba32sint'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup71);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.draw(150, 74, 109_880_410, 638_680_163);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer15, 'uint32', 1_136, 3_618);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({entries: [{binding: 49, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }}]});
+let commandEncoder110 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({
+  label: '\u{1f818}\u6dc9\u{1f9ff}\u0713\u026d\u16bc\u{1f671}\uc724\u272a',
+  type: 'occlusion',
+  count: 398,
+});
+let textureView122 = texture108.createView({});
+let sampler88 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.02,
+  lodMaxClamp: 64.64,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup34, new Uint32Array(3509), 362, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(2, buffer36);
+} catch {}
+let arrayBuffer18 = buffer75.getMappedRange(0, 1156);
+let offscreenCanvas2 = new OffscreenCanvas(94, 31);
+let textureView123 = texture120.createView({label: '\u000a\u5788\u232d', dimension: '2d'});
+let renderPassEncoder35 = commandEncoder110.beginRenderPass({
+  colorAttachments: [{
+  view: textureView80,
+  clearValue: { r: -1.302, g: -276.9, b: -510.2, a: -282.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 52213676,
+});
+let sampler89 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.40,
+  lodMaxClamp: 89.46,
+  maxAnisotropy: 7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup18, new Uint32Array(4538), 122, 0);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup72 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 78, resource: textureView11},
+    {binding: 88, resource: textureView92},
+    {binding: 126, resource: sampler12},
+  ],
+});
+let sampler90 = device0.createSampler({
+  label: '\u46c4\u67d4',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.66,
+  lodMaxClamp: 96.03,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(2, bindGroup48, new Uint32Array(126), 1, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(89, 35, 199_862_017, 1_001_570_416);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(13, 331, 0, 62_880_876, 164_880_475);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer6, 76);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer61, 'uint16', 94, 315);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let computePassEncoder72 = commandEncoder111.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle17 = renderBundleEncoder17.finish({});
+try {
+computePassEncoder57.setBindGroup(3, bindGroup60, new Uint32Array(10), 1, 0);
+} catch {}
+try {
+computePassEncoder39.dispatchWorkgroupsIndirect(buffer62, 468);
+} catch {}
+try {
+renderPassEncoder7.draw(36, 13, 716_637_481, 238_307_872);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer70, 'uint32', 92, 237);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline1);
+} catch {}
+let textureView124 = texture25.createView({baseMipLevel: 0});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer42, 1_680);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer19 = buffer12.getMappedRange(256, 840);
+let gpuCanvasContext2 = offscreenCanvas2.getContext('webgpu');
+try {
+adapter0.label = '\u5508\ua84a\u0d0b\u4b80\u{1fd09}';
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 36, resource: textureView40},
+    {binding: 376, resource: {buffer: buffer3, offset: 1024, size: 3499}},
+  ],
+});
+let texture155 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView125 = texture43.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame14});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(0, bindGroup29, new Uint32Array(267), 130, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer54, 480); };
+} catch {}
+try {
+renderPassEncoder23.draw(269, 39, 424_212_845, 531_137_241);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer42, 716);
+} catch {}
+try {
+computePassEncoder57.pushDebugGroup('\ued58');
+} catch {}
+let bindGroup74 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView62}]});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder32); computePassEncoder32.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -230.7, g: -584.5, b: 201.3, a: -544.2, });
+} catch {}
+try {
+renderPassEncoder8.draw(166, 109, 533_560_655, 90_907_630);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer9, 108);
+} catch {}
+let textureView126 = texture95.createView({});
+let sampler91 = device0.createSampler({
+  label: '\u0cb2\uda2d\u04f8\u099d',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 47.26,
+  lodMaxClamp: 66.24,
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(5, buffer70, 2_176, 215);
+} catch {}
+try {
+renderPassEncoder7.popDebugGroup();
+} catch {}
+document.body.append(canvas0);
+try {
+computePassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup66, new Uint32Array(170), 55, 0);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(38, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer43, 1_708);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer62, 1_072);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer48, 'uint32', 3_480, 643);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer39, 312, 305);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 2092, new BigUint64Array(103), 12, 16);
+} catch {}
+let bindGroup75 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 408, resource: sampler57}]});
+let pipelineLayout12 = device0.createPipelineLayout({label: '\uba2d\u{1fbcb}\ud5ba\u{1fec2}', bindGroupLayouts: []});
+let textureView127 = texture143.createView({format: 'r16float', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder11.draw(116, 79, 2_993_877_267, 2_130_985_240);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer24, 88);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 4, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(498).fill(150), /* required buffer size: 498 */
+{offset: 498, bytesPerRow: 185}, {width: 44, height: 34, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 47, y: 33, z: 44},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer79 = device0.createBuffer({
+  size: 1748,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder112 = device0.createCommandEncoder();
+let computePassEncoder73 = commandEncoder112.beginComputePass({label: '\u5c41\u{1fe96}\u{1ffe3}\u{1f6b6}\u{1f7fa}\u08b3\u{1faa9}'});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder24.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer72, 0, 100);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+adapter0.label = '\u1cf9\u2a8e';
+} catch {}
+let buffer80 = device0.createBuffer({size: 23157, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(0, bindGroup10, new Uint32Array(981), 629, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle13, renderBundle10, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder7.draw(270, 364, 928_602_451, 116_786_990);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer32, 3_332);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer22, 1_492);
+} catch {}
+try {
+buffer23.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(420).fill(175), /* required buffer size: 420 */
+{offset: 420}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 265,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer81 = device0.createBuffer({size: 19618, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let textureView128 = texture59.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({label: '\u893f\u0a85\u43ea\u6f67\udd3a', colorFormats: ['rgba32sint'], stencilReadOnly: false});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.draw(286, 46, 1_117_896_199, 15_180_402);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer7, 1_264);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer75, 'uint16', 1_040, 3_340);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer44, 'uint32', 1_668, 714);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 32},
+  aspect: 'all',
+}, new Uint8Array(60_683).fill(146), /* required buffer size: 60_683 */
+{offset: 27, bytesPerRow: 420, rowsPerImage: 14}, {width: 44, height: 5, depthOrArrayLayers: 11});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({label: '\u01da\uc6b1\u0abf\u012f'});
+let texture156 = device0.createTexture({
+  label: '\u9a81\uc09f\u0f79\u0f46\u0166\ue251',
+  size: [48, 20, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder74 = commandEncoder113.beginComputePass();
+let renderBundle19 = renderBundleEncoder19.finish({label: '\ucee7\u0f9b\u0701\u075e'});
+let sampler92 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 29.19, lodMaxClamp: 56.88});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer26, 2_432, 2_150);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer40, 1876, buffer61, 1284, 1732);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 896 */
+  offset: 896,
+  bytesPerRow: 1536,
+  buffer: buffer20,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+video2.width = 11;
+let commandEncoder114 = device0.createCommandEncoder({});
+let texture157 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture158 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder75 = commandEncoder2.beginComputePass({});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup33, new Uint32Array(279), 33, 0);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.draw(103, 111, 603_701_715, 1_263_164_064);
+} catch {}
+try {
+commandEncoder114.insertDebugMarker('\u{1f91f}');
+} catch {}
+await gc();
+let textureView129 = texture117.createView({mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 1});
+let renderPassEncoder36 = commandEncoder114.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 111,
+  clearValue: { r: -871.6, g: 936.2, b: 518.4, a: 479.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer34, 8_492);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer44, 3_088);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer42, 1_984);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+computePassEncoder57.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(36).fill(230), /* required buffer size: 36 */
+{offset: 36, bytesPerRow: 34}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({entries: [{binding: 246, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }}]});
+let textureView130 = texture74.createView({});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup70);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 79}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @size(4) f0: array<f16, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @size(4) f0: array<array<array<f16, 1>, 1>, 1>,
+}
+@group(0) @binding(36) var<uniform> buffer82: array<array<f16, 1>, 2>;
+@group(0) @binding(407) var tex6: texture_2d<i32>;
+@group(0) @binding(19) var tex7: texture_depth_2d;
+struct VertexOutput3 {
+  @builtin(position) f7: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput3 {
+  var out: VertexOutput3;
+  _ = textureLoad(tex6, vec2i(), 0);
+  return out;
+}
+struct FragmentOutput1 {
+  @location(1) f0: vec2u,
+  @location(0) f1: f32,
+  @location(5) @interpolate(flat, center) f2: vec2i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  if bool(textureLoad(tex7, vec2i(), 0)) {
+    out.f1 = f32(textureLoad(tex6, vec2i(), 0)[2]);
+  }
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  _ = textureLoad(tex7, vec2i(), 0);
+  _ = buffer82[0];
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute1() {
+  _ = buffer82[0];
+  _ = buffer82[1];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup76 = device0.createBindGroup({
+  label: '\u7640\u0e3a\u{1fcc5}\ufc29',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 376, resource: {buffer: buffer78, offset: 768, size: 371}},
+    {binding: 36, resource: textureView52},
+  ],
+});
+try {
+computePassEncoder75.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer42, 368);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+try {
+window.someLabel = textureView128.label;
+} catch {}
+let bindGroup77 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler44}]});
+let externalTexture16 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer34, 320); };
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup41, new Uint32Array(592), 102, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer81, 3_708);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer19);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({});
+let computePassEncoder76 = commandEncoder115.beginComputePass({label: '\u9d44\u6dba\u{1fbb5}\u791f\u00fc\u0abc\u88b4\u{1fbb0}\ub464\u{1fbd7}\u96eb'});
+try {
+computePassEncoder71.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer29, 'uint32', 860, 367);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer63, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48).fill(167), /* required buffer size: 48 */
+{offset: 48}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer83 = device0.createBuffer({
+  label: '\u0c93\u57d6\u0917\ub1f7\u63ab',
+  size: 36241,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder36.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer37, 776);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer49, 'uint32', 2_016, 254);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer55, 4, 95);
+} catch {}
+let arrayBuffer20 = buffer36.getMappedRange(560, 1680);
+let buffer84 = device0.createBuffer({
+  size: 5125,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler93 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.94,
+  lodMaxClamp: 74.94,
+});
+try {
+renderPassEncoder11.drawIndirect(buffer18, 144);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer12, 'uint16', 1_586, 4_850);
+} catch {}
+let arrayBuffer21 = buffer45.getMappedRange(0, 212);
+await gc();
+let buffer85 = device0.createBuffer({size: 30466, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+computePassEncoder32.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(59, 171, 4, 343_138_227, 1_205_525_011);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer32, 752);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer49, 'uint16', 32, 2_550);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u{1f70e}\u0401\u{1f984}\u2048\u{1f7c1}\u{1fdb3}',
+  entries: [
+    {
+      binding: 34,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder116 = device0.createCommandEncoder({label: '\u086c\u{1ff48}\u{1fd32}\ue8d8\u54ea'});
+let texture159 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 27},
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder37 = commandEncoder116.beginRenderPass({
+  label: '\u294e\u2aa7\uadc4\ud59a\u55ea\u3ded\u08ac\u00e4\ufa87',
+  colorAttachments: [{
+  view: textureView129,
+  clearValue: { r: -1.206, g: 69.15, b: -617.0, a: 310.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler94 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 78.73,
+});
+try {
+computePassEncoder62.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder8.draw(16, 132, 163_379_683, 217_274_355);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer80, 3_892);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer7, 'uint16', 328, 2_456);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 59 max align: 1 */
+struct T0 {
+  @align(1) @size(28) f0: array<array<f32, 1>, 1>,
+  @align(1) @size(19) f1: array<vec4f, 1>,
+  @align(1) f2: array<vec2h, 3>,
+}
+@group(0) @binding(19) var tex9: texture_2d<f32>;
+@group(0) @binding(407) var tex8: texture_2d<i32>;
+@group(0) @binding(36) var<uniform> buffer86: vec2h;
+struct VertexOutput4 {
+  @location(3) f8: vec2h,
+  @location(11) f9: vec4f,
+  @location(6) @interpolate(flat, centroid) f10: i32,
+  @location(15) @interpolate(flat, centroid) f11: vec2i,
+  @location(9) @interpolate(linear, centroid) f12: vec2h,
+  @builtin(position) f13: vec4f,
+  @location(14) f14: vec4h,
+  @location(0) @interpolate(flat, center) f15: vec4i
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4i) -> VertexOutput4 {
+  var out: VertexOutput4;
+  if bool(textureLoad(tex8, vec2i(), 0)[0]) {
+    out.f8 += vec2h(-53868.6);
+  }
+  out.f10 = i32(a0[1]);
+  if bool(a0[0]) {
+    out.f11 = a0.gg;
+  }
+  return out;
+}`,
+  sourceMap: {},
+});
+let textureView131 = texture159.createView({dimension: '2d', format: 'rgba16uint', baseArrayLayer: 1});
+let texture160 = device0.createTexture({
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup51, new Uint32Array(779), 144, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer24, 4);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer84, 600, 79);
+} catch {}
+let buffer87 = device0.createBuffer({size: 3161, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture161 = device0.createTexture({
+  size: [48, 20, 87],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup9, new Uint32Array(463), 18, 0);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder5.draw(94, 232, 6_100_356, 1_743_491_865);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(2, 0, 3, 187_411_199, 319_445_786);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer81, 10_160);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let commandEncoder117 = device0.createCommandEncoder({label: '\ud8f3\u09aa'});
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup8, new Uint32Array(254), 20, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(78, 100, 225, -1_937_676_402, 328_661_041);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer65, 'uint32', 2_404, 1_630);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet9, 30, 7, buffer5, 256);
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 1786});
+let renderPassEncoder38 = commandEncoder118.beginRenderPass({
+  colorAttachments: [{
+  view: textureView123,
+  clearValue: { r: 773.7, g: -479.6, b: -557.7, a: -599.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer5, 224); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(195, 23, 320, 495_701_662, 105_952_994);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer29, 132);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer87, 512);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer32, 204, 1_407);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer46, 556, buffer65, 916, 116);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 313,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView132 = texture50.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 8, arrayLayerCount: 4});
+let renderPassEncoder39 = commandEncoder117.beginRenderPass({
+  label: '\u5882\u{1fc7b}\u{1f718}\u1f84\u0166',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 35,
+  clearValue: { r: -940.5, g: -905.2, b: -180.8, a: 439.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 34365026,
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(2, bindGroup26, new Uint32Array(55), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer81, 2_420); };
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle4, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder25.draw(198, 11, 2_815_652_377, 1_600_140_765);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(1, 78, 0, 23_984_916, 17_910_153);
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 36, resource: textureView40},
+    {binding: 376, resource: {buffer: buffer5, offset: 0, size: 305}},
+  ],
+});
+let textureView133 = texture45.createView({mipLevelCount: 1});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(46);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer42, 1_404);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 372, new Int16Array(328), 35, 8);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let texture162 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 98},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup4, new Uint32Array(18), 1, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup45, new Uint32Array(641), 45, 0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer63);
+} catch {}
+let textureView134 = texture105.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 3});
+let sampler95 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 55.42,
+  lodMaxClamp: 86.75,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder23.draw(300, 92, 2_239_024_858, 901_767_130);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(3, 84, 1, 582_726_579, 616_608_247);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer16, 64);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer55);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet10, 87, 75, buffer71, 256);
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 115, resource: sampler23},
+    {binding: 129, resource: {buffer: buffer56, offset: 4352}},
+    {binding: 125, resource: {buffer: buffer32, offset: 0, size: 72}},
+    {binding: 348, resource: textureView37},
+    {binding: 71, resource: textureView78},
+  ],
+});
+let commandEncoder119 = device0.createCommandEncoder({label: '\u034c\udcfd\u{1f8e7}\u{1f92a}\u0871'});
+let computePassEncoder77 = commandEncoder119.beginComputePass();
+let renderPassEncoder40 = commandEncoder51.beginRenderPass({
+  colorAttachments: [{
+  view: textureView129,
+  clearValue: { r: 878.9, g: -629.3, b: 975.7, a: -822.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder18.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(198, 132, 674_970_455, 3_552_634);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(25, 13, 11, 97_203_742, 66_555_608);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'astc-5x5-unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer88 = device0.createBuffer({size: 3489, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup28, new Uint32Array(3510), 258, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer54, 284);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(46).fill(177), /* required buffer size: 46 */
+{offset: 31, bytesPerRow: 3}, {width: 0, height: 6, depthOrArrayLayers: 1});
+} catch {}
+let imageData16 = new ImageData(24, 52);
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 342,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 39, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 356,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer89 = device0.createBuffer({
+  size: 1174,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder120 = device0.createCommandEncoder({});
+let computePassEncoder78 = commandEncoder120.beginComputePass();
+try {
+computePassEncoder54.setBindGroup(1, bindGroup69, new Uint32Array(10000), 1_691, 0);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder23.draw(160, 51, 2_311_199_048, 1_076_816_169);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 41, 26, -1_234_851_205, 18_527_888);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer36, 5_740);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer7, 'uint32', 1_040, 3_335);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(3_783).fill(172), /* required buffer size: 3_783 */
+{offset: 399, bytesPerRow: 24, rowsPerImage: 14}, {width: 0, height: 2, depthOrArrayLayers: 11});
+} catch {}
+let buffer90 = device0.createBuffer({
+  size: 28822,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture163 = device0.createTexture({size: [24, 10, 43], dimension: '3d', format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder25.draw(57, 17, 1_656_687_861, 147_650_612);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(24, 252, 25, 320_076_249, 1_633_685_984);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer11, 2_236, 2_036);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  label: '\u{1ff01}\uebe4\u06ff\ue9a3\ud7e5',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 999, resource: textureView41},
+    {binding: 52, resource: textureView15},
+    {binding: 202, resource: textureView2},
+    {binding: 243, resource: {buffer: buffer34, offset: 2816, size: 15700}},
+  ],
+});
+let sampler96 = device0.createSampler({
+  label: '\ua4e5\u6dfe\u7d10\u9b06\u0805\u0d77\u0538\u{1fb70}\u{1f837}\ue5cf\u{1f714}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.149,
+  lodMaxClamp: 16.82,
+});
+try {
+renderPassEncoder11.draw(184, 230, 661_633_725, 2_200_229_556);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 131, 2, 138_688_707, 524_563_668);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer48, 'uint32', 232, 550);
+} catch {}
+try {
+texture23.destroy();
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise22;
+} catch {}
+let buffer91 = device0.createBuffer({size: 4739, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder121 = device0.createCommandEncoder({});
+let computePassEncoder79 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup17, new Uint32Array(253), 10, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup42, new Uint32Array(5286), 237, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(190, 53, 648_524_572, 3_178_873);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(429, 228, 342, 575_212_235, 11_518_621);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer24, 228);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer85, 'uint16', 1_914, 8_862);
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+try {
+  await promise21;
+} catch {}
+let buffer92 = device0.createBuffer({
+  label: '\u23e3\u3c6e',
+  size: 3868,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 315});
+let texture164 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let texture165 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder79.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1_453, 113, 272, 48_217_892, 79_561_718);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer29, 320);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer20, 'uint16', 2_860, 224);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let arrayBuffer22 = buffer72.getMappedRange(0, 864);
+let canvas1 = document.createElement('canvas');
+let buffer93 = device0.createBuffer({
+  size: 587,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView135 = texture103.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 3});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup28, new Uint32Array(3623), 460, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup1, new Uint32Array(1973), 129, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(779, 352, 798_264_739, 89_424_165);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer7, 768);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer83, 1_288);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer77, 3_892);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 7300, new Float32Array(1512), 209, 16);
+} catch {}
+let gpuCanvasContext3 = canvas1.getContext('webgpu');
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], sampleCount: 1, stencilReadOnly: true});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder48.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(3, bindGroup62, new Uint32Array(1652), 848, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer39, 'uint32', 4, 475);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer23 = buffer77.getMappedRange(0, 5704);
+let bindGroup81 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView13}]});
+let textureView136 = texture16.createView({label: '\u{1f86f}\ue23b\u683c\u22b2\ube51\u253c\u622f\u1bb0', mipLevelCount: 1});
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup38, new Uint32Array(3459), 309, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(212, 487, 2_697_407_029, 45_507_692);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(5, 37, 28, 85_147_406, 128_118_648);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer7, 2_120);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.pushDebugGroup('\u{1fcb9}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData16,
+  origin: { x: 0, y: 11 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture18 = device0.importExternalTexture({label: '\u6819\u81f6\u{1f7ca}\u{1fcd0}\u6e85\u790c\u0882\u3fad\u9084', source: videoFrame4});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer81, 1_852); };
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+renderPassEncoder25.draw(449, 271, 494_461_715, 265_780_078);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(7, 58, 3, 36_618_750, 201_213_704);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer42, 'uint32', 1_244, 2_161);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer78, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup42, new Uint32Array(6502), 232, 0);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(7, buffer27, 4, 1_617);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer35);
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'film', transfer: 'bt2020_10bit'} });
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let textureView137 = texture66.createView({
+  label: '\u536d\u8ebc\u13a3\u00cb\ucb17\ubec5',
+  dimension: 'cube-array',
+  baseMipLevel: 0,
+  baseArrayLayer: 2,
+  arrayLayerCount: 6,
+});
+let textureView138 = texture154.createView({mipLevelCount: 1});
+let computePassEncoder80 = commandEncoder122.beginComputePass({});
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup21, new Uint32Array(3983), 148, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer14, 104, 66);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(7, buffer54, 0, 529);
+} catch {}
+try {
+commandEncoder49.copyBufferToBuffer(buffer45, 676, buffer2, 1268, 20);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+window.someLabel = texture21.label;
+} catch {}
+let textureView139 = texture6.createView({label: '\u0938\u0d4b\ud94b\u0bac\uda1d', dimension: '2d', baseArrayLayer: 1});
+let renderPassEncoder41 = commandEncoder49.beginRenderPass({
+  colorAttachments: [{
+  view: textureView99,
+  depthSlice: 61,
+  clearValue: { r: 934.7, g: 950.6, b: 944.7, a: -908.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture19 = device0.importExternalTexture({label: '\u0ccd\u967f\u42a1\ua26a\ue306\u{1fa5f}\u0956', source: videoFrame5});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup6, new Uint32Array(30), 0, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 42, 19, 356_122_166, 1_521_315_238);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup18, new Uint32Array(3804), 165, 0);
+} catch {}
+try {
+renderPassEncoder9.popDebugGroup();
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout13]});
+let texture166 = device0.createTexture({
+  label: '\u26e4\u2e2d\uab56\u095a\u0e3d',
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView140 = texture22.createView({arrayLayerCount: 11});
+let renderBundle20 = renderBundleEncoder20.finish();
+try {
+computePassEncoder80.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup71, new Uint32Array(1055), 68, 0);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder23.draw(124, 104, 661_364_062, 325_812_046);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer78.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 6, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(276).fill(204), /* required buffer size: 276 */
+{offset: 276, bytesPerRow: 129}, {width: 4, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(39, 423);
+let textureView141 = texture156.createView({dimension: '2d-array'});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup68, new Uint32Array(2632), 350, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer17, 328);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer27, 52);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline1);
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({});
+let textureView142 = texture97.createView({});
+let texture167 = device0.createTexture({
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 37, 6, -1_159_482_664, 103_934_459);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer74, 8_020);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 532, new Int16Array(1161), 411, 20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup82 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 246, resource: sampler10}]});
+let texture168 = device0.createTexture({
+  size: {width: 8, height: 6, depthOrArrayLayers: 1},
+  format: 'astc-8x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder42 = commandEncoder123.beginRenderPass({
+  label: '\u0a80\u{1fedd}',
+  colorAttachments: [{
+  view: textureView138,
+  clearValue: { r: -800.9, g: -221.8, b: -264.0, a: -8.194, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder46.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer39, 'uint16', 138, 14);
+} catch {}
+document.body.prepend(img0);
+let bindGroup83 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 280, resource: {buffer: buffer77, offset: 4608}}]});
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer29, 44);
+} catch {}
+try {
+  await buffer51.mapAsync(GPUMapMode.WRITE, 0, 116);
+} catch {}
+let commandEncoder124 = device0.createCommandEncoder({});
+let computePassEncoder81 = commandEncoder124.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer32, 1_020); };
+} catch {}
+let imageData17 = new ImageData(20, 20);
+let bindGroup84 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 376, resource: {buffer: buffer5, offset: 0, size: 16}},
+    {binding: 36, resource: textureView40},
+  ],
+});
+let texture169 = device0.createTexture({
+  label: '\u5e0f\u6341\u0533\ub811\u4543\uceca\u6811\u0f36\u0cab\u1e66\u6ac4',
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u3426\u0e19\u8dbb\u0f79\ue62f\u293a\u3326\u00ea\u{1fb5e}',
+  colorFormats: ['r16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder7.draw(200, 83, 1_076_292_124, 3_103_184_985);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 83, 1, 219_149_434, 326_108_555);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer27, 4_624);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer16, 0, 1_461);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let texture170 = device0.createTexture({
+  label: '\u7a8c\u4df7\u7fd2\u0ba8\u6035\u{1fe8c}\u039e\u0e41',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture171 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder82 = commandEncoder125.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder7.draw(72, 46, 402_882_525, 1_377_180_893);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(1, 36, 3, 273_647_603, 309_911_885);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup8, new Uint32Array(279), 24, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer29, 'uint16', 632, 245);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer70, 0, 191);
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder126 = device0.createCommandEncoder({});
+let texture172 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder43 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView18,
+  clearValue: { r: -526.7, g: 364.8, b: -442.5, a: 139.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup78);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup22, new Uint32Array(1066), 6, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(143, 183, 2_012_631_655, 726_915_946);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer74, 2_800);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer73, 144, 430);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup34, new Uint32Array(706), 29, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4_294_967_294, undefined, 266_350_030);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer94 = device0.createBuffer({
+  size: 5780,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder127 = device0.createCommandEncoder();
+let computePassEncoder83 = commandEncoder127.beginComputePass({});
+let sampler97 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.18,
+  maxAnisotropy: 13,
+});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'display-p3'});
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer12, 588);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer29, 1_104);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer84, 100, 931);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer23, 'uint32', 324, 115);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(31_809).fill(26), /* required buffer size: 31_809 */
+{offset: 356, bytesPerRow: 143, rowsPerImage: 53}, {width: 17, height: 8, depthOrArrayLayers: 5});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let renderPassEncoder44 = commandEncoder128.beginRenderPass({
+  label: '\u071d\u9302\u{1ff28}\u7f76\u0d5b\u5b26\u{1fb4f}\u{1fada}\u0c9f\u070c',
+  colorAttachments: [{view: textureView47, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+computePassEncoder81.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(93, 65, 27, 197_157_385, 1_004_460_405);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer44, 1_076);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer41, 'uint16', 106, 880);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+let imageData18 = new ImageData(48, 20);
+let buffer95 = device0.createBuffer({
+  label: '\u{1f79c}\u4def\u{1f85d}\u{1ffef}\u955f\u{1fab4}\u06c2\u5dd6\u0e6d\u8115\u058f',
+  size: 12824,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let texture173 = device0.createTexture({
+  label: '\ueffc\u0df2\u0f54\u05d5\u0e2b\u8c20\uceb3\u{1f97a}\u03ee\uaec5\u{1fb48}',
+  size: [16, 16, 17],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32sint'],
+});
+let renderPassEncoder45 = commandEncoder129.beginRenderPass({
+  colorAttachments: [{
+  view: textureView80,
+  clearValue: { r: 85.20, g: -66.57, b: -799.1, a: -283.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler98 = device0.createSampler({
+  label: '\u22e0\u{1f66b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.67,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup41, new Uint32Array(3275), 1_122, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(5, 35, 5, 346_664_739, 710_349_547);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer69, 912);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup32, new Uint32Array(4607), 162, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(40).fill(227), /* required buffer size: 40 */
+{offset: 40}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+let textureView143 = texture74.createView({label: '\ue181\u6824\u07e9\u72a4'});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame14});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup36, new Uint32Array(184), 23, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer71, 264);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+let buffer96 = device0.createBuffer({
+  size: 8220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let texture174 = device0.createTexture({
+  size: [48, 20, 42],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler99 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'clamp-to-edge', lodMaxClamp: 94.03});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup78, new Uint32Array(2241), 192, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer74, 4_908); };
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle4, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(3, 968, 1, -2_120_946_035, 2_370_634_724);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(7, buffer14, 128);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup85 = device0.createBindGroup({
+  label: '\uae60\ubdc3\u5ed2\u6c53\u0d93',
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 356, resource: {buffer: buffer34, offset: 2560, size: 1780}},
+    {binding: 342, resource: sampler33},
+    {binding: 33, resource: sampler31},
+    {binding: 39, resource: externalTexture15},
+  ],
+});
+let commandEncoder130 = device0.createCommandEncoder({});
+let texture175 = device0.createTexture({
+  size: [192],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView144 = texture146.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let renderPassEncoder46 = commandEncoder130.beginRenderPass({
+  colorAttachments: [{view: textureView80, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 317371112,
+});
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer56, 472);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup14, new Uint32Array(3565), 1_720, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(104_917).fill(50), /* required buffer size: 104_917 */
+{offset: 53, bytesPerRow: 232, rowsPerImage: 90}, {width: 0, height: 3, depthOrArrayLayers: 6});
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup7, new Uint32Array(150), 14, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer75, 'uint32', 1_968, 1_193);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4, buffer89, 412);
+} catch {}
+let imageData19 = new ImageData(8, 40);
+let buffer97 = device0.createBuffer({
+  label: '\u{1fe6b}\u0e51\u07f6\u6397\u{1fa67}\u21f1',
+  size: 2944,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder131 = device0.createCommandEncoder({});
+let textureView145 = texture104.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder47 = commandEncoder131.beginRenderPass({colorAttachments: [{view: textureView80, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup70, new Uint32Array(593), 34, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(261, 232, 416_783_666, 536_199_528);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer6, 4);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+let texture176 = device0.createTexture({
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler100 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less-equal',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(2, bindGroup76, new Uint32Array(482), 52, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline1);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let buffer98 = device0.createBuffer({size: 25061, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder132 = device0.createCommandEncoder();
+let computePassEncoder84 = commandEncoder132.beginComputePass({});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder45.end();
+} catch {}
+try {
+renderPassEncoder25.draw(176, 387, 389_461_056, 25_132_379);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer98, 'uint32', 252, 2_819);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(7, buffer46, 124, 171);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer36, 10_244);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let texture177 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView146 = texture43.createView({label: '\u{1f80f}\uf342\u3b26\ufc76', dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+computePassEncoder60.setBindGroup(1, bindGroup48, new Uint32Array(21), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer39, 308); };
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup54, new Uint32Array(951), 32, 0);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(78);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setViewport(8.355596889047067, 0.8473077405068974, 10.709357848134308, 2.9833269481455504, 0.269406966393542, 0.8431758131287864);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer29, 1_044);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer41, 'uint32', 2_668, 2_023);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup0, new Uint32Array(236), 71, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer89, 'uint32', 244, 155);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let buffer99 = device0.createBuffer({
+  label: '\ufb68\u0911\u5575\ud890\u{1f922}\u0f0b',
+  size: 10151,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture178 = device0.createTexture({size: [16], sampleCount: 1, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_DST});
+let sampler101 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.47,
+  lodMaxClamp: 83.82,
+});
+let externalTexture22 = device0.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer42, 744); };
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(206, 25, 29, 695_099_806, 559_085_209);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup9, new Uint32Array(401), 1, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer46);
+} catch {}
+try {
+computePassEncoder41.pushDebugGroup('\ubc4b');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'astc-10x6-unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder({});
+let texture179 = device0.createTexture({
+  size: [16, 16, 12],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder85 = commandEncoder133.beginComputePass({label: '\u{1f85d}\u645b\ub8a8\u4e62\ud56a\u02eb\u{1f6e5}\u05ca\u{1f95f}\u0064'});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup25, new Uint32Array(5164), 12, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup38, new Uint32Array(890), 27, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(27, 111, 1_700_511_572, 885_856_833);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 35, 5, 7_236_762, 157_643_124);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer69, 656);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer61, 104);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer28, 'uint32', 3_828, 1_683);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(7, buffer11, 0, 3_704);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 13},
+  aspect: 'all',
+}, new Uint8Array(3_149).fill(28), /* required buffer size: 3_149 */
+{offset: 133, bytesPerRow: 181, rowsPerImage: 3}, {width: 30, height: 2, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise23;
+} catch {}
+let bindGroup86 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler87}]});
+let buffer100 = device0.createBuffer({
+  size: 6899,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture180 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup75, new Uint32Array(725), 59, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder23.draw(7, 82, 1_293_303_741, 2_131_266_667);
+} catch {}
+let buffer101 = device0.createBuffer({
+  size: 17364,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer101, 12); };
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(6, 1, 3, 1);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer18, 496);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer3, 384, 2_044);
+} catch {}
+try {
+adapter0.label = '\u3910\u741d\u{1fe10}\u044b\u0cf1\u058a\u{1f9a4}';
+} catch {}
+let querySet14 = device0.createQuerySet({label: '\u{1fdbc}\ufe53\u4e67\u0d9c\u3e39\u{1f629}', type: 'occlusion', count: 185});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup81, new Uint32Array(872), 430, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(25, 35, 2_408_240_309, 394_811_860);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 34, 1, 291_704_948, 839_330_044);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer29, 1_512);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer80, 3_032);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer41, 'uint16', 1_338, 1_156);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(3, buffer65);
+} catch {}
+try {
+commandEncoder134.resolveQuerySet(querySet1, 2, 25, buffer65, 2816);
+} catch {}
+let commandEncoder135 = device0.createCommandEncoder({});
+let textureView147 = texture162.createView({dimension: '2d', baseArrayLayer: 25});
+let renderPassEncoder48 = commandEncoder134.beginRenderPass({
+  label: '\u1cce\ub873\u435a\ube7b\u2296\u6d9e',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 36,
+  clearValue: { r: 661.7, g: 137.3, b: -904.4, a: 112.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+commandEncoder135.clearBuffer(buffer96);
+} catch {}
+let texture181 = device0.createTexture({
+  size: [24],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder49 = commandEncoder135.beginRenderPass({
+  colorAttachments: [{view: textureView80, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer42, 240);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture169,
+  mipLevel: 1,
+  origin: {x: 8, y: 4, z: 3},
+  aspect: 'all',
+}, new Uint8Array(57_922).fill(170), /* required buffer size: 57_922 */
+{offset: 314, bytesPerRow: 284, rowsPerImage: 95}, {width: 15, height: 13, depthOrArrayLayers: 3});
+} catch {}
+let buffer102 = device0.createBuffer({
+  size: 1993,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder15.dispatchWorkgroups(2, 2, 1);
+} catch {}
+try {
+computePassEncoder25.pushDebugGroup('\u0e04');
+} catch {}
+try {
+  await promise24;
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 88, resource: textureView63},
+    {binding: 78, resource: textureView5},
+    {binding: 126, resource: sampler12},
+  ],
+});
+let commandEncoder136 = device0.createCommandEncoder({label: '\u{1fa11}\ub4df\uea50\u0700\u{1f8b4}\u{1fad7}\u5e9e\u0c3d'});
+let texture182 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView148 = texture2.createView({dimension: '2d-array'});
+let renderPassEncoder50 = commandEncoder136.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 14,
+  clearValue: { r: -973.8, g: 989.2, b: -269.7, a: -819.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup84);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer23, 916);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline1);
+} catch {}
+document.body.prepend(canvas1);
+let canvas2 = document.createElement('canvas');
+let imageData20 = new ImageData(28, 8);
+let videoFrame22 = new VideoFrame(videoFrame18, {timestamp: 0});
+try {
+adapter0.label = '\u0745\u03ec\ub53a\u56a4';
+} catch {}
+let textureView149 = texture86.createView({});
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup18, new Uint32Array(5298), 487, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer18, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(76).fill(151), /* required buffer size: 76 */
+{offset: 76}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData21 = new ImageData(68, 52);
+try {
+adapter0.label = '\u0235\ua6ed\u{1fe58}\udfa7';
+} catch {}
+let textureView150 = texture66.createView({
+  label: '\u080a\ub47c\u0849\u0d9f\u2131\ud5eb',
+  dimension: 'cube-array',
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let texture183 = device0.createTexture({
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder23.draw(31, 77, 430_044_603, 2_201_093_308);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 238, 0, 821_486_512, 222_037_628);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture184 = device0.createTexture({
+  label: '\ua3f7\u70a3\u25b8\u{1fd51}\u0cfe',
+  size: [24, 10, 43],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture185 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(2, 168, 23, 196_423_164, 1_376_927_795);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+await gc();
+let imageData22 = new ImageData(48, 92);
+let textureView151 = texture48.createView({label: '\u011f\ud953\ubb2e\u2c31\ue335\u78e1\ua0c6\u131c\u0f76', format: 'rg32uint'});
+let sampler102 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.01,
+  compare: 'always',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder11.draw(167, 224, 189_618_591, 214_849_083);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer70, 'uint32', 756, 101);
+} catch {}
+let texture186 = gpuCanvasContext4.getCurrentTexture();
+let externalTexture23 = device0.importExternalTexture({label: '\u813b\u{1f665}\ub7c2\u03c8\ua90b\u0af8\u{1fde2}', source: videoFrame15, colorSpace: 'srgb'});
+try {
+renderPassEncoder40.setIndexBuffer(buffer85, 'uint16', 6_966, 3_037);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer24 = buffer55.getMappedRange(416, 4);
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 139}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 6, y: 1, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder137 = device0.createCommandEncoder({});
+let computePassEncoder86 = commandEncoder137.beginComputePass({});
+let sampler103 = device0.createSampler({
+  label: '\u0044\ua75c\u61cb\u0608\u{1f7b9}\u{1f7a0}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 16.34,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup7, new Uint32Array(4272), 528, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup47, new Uint32Array(258), 12, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle21, renderBundle21, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer7, 'uint32', 1_284, 3_630);
+} catch {}
+let promise25 = shaderModule2.getCompilationInfo();
+await gc();
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let buffer103 = device0.createBuffer({
+  label: '\u009d\uca21\ua678\u3aa0\u0b93\uc587\u6229\u0e93\u1473\u0c25\u070d',
+  size: 1429,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder82.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 565.9, g: -674.4, b: -677.9, a: -548.5, });
+} catch {}
+try {
+computePassEncoder41.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({});
+let renderPassEncoder51 = commandEncoder138.beginRenderPass({
+  colorAttachments: [{
+  view: textureView138,
+  clearValue: { r: -725.2, g: -899.7, b: 331.2, a: -298.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup54, []);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(1, bindGroup64, new Uint32Array(1401), 96, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(115, 477, 360_151_299, 58_268_398);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(1, 59, 0, 486_342_021, 571_978_633);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer93, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer12, 'uint32', 816, 284);
+} catch {}
+let arrayBuffer25 = buffer54.getMappedRange(10248, 0);
+let commandEncoder139 = device0.createCommandEncoder({});
+let textureView152 = texture135.createView({});
+let computePassEncoder87 = commandEncoder139.beginComputePass({});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder36.beginOcclusionQuery(67);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer20, 'uint32', 4_024, 680);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let arrayBuffer26 = buffer35.getMappedRange(4152, 412);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup88 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler72}]});
+let commandEncoder140 = device0.createCommandEncoder({});
+let computePassEncoder88 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup68);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(1, bindGroup15, new Uint32Array(4463), 107, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle5, renderBundle2, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder46.setViewport(6.645079773905838, 7.256074501279869, 4.915840769088988, 6.39305524151595, 0.5746909837064953, 0.988129981403754);
+} catch {}
+try {
+renderPassEncoder23.draw(76, 360, 2_928_963_688, 1_086_878_280);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer87, 464);
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame20);
+let texture187 = device0.createTexture({
+  label: '\u{1ffaf}\u{1ff2e}\u909a\u{1fe28}',
+  size: {width: 96, height: 40, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler104 = device0.createSampler({
+  label: '\u2897\u07ca\u909d\u{1f8b5}\uf579\u{1fec9}\u0180\u{1f71b}\ua200\u06dd',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.066,
+  lodMaxClamp: 41.54,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup15, new Uint32Array(2917), 133, 0);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.draw(11, 278, 358_602_334, 349_187_273);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer7, 3_804);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 223});
+let texture188 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder48.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer69, 924);
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup('\ud2f7');
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 115, resource: sampler34},
+    {binding: 129, resource: {buffer: buffer3, offset: 3328}},
+    {binding: 125, resource: {buffer: buffer13, offset: 512, size: 104}},
+    {binding: 71, resource: textureView78},
+    {binding: 348, resource: textureView37},
+  ],
+});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup70, new Uint32Array(3560), 157, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup0, new Uint32Array(1617), 248, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer71, 248);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline0);
+} catch {}
+let buffer104 = device0.createBuffer({
+  size: 13384,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer102, 1_248); };
+} catch {}
+try {
+renderPassEncoder11.draw(82, 144, 925_451_130, 2_070_114_486);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer93, 'uint16', 270, 56);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 23, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData10);
+let commandEncoder141 = device0.createCommandEncoder();
+let texture189 = device0.createTexture({
+  size: [192, 80, 88],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView153 = texture31.createView({label: '\u{1fdfc}\u0bf5', mipLevelCount: 1});
+let computePassEncoder89 = commandEncoder141.beginComputePass({});
+let sampler105 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.24,
+  lodMaxClamp: 96.81,
+  compare: 'equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.draw(322, 653, 439_339_224, 31_829_911);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer104, 248);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer98, 'uint16', 3_156, 772);
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'bt2020_10bit'} });
+let bindGroup90 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView126}]});
+let buffer105 = device0.createBuffer({
+  label: '\u{1f6a1}\u838a',
+  size: 28056,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let textureView154 = texture73.createView({dimension: '2d', format: 'rgba32sint'});
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer24, 104);
+} catch {}
+let gpuCanvasContext5 = canvas2.getContext('webgpu');
+let sampler106 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.66,
+  lodMaxClamp: 76.14,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer12, 1_208);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer7, 3_040);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer89, 'uint16', 250, 711);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer106 = device0.createBuffer({size: 4309, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder142 = device0.createCommandEncoder();
+let computePassEncoder90 = commandEncoder142.beginComputePass({});
+let sampler107 = device0.createSampler({magFilter: 'nearest', lodMinClamp: 45.31, lodMaxClamp: 72.61, compare: 'never', maxAnisotropy: 1});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup74, new Uint32Array(6870), 2_421, 0);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder8.draw(124, 117, 760_978_847, 78_176_030);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer70, 0, 714);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @align(1) f0: array<i32>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: array<atomic<i32>>,
+}
+@group(0) @binding(36) var<uniform> buffer107: array<f16, 2>;
+@group(0) @binding(407) var tex10: texture_cube<f32>;
+@group(0) @binding(19) var tex11: texture_depth_2d_array;
+struct VertexOutput5 {
+  @builtin(position) f16: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput5 {
+  var out: VertexOutput5;
+  return out;
+}
+struct FragmentOutput2 {
+  @location(7) @interpolate(flat, center) f0: vec4u,
+  @location(3) f1: vec3u,
+  @location(0) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  return out;
+}
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+});
+let buffer108 = device0.createBuffer({
+  size: 10428,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+let texture190 = gpuCanvasContext2.getCurrentTexture();
+let sampler108 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 66.79});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup62, new Uint32Array(1402), 46, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup46, []);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer29, 1_252);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer72, 284);
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  label: '\u0204\u0809\u810a\u8541\u{1f91a}',
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer79, offset: 0, size: 128}}],
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let computePassEncoder91 = commandEncoder144.beginComputePass({});
+let renderPassEncoder52 = commandEncoder143.beginRenderPass({
+  colorAttachments: [{
+  view: textureView18,
+  clearValue: { r: 0.1334, g: 70.10, b: -398.7, a: 428.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup70, new Uint32Array(7891), 1_404, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(14, 79, 96, 153_668_050, 526_209_709);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer56, 1_180);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer96, 'uint16', 520, 195);
+} catch {}
+let arrayBuffer27 = buffer49.getMappedRange();
+let buffer109 = device0.createBuffer({
+  size: 2861,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture191 = gpuCanvasContext3.getCurrentTexture();
+let textureView155 = texture176.createView({});
+let sampler109 = device0.createSampler({
+  label: '\u0e45\u0049\u8b6c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.39,
+  lodMaxClamp: 62.40,
+  maxAnisotropy: 5,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroupsIndirect(buffer34, 8_320); };
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.draw(217, 15, 110_136_968, 283_481_040);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer23, 372);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({label: '\ub4b5\ua13c\u30de\u{1f754}\u{1fcf9}\ua93a\u0a8a\u671c\uf85a\ub31e'});
+let texture192 = device0.createTexture({
+  size: [96, 40, 174],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView156 = texture21.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 10});
+let computePassEncoder92 = commandEncoder145.beginComputePass();
+try {
+computePassEncoder92.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(0, 140, 167, 150_618_348, 1_057_155_015);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer63, 160);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer93, 'uint32', 156, 245);
+} catch {}
+let commandEncoder146 = device0.createCommandEncoder();
+let texture193 = device0.createTexture({
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup22, new Uint32Array(1251), 199, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(40);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(489, 62, 195, 515_989_659, 70_159_577);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder146.copyBufferToBuffer(buffer73, 720, buffer78, 2932, 580);
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+let sampler110 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.60,
+  lodMaxClamp: 89.43,
+  compare: 'always',
+});
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.draw(6, 49, 132_757_681, 1_081_676_877);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(28, 386, 0, 2_002_689_253, 20_010_190);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer84, 336);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer84, 808);
+} catch {}
+let texture194 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder53 = commandEncoder146.beginRenderPass({
+  label: '\ucb0a\u0eaa\uf102\ue626\u0fb7\u09a0\uaae1\uee8e',
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 41,
+  clearValue: { r: 826.9, g: -193.6, b: -332.7, a: -973.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.70,
+  lodMaxClamp: 98.78,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.setViewport(116.38103925440748, 77.55628796007537, 17.607855644090012, 0.3096251025900059, 0.6783397603495971, 0.6825936011106046);
+} catch {}
+try {
+renderPassEncoder25.draw(108, 67, 575_376_648, 595_465_596);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(204, 300, 140, 189_546_809, 897_836_468);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer50, 'uint16', 8, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u2d6c');
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let imageData23 = new ImageData(64, 44);
+try {
+renderPassEncoder5.drawIndexed(0, 566, 1, 1_362_091_304, 583_695_609);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer81, 1_128);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer32, 1_236);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer18, 'uint16', 254, 803);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer19);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer25.detached) { new Uint8Array(arrayBuffer25).fill(0x55); };
+} catch {}
+let texture195 = device0.createTexture({
+  size: [192, 80, 1],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView157 = texture109.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup66, new Uint32Array(214), 18, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup36, new Uint32Array(1609), 68, 0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+let video3 = await videoWithData(85);
+let texture196 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler112 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 49.79,
+  lodMaxClamp: 90.05,
+  compare: 'less',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder25.draw(107, 92, 110_173_391, 551_344_881);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(17, 140, 31, 73_735_834, 668_727_622);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer71, 20);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer12, 600);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(128).fill(27), /* required buffer size: 128 */
+{offset: 128}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video3);
+canvas0.height = 490;
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'gamma22curve'} });
+let videoFrame25 = videoFrame17.clone();
+let bindGroup92 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView93}]});
+let querySet16 = device0.createQuerySet({label: '\u075a\u499a\u68c1\u8532\u4ab5\u2c90\ucfb0', type: 'occlusion', count: 962});
+let texture197 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView158 = texture172.createView({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], stencilReadOnly: true});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(2, 113, 42, 88_888_795, 221_996_722);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer12, 2_500);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer65, 'uint32', 1_376, 1_293);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 42, y: 10 },
+  flipY: false,
+}, {
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup93 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer42, offset: 2304, size: 136}}],
+});
+let texture198 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 27},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let textureView159 = texture159.createView({dimension: '2d'});
+try {
+renderPassEncoder21.executeBundles([renderBundle17, renderBundle5, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer12, 940);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer41, 'uint32', 604, 3_471);
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 3434,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder147 = device0.createCommandEncoder({});
+let textureView160 = texture1.createView({});
+let computePassEncoder93 = commandEncoder147.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(2, bindGroup34, new Uint32Array(7392), 934, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup86, []);
+} catch {}
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle5, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder11.draw(77, 103, 451_212_076, 460_598_975);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(592, 239, 55, -1_925_559_306, 218_753_687);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer14, 0);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder148 = device0.createCommandEncoder({});
+let textureView161 = texture18.createView({});
+let renderPassEncoder54 = commandEncoder148.beginRenderPass({
+  label: '\u7a99\u{1fce8}\u9163\u{1fc94}\u0adb\u{1f61d}\u0d16',
+  colorAttachments: [{view: textureView49, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet10,
+});
+let sampler113 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 88.86,
+  lodMaxClamp: 93.06,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1, 3, 2); };
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder8.draw(34, 15, 733_779_666, 117_306_426);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(13, 93, 13, -1_691_928_649, 2_086_506_666);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer108, 'uint16', 1_322, 113);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder52.insertDebugMarker('\u3b58');
+} catch {}
+document.body.prepend(img0);
+let sampler114 = device0.createSampler({
+  label: '\u4e20\u{1fc2a}\u15b1\ud01b\u5757\uab4e\u{1f851}\u{1f7cb}\u2cad\uba43',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.23,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup56, []);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup77, new Uint32Array(11), 0, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder34.draw(50, 100, 153_530_426, 343_500_561);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(3, buffer55, 0, 17);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder();
+let textureView162 = texture124.createView({});
+let computePassEncoder94 = commandEncoder149.beginComputePass({});
+let sampler115 = device0.createSampler({
+  label: '\u015e\u35f2\u0ad9\u{1fd07}\u0120\u5812',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.111,
+  lodMaxClamp: 28.94,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup34, new Uint32Array(638), 241, 0);
+} catch {}
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+renderPassEncoder9.setViewport(166.6884178891709, 27.277516494691348, 2.9023389758623614, 9.769920480353305, 0.1373247196042765, 0.16189437969587905);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(1, 14, 3, 40_306_061, 423_935_410);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(1, buffer84);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u06ed');
+} catch {}
+let textureView163 = texture73.createView({
+  label: '\u{1f7fb}\u{1fdda}\u56b5\u36df\u{1fef2}\u4159\u{1fdd7}\u0eca\u4d1d\u2332\u7e17',
+  dimension: '2d',
+});
+let computePassEncoder95 = commandEncoder2.beginComputePass({});
+let sampler116 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.15,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder94.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(78, 106, 150, 5_841_813, 210_905_374);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer71, 972);
+} catch {}
+try {
+computePassEncoder25.popDebugGroup();
+} catch {}
+let bindGroup94 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 85, resource: textureView2}]});
+let buffer111 = device0.createBuffer({
+  size: 20565,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture199 = device0.createTexture({
+  size: {width: 192},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8unorm'],
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup49, new Uint32Array(658), 283, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.draw(141, 40, 1_569_453_478, 14_479_525);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer55, 'uint32', 60, 14);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer106, 0, 281);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer100, 'uint16', 592, 3_666);
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder({label: '\u4f9a\u8e16\u{1f72e}\uc070\u7554\u{1fd5e}\ubc8a\u81c6'});
+let computePassEncoder96 = commandEncoder150.beginComputePass({});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(0, bindGroup7, new Uint32Array(1905), 89, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(29, 313, 25, 322_790_195, 990_815_194);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer5, 56);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer29, 592);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer50, 0, 9);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(581).fill(199), /* required buffer size: 581 */
+{offset: 42, bytesPerRow: 41, rowsPerImage: 13}, {width: 3, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 29, y: 2, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 52, resource: textureView45},
+    {binding: 999, resource: textureView17},
+    {binding: 243, resource: {buffer: buffer84, offset: 768, size: 128}},
+    {binding: 202, resource: textureView2},
+  ],
+});
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder9.draw(352, 1_000, 757_789_954, 316_361_445);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 54, 3, -1_448_622_372, 60_487_792);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer36, 156);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+document.body.prepend(img0);
+let bindGroup96 = device0.createBindGroup({
+  label: '\u{1ffc9}\uca3e\u{1fa22}\ua070',
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView42}],
+});
+let commandEncoder151 = device0.createCommandEncoder();
+let texture200 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder55 = commandEncoder151.beginRenderPass({colorAttachments: [{view: textureView47, loadOp: 'clear', storeOp: 'discard'}]});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder90.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(162, 275, 69, 295_069_414, 816_789_176);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer34, 9_160);
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  label: '\u9e9c\ue546\u2a50\u04c9\u{1fc3b}\u787b',
+  layout: bindGroupLayout6,
+  entries: [{binding: 127, resource: textureView59}],
+});
+let buffer112 = device0.createBuffer({
+  label: '\u{1f706}\uc1f3\u{1fef6}\u6a14\u372f\u8dd1\u{1f770}\u01c2\u061b\u00ad\u{1fb9f}',
+  size: 14054,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+let texture201 = device0.createTexture({
+  size: [192, 80, 1],
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder97 = commandEncoder152.beginComputePass({});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(343);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle9, renderBundle9, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer19, 52);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer91, 'uint32', 1_316, 1_154);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(275, 176, 336, 1_174_285_626, 2_269_141_739);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer39, 380);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer81, 2_576);
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'smpteSt4281'} });
+let commandEncoder153 = device0.createCommandEncoder({});
+let textureView164 = texture36.createView({baseMipLevel: 0});
+let computePassEncoder98 = commandEncoder153.beginComputePass();
+try {
+renderPassEncoder34.draw(159, 10, 1_251_494_815, 432_648_946);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer37, 308);
+} catch {}
+try {
+renderPassEncoder5.pushDebugGroup('\u0129');
+} catch {}
+let bindGroup98 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 116, resource: textureView137}]});
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 232, 0, -1_785_927_503, 32_992_903);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer13, 'uint32', 116, 186);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture202 = device0.createTexture({
+  size: [48, 20, 1],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(2, bindGroup95, new Uint32Array(1249), 33, 0);
+} catch {}
+try {
+computePassEncoder15.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup98);
+} catch {}
+try {
+renderPassEncoder8.draw(76, 143, 528_028_343, 95_485_429);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(61, 378, 23, 415_145_109, 1_291_270_154);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer62, 2_136);
+} catch {}
+try {
+renderPassEncoder5.popDebugGroup();
+} catch {}
+let bindGroup99 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 34, resource: textureView131}]});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup99);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.draw(397, 11, 2_048_923_360, 762_033_656);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 208, new BigUint64Array(12573), 383, 68);
+} catch {}
+let textureView165 = texture18.createView({});
+let externalTexture24 = device0.importExternalTexture({source: video1});
+try {
+renderPassEncoder49.draw(190, 180, 1_045_487_041, 1_255_948_860);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(6, 313, 10, 147_045_524, 3_980_279_256);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer39, 8);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer27, 'uint16', 980, 278);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(179).fill(129), /* required buffer size: 179 */
+{offset: 179, rowsPerImage: 4}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView96}]});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup90, new Uint32Array(1194), 104, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer84, 3_068); };
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup97, new Uint32Array(4150), 1_634, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(266, 389, 39, 341_108_495, 779_768_734);
+} catch {}
+let imageData24 = new ImageData(12, 48);
+let bindGroup101 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler14}]});
+let buffer113 = device0.createBuffer({
+  size: 10702,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder154 = device0.createCommandEncoder({});
+let computePassEncoder99 = commandEncoder154.beginComputePass({});
+let sampler117 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 30.49,
+  lodMaxClamp: 57.77,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup62, new Uint32Array(681), 79, 0);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder25.draw(45, 147, 759_572_356, 283_782_696);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer65, 0);
+} catch {}
+let commandEncoder155 = device0.createCommandEncoder({});
+let texture203 = gpuCanvasContext5.getCurrentTexture();
+let textureView166 = texture191.createView({dimension: '2d-array', format: 'rgba8unorm', baseArrayLayer: 0});
+let computePassEncoder100 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+computePassEncoder78.setBindGroup(1, bindGroup25, new Uint32Array(1721), 53, 0);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle13, renderBundle6, renderBundle13, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder8.draw(513, 137, 353_348_092, 512_191_445);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer72, 152);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer109, 'uint16', 592, 231);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let bindGroup102 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 280, resource: {buffer: buffer44, offset: 256}}]});
+let textureView167 = texture66.createView({dimension: 'cube'});
+let sampler118 = device0.createSampler({
+  label: '\u5655\u0036\u6594\ubfc5',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.05,
+  lodMaxClamp: 55.81,
+});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup15, new Uint32Array(6055), 1_009, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer97, 144);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(4, buffer22, 344, 1_857);
+} catch {}
+let arrayBuffer28 = buffer60.getMappedRange(0, 76);
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 224,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 526,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 123,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 513,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder156 = device0.createCommandEncoder();
+let textureView168 = texture79.createView({dimension: '2d-array'});
+let computePassEncoder101 = commandEncoder156.beginComputePass({});
+try {
+renderPassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer50, 8, 0);
+} catch {}
+let texture204 = device0.createTexture({
+  size: [192, 80, 349],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler119 = device0.createSampler({
+  label: '\u0fc8\u042b\u7d63\u{1fb76}\u01e2\u7b6d\u00f4\u{1f9a6}',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.03,
+  lodMaxClamp: 89.99,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer111);
+} catch {}
+let commandEncoder157 = device0.createCommandEncoder();
+let texture205 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 30},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder56 = commandEncoder157.beginRenderPass({
+  label: '\ud4c9\u4841\u0e44\u0dd6\uea51\u3c09\u03a6',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 66,
+  clearValue: { r: 14.84, g: 121.5, b: 433.8, a: 972.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup90);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(2, bindGroup6, new Uint32Array(866), 326, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer37, 808); };
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup99, new Uint32Array(700), 106, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle13, renderBundle10, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder11.draw(163, 10, 1_078_967_506, 18_497_893);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer44, 984);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer101, 92);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer91, 'uint32', 196, 533);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(5, buffer6, 216, 6);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder158 = device0.createCommandEncoder();
+let querySet17 = device0.createQuerySet({label: '\ua63e\ud633\u06f2', type: 'occlusion', count: 784});
+let textureView169 = texture205.createView({});
+let texture206 = device0.createTexture({
+  label: '\ud0ca\u95f0\u{1fe63}\u065a\uedac',
+  size: {width: 16, height: 16, depthOrArrayLayers: 91},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView170 = texture127.createView({mipLevelCount: 1});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup88);
+} catch {}
+try {
+renderPassEncoder55.setViewport(15.082017713688824, 18.974453102739773, 30.178617062282957, 0.44161951584266074, 0.13895849209150313, 0.35172239645985715);
+} catch {}
+try {
+commandEncoder158.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3872 */
+  offset: 3872,
+  buffer: buffer46,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 58});
+let computePassEncoder102 = commandEncoder158.beginComputePass({});
+try {
+computePassEncoder102.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.draw(205, 29, 365_156_222, 979_375_937);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer34, 1_144);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer83, 916);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+ // await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder159 = device0.createCommandEncoder();
+let textureView171 = texture41.createView({dimension: '2d', baseArrayLayer: 1});
+let texture207 = device0.createTexture({
+  label: '\u0d0e\u0369\u{1feb5}\ub04e\u484e\u7372\u{1f96a}\u04cc\u6098\ud8c2\u0e6e',
+  size: [24],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder49.setBindGroup(2, bindGroup93, new Uint32Array(1320), 979, 0);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer102, 52);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer102, 124);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline0);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let bindGroup103 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 246, resource: sampler78}]});
+let commandEncoder160 = device0.createCommandEncoder({});
+let textureView172 = texture47.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder103 = commandEncoder159.beginComputePass({});
+try {
+computePassEncoder101.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer102, 0);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let sampler120 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.51,
+  lodMaxClamp: 19.83,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder103.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup32, new Uint32Array(497), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(20, 121, 2_909_309_157, 95_616_272);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer20, 1_888);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer19, 28);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer61, 'uint32', 708, 87);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(3, buffer46);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder160.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 60, y: 12, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2592 */
+  offset: 2592,
+  buffer: buffer83,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder160.clearBuffer(buffer20, 2704, 1296);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 39, resource: externalTexture11},
+    {binding: 342, resource: sampler39},
+    {binding: 356, resource: {buffer: buffer112, offset: 2048, size: 1208}},
+    {binding: 33, resource: sampler24},
+  ],
+});
+let textureView173 = texture183.createView({label: '\ue801\udd67\u{1ff3e}\u4ebf\u0e2f\u0988\u{1f99e}'});
+let computePassEncoder104 = commandEncoder160.beginComputePass({});
+try {
+computePassEncoder104.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup91, new Uint32Array(875), 107, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(214, 0, 965_081_123, 32_581_474);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer87, 848);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(2, buffer75);
+} catch {}
+let sampler121 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 45.04,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup62, new Uint32Array(672), 21, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup78, new Uint32Array(996), 176, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(15, 222, 560_017_095, 491_645_236);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(111, 37, 75, 151_637_794, 231_724_270);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer43, 604);
+} catch {}
+let commandEncoder161 = device0.createCommandEncoder({});
+let computePassEncoder105 = commandEncoder161.beginComputePass();
+let sampler122 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.68,
+  lodMaxClamp: 39.88,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup87, new Uint32Array(1520), 160, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer74, 'uint32', 7_796, 864);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let texture208 = device0.createTexture({
+  size: [192, 80, 349],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView174 = texture131.createView({dimension: '3d', format: 'r16sint', baseArrayLayer: 0});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame18});
+try {
+renderPassEncoder9.drawIndexed(32, 36, 7, 206_287_447, 713_415_585);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(7, buffer103, 0, 144);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(201).fill(130), /* required buffer size: 201 */
+{offset: 201, bytesPerRow: 168, rowsPerImage: 84}, {width: 20, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder162 = device0.createCommandEncoder({});
+let renderPassEncoder57 = commandEncoder162.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: -729.3, g: 827.6, b: 768.4, a: 754.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 527421945,
+});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup92, new Uint32Array(2721), 186, 0);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer81, 2_020);
+} catch {}
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 28,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let buffer114 = device0.createBuffer({
+  label: '\u8f1e\u04bf\u09a9\ud28e',
+  size: 25401,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+let textureView175 = texture79.createView({dimension: '2d-array', format: 'r32uint', baseArrayLayer: 0});
+try {
+computePassEncoder60.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(2, bindGroup99, new Uint32Array(1834), 167, 0);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(303, 2, 8, 589_058_812, 469_096_675);
+} catch {}
+let buffer115 = device0.createBuffer({
+  size: 26048,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture209 = device0.createTexture({
+  size: [96, 40, 1],
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture210 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView176 = texture138.createView({dimension: '2d-array', aspect: 'all'});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup18, new Uint32Array(1107), 47, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(202, 57, 427_245_133, 515_371_263);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer27, 'uint16', 66, 1_042);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer16, 904, 871);
+} catch {}
+try {
+commandEncoder163.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 20, y: 28, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 2, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder164 = device0.createCommandEncoder({label: '\u{1fb7b}\u{1f996}\u0a08\u{1f6fe}\u1a77\u2aba\u7df1\u14f0\ua38e\u04c1\u00a4'});
+let textureView177 = texture209.createView({});
+let texture211 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView178 = texture99.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder58 = commandEncoder163.beginRenderPass({
+  label: '\u9b28\u0298\u{1fcd0}\u6017\u7d2c',
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: 889.9, g: 463.0, b: -411.5, a: -361.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet12,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(33, 120, 26, -1_954_805_994, 1_106_940_826);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer111, 'uint32', 3_160, 900);
+} catch {}
+try {
+renderPassEncoder40.insertDebugMarker('\u{1fce4}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 24, y: 27, z: 88},
+  aspect: 'all',
+}, new Uint8Array(439_352).fill(5), /* required buffer size: 439_352 */
+{offset: 4, bytesPerRow: 475, rowsPerImage: 70}, {width: 28, height: 15, depthOrArrayLayers: 14});
+} catch {}
+let renderPassEncoder59 = commandEncoder164.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: -680.6, g: 821.3, b: 982.7, a: 736.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer16, 1_164);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer44, 660);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(54).fill(202), /* required buffer size: 54 */
+{offset: 54}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise27;
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 163,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer116 = device0.createBuffer({size: 29515, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 553});
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup93);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer100, 'uint16', 1_066, 472);
+} catch {}
+let buffer117 = device0.createBuffer({
+  size: 7926,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture212 = device0.createTexture({
+  label: '\u04d1\u7b09\u0ff1\u{1f754}\uaada\u336f\u1754\u44a4',
+  size: {width: 96, height: 40, depthOrArrayLayers: 11},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler123 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.55,
+  lodMaxClamp: 94.31,
+  maxAnisotropy: 14,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer101, 744);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4, buffer85, 2_228, 186);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer91, 492, new Int16Array(11499), 251, 120);
+} catch {}
+let bindGroup105 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView51}]});
+let commandEncoder165 = device0.createCommandEncoder({label: '\u693d\u{1ffaa}\uf1ac\u3652\u0d3c\u7c8a\u0174\uec88\u{1fd93}\u0e9a\uc079'});
+let computePassEncoder106 = commandEncoder165.beginComputePass({});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup21, new Uint32Array(482), 33, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder59.setScissorRect(1, 1, 3, 3);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer12, 1_628);
+} catch {}
+try {
+renderPassEncoder46.insertDebugMarker('\u072d');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 18, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(150).fill(54), /* required buffer size: 150 */
+{offset: 150, bytesPerRow: 176, rowsPerImage: 69}, {width: 11, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let buffer118 = device0.createBuffer({size: 4827, usage: GPUBufferUsage.QUERY_RESOLVE});
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer27, 2_428);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer20, 1_404);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup106 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView102}]});
+let pipelineLayout15 = device0.createPipelineLayout({
+  label: '\uce6c\u40bc\u{1fa1e}\u0913\u0706\ue76f\u{1f890}\uf170\u{1f8fb}\u{1fede}',
+  bindGroupLayouts: [],
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 10.69,
+});
+try {
+computePassEncoder62.dispatchWorkgroupsIndirect(buffer117, 5_800);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup78, new Uint32Array(4463), 245, 0);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(0, 4, 0, 0);
+} catch {}
+let bindGroup107 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 28, resource: textureView177}]});
+let buffer119 = device0.createBuffer({size: 12246, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder166 = device0.createCommandEncoder({});
+let texture213 = device0.createTexture({
+  label: '\uf172\u{1fb78}\ua1fa\uba5d\u0b51\u6b52\uc635\u11ef\u0b62',
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView179 = texture5.createView({dimension: '2d', mipLevelCount: 1});
+let renderPassEncoder60 = commandEncoder166.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: 957.6, g: 752.0, b: 59.26, a: 412.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet16,
+});
+try {
+computePassEncoder104.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+computePassEncoder87.end();
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup64, new Uint32Array(1010), 7, 0);
+} catch {}
+try {
+renderPassEncoder23.draw(32, 165, 1_159_235_079, 363_380_601);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(162, 270, 200, 101_720_145, 421_896_448);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer5, 132);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer31, 'uint32', 7_864, 3_839);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer65, 5_720, 2_422);
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 39, resource: externalTexture15},
+    {binding: 33, resource: sampler34},
+    {binding: 356, resource: {buffer: buffer77, offset: 0, size: 3456}},
+    {binding: 342, resource: sampler23},
+  ],
+});
+let textureView180 = texture164.createView({label: '\u0635\u284e\u030d\u3c31\u75a1\u0f60\u46d5\u0b48', dimension: 'cube'});
+let computePassEncoder107 = commandEncoder139.beginComputePass({});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup71, new Uint32Array(2266), 147, 0);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(74, 199, 176, 76_758_412, 445_262_431);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer74, 'uint16', 3_596, 7_558);
+} catch {}
+let texture214 = gpuCanvasContext0.getCurrentTexture();
+let textureView181 = texture53.createView({mipLevelCount: 1});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame21});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.draw(8, 25, 758_824_365, 843_872_652);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(5, buffer12, 0, 1_007);
+} catch {}
+let commandEncoder167 = device0.createCommandEncoder({});
+let texture215 = device0.createTexture({
+  size: [48],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder108 = commandEncoder167.beginComputePass({});
+let sampler125 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 35.87,
+  lodMaxClamp: 71.78,
+  compare: 'less',
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup73, new Uint32Array(492), 26, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer71, 36); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder5.draw(40, 212, 107_170_211, 913_304_941);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(2, 7, 6, 125_886_894, 267_112_075);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer7, 3_320);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 108});
+let texture216 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 58},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup103);
+} catch {}
+try {
+computePassEncoder93.setBindGroup(1, bindGroup17, new Uint32Array(428), 93, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder34.draw(109, 463, 57_798_223, 1_134_395_081);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(17, 10, 1, -1_745_499_375, 837_128_325);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline0);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+@group(0) @binding(36) var st0: texture_storage_2d<rgba16sint, write>;
+@group(0) @binding(376) var<uniform> buffer120: array<array<f32, 1>, 1>;
+struct VertexOutput6 {
+  @location(2) f17: f16,
+  @location(8) f18: vec3h,
+  @builtin(position) f19: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput6 {
+  var out: VertexOutput6;
+  _ = buffer120[0];
+  out.f17 = f16(-35882.9);
+  return out;
+}
+struct FragmentOutput3 {
+  @location(0) @interpolate(flat, center) f0: vec2i,
+  @location(1) @interpolate(flat) f1: vec3u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  return out;
+}
+struct FragmentOutput4 {
+  @location(0) @interpolate(flat) f0: vec4i,
+  @location(6) f1: vec3f
+}
+
+@fragment
+fn fragment1() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  return out;
+}
+
+fn coverageHelper0() {
+  _ = cross(vec3(), vec3());
+  _ = min((1<<62), (1<<33));
+  _ = max((1<<62), (1<<33));
+  _ = determinant(mat2x2(vec2(), vec2()));
+  _ = determinant(mat3x3(vec3(), vec3(), vec3()));
+  _ = determinant(mat4x4(vec4(), vec4(), vec4(), vec4()));
+
+  let i32_: i32 = 1;
+  let u32_: u32 = 1;
+  let f32_: f32 = .1;
+  let f16_: f16 = .1;
+  let bool_: bool = true;
+  let vec2b_ = vec2<bool>();
+  let vec3b_ = vec3<bool>();
+  let vec4b_ = vec4<bool>();
+  let vec2i_ = vec2i(1);
+  let vec3i_ = vec3i(1);
+  let vec4i_ = vec4i(1);
+  let vec2u_ = vec2u(1);
+  let vec3u_ = vec3u(1);
+  let vec4u_ = vec4u(1);
+  let vec2f_ = vec2f(.1);
+  let vec3f_ = vec3f(.1);
+  let vec4f_ = vec4f(.1);
+  let vec2h_ = vec2h(.1);
+  let vec3h_ = vec3h(.1);
+  let vec4h_ = vec4h(.1);
+  let mat3x2f_ = mat3x2f();
+  let mat3x3f_ = mat3x3f();
+  let mat3x4f_ = mat3x4f();
+  let mat4x4f_ = mat4x4f();
+  let mat4x3f_ = mat4x3f();
+  let mat4x2f_ = mat4x2f();
+  let mat2x4f_ = mat2x4f();
+  let mat2x3f_ = mat2x3f();
+  let mat2x2f_ = mat2x2f();
+  let mat3x2h_ = mat3x2h();
+  let mat3x3h_ = mat3x3h();
+  let mat3x4h_ = mat3x4h();
+  let mat4x4h_ = mat4x4h();
+  let mat4x3h_ = mat4x3h();
+  let mat4x2h_ = mat4x2h();
+  let mat2x4h_ = mat2x4h();
+  let mat2x3h_ = mat2x3h();
+  let mat2x2h_ = mat2x2h();
+
+  if true {
+    var h = 0x1p-24h;
+  } else if false {
+    var h = 0x1p-24h;
+  } else {
+    var h = 0x1p-24h;
+  }
+
+  _ = bitcast<i32>(0i);
+  _ = bitcast<i32>(0u);
+  _ = bitcast<i32>(0f);
+  _ = bitcast<i32>(0);
+  _ = bitcast<i32>(0.);
+  _ = bitcast<u32>(0i);
+  _ = bitcast<u32>(0u);
+  _ = bitcast<u32>(0f);
+  _ = bitcast<u32>(0);
+  _ = bitcast<u32>(0.);
+  _ = bitcast<f32>(0i);
+  _ = bitcast<f32>(0u);
+  _ = bitcast<f32>(0f);
+  _ = bitcast<f32>(0);
+  _ = bitcast<f32>(0.);
+  _ = bitcast<vec2i>(vec2i_);
+  _ = bitcast<vec2i>(vec2u_);
+  _ = bitcast<vec2i>(vec2f_);
+  _ = bitcast<vec2i>(vec2());
+  _ = bitcast<vec2i>(vec2(0.));
+  _ = bitcast<vec2u>(vec2i_);
+  _ = bitcast<vec2u>(vec2u_);
+  _ = bitcast<vec2u>(vec2f_);
+  _ = bitcast<vec2u>(vec2());
+  _ = bitcast<vec2u>(vec2(0.));
+  _ = bitcast<vec2f>(vec2i_);
+  _ = bitcast<vec2f>(vec2u_);
+  _ = bitcast<vec2f>(vec2f_);
+  _ = bitcast<vec2f>(vec2());
+  _ = bitcast<vec2f>(vec2(0.));
+  _ = bitcast<vec3i>(vec3i_);
+  _ = bitcast<vec3i>(vec3u_);
+  _ = bitcast<vec3i>(vec3f_);
+  _ = bitcast<vec3i>(vec3());
+  _ = bitcast<vec3i>(vec3(0.));
+  _ = bitcast<vec3u>(vec3i_);
+  _ = bitcast<vec3u>(vec3u_);
+  _ = bitcast<vec3u>(vec3f_);
+  _ = bitcast<vec3u>(vec3());
+  _ = bitcast<vec3u>(vec3(0.));
+  _ = bitcast<vec3f>(vec3i_);
+  _ = bitcast<vec3f>(vec3u_);
+  _ = bitcast<vec3f>(vec3f_);
+  _ = bitcast<vec3f>(vec3());
+  _ = bitcast<vec3f>(vec3(0.));
+  _ = bitcast<vec4i>(vec4i_);
+  _ = bitcast<vec4i>(vec4u_);
+  _ = bitcast<vec4i>(vec4f_);
+  _ = bitcast<vec4i>(vec4());
+  _ = bitcast<vec4i>(vec4(0.));
+  _ = bitcast<vec4u>(vec4i_);
+  _ = bitcast<vec4u>(vec4u_);
+  _ = bitcast<vec4u>(vec4f_);
+  _ = bitcast<vec4u>(vec4());
+  _ = bitcast<vec4u>(vec4(0.));
+  _ = bitcast<vec4f>(vec4i_);
+  _ = bitcast<vec4f>(vec4u_);
+  _ = bitcast<vec4f>(vec4f_);
+  _ = bitcast<vec4f>(vec4());
+  _ = bitcast<vec4f>(vec4(0.));
+
+  _ = bitcast<vec2h>(0);
+  _ = bitcast<vec2h>(0.);
+  _ = bitcast<vec2h>(0u);
+  _ = bitcast<vec2h>(0i);
+  _ = bitcast<vec2h>(0f);
+  _ = bitcast<vec4h>(vec2());
+  _ = bitcast<vec4h>(vec2(0.));
+  _ = bitcast<vec4h>(vec2u_);
+  _ = bitcast<vec4h>(vec2i_);
+  _ = bitcast<vec4h>(vec2f_);
+  _ = bitcast<u32>(vec2h_);
+  _ = bitcast<i32>(vec2h_);
+  _ = bitcast<f32>(vec2h_);
+  _ = bitcast<vec2u>(vec4h_);
+  _ = bitcast<vec2i>(vec4h_);
+  _ = bitcast<vec2f>(vec4h_);
+
+  _ = array(frexp(f32_), frexp(f32_), frexp(f32_), frexp(f32_));
+  _ = array(frexp(f16_), frexp(f16_), frexp(f16_));
+  _ = array(modf(f32_), modf(f32_));
+  _ = array(modf(f16_), modf(f16_), modf(f16_), modf(f16_), modf(f16_));
+
+  _ = !bool_;
+  _ = !vec2b_;
+  _ = !vec3b_;
+  _ = !vec4b_;
+  _ = bool_ || bool_;
+  _ = bool_ && bool_;
+  _ = bool_ | bool_;
+  _ = vec2b_ | vec2b_;
+  _ = vec3b_ | vec3b_;
+  _ = vec4b_ | vec4b_;
+  _ = i32_ | i32_;
+  _ = u32_ | u32_;
+  _ = vec2i_ | vec2i_;
+  _ = vec3i_ | vec3i_;
+  _ = vec4i_ | vec4i_;
+  _ = vec2u_ | vec2u_;
+  _ = vec3u_ | vec3u_;
+  _ = vec4u_ | vec4u_;
+  _ = bool_ & bool_;
+  _ = vec2b_ & vec2b_;
+  _ = vec3b_ & vec3b_;
+  _ = vec4b_ & vec4b_;
+  _ = i32_ & i32_;
+  _ = u32_ & u32_;
+  _ = vec2i_ & vec2i_;
+  _ = vec3i_ & vec3i_;
+  _ = vec4i_ & vec4i_;
+  _ = vec2u_ & vec2u_;
+  _ = vec3u_ & vec3u_;
+  _ = vec4u_ & vec4u_;
+  _ = -f32_;
+  _ = -i32_;
+  _ = -f16_;
+  _ = -vec2f_;
+  _ = -vec3f_;
+  _ = -vec4f_;
+  _ = -vec2i_;
+  _ = -vec3i_;
+  _ = -vec4i_;
+  _ = -vec2h_;
+  _ = -vec3h_;
+  _ = -vec4h_;
+  _ = i32_ - i32_;
+  _ = u32_ - u32_;
+  _ = f32_ - f32_;
+  _ = f16_ - f16_;
+  _ = vec2i_ - i32_;
+  _ = vec3i_ - i32_;
+  _ = vec4i_ - i32_;
+  _ = vec2u_ - u32_;
+  _ = vec3u_ - u32_;
+  _ = vec4u_ - u32_;
+  _ = vec2f_ - f32_;
+  _ = vec3f_ - f32_;
+  _ = vec4f_ - f32_;
+  _ = vec2h_ - f16_;
+  _ = vec3h_ - f16_;
+  _ = vec4h_ - f16_;
+  _ = i32_ - vec2i_;
+  _ = i32_ - vec3i_;
+  _ = i32_ - vec4i_;
+  _ = u32_ - vec2u_;
+  _ = u32_ - vec3u_;
+  _ = u32_ - vec4u_;
+  _ = f32_ - vec2f_;
+  _ = f32_ - vec3f_;
+  _ = f32_ - vec4f_;
+  _ = f16_ - vec2h_;
+  _ = f16_ - vec3h_;
+  _ = f16_ - vec4h_;
+  _ = vec2i_ - vec2i_;
+  _ = vec3i_ - vec3i_;
+  _ = vec4i_ - vec4i_;
+  _ = vec2u_ - vec2u_;
+  _ = vec3u_ - vec3u_;
+  _ = vec4u_ - vec4u_;
+  _ = vec2f_ - vec2f_;
+  _ = vec3f_ - vec3f_;
+  _ = vec4f_ - vec4f_;
+  _ = vec2h_ - vec2h_;
+  _ = vec3h_ - vec3h_;
+  _ = vec4h_ - vec4h_;
+  _ = mat2x2f_ - mat2x2f_;
+  _ = mat2x3f_ - mat2x3f_;
+  _ = mat2x4f_ - mat2x4f_;
+  _ = mat3x2f_ - mat3x2f_;
+  _ = mat3x3f_ - mat3x3f_;
+  _ = mat3x4f_ - mat3x4f_;
+  _ = mat4x2f_ - mat4x2f_;
+  _ = mat4x3f_ - mat4x3f_;
+  _ = mat4x4f_ - mat4x4f_;
+  _ = mat2x2h_ - mat2x2h_;
+  _ = mat2x3h_ - mat2x3h_;
+  _ = mat2x4h_ - mat2x4h_;
+  _ = mat3x2h_ - mat3x2h_;
+  _ = mat3x3h_ - mat3x3h_;
+  _ = mat3x4h_ - mat3x4h_;
+  _ = mat4x2h_ - mat4x2h_;
+  _ = mat4x3h_ - mat4x3h_;
+  _ = mat4x4h_ - mat4x4h_;
+  _ = i32_ + i32_;
+  _ = u32_ + u32_;
+  _ = f32_ + f32_;
+  _ = f16_ + f16_;
+  _ = vec2i_ + i32_;
+  _ = vec3i_ + i32_;
+  _ = vec4i_ + i32_;
+  _ = vec2u_ + u32_;
+  _ = vec3u_ + u32_;
+  _ = vec4u_ + u32_;
+  _ = vec2f_ + f32_;
+  _ = vec3f_ + f32_;
+  _ = vec4f_ + f32_;
+  _ = vec2h_ + f16_;
+  _ = vec3h_ + f16_;
+  _ = vec4h_ + f16_;
+  _ = i32_ + vec2i_;
+  _ = i32_ + vec3i_;
+  _ = i32_ + vec4i_;
+  _ = u32_ + vec2u_;
+  _ = u32_ + vec3u_;
+  _ = u32_ + vec4u_;
+  _ = f32_ + vec2f_;
+  _ = f32_ + vec3f_;
+  _ = f32_ + vec4f_;
+  _ = f16_ + vec2h_;
+  _ = f16_ + vec3h_;
+  _ = f16_ + vec4h_;
+  _ = vec2i_ + vec2i_;
+  _ = vec3i_ + vec3i_;
+  _ = vec4i_ + vec4i_;
+  _ = vec2u_ + vec2u_;
+  _ = vec3u_ + vec3u_;
+  _ = vec4u_ + vec4u_;
+  _ = vec2f_ + vec2f_;
+  _ = vec3f_ + vec3f_;
+  _ = vec4f_ + vec4f_;
+  _ = vec2h_ + vec2h_;
+  _ = vec3h_ + vec3h_;
+  _ = vec4h_ + vec4h_;
+  _ = mat2x2f_ + mat2x2f_;
+  _ = mat2x3f_ + mat2x3f_;
+  _ = mat2x4f_ + mat2x4f_;
+  _ = mat3x2f_ + mat3x2f_;
+  _ = mat3x3f_ + mat3x3f_;
+  _ = mat3x4f_ + mat3x4f_;
+  _ = mat4x2f_ + mat4x2f_;
+  _ = mat4x3f_ + mat4x3f_;
+  _ = mat4x4f_ + mat4x4f_;
+  _ = mat2x2h_ + mat2x2h_;
+  _ = mat2x3h_ + mat2x3h_;
+  _ = mat2x4h_ + mat2x4h_;
+  _ = mat3x2h_ + mat3x2h_;
+  _ = mat3x3h_ + mat3x3h_;
+  _ = mat3x4h_ + mat3x4h_;
+  _ = mat4x2h_ + mat4x2h_;
+  _ = mat4x3h_ + mat4x3h_;
+  _ = mat4x4h_ + mat4x4h_;
+  _ = i32_ % i32_;
+  _ = u32_ % u32_;
+  _ = f32_ % f32_;
+  _ = f16_ % f16_;
+  _ = vec2i_ % i32_;
+  _ = vec3i_ % i32_;
+  _ = vec4i_ % i32_;
+  _ = vec2u_ % u32_;
+  _ = vec3u_ % u32_;
+  _ = vec4u_ % u32_;
+  _ = vec2f_ % f32_;
+  _ = vec3f_ % f32_;
+  _ = vec4f_ % f32_;
+  _ = vec2h_ % f16_;
+  _ = vec3h_ % f16_;
+  _ = vec4h_ % f16_;
+  _ = i32_ % vec2i_;
+  _ = i32_ % vec3i_;
+  _ = i32_ % vec4i_;
+  _ = u32_ % vec2u_;
+  _ = u32_ % vec3u_;
+  _ = u32_ % vec4u_;
+  _ = f32_ % vec2f_;
+  _ = f32_ % vec3f_;
+  _ = f32_ % vec4f_;
+  _ = f16_ % vec2h_;
+  _ = f16_ % vec3h_;
+  _ = f16_ % vec4h_;
+  _ = vec2i_ % vec2i_;
+  _ = vec3i_ % vec3i_;
+  _ = vec4i_ % vec4i_;
+  _ = vec2u_ % vec2u_;
+  _ = vec3u_ % vec3u_;
+  _ = vec4u_ % vec4u_;
+  _ = vec2f_ % vec2f_;
+  _ = vec3f_ % vec3f_;
+  _ = vec4f_ % vec4f_;
+  _ = vec2h_ % vec2h_;
+  _ = vec3h_ % vec3h_;
+  _ = vec4h_ % vec4h_;
+  _ = i32_ * i32_;
+  _ = u32_ * u32_;
+  _ = f32_ * f32_;
+  _ = f16_ * f16_;
+  _ = vec2i_ * i32_;
+  _ = vec3i_ * i32_;
+  _ = vec4i_ * i32_;
+  _ = vec2u_ * u32_;
+  _ = vec3u_ * u32_;
+  _ = vec4u_ * u32_;
+  _ = vec2f_ * f32_;
+  _ = vec3f_ * f32_;
+  _ = vec4f_ * f32_;
+  _ = vec2h_ * f16_;
+  _ = vec3h_ * f16_;
+  _ = vec4h_ * f16_;
+  _ = i32_ * vec2i_;
+  _ = i32_ * vec3i_;
+  _ = i32_ * vec4i_;
+  _ = u32_ * vec2u_;
+  _ = u32_ * vec3u_;
+  _ = u32_ * vec4u_;
+  _ = f32_ * vec2f_;
+  _ = f32_ * vec3f_;
+  _ = f32_ * vec4f_;
+  _ = f16_ * vec2h_;
+  _ = f16_ * vec3h_;
+  _ = f16_ * vec4h_;
+  _ = vec2i_ * vec2i_;
+  _ = vec3i_ * vec3i_;
+  _ = vec4i_ * vec4i_;
+  _ = vec2u_ * vec2u_;
+  _ = vec3u_ * vec3u_;
+  _ = vec4u_ * vec4u_;
+  _ = vec2f_ * vec2f_;
+  _ = vec3f_ * vec3f_;
+  _ = vec4f_ * vec4f_;
+  _ = vec2h_ * vec2h_;
+  _ = vec3h_ * vec3h_;
+  _ = vec4h_ * vec4h_;
+  _ = mat2x2f_ * f32_;
+  _ = mat2x3f_ * f32_;
+  _ = mat2x4f_ * f32_;
+  _ = mat3x2f_ * f32_;
+  _ = mat3x3f_ * f32_;
+  _ = mat3x4f_ * f32_;
+  _ = mat4x2f_ * f32_;
+  _ = mat4x3f_ * f32_;
+  _ = mat4x4f_ * f32_;
+  _ = mat2x2h_ * f16_;
+  _ = mat2x3h_ * f16_;
+  _ = mat2x4h_ * f16_;
+  _ = mat3x2h_ * f16_;
+  _ = mat3x3h_ * f16_;
+  _ = mat3x4h_ * f16_;
+  _ = mat4x2h_ * f16_;
+  _ = mat4x3h_ * f16_;
+  _ = mat4x4h_ * f16_;
+  _ = f32_ * mat2x2f_;
+  _ = f32_ * mat2x3f_;
+  _ = f32_ * mat2x4f_;
+  _ = f32_ * mat3x2f_;
+  _ = f32_ * mat3x3f_;
+  _ = f32_ * mat3x4f_;
+  _ = f32_ * mat4x2f_;
+  _ = f32_ * mat4x3f_;
+  _ = f32_ * mat4x4f_;
+  _ = f16_ * mat2x2h_;
+  _ = f16_ * mat2x3h_;
+  _ = f16_ * mat2x4h_;
+  _ = f16_ * mat3x2h_;
+  _ = f16_ * mat3x3h_;
+  _ = f16_ * mat3x4h_;
+  _ = f16_ * mat4x2h_;
+  _ = f16_ * mat4x3h_;
+  _ = f16_ * mat4x4h_;
+  _ = mat2x2f_ * vec2f_;
+  _ = mat2x3f_ * vec2f_;
+  _ = mat2x4f_ * vec2f_;
+  _ = mat3x2f_ * vec3f_;
+  _ = mat3x3f_ * vec3f_;
+  _ = mat3x4f_ * vec3f_;
+  _ = mat4x2f_ * vec4f_;
+  _ = mat4x3f_ * vec4f_;
+  _ = mat4x4f_ * vec4f_;
+  _ = mat2x2h_ * vec2h_;
+  _ = mat2x3h_ * vec2h_;
+  _ = mat2x4h_ * vec2h_;
+  _ = mat3x2h_ * vec3h_;
+  _ = mat3x3h_ * vec3h_;
+  _ = mat3x4h_ * vec3h_;
+  _ = mat4x2h_ * vec4h_;
+  _ = mat4x3h_ * vec4h_;
+  _ = mat4x4h_ * vec4h_;
+  _ = vec2f_ * mat2x2f_;
+  _ = vec3f_ * mat2x3f_;
+  _ = vec4f_ * mat2x4f_;
+  _ = vec2f_ * mat3x2f_;
+  _ = vec3f_ * mat3x3f_;
+  _ = vec4f_ * mat3x4f_;
+  _ = vec2f_ * mat4x2f_;
+  _ = vec3f_ * mat4x3f_;
+  _ = vec4f_ * mat4x4f_;
+  _ = vec2h_ * mat2x2h_;
+  _ = vec3h_ * mat2x3h_;
+  _ = vec4h_ * mat2x4h_;
+  _ = vec2h_ * mat3x2h_;
+  _ = vec3h_ * mat3x3h_;
+  _ = vec4h_ * mat3x4h_;
+  _ = vec2h_ * mat4x2h_;
+  _ = vec3h_ * mat4x3h_;
+  _ = vec4h_ * mat4x4h_;
+  _ = mat2x2f_ * mat2x2f_;
+  _ = mat3x2f_ * mat2x3f_;
+  _ = mat4x2f_ * mat2x4f_;
+  _ = mat2x3f_ * mat2x2f_;
+  _ = mat3x3f_ * mat2x3f_;
+  _ = mat4x3f_ * mat2x4f_;
+  _ = mat2x4f_ * mat2x2f_;
+  _ = mat3x4f_ * mat2x3f_;
+  _ = mat4x4f_ * mat2x4f_;
+  _ = mat2x2f_ * mat3x2f_;
+  _ = mat3x2f_ * mat3x3f_;
+  _ = mat4x2f_ * mat3x4f_;
+  _ = mat2x3f_ * mat3x2f_;
+  _ = mat3x3f_ * mat3x3f_;
+  _ = mat4x3f_ * mat3x4f_;
+  _ = mat2x4f_ * mat3x2f_;
+  _ = mat3x4f_ * mat3x3f_;
+  _ = mat4x4f_ * mat3x4f_;
+  _ = mat2x2f_ * mat4x2f_;
+  _ = mat3x2f_ * mat4x3f_;
+  _ = mat4x2f_ * mat4x4f_;
+  _ = mat2x3f_ * mat4x2f_;
+  _ = mat3x3f_ * mat4x3f_;
+  _ = mat4x3f_ * mat4x4f_;
+  _ = mat2x4f_ * mat4x2f_;
+  _ = mat3x4f_ * mat4x3f_;
+  _ = mat4x4f_ * mat4x4f_;
+  _ = mat2x2h_ * mat2x2h_;
+  _ = mat3x2h_ * mat2x3h_;
+  _ = mat4x2h_ * mat2x4h_;
+  _ = mat2x3h_ * mat2x2h_;
+  _ = mat3x3h_ * mat2x3h_;
+  _ = mat4x3h_ * mat2x4h_;
+  _ = mat2x4h_ * mat2x2h_;
+  _ = mat3x4h_ * mat2x3h_;
+  _ = mat4x4h_ * mat2x4h_;
+  _ = mat2x2h_ * mat3x2h_;
+  _ = mat3x2h_ * mat3x3h_;
+  _ = mat4x2h_ * mat3x4h_;
+  _ = mat2x3h_ * mat3x2h_;
+  _ = mat3x3h_ * mat3x3h_;
+  _ = mat4x3h_ * mat3x4h_;
+  _ = mat2x4h_ * mat3x2h_;
+  _ = mat3x4h_ * mat3x3h_;
+  _ = mat4x4h_ * mat3x4h_;
+  _ = mat2x2h_ * mat4x2h_;
+  _ = mat3x2h_ * mat4x3h_;
+  _ = mat4x2h_ * mat4x4h_;
+  _ = mat2x3h_ * mat4x2h_;
+  _ = mat3x3h_ * mat4x3h_;
+  _ = mat4x3h_ * mat4x4h_;
+  _ = mat2x4h_ * mat4x2h_;
+  _ = mat3x4h_ * mat4x3h_;
+  _ = mat4x4h_ * mat4x4h_;
+  _ = i32_ / i32_;
+  _ = u32_ / u32_;
+  _ = f32_ / f32_;
+  _ = f16_ / f16_;
+  _ = vec2i_ / i32_;
+  _ = vec3i_ / i32_;
+  _ = vec4i_ / i32_;
+  _ = vec2u_ / u32_;
+  _ = vec3u_ / u32_;
+  _ = vec4u_ / u32_;
+  _ = vec2f_ / f32_;
+  _ = vec3f_ / f32_;
+  _ = vec4f_ / f32_;
+  _ = vec2h_ / f16_;
+  _ = vec3h_ / f16_;
+  _ = vec4h_ / f16_;
+  _ = i32_ / vec2i_;
+  _ = i32_ / vec3i_;
+  _ = i32_ / vec4i_;
+  _ = u32_ / vec2u_;
+  _ = u32_ / vec3u_;
+  _ = u32_ / vec4u_;
+  _ = f32_ / vec2f_;
+  _ = f32_ / vec3f_;
+  _ = f32_ / vec4f_;
+  _ = f16_ / vec2h_;
+  _ = f16_ / vec3h_;
+  _ = f16_ / vec4h_;
+  _ = vec2i_ / vec2i_;
+  _ = vec3i_ / vec3i_;
+  _ = vec4i_ / vec4i_;
+  _ = vec2u_ / vec2u_;
+  _ = vec3u_ / vec3u_;
+  _ = vec4u_ / vec4u_;
+  _ = vec2f_ / vec2f_;
+  _ = vec3f_ / vec3f_;
+  _ = vec4f_ / vec4f_;
+  _ = vec2h_ / vec2h_;
+  _ = vec3h_ / vec3h_;
+  _ = vec4h_ / vec4h_;
+  _ = i32_ % i32_;
+  _ = u32_ % u32_;
+  _ = f32_ % f32_;
+  _ = f16_ % f16_;
+  _ = vec2i_ % i32_;
+  _ = vec3i_ % i32_;
+  _ = vec4i_ % i32_;
+  _ = vec2u_ % u32_;
+  _ = vec3u_ % u32_;
+  _ = vec4u_ % u32_;
+  _ = vec2f_ % f32_;
+  _ = vec3f_ % f32_;
+  _ = vec4f_ % f32_;
+  _ = vec2h_ % f16_;
+  _ = vec3h_ % f16_;
+  _ = vec4h_ % f16_;
+  _ = i32_ % vec2i_;
+  _ = i32_ % vec3i_;
+  _ = i32_ % vec4i_;
+  _ = u32_ % vec2u_;
+  _ = u32_ % vec3u_;
+  _ = u32_ % vec4u_;
+  _ = f32_ % vec2f_;
+  _ = f32_ % vec3f_;
+  _ = f32_ % vec4f_;
+  _ = f16_ % vec2h_;
+  _ = f16_ % vec3h_;
+  _ = f16_ % vec4h_;
+  _ = vec2i_ % vec2i_;
+  _ = vec3i_ % vec3i_;
+  _ = vec4i_ % vec4i_;
+  _ = vec2u_ % vec2u_;
+  _ = vec3u_ % vec3u_;
+  _ = vec4u_ % vec4u_;
+  _ = vec2f_ % vec2f_;
+  _ = vec3f_ % vec3f_;
+  _ = vec4f_ % vec4f_;
+  _ = vec2h_ % vec2h_;
+  _ = vec3h_ % vec3h_;
+  _ = vec4h_ % vec4h_;
+  _ = i32_ == i32_;
+  _ = u32_ == u32_;
+  _ = f32_ == f32_;
+  _ = f16_ == f16_;
+  _ = bool_ == bool_;
+  _ = vec2i_ == vec2i_;
+  _ = vec3i_ == vec3i_;
+  _ = vec4i_ == vec4i_;
+  _ = vec2u_ == vec2u_;
+  _ = vec3u_ == vec3u_;
+  _ = vec4u_ == vec4u_;
+  _ = vec2f_ == vec2f_;
+  _ = vec3f_ == vec3f_;
+  _ = vec4f_ == vec4f_;
+  _ = vec2h_ == vec2h_;
+  _ = vec3h_ == vec3h_;
+  _ = vec4h_ == vec4h_;
+  _ = vec2b_ == vec2b_;
+  _ = vec3b_ == vec3b_;
+  _ = vec4b_ == vec4b_;
+  _ = i32_ != i32_;
+  _ = u32_ != u32_;
+  _ = f32_ != f32_;
+  _ = f16_ != f16_;
+  _ = bool_ != bool_;
+  _ = vec2i_ != vec2i_;
+  _ = vec3i_ != vec3i_;
+  _ = vec4i_ != vec4i_;
+  _ = vec2u_ != vec2u_;
+  _ = vec3u_ != vec3u_;
+  _ = vec4u_ != vec4u_;
+  _ = vec2f_ != vec2f_;
+  _ = vec3f_ != vec3f_;
+  _ = vec4f_ != vec4f_;
+  _ = vec2h_ != vec2h_;
+  _ = vec3h_ != vec3h_;
+  _ = vec4h_ != vec4h_;
+  _ = vec2b_ != vec2b_;
+  _ = vec3b_ != vec3b_;
+  _ = vec4b_ != vec4b_;
+  _ = i32_ < i32_;
+  _ = u32_ < u32_;
+  _ = f32_ < f32_;
+  _ = f16_ < f16_;
+  _ = vec2i_ < vec2i_;
+  _ = vec3i_ < vec3i_;
+  _ = vec4i_ < vec4i_;
+  _ = vec2u_ < vec2u_;
+  _ = vec3u_ < vec3u_;
+  _ = vec4u_ < vec4u_;
+  _ = vec2f_ < vec2f_;
+  _ = vec3f_ < vec3f_;
+  _ = vec4f_ < vec4f_;
+  _ = vec2h_ < vec2h_;
+  _ = vec3h_ < vec3h_;
+  _ = vec4h_ < vec4h_;
+  _ = i32_ <= i32_;
+  _ = u32_ <= u32_;
+  _ = f32_ <= f32_;
+  _ = f16_ <= f16_;
+  _ = vec2i_ <= vec2i_;
+  _ = vec3i_ <= vec3i_;
+  _ = vec4i_ <= vec4i_;
+  _ = vec2u_ <= vec2u_;
+  _ = vec3u_ <= vec3u_;
+  _ = vec4u_ <= vec4u_;
+  _ = vec2f_ <= vec2f_;
+  _ = vec3f_ <= vec3f_;
+  _ = vec4f_ <= vec4f_;
+  _ = vec2h_ <= vec2h_;
+  _ = vec3h_ <= vec3h_;
+  _ = vec4h_ <= vec4h_;
+  _ = i32_ > i32_;
+  _ = u32_ > u32_;
+  _ = f32_ > f32_;
+  _ = f16_ > f16_;
+  _ = vec2i_ > vec2i_;
+  _ = vec3i_ > vec3i_;
+  _ = vec4i_ > vec4i_;
+  _ = vec2u_ > vec2u_;
+  _ = vec3u_ > vec3u_;
+  _ = vec4u_ > vec4u_;
+  _ = vec2f_ > vec2f_;
+  _ = vec3f_ > vec3f_;
+  _ = vec4f_ > vec4f_;
+  _ = vec2h_ > vec2h_;
+  _ = vec3h_ > vec3h_;
+  _ = vec4h_ > vec4h_;
+  _ = i32_ >= i32_;
+  _ = u32_ >= u32_;
+  _ = f32_ >= f32_;
+  _ = f16_ >= f16_;
+  _ = vec2i_ >= vec2i_;
+  _ = vec3i_ >= vec3i_;
+  _ = vec4i_ >= vec4i_;
+  _ = vec2u_ >= vec2u_;
+  _ = vec3u_ >= vec3u_;
+  _ = vec4u_ >= vec4u_;
+  _ = vec2f_ >= vec2f_;
+  _ = vec3f_ >= vec3f_;
+  _ = vec4f_ >= vec4f_;
+  _ = vec2h_ >= vec2h_;
+  _ = vec3h_ >= vec3h_;
+  _ = vec4h_ >= vec4h_;
+  _ = ~i32_;
+  _ = ~u32_;
+  _ = ~vec2i_;
+  _ = ~vec3i_;
+  _ = ~vec4i_;
+  _ = ~vec2u_;
+  _ = ~vec3u_;
+  _ = ~vec4u_;
+  _ = i32_ ^ i32_;
+  _ = u32_ ^ u32_;
+  _ = vec2i_ ^ vec2i_;
+  _ = vec3i_ ^ vec3i_;
+  _ = vec4i_ ^ vec4i_;
+  _ = vec2u_ ^ vec2u_;
+  _ = vec3u_ ^ vec3u_;
+  _ = vec4u_ ^ vec4u_;
+  _ = i32_ << u32_;
+  _ = u32_ << u32_;
+  _ = vec2i_ << vec2u_;
+  _ = vec3i_ << vec3u_;
+  _ = vec4i_ << vec4u_;
+  _ = vec2u_ << vec2u_;
+  _ = vec3u_ << vec3u_;
+  _ = vec4u_ << vec4u_;
+  _ = i32_ >> u32_;
+  _ = u32_ >> u32_;
+  _ = vec2i_ >> vec2u_;
+  _ = vec3i_ >> vec3u_;
+  _ = vec4i_ >> vec4u_;
+  _ = vec2u_ >> vec2u_;
+  _ = vec3u_ >> vec3u_;
+  _ = vec4u_ >> vec4u_;
+
+  _ = bool();
+  _ = bool(i32_);
+  _ = bool(u32_);
+  _ = bool(f32_);
+  _ = bool(f16_);
+  _ = bool(bool_);
+  _ = i32();
+  _ = i32(i32_);
+  _ = i32(u32_);
+  _ = i32(f32_);
+  _ = i32(f16_);
+  _ = i32(bool_);
+  _ = u32();
+  _ = u32(i32_);
+  _ = u32(u32_);
+  _ = u32(f32_);
+  _ = u32(f16_);
+  _ = u32(bool_);
+  _ = f32();
+  _ = f32(i32_);
+  _ = f32(u32_);
+  _ = f32(f32_);
+  _ = f32(f16_);
+  _ = f32(bool_);
+  _ = f16();
+  _ = f16(i32_);
+  _ = f16(u32_);
+  _ = f16(f32_);
+  _ = f16(f16_);
+  _ = f16(bool_);
+  _ = vec2();
+  _ = vec2();
+  _ = vec2();
+  _ = vec2();
+  _ = vec2();
+  _ = vec2(i32_);
+  _ = vec2(u32_);
+  _ = vec2(f32_);
+  _ = vec2(f16_);
+  _ = vec2(bool_);
+  _ = vec2(vec2i_);
+  _ = vec2(vec2u_);
+  _ = vec2(vec2f_);
+  _ = vec2(vec2h_);
+  _ = vec2(vec2b_);
+  _ = vec2(vec2i_);
+  _ = vec2(vec2u_);
+  _ = vec2(vec2f_);
+  _ = vec2(vec2h_);
+  _ = vec2(vec2b_);
+  _ = vec2(vec2i_);
+  _ = vec2(vec2u_);
+  _ = vec2(vec2f_);
+  _ = vec2(vec2h_);
+  _ = vec2(vec2b_);
+  _ = vec2(vec2i_);
+  _ = vec2(vec2u_);
+  _ = vec2(vec2f_);
+  _ = vec2(vec2h_);
+  _ = vec2(vec2b_);
+  _ = vec2(vec2i_);
+  _ = vec2(vec2u_);
+  _ = vec2(vec2f_);
+  _ = vec2(vec2h_);
+  _ = vec2(vec2b_);
+  _ = vec2(vec2i_);
+  _ = vec2(vec2u_);
+  _ = vec2(vec2f_);
+  _ = vec2(vec2h_);
+  _ = vec2(vec2b_);
+  _ = vec2(i32_, i32_);
+  _ = vec2(u32_, u32_);
+  _ = vec2(f32_, f32_);
+  _ = vec2(f16_, f16_);
+  _ = vec2(bool_, bool_);
+  _ = vec2();
+  _ = vec3();
+  _ = vec3();
+  _ = vec3();
+  _ = vec3();
+  _ = vec3();
+  _ = vec3(i32_);
+  _ = vec3(u32_);
+  _ = vec3(f32_);
+  _ = vec3(f16_);
+  _ = vec3(bool_);
+  _ = vec3(vec3i_);
+  _ = vec3(vec3u_);
+  _ = vec3(vec3f_);
+  _ = vec3(vec3h_);
+  _ = vec3(vec3b_);
+  _ = vec3(vec3i_);
+  _ = vec3(vec3u_);
+  _ = vec3(vec3f_);
+  _ = vec3(vec3h_);
+  _ = vec3(vec3b_);
+  _ = vec3(vec3i_);
+  _ = vec3(vec3u_);
+  _ = vec3(vec3f_);
+  _ = vec3(vec3h_);
+  _ = vec3(vec3b_);
+  _ = vec3(vec3i_);
+  _ = vec3(vec3u_);
+  _ = vec3(vec3f_);
+  _ = vec3(vec3h_);
+  _ = vec3(vec3b_);
+  _ = vec3(vec3i_);
+  _ = vec3(vec3u_);
+  _ = vec3(vec3f_);
+  _ = vec3(vec3h_);
+  _ = vec3(vec3b_);
+  _ = vec3(vec3i_);
+  _ = vec3(vec3u_);
+  _ = vec3(vec3f_);
+  _ = vec3(vec3h_);
+  _ = vec3(vec3b_);
+  _ = vec3(i32_, i32_, i32_);
+  _ = vec3(u32_, u32_, u32_);
+  _ = vec3(f32_, f32_, f32_);
+  _ = vec3(f16_, f16_, f16_);
+  _ = vec3(bool_, bool_, bool_);
+  _ = vec3(vec2i_, i32_);
+  _ = vec3(vec2u_, u32_);
+  _ = vec3(vec2f_, f32_);
+  _ = vec3(vec2h_, f16_);
+  _ = vec3(vec2b_, bool_);
+  _ = vec3(i32_, vec2i_);
+  _ = vec3(u32_, vec2u_);
+  _ = vec3(f32_, vec2f_);
+  _ = vec3(f16_, vec2h_);
+  _ = vec3(bool_, vec2b_);
+  _ = vec3();
+  _ = vec4();
+  _ = vec4();
+  _ = vec4();
+  _ = vec4();
+  _ = vec4();
+  _ = vec4(i32_);
+  _ = vec4(u32_);
+  _ = vec4(f32_);
+  _ = vec4(f16_);
+  _ = vec4(bool_);
+  _ = vec4(vec4i_);
+  _ = vec4(vec4u_);
+  _ = vec4(vec4f_);
+  _ = vec4(vec4h_);
+  _ = vec4(vec4b_);
+  _ = vec4(vec4i_);
+  _ = vec4(vec4u_);
+  _ = vec4(vec4f_);
+  _ = vec4(vec4h_);
+  _ = vec4(vec4b_);
+  _ = vec4(vec4i_);
+  _ = vec4(vec4u_);
+  _ = vec4(vec4f_);
+  _ = vec4(vec4h_);
+  _ = vec4(vec4b_);
+  _ = vec4(vec4i_);
+  _ = vec4(vec4u_);
+  _ = vec4(vec4f_);
+  _ = vec4(vec4h_);
+  _ = vec4(vec4b_);
+  _ = vec4(vec4i_);
+  _ = vec4(vec4u_);
+  _ = vec4(vec4f_);
+  _ = vec4(vec4h_);
+  _ = vec4(vec4b_);
+  _ = vec4(vec4i_);
+  _ = vec4(vec4u_);
+  _ = vec4(vec4f_);
+  _ = vec4(vec4h_);
+  _ = vec4(vec4b_);
+  _ = vec4(i32_, i32_, i32_, i32_);
+  _ = vec4(u32_, u32_, u32_, u32_);
+  _ = vec4(f32_, f32_, f32_, f32_);
+  _ = vec4(f16_, f16_, f16_, f16_);
+  _ = vec4(bool_, bool_, bool_, bool_);
+  _ = vec4(i32_, vec2i_, i32_);
+  _ = vec4(u32_, vec2u_, u32_);
+  _ = vec4(f32_, vec2f_, f32_);
+  _ = vec4(f16_, vec2h_, f16_);
+  _ = vec4(bool_, vec2b_, bool_);
+  _ = vec4(i32_, i32_, vec2i_);
+  _ = vec4(u32_, u32_, vec2u_);
+  _ = vec4(f32_, f32_, vec2f_);
+  _ = vec4(f16_, f16_, vec2h_);
+  _ = vec4(bool_, bool_, vec2b_);
+  _ = vec4(vec2i_, i32_, i32_);
+  _ = vec4(vec2u_, u32_, u32_);
+  _ = vec4(vec2f_, f32_, f32_);
+  _ = vec4(vec2h_, f16_, f16_);
+  _ = vec4(vec2b_, bool_, bool_);
+  _ = vec4(vec2i_, vec2i_);
+  _ = vec4(vec2u_, vec2u_);
+  _ = vec4(vec2f_, vec2f_);
+  _ = vec4(vec2h_, vec2h_);
+  _ = vec4(vec2b_, vec2b_);
+  _ = vec4(vec3i_, i32_);
+  _ = vec4(vec3u_, u32_);
+  _ = vec4(vec3f_, f32_);
+  _ = vec4(vec3h_, f16_);
+  _ = vec4(vec3b_, bool_);
+  _ = vec4(i32_, vec3i_);
+  _ = vec4(u32_, vec3u_);
+  _ = vec4(f32_, vec3f_);
+  _ = vec4(f16_, vec3h_);
+  _ = vec4(bool_, vec3b_);
+  _ = vec4();
+  _ = mat2x2(mat2x2f_);
+  _ = mat2x2(mat2x2h_);
+  _ = mat2x2(mat2x2f_);
+  _ = mat2x2(mat2x2h_);
+  _ = mat2x2(mat2x2f_);
+  _ = mat2x2(mat2x2h_);
+  _ = mat2x2(f32_, f32_, f32_, f32_);
+  _ = mat2x2(f16_, f16_, f16_, f16_);
+  _ = mat2x2(vec2f_, vec2f_);
+  _ = mat2x2(vec2h_, vec2h_);
+  _ = mat2x3(mat2x3f_);
+  _ = mat2x3(mat2x3h_);
+  _ = mat2x3(mat2x3f_);
+  _ = mat2x3(mat2x3h_);
+  _ = mat2x3(mat2x3f_);
+  _ = mat2x3(mat2x3h_);
+  _ = mat2x3(f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat2x3(f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat2x3(vec3f_, vec3f_);
+  _ = mat2x3(vec3h_, vec3h_);
+  _ = mat2x4(mat2x4f_);
+  _ = mat2x4(mat2x4h_);
+  _ = mat2x4(mat2x4f_);
+  _ = mat2x4(mat2x4h_);
+  _ = mat2x4(mat2x4f_);
+  _ = mat2x4(mat2x4h_);
+  _ = mat2x4(f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat2x4(f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat2x4(vec4f_, vec4f_);
+  _ = mat2x4(vec4h_, vec4h_);
+  _ = mat3x2(mat3x2f_);
+  _ = mat3x2(mat3x2h_);
+  _ = mat3x2(mat3x2f_);
+  _ = mat3x2(mat3x2h_);
+  _ = mat3x2(mat3x2f_);
+  _ = mat3x2(mat3x2h_);
+  _ = mat3x2(f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat3x2(f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat3x2(vec2f_, vec2f_, vec2f_);
+  _ = mat3x2(vec2h_, vec2h_, vec2h_);
+  _ = mat3x3(mat3x3f_);
+  _ = mat3x3(mat3x3h_);
+  _ = mat3x3(mat3x3f_);
+  _ = mat3x3(mat3x3h_);
+  _ = mat3x3(mat3x3f_);
+  _ = mat3x3(mat3x3h_);
+  _ = mat3x3(f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat3x3(f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat3x3(vec3f_, vec3f_, vec3f_);
+  _ = mat3x3(vec3h_, vec3h_, vec3h_);
+  _ = mat3x4(mat3x4f_);
+  _ = mat3x4(mat3x4h_);
+  _ = mat3x4(mat3x4f_);
+  _ = mat3x4(mat3x4h_);
+  _ = mat3x4(mat3x4f_);
+  _ = mat3x4(mat3x4h_);
+  _ = mat3x4(f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat3x4(f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat3x4(vec4f_, vec4f_, vec4f_);
+  _ = mat3x4(vec4h_, vec4h_, vec4h_);
+  _ = mat4x2(mat4x2f_);
+  _ = mat4x2(mat4x2h_);
+  _ = mat4x2(mat4x2f_);
+  _ = mat4x2(mat4x2h_);
+  _ = mat4x2(mat4x2f_);
+  _ = mat4x2(mat4x2h_);
+  _ = mat4x2(f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat4x2(f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat4x2(vec2f_, vec2f_, vec2f_, vec2f_);
+  _ = mat4x2(vec2h_, vec2h_, vec2h_, vec2h_);
+  _ = mat4x3(mat4x3f_);
+  _ = mat4x3(mat4x3h_);
+  _ = mat4x3(mat4x3f_);
+  _ = mat4x3(mat4x3h_);
+  _ = mat4x3(mat4x3f_);
+  _ = mat4x3(mat4x3h_);
+  _ = mat4x3(f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat4x3(f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat4x3(vec3f_, vec3f_, vec3f_, vec3f_);
+  _ = mat4x3(vec3h_, vec3h_, vec3h_, vec3h_);
+  _ = mat4x4(mat4x4f_);
+  _ = mat4x4(mat4x4h_);
+  _ = mat4x4(mat4x4f_);
+  _ = mat4x4(mat4x4h_);
+  _ = mat4x4(mat4x4f_);
+  _ = mat4x4(mat4x4h_);
+  _ = mat4x4(f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_, f32_);
+  _ = mat4x4(f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_, f16_);
+  _ = mat4x4(vec4f_, vec4f_, vec4f_, vec4f_);
+  _ = mat4x4(vec4h_, vec4h_, vec4h_, vec4h_);
+
+  _ = all(vec2b_);
+  _ = all(vec3b_);
+  _ = all(vec4b_);
+  _ = all(bool_);
+  _ = all(bool_);
+  _ = all(bool_);
+  _ = any(vec2b_);
+  _ = any(vec3b_);
+  _ = any(vec4b_);
+  _ = any(bool_);
+  _ = any(bool_);
+  _ = any(bool_);
+  _ = select(i32_, i32_, bool_);
+  _ = select(u32_, u32_, bool_);
+  _ = select(f32_, f32_, bool_);
+  _ = select(f16_, f16_, bool_);
+  _ = select(bool_, bool_, bool_);
+  _ = select(vec2i_, vec2i_, bool_);
+  _ = select(vec3i_, vec3i_, bool_);
+  _ = select(vec4i_, vec4i_, bool_);
+  _ = select(vec2u_, vec2u_, bool_);
+  _ = select(vec3u_, vec3u_, bool_);
+  _ = select(vec4u_, vec4u_, bool_);
+  _ = select(vec2f_, vec2f_, bool_);
+  _ = select(vec3f_, vec3f_, bool_);
+  _ = select(vec4f_, vec4f_, bool_);
+  _ = select(vec2h_, vec2h_, bool_);
+  _ = select(vec3h_, vec3h_, bool_);
+  _ = select(vec4h_, vec4h_, bool_);
+  _ = select(vec2b_, vec2b_, bool_);
+  _ = select(vec3b_, vec3b_, bool_);
+  _ = select(vec4b_, vec4b_, bool_);
+  _ = select(vec2i_, vec2i_, vec2b_);
+  _ = select(vec3i_, vec3i_, vec3b_);
+  _ = select(vec4i_, vec4i_, vec4b_);
+  _ = select(vec2u_, vec2u_, vec2b_);
+  _ = select(vec3u_, vec3u_, vec3b_);
+  _ = select(vec4u_, vec4u_, vec4b_);
+  _ = select(vec2f_, vec2f_, vec2b_);
+  _ = select(vec3f_, vec3f_, vec3b_);
+  _ = select(vec4f_, vec4f_, vec4b_);
+  _ = select(vec2h_, vec2h_, vec2b_);
+  _ = select(vec3h_, vec3h_, vec3b_);
+  _ = select(vec4h_, vec4h_, vec4b_);
+  _ = select(vec2b_, vec2b_, vec2b_);
+  _ = select(vec3b_, vec3b_, vec3b_);
+  _ = select(vec4b_, vec4b_, vec4b_);
+  _ = acos(f32_);
+  _ = acos(f16_);
+  _ = acos(vec2f_);
+  _ = acos(vec3f_);
+  _ = acos(vec4f_);
+  _ = acos(vec2h_);
+  _ = acos(vec3h_);
+  _ = acos(vec4h_);
+  _ = asin(f32_);
+  _ = asin(f16_);
+  _ = asin(vec2f_);
+  _ = asin(vec3f_);
+  _ = asin(vec4f_);
+  _ = asin(vec2h_);
+  _ = asin(vec3h_);
+  _ = asin(vec4h_);
+  _ = atan(f32_);
+  _ = atan(f16_);
+  _ = atan(vec2f_);
+  _ = atan(vec3f_);
+  _ = atan(vec4f_);
+  _ = atan(vec2h_);
+  _ = atan(vec3h_);
+  _ = atan(vec4h_);
+  _ = cos(f32_);
+  _ = cos(f16_);
+  _ = cos(vec2f_);
+  _ = cos(vec3f_);
+  _ = cos(vec4f_);
+  _ = cos(vec2h_);
+  _ = cos(vec3h_);
+  _ = cos(vec4h_);
+  _ = sin(f32_);
+  _ = sin(f16_);
+  _ = sin(vec2f_);
+  _ = sin(vec3f_);
+  _ = sin(vec4f_);
+  _ = sin(vec2h_);
+  _ = sin(vec3h_);
+  _ = sin(vec4h_);
+  _ = tan(f32_);
+  _ = tan(f16_);
+  _ = tan(vec2f_);
+  _ = tan(vec3f_);
+  _ = tan(vec4f_);
+  _ = tan(vec2h_);
+  _ = tan(vec3h_);
+  _ = tan(vec4h_);
+  _ = acosh(1f);
+  _ = acosh(1h);
+  _ = acosh(vec2f(1));
+  _ = acosh(vec3f(1));
+  _ = acosh(vec4f(1));
+  _ = acosh(vec2h(1));
+  _ = acosh(vec3h(1));
+  _ = acosh(vec4h(1));
+  _ = asinh(f32_);
+  _ = asinh(f16_);
+  _ = asinh(vec2f_);
+  _ = asinh(vec3f_);
+  _ = asinh(vec4f_);
+  _ = asinh(vec2h_);
+  _ = asinh(vec3h_);
+  _ = asinh(vec4h_);
+  _ = atanh(f32_);
+  _ = atanh(f16_);
+  _ = atanh(vec2f_);
+  _ = atanh(vec3f_);
+  _ = atanh(vec4f_);
+  _ = atanh(vec2h_);
+  _ = atanh(vec3h_);
+  _ = atanh(vec4h_);
+  _ = cosh(f32_);
+  _ = cosh(f16_);
+  _ = cosh(vec2f_);
+  _ = cosh(vec3f_);
+  _ = cosh(vec4f_);
+  _ = cosh(vec2h_);
+  _ = cosh(vec3h_);
+  _ = cosh(vec4h_);
+  _ = sinh(f32_);
+  _ = sinh(f16_);
+  _ = sinh(vec2f_);
+  _ = sinh(vec3f_);
+  _ = sinh(vec4f_);
+  _ = sinh(vec2h_);
+  _ = sinh(vec3h_);
+  _ = sinh(vec4h_);
+  _ = tanh(f32_);
+  _ = tanh(f16_);
+  _ = tanh(vec2f_);
+  _ = tanh(vec3f_);
+  _ = tanh(vec4f_);
+  _ = tanh(vec2h_);
+  _ = tanh(vec3h_);
+  _ = tanh(vec4h_);
+  _ = abs(i32_);
+  _ = abs(u32_);
+  _ = abs(f32_);
+  _ = abs(f16_);
+  _ = abs(vec2i_);
+  _ = abs(vec3i_);
+  _ = abs(vec4i_);
+  _ = abs(vec2u_);
+  _ = abs(vec3u_);
+  _ = abs(vec4u_);
+  _ = abs(vec2f_);
+  _ = abs(vec3f_);
+  _ = abs(vec4f_);
+  _ = abs(vec2h_);
+  _ = abs(vec3h_);
+  _ = abs(vec4h_);
+  _ = atan2(f32_, f32_);
+  _ = atan2(f16_, f16_);
+  _ = atan2(vec2f_, vec2f_);
+  _ = atan2(vec3f_, vec3f_);
+  _ = atan2(vec4f_, vec4f_);
+  _ = atan2(vec2h_, vec2h_);
+  _ = atan2(vec3h_, vec3h_);
+  _ = atan2(vec4h_, vec4h_);
+  _ = ceil(f32_);
+  _ = ceil(f16_);
+  _ = ceil(vec2f_);
+  _ = ceil(vec3f_);
+  _ = ceil(vec4f_);
+  _ = ceil(vec2h_);
+  _ = ceil(vec3h_);
+  _ = ceil(vec4h_);
+  _ = clamp(i32_, i32_, i32_);
+  _ = clamp(u32_, u32_, u32_);
+  _ = clamp(f32_, f32_, f32_);
+  _ = clamp(f16_, f16_, f16_);
+  _ = clamp(vec2i_, vec2i_, vec2i_);
+  _ = clamp(vec3i_, vec3i_, vec3i_);
+  _ = clamp(vec4i_, vec4i_, vec4i_);
+  _ = clamp(vec2u_, vec2u_, vec2u_);
+  _ = clamp(vec3u_, vec3u_, vec3u_);
+  _ = clamp(vec4u_, vec4u_, vec4u_);
+  _ = clamp(vec2f_, vec2f_, vec2f_);
+  _ = clamp(vec3f_, vec3f_, vec3f_);
+  _ = clamp(vec4f_, vec4f_, vec4f_);
+  _ = clamp(vec2h_, vec2h_, vec2h_);
+  _ = clamp(vec3h_, vec3h_, vec3h_);
+  _ = clamp(vec4h_, vec4h_, vec4h_);
+  _ = countLeadingZeros(i32_);
+  _ = countLeadingZeros(u32_);
+  _ = countLeadingZeros(vec2i_);
+  _ = countLeadingZeros(vec3i_);
+  _ = countLeadingZeros(vec4i_);
+  _ = countLeadingZeros(vec2u_);
+  _ = countLeadingZeros(vec3u_);
+  _ = countLeadingZeros(vec4u_);
+  _ = countOneBits(i32_);
+  _ = countOneBits(u32_);
+  _ = countOneBits(vec2i_);
+  _ = countOneBits(vec3i_);
+  _ = countOneBits(vec4i_);
+  _ = countOneBits(vec2u_);
+  _ = countOneBits(vec3u_);
+  _ = countOneBits(vec4u_);
+  _ = countTrailingZeros(i32_);
+  _ = countTrailingZeros(u32_);
+  _ = countTrailingZeros(vec2i_);
+  _ = countTrailingZeros(vec3i_);
+  _ = countTrailingZeros(vec4i_);
+  _ = countTrailingZeros(vec2u_);
+  _ = countTrailingZeros(vec3u_);
+  _ = countTrailingZeros(vec4u_);
+  _ = cross(vec3f_, vec3f_);
+  _ = cross(vec3h_, vec3h_);
+  _ = degrees(f32_);
+  _ = degrees(f16_);
+  _ = degrees(vec2f_);
+  _ = degrees(vec3f_);
+  _ = degrees(vec4f_);
+  _ = degrees(vec2h_);
+  _ = degrees(vec3h_);
+  _ = degrees(vec4h_);
+  _ = determinant(mat2x2f_);
+  _ = determinant(mat3x3f_);
+  _ = determinant(mat4x4f_);
+  _ = determinant(mat2x2h_);
+  _ = determinant(mat3x3h_);
+  _ = determinant(mat4x4h_);
+  _ = distance(f32_, f32_);
+  _ = distance(f16_, f16_);
+  _ = distance(vec2f_, vec2f_);
+  _ = distance(vec3f_, vec3f_);
+  _ = distance(vec4f_, vec4f_);
+  _ = distance(vec2h_, vec2h_);
+  _ = distance(vec3h_, vec3h_);
+  _ = distance(vec4h_, vec4h_);
+  _ = dot(vec2i_, vec2i_);
+  _ = dot(vec3i_, vec3i_);
+  _ = dot(vec4i_, vec4i_);
+  _ = dot(vec2u_, vec2u_);
+  _ = dot(vec3u_, vec3u_);
+  _ = dot(vec4u_, vec4u_);
+  _ = dot(vec2f_, vec2f_);
+  _ = dot(vec3f_, vec3f_);
+  _ = dot(vec4f_, vec4f_);
+  _ = dot(vec2h_, vec2h_);
+  _ = dot(vec3h_, vec3h_);
+  _ = dot(vec4h_, vec4h_);
+  _ = dot4U8Packed(u32_, u32_);
+  _ = dot4I8Packed(u32_, u32_);
+  _ = exp(f32_);
+  _ = exp(f16_);
+  _ = exp(vec2f_);
+  _ = exp(vec3f_);
+  _ = exp(vec4f_);
+  _ = exp(vec2h_);
+  _ = exp(vec3h_);
+  _ = exp(vec4h_);
+  _ = exp2(f32_);
+  _ = exp2(f16_);
+  _ = exp2(vec2f_);
+  _ = exp2(vec3f_);
+  _ = exp2(vec4f_);
+  _ = exp2(vec2h_);
+  _ = exp2(vec3h_);
+  _ = exp2(vec4h_);
+  _ = extractBits(i32_, u32_, u32_);
+  _ = extractBits(vec2i_, u32_, u32_);
+  _ = extractBits(vec3i_, u32_, u32_);
+  _ = extractBits(vec4i_, u32_, u32_);
+  _ = extractBits(u32_, u32_, u32_);
+  _ = extractBits(vec2u_, u32_, u32_);
+  _ = extractBits(vec3u_, u32_, u32_);
+  _ = extractBits(vec4u_, u32_, u32_);
+  _ = faceForward(vec2f_, vec2f_, vec2f_);
+  _ = faceForward(vec3f_, vec3f_, vec3f_);
+  _ = faceForward(vec4f_, vec4f_, vec4f_);
+  _ = faceForward(vec2h_, vec2h_, vec2h_);
+  _ = faceForward(vec3h_, vec3h_, vec3h_);
+  _ = faceForward(vec4h_, vec4h_, vec4h_);
+  _ = firstLeadingBit(i32_);
+  _ = firstLeadingBit(vec2i_);
+  _ = firstLeadingBit(vec3i_);
+  _ = firstLeadingBit(vec4i_);
+  _ = firstLeadingBit(u32_);
+  _ = firstLeadingBit(vec2u_);
+  _ = firstLeadingBit(vec3u_);
+  _ = firstLeadingBit(vec4u_);
+  _ = firstTrailingBit(i32_);
+  _ = firstTrailingBit(u32_);
+  _ = firstTrailingBit(vec2i_);
+  _ = firstTrailingBit(vec3i_);
+  _ = firstTrailingBit(vec4i_);
+  _ = firstTrailingBit(vec2u_);
+  _ = firstTrailingBit(vec3u_);
+  _ = firstTrailingBit(vec4u_);
+  _ = floor(f32_);
+  _ = floor(f16_);
+  _ = floor(vec2f_);
+  _ = floor(vec3f_);
+  _ = floor(vec4f_);
+  _ = floor(vec2h_);
+  _ = floor(vec3h_);
+  _ = floor(vec4h_);
+  _ = fma(f32_, f32_, f32_);
+  _ = fma(f16_, f16_, f16_);
+  _ = fma(vec2f_, vec2f_, vec2f_);
+  _ = fma(vec3f_, vec3f_, vec3f_);
+  _ = fma(vec4f_, vec4f_, vec4f_);
+  _ = fma(vec2h_, vec2h_, vec2h_);
+  _ = fma(vec3h_, vec3h_, vec3h_);
+  _ = fma(vec4h_, vec4h_, vec4h_);
+  _ = fract(f32_);
+  _ = fract(f16_);
+  _ = fract(vec2f_);
+  _ = fract(vec3f_);
+  _ = fract(vec4f_);
+  _ = fract(vec2h_);
+  _ = fract(vec3h_);
+  _ = fract(vec4h_);
+  _ = frexp(f32_);
+  _ = frexp(f16_);
+  _ = frexp(0);
+  _ = frexp(vec2f_);
+  _ = frexp(vec2h_);
+  _ = frexp(vec2());
+  _ = frexp(vec3f_);
+  _ = frexp(vec3h_);
+  _ = frexp(vec3());
+  _ = frexp(vec4f_);
+  _ = frexp(vec4h_);
+  _ = frexp(vec4());
+  _ = insertBits(i32_, i32_, u32_, u32_);
+  _ = insertBits(u32_, u32_, u32_, u32_);
+  _ = insertBits(vec2i_, vec2i_, u32_, u32_);
+  _ = insertBits(vec3i_, vec3i_, u32_, u32_);
+  _ = insertBits(vec4i_, vec4i_, u32_, u32_);
+  _ = insertBits(vec2u_, vec2u_, u32_, u32_);
+  _ = insertBits(vec3u_, vec3u_, u32_, u32_);
+  _ = insertBits(vec4u_, vec4u_, u32_, u32_);
+  _ = inverseSqrt(f32_);
+  _ = inverseSqrt(f16_);
+  _ = inverseSqrt(vec2f_);
+  _ = inverseSqrt(vec3f_);
+  _ = inverseSqrt(vec4f_);
+  _ = inverseSqrt(vec2h_);
+  _ = inverseSqrt(vec3h_);
+  _ = inverseSqrt(vec4h_);
+  _ = ldexp(f32_, i32_);
+  _ = ldexp(f16_, i32_);
+  _ = ldexp(0, 0);
+  _ = ldexp(vec2f_, vec2i_);
+  _ = ldexp(vec3f_, vec3i_);
+  _ = ldexp(vec4f_, vec4i_);
+  _ = ldexp(vec2h_, vec2i_);
+  _ = ldexp(vec3h_, vec3i_);
+  _ = ldexp(vec4h_, vec4i_);
+  _ = length(f32_);
+  _ = length(f16_);
+  _ = length(vec2f_);
+  _ = length(vec3f_);
+  _ = length(vec4f_);
+  _ = length(vec2h_);
+  _ = length(vec3h_);
+  _ = length(vec4h_);
+  _ = log(f32_);
+  _ = log(f16_);
+  _ = log(vec2f_);
+  _ = log(vec3f_);
+  _ = log(vec4f_);
+  _ = log(vec2h_);
+  _ = log(vec3h_);
+  _ = log(vec4h_);
+  _ = log2(f32_);
+  _ = log2(f16_);
+  _ = log2(vec2f_);
+  _ = log2(vec3f_);
+  _ = log2(vec4f_);
+  _ = log2(vec2h_);
+  _ = log2(vec3h_);
+  _ = log2(vec4h_);
+  _ = max(i32_, i32_);
+  _ = max(u32_, u32_);
+  _ = max(f32_, f32_);
+  _ = max(f16_, f16_);
+  _ = max(vec2i_, vec2i_);
+  _ = max(vec3i_, vec3i_);
+  _ = max(vec4i_, vec4i_);
+  _ = max(vec2u_, vec2u_);
+  _ = max(vec3u_, vec3u_);
+  _ = max(vec4u_, vec4u_);
+  _ = max(vec2f_, vec2f_);
+  _ = max(vec3f_, vec3f_);
+  _ = max(vec4f_, vec4f_);
+  _ = max(vec2h_, vec2h_);
+  _ = max(vec3h_, vec3h_);
+  _ = max(vec4h_, vec4h_);
+  _ = min(i32_, i32_);
+  _ = min(u32_, u32_);
+  _ = min(f32_, f32_);
+  _ = min(f16_, f16_);
+  _ = min(vec2i_, vec2i_);
+  _ = min(vec3i_, vec3i_);
+  _ = min(vec4i_, vec4i_);
+  _ = min(vec2u_, vec2u_);
+  _ = min(vec3u_, vec3u_);
+  _ = min(vec4u_, vec4u_);
+  _ = min(vec2f_, vec2f_);
+  _ = min(vec3f_, vec3f_);
+  _ = min(vec4f_, vec4f_);
+  _ = min(vec2h_, vec2h_);
+  _ = min(vec3h_, vec3h_);
+  _ = min(vec4h_, vec4h_);
+  _ = mix(f32_, f32_, f32_);
+  _ = mix(f16_, f16_, f16_);
+  _ = mix(vec2f_, vec2f_, vec2f_);
+  _ = mix(vec3f_, vec3f_, vec3f_);
+  _ = mix(vec4f_, vec4f_, vec4f_);
+  _ = mix(vec2h_, vec2h_, vec2h_);
+  _ = mix(vec3h_, vec3h_, vec3h_);
+  _ = mix(vec4h_, vec4h_, vec4h_);
+  _ = mix(vec2f_, vec2f_, f32_);
+  _ = mix(vec3f_, vec3f_, f32_);
+  _ = mix(vec4f_, vec4f_, f32_);
+  _ = mix(vec2h_, vec2h_, f16_);
+  _ = mix(vec3h_, vec3h_, f16_);
+  _ = mix(vec4h_, vec4h_, f16_);
+  _ = modf(f32_);
+  _ = modf(f16_);
+  _ = modf(0);
+  _ = modf(vec2f_);
+  _ = modf(vec2h_);
+  _ = modf(vec2());
+  _ = modf(vec3f_);
+  _ = modf(vec3h_);
+  _ = modf(vec3());
+  _ = modf(vec4f_);
+  _ = modf(vec4h_);
+  _ = modf(vec4());
+  _ = normalize(vec2f_);
+  _ = normalize(vec3f_);
+  _ = normalize(vec4f_);
+  _ = normalize(vec2h_);
+  _ = normalize(vec3h_);
+  _ = normalize(vec4h_);
+  _ = pow(f32_, f32_);
+  _ = pow(f16_, f16_);
+  _ = pow(vec2f_, vec2f_);
+  _ = pow(vec3f_, vec3f_);
+  _ = pow(vec4f_, vec4f_);
+  _ = pow(vec2h_, vec2h_);
+  _ = pow(vec3h_, vec3h_);
+  _ = pow(vec4h_, vec4h_);
+  _ = quantizeToF16(f32_);
+  _ = quantizeToF16(vec2f_);
+  _ = quantizeToF16(vec3f_);
+  _ = quantizeToF16(vec4f_);
+  _ = radians(f32_);
+  _ = radians(f16_);
+  _ = radians(vec2f_);
+  _ = radians(vec3f_);
+  _ = radians(vec4f_);
+  _ = radians(vec2h_);
+  _ = radians(vec3h_);
+  _ = radians(vec4h_);
+  _ = reflect(vec2f_, vec2f_);
+  _ = reflect(vec3f_, vec3f_);
+  _ = reflect(vec4f_, vec4f_);
+  _ = reflect(vec2h_, vec2h_);
+  _ = reflect(vec3h_, vec3h_);
+  _ = reflect(vec4h_, vec4h_);
+  _ = refract(vec2f_, vec2f_, f32_);
+  _ = refract(vec3f_, vec3f_, f32_);
+  _ = refract(vec4f_, vec4f_, f32_);
+  _ = refract(vec2h_, vec2h_, f16_);
+  _ = refract(vec3h_, vec3h_, f16_);
+  _ = refract(vec4h_, vec4h_, f16_);
+  _ = reverseBits(i32_);
+  _ = reverseBits(u32_);
+  _ = reverseBits(vec2i_);
+  _ = reverseBits(vec3i_);
+  _ = reverseBits(vec4i_);
+  _ = reverseBits(vec2u_);
+  _ = reverseBits(vec3u_);
+  _ = reverseBits(vec4u_);
+  _ = round(f32_);
+  _ = round(f16_);
+  _ = round(vec2f_);
+  _ = round(vec3f_);
+  _ = round(vec4f_);
+  _ = round(vec2h_);
+  _ = round(vec3h_);
+  _ = round(vec4h_);
+  _ = saturate(f32_);
+  _ = saturate(f16_);
+  _ = saturate(vec2f_);
+  _ = saturate(vec3f_);
+  _ = saturate(vec4f_);
+  _ = saturate(vec2h_);
+  _ = saturate(vec3h_);
+  _ = saturate(vec4h_);
+  _ = sign(f32_);
+  _ = sign(i32_);
+  _ = sign(f16_);
+  _ = sign(vec2f_);
+  _ = sign(vec3f_);
+  _ = sign(vec4f_);
+  _ = sign(vec2i_);
+  _ = sign(vec3i_);
+  _ = sign(vec4i_);
+  _ = sign(vec2h_);
+  _ = sign(vec3h_);
+  _ = sign(vec4h_);
+  _ = smoothstep(1,2,3);
+  _ = smoothstep(1h,2h,3h);
+  _ = smoothstep(vec2f(1), vec2f(2), vec2f(3));
+  _ = smoothstep(vec3f(1), vec3f(2), vec3f(3));
+  _ = smoothstep(vec4f(1), vec4f(2), vec4f(3));
+  _ = smoothstep(vec2h(1), vec2h(2), vec2h(3));
+  _ = smoothstep(vec3h(1), vec3h(2), vec3h(3));
+  _ = smoothstep(vec4h(1), vec4h(2), vec4h(3));
+  _ = sqrt(f32_);
+  _ = sqrt(f16_);
+  _ = sqrt(vec2f_);
+  _ = sqrt(vec3f_);
+  _ = sqrt(vec4f_);
+  _ = sqrt(vec2h_);
+  _ = sqrt(vec3h_);
+  _ = sqrt(vec4h_);
+  _ = step(f32_, f32_);
+  _ = step(f16_, f16_);
+  _ = step(vec2f_, vec2f_);
+  _ = step(vec3f_, vec3f_);
+  _ = step(vec4f_, vec4f_);
+  _ = step(vec2h_, vec2h_);
+  _ = step(vec3h_, vec3h_);
+  _ = step(vec4h_, vec4h_);
+  _ = transpose(mat2x2f_);
+  _ = transpose(mat2x3f_);
+  _ = transpose(mat2x4f_);
+  _ = transpose(mat3x2f_);
+  _ = transpose(mat3x3f_);
+  _ = transpose(mat3x4f_);
+  _ = transpose(mat4x2f_);
+  _ = transpose(mat4x3f_);
+  _ = transpose(mat4x4f_);
+  _ = transpose(mat2x2h_);
+  _ = transpose(mat2x3h_);
+  _ = transpose(mat2x4h_);
+  _ = transpose(mat3x2h_);
+  _ = transpose(mat3x3h_);
+  _ = transpose(mat3x4h_);
+  _ = transpose(mat4x2h_);
+  _ = transpose(mat4x3h_);
+  _ = transpose(mat4x4h_);
+  _ = trunc(f32_);
+  _ = trunc(f16_);
+  _ = trunc(vec2f_);
+  _ = trunc(vec3f_);
+  _ = trunc(vec4f_);
+  _ = trunc(vec2h_);
+  _ = trunc(vec3h_);
+  _ = trunc(vec4h_);
+  _ = pack4x8snorm(vec4f_);
+  _ = pack4x8unorm(vec4f_);
+  _ = pack4xI8(vec4i_);
+  _ = pack4xU8(vec4u_);
+  _ = pack4xI8Clamp(vec4i_);
+  _ = pack4xU8Clamp(vec4u_);
+  _ = pack2x16snorm(vec2f_);
+  _ = pack2x16unorm(vec2f_);
+  _ = pack2x16float(vec2f_);
+  _ = unpack4x8snorm(u32_);
+  _ = unpack4x8unorm(u32_);
+  _ = unpack4xI8(u32_);
+  _ = unpack4xU8(u32_);
+  _ = unpack2x16snorm(u32_);
+  _ = unpack2x16unorm(u32_);
+  _ = unpack2x16float(u32_);
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u) {
+  coverageHelper0();
+  _ = buffer120;
+  _ = buffer120[0];
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  _ = buffer120[0];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet21 = device0.createQuerySet({label: '\u{1fd75}\u01ff\u{1fa10}\u0697\ua5fe\u25a6\u162b\u9e17\u0b5a', type: 'occlusion', count: 273});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({label: '\u48a8\uff4f\u66ff\uddc6\u{1ff3c}\ud9e1', colorFormats: ['rgba32sint'], depthReadOnly: true});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup10, new Uint32Array(1078), 119, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder42.setViewport(18.846919149630068, 6.1302617464826294, 2.368683429607768, 0.153221759029744, 0.7044765110694671, 0.8203635048920564);
+} catch {}
+try {
+renderPassEncoder23.draw(56, 90, 1_636_423_280, 587_045_839);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer97, 156);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer12, 668);
+} catch {}
+let bindGroup109 = device0.createBindGroup({
+  label: '\u0336\ue93c\ucf20\u0d68\u0caf\u2171\u1b55',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 36, resource: {buffer: buffer77, offset: 7680, size: 7959}},
+    {binding: 19, resource: textureView2},
+    {binding: 407, resource: textureView8},
+  ],
+});
+let buffer121 = device0.createBuffer({
+  size: 3805,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder168 = device0.createCommandEncoder({});
+let renderPassEncoder61 = commandEncoder168.beginRenderPass({
+  colorAttachments: [{
+  view: textureView34,
+  depthSlice: 36,
+  clearValue: { r: -315.1, g: -742.3, b: 231.6, a: -30.33, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder108.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.setBlendConstant({ r: 651.8, g: 894.7, b: -629.0, a: 580.1, });
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer16, 72);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(1, buffer16, 112, 23);
+} catch {}
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 28, resource: textureView177}]});
+let texture217 = device0.createTexture({
+  size: [96, 40, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView182 = texture118.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+renderPassEncoder9.draw(17, 130, 1_092_071_360, 1_732_128_975);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(220, 181, 36, 286_688_965, 39_265_773);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer22, 1_764);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer55, 'uint32', 204, 155);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer85, 6_000, 1_079);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+ // await adapter0.requestAdapterInfo();
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle20, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer37, 2_480);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer72, 412);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer90, 'uint32', 2_344, 1_026);
+} catch {}
+let buffer122 = device0.createBuffer({
+  size: 8293,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle24 = renderBundleEncoder24.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(484, 231, 45, 133_711_003, 817_912_031);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+texture96.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 2028, new Int16Array(650), 65, 40);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt709', transfer: 'smpte170m'} });
+let buffer123 = device0.createBuffer({size: 7707, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup40, new Uint32Array(1383), 190, 0);
+} catch {}
+try {
+renderPassEncoder60.setViewport(15.996253325538728, 9.13326351240404, 3.0825806467824095, 0.5159859472633749, 0.788397195602728, 0.8332070200916775);
+} catch {}
+try {
+renderPassEncoder34.draw(172, 18, 473_610_942, 25_952_478);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer74, 7_348);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer42, 'uint16', 408, 1_696);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer104, 648, 765);
+} catch {}
+try {
+buffer85.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup111 = device0.createBindGroup({
+  label: '\u1fac\u9eb7\ubed2\ue84b\u8f17',
+  layout: bindGroupLayout12,
+  entries: [{binding: 408, resource: sampler116}],
+});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1930});
+let texture218 = device0.createTexture({
+  label: '\u0e29\ue40b\ubfad\u81e8\u5489\u88fb\uce3b\u33b5\u2232',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder27.setViewport(7.813448180097698, 1.45772237786103, 0.051257468304780646, 7.410187408788005, 0.27923433749767745, 0.8685266627240676);
+} catch {}
+try {
+renderPassEncoder46.draw(179, 142, 332_942_465, 38_051_450);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(103, 25, 276, 177_713_414, 1_370_242_110);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer27, 424);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer7, 'uint32', 332, 440);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(3, buffer50);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+} catch {}
+let textureView183 = texture41.createView({baseMipLevel: 0, baseArrayLayer: 0, arrayLayerCount: 5});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(18, 288, 3, 212_110_715, 177_945_682);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer80, 152);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer102, 72);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer104, 5_284, 1_457);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let sampler126 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 71.42,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder99.setBindGroup(1, bindGroup105, new Uint32Array(1173), 61, 0);
+} catch {}
+try {
+computePassEncoder66.dispatchWorkgroupsIndirect(buffer22, 908);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(17, 11, 133, 290_910_552, 182_288_391);
+} catch {}
+document.body.prepend(video0);
+let buffer124 = device0.createBuffer({
+  label: '\u0853\uf6c5\u0ab7\uf7b8\u{1f7ff}\u3c3f\uaad4\u{1f83a}\u{1fb3a}\uf3bf',
+  size: 9032,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture219 = gpuCanvasContext5.getCurrentTexture();
+let sampler127 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.21,
+  lodMaxClamp: 94.37,
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup53, new Uint32Array(3154), 28, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle4, renderBundle19, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder46.draw(92, 197, 57_992_758, 113_856_062);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(24, 286, 45, 426_785_698, 571_234_417);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer16, 856);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer15, 'uint16', 4_806, 581);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder169 = device0.createCommandEncoder({});
+let texture220 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm'],
+});
+let renderPassEncoder62 = commandEncoder169.beginRenderPass({colorAttachments: [{view: textureView164, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder78.setBindGroup(1, bindGroup76, new Uint32Array(1490), 142, 0);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+renderPassEncoder5.draw(83, 39, 86_465_457, 977_151_878);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer74, 10_216);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer73);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture146,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7).fill(255), /* required buffer size: 7 */
+{offset: 7, bytesPerRow: 143}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({});
+try {
+renderPassEncoder16.setIndexBuffer(buffer44, 'uint32', 3_552, 1_664);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder170.clearBuffer(buffer79, 452);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u{1f695}\u{1f8a5}\u{1fee6}\u12dd\u0872\u7f80\u{1fd17}\u096f\uf05b\u49c4',
+  code: `
+enable f16;
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @size(4) f0: f16,
+}
+@group(0) @binding(280) var<storage, read_write> buffer125: T0;
+struct VertexOutput7 {
+  @builtin(position) f20: vec4f
+}
+
+@vertex
+fn vertex0(@location(3) @interpolate(linear) a0: vec4h, @location(11) a1: i32, @location(2) @interpolate(flat) a2: vec2i, @location(7) a3: f32) -> VertexOutput7 {
+  var out: VertexOutput7;
+  if bool(a1) {
+    var v: vec4f;
+  }
+  return out;
+}
+struct FragmentOutput5 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) @interpolate(perspective) f1: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  buffer125.f0 = f16(-51881.1);
+  return out;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1(@builtin(local_invocation_index) a0: u32, @builtin(num_workgroups) a1: vec3u, @builtin(local_invocation_id) a2: vec3u) {
+}`,
+  hints: {},
+});
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12]});
+let computePassEncoder109 = commandEncoder170.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(1, bindGroup72, new Uint32Array(276), 9, 0);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup24, new Uint32Array(1367), 29, 0);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle15, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder49.draw(85, 315, 232_535_619, 1_996_046_056);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer63, 40);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer95, 'uint32', 3_424, 4_901);
+} catch {}
+try {
+window.someLabel = externalTexture10.label;
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup22, new Uint32Array(156), 4, 0);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(243);
+} catch {}
+try {
+renderPassEncoder34.setViewport(2.9910599528696036, 8.247366573067636, 7.507498107424423, 2.577467779640739, 0.2737965101020118, 0.8692197728326796);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(37, 58, 31, 1_099_105_336, 1_881_816_088);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder59.insertDebugMarker('\u01ad');
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup109);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(91, 28, 4, 323_989_900, 1_522_337_401);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer93, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer108, 'uint16', 0, 94);
+} catch {}
+document.body.append(canvas1);
+let buffer126 = device0.createBuffer({size: 15735, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture221 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame22, colorSpace: 'display-p3'});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(498, 72, 20, 231_574_724, 946_461_357);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer62, 956);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer75, 'uint16', 1_964, 1_772);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 37 max align: 1 */
+struct T0 {
+  @align(1) @size(33) f0: vec3u,
+  @align(1) @size(4) f1: array<f16>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: array<atomic<u32>, 1>,
+}
+@group(0) @binding(376) var<uniform> buffer127: u32;
+@group(0) @binding(36) var st1: texture_storage_2d<rgba16sint, write>;
+struct VertexOutput8 {
+  @builtin(position) f21: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput8 {
+  var out: VertexOutput8;
+  if bool(buffer127) {
+    var v: vec4f;
+  }
+  return out;
+}
+struct VertexOutput9 {
+  @builtin(position) f22: vec4f,
+  @location(9) f23: vec3h,
+  @location(13) f24: vec4h,
+  @location(10) f25: vec4u,
+  @location(11) f26: vec2u,
+  @location(1) f27: vec2f,
+  @location(0) f28: vec2h,
+  @location(15) f29: vec3u,
+  @location(14) f30: vec3f
+}
+
+@vertex
+fn vertex1() -> VertexOutput9 {
+  var out: VertexOutput9;
+  if bool(buffer127) {
+    var v: vec4f;
+  }
+  out.f29 = vec3u(bitcast<u32>(buffer127));
+  out.f26 = vec2u(bitcast<u32>(buffer127));
+  return out;
+}
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32, @builtin(local_invocation_id) a1: vec3u, @builtin(global_invocation_id) a2: vec3u, @builtin(num_workgroups) a3: vec3u, @builtin(workgroup_id) a4: vec3u) {
+}
+
+@compute @workgroup_size(6, 1, 1)
+fn compute1(@builtin(local_invocation_index) a0: u32) {
+}`,
+  sourceMap: {},
+});
+let commandEncoder171 = device0.createCommandEncoder({label: '\uc094\u82c3\uf07a'});
+let texture222 = device0.createTexture({
+  size: {width: 48},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView184 = texture68.createView({});
+let computePassEncoder110 = commandEncoder171.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup111, new Uint32Array(1086), 818, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.draw(162, 10, 1_740_306_440, 24_571_639);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer56, 700);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer29, 156);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer16, 'uint32', 196, 216);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer29 = buffer61.getMappedRange(96, 184);
+let commandEncoder172 = device0.createCommandEncoder({label: '\uc2e4\u9005\u8b86\u8a58\u{1fa33}\u{1f911}\u1980'});
+let textureView185 = texture205.createView({});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(1, bindGroup5, new Uint32Array(1870), 483, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle21, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer66, 'uint32', 432, 862);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline2);
+} catch {}
+try {
+buffer98.unmap();
+} catch {}
+try {
+commandEncoder172.copyBufferToBuffer(buffer42, 1548, buffer100, 416, 380);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer104, 6660, new Int16Array(9214), 661, 172);
+} catch {}
+let buffer128 = device0.createBuffer({
+  label: '\ufa06\u4545\u5fa4\u3466\u00b0\u0de5\u6461\u0ef5\u{1f906}\ub043',
+  size: 4246,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView186 = texture216.createView({baseArrayLayer: 2, arrayLayerCount: 6});
+let computePassEncoder111 = commandEncoder172.beginComputePass({label: '\u3709\u005d\u0c87\ucabe\u0a0a\u{1f717}\uefb1\ue94d\u08ee\u629a\uc0ae'});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer115, 9_984); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup5, new Uint32Array(1367), 87, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(2, 44, 15, 1_628_460_251, 91_656_387);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer121, 'uint16', 222, 29);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder({});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 137});
+let texture223 = device0.createTexture({
+  size: {width: 16},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder112 = commandEncoder173.beginComputePass();
+try {
+renderPassEncoder51.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder5.draw(2, 142, 57_698_438, 679_444_540);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(40, 273, 17, 161_566_300, 1_272_361_592);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer92, 'uint32', 572, 829);
+} catch {}
+try {
+externalTexture6.label = '\u863d\u0572\u5622';
+} catch {}
+let bindGroup112 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler108}]});
+let commandEncoder174 = device0.createCommandEncoder({});
+let texture224 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView187 = texture157.createView({label: '\u1cdc\u13e3\uc663\u1fe0\u0f3c\u{1fed5}\u0765\u0b81\u{1fdbe}', dimension: '2d'});
+try {
+computePassEncoder112.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder54.setScissorRect(1, 0, 3, 2);
+} catch {}
+try {
+renderPassEncoder8.setViewport(10.411114607702094, 1.582207825284827, 33.646586939498135, 0.6154016142481746, 0.4195767775987327, 0.935036496165892);
+} catch {}
+try {
+renderPassEncoder11.draw(462, 88, 547_562_870, 116_122_722);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer29, 'uint16', 94, 232);
+} catch {}
+let texture225 = device0.createTexture({size: {width: 192}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView188 = texture142.createView({label: '\u{1ffe6}\u{1fe5b}\u7031\u0ffa\uea93\u0437\u{1fee2}\u0d1a\u8949\u{1fdde}'});
+let computePassEncoder113 = commandEncoder174.beginComputePass({});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(1, bindGroup106, new Uint32Array(444), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(248, 146, 14, -2_127_657_873, 834_856_811);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer63, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer92, 1_152, 182);
+} catch {}
+let commandEncoder175 = device0.createCommandEncoder();
+let textureView189 = texture209.createView({});
+let renderPassEncoder63 = commandEncoder175.beginRenderPass({colorAttachments: [{view: textureView21, depthSlice: 3, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup78);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer115, 17_796); };
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(3, bindGroup94, new Uint32Array(2230), 210, 0);
+} catch {}
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(105, 0, 88, 213_323_259, 232_684_479);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer32, 2_836);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer90, 4_276, 4_027);
+} catch {}
+let arrayBuffer30 = buffer61.getMappedRange(0, 20);
+try {
+renderPassEncoder9.insertDebugMarker('\u7880');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let buffer129 = device0.createBuffer({
+  size: 23700,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder176 = device0.createCommandEncoder();
+try {
+computePassEncoder72.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer18, 312); };
+} catch {}
+try {
+renderPassEncoder5.draw(6, 177, 1_817_252_023, 825_191_836);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(291, 231, 60, 212_118_952, 1_166_932_303);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer34, 7_260);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer61, 440);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer121, 'uint16', 2_176, 27);
+} catch {}
+try {
+commandEncoder176.resolveQuerySet(querySet11, 24, 41, buffer92, 256);
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder177 = device0.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder176.beginComputePass();
+let sampler128 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.28,
+  lodMaxClamp: 57.98,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder111.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder8.draw(12, 172, 1_048_157_566, 357_711_708);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 239, 0, 133_570_486, 171_355_774);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer12, 1_336);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 5628, new BigUint64Array(19463), 5252, 84);
+} catch {}
+let texture226 = device0.createTexture({size: [192, 80, 1], format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let textureView190 = texture207.createView({baseMipLevel: 0});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup105, new Uint32Array(6831), 347, 0);
+} catch {}
+try {
+computePassEncoder27.dispatchWorkgroupsIndirect(buffer42, 2_808);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup108, new Uint32Array(2583), 61, 0);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder34.draw(128, 20, 1_586_545_978, 98_132_328);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer102, 396);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder177.copyTextureToBuffer({
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 26 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4516 */
+  offset: 4516,
+  buffer: buffer112,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder177.clearBuffer(buffer101);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(137).fill(140), /* required buffer size: 137 */
+{offset: 137, bytesPerRow: 82}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup113 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView29}]});
+let buffer130 = device0.createBuffer({size: 43634, usage: GPUBufferUsage.COPY_SRC});
+let computePassEncoder115 = commandEncoder177.beginComputePass({});
+let sampler129 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.33,
+  lodMaxClamp: 89.53,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup36, new Uint32Array(199), 0, 0);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer112, 1_300);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer29, 16);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer114, 'uint16', 496, 10_258);
+} catch {}
+try {
+if (!arrayBuffer28.detached) { new Uint8Array(arrayBuffer28).fill(0x55); };
+} catch {}
+let bindGroup114 = device0.createBindGroup({label: '\u0a5e\u056a', layout: bindGroupLayout14, entries: [{binding: 85, resource: textureView16}]});
+let buffer131 = device0.createBuffer({
+  size: 938,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder178 = device0.createCommandEncoder({});
+let texture227 = device0.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView191 = texture68.createView({});
+let computePassEncoder116 = commandEncoder178.beginComputePass({});
+let sampler130 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.14,
+  lodMaxClamp: 60.59,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(0, bindGroup15, new Uint32Array(1177), 227, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(178);
+} catch {}
+try {
+renderPassEncoder5.draw(63, 246, 254_403_238, 33_154_026);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(112, 116, 845, 144_104_101, 84_057_696);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer81, 4_344);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer31 = buffer21.getMappedRange(104, 16);
+try {
+device0.queue.writeBuffer(buffer34, 4, new Float32Array(4190), 810, 768);
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let querySet24 = device0.createQuerySet({label: '\u97da\u058d\u{1f8f1}\u42f3\uc6b6\u1b2c\ua8bc\u15db\u0a62', type: 'occlusion', count: 253});
+let texture228 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 59},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView192 = texture111.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 2});
+let externalTexture28 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup113);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 120, 0, 701_809_473, 350_534_258);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer39, 288);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let commandEncoder179 = device0.createCommandEncoder();
+let textureView193 = texture120.createView({baseArrayLayer: 3, arrayLayerCount: 24});
+let texture229 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView194 = texture118.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder117 = commandEncoder179.beginComputePass({});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup73, new Uint32Array(6556), 248, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup6, new Uint32Array(4484), 1_542, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(417, 268, 2_145_640_500, 6_548_713);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer69, 'uint16', 3_258, 1_566);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer27);
+} catch {}
+try {
+buffer117.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 59}
+*/
+{
+  source: video1,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture228,
+  mipLevel: 1,
+  origin: {x: 22, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData25 = new ImageData(44, 12);
+try {
+renderPassEncoder40.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer12, 304);
+} catch {}
+try {
+computePassEncoder78.setBindGroup(2, bindGroup92, new Uint32Array(2763), 463, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup72);
+} catch {}
+await gc();
+let buffer132 = device0.createBuffer({
+  label: '\u{1f8e4}\u7c76\u{1faf5}\ub911\u0b87',
+  size: 2782,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder180 = device0.createCommandEncoder({});
+let textureView195 = texture57.createView({baseArrayLayer: 47, arrayLayerCount: 24});
+let computePassEncoder118 = commandEncoder180.beginComputePass({});
+let sampler131 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.37,
+  lodMaxClamp: 72.70,
+});
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup93, new Uint32Array(1090), 167, 0);
+} catch {}
+try {
+renderPassEncoder49.draw(214, 30, 415_649_728, 122_808_684);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(676, 63, 2_103, 364_488_720, 2_058_345_839);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer124, 1_844);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 310,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup115 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 5, resource: textureView16},
+    {binding: 41, resource: textureView2},
+    {binding: 89, resource: textureView60},
+  ],
+});
+let texture230 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 215},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture231 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView196 = texture56.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let sampler132 = device0.createSampler({
+  label: '\u0fff\u54d3\u3a97\u91cd\uc154\u06fc\u{1fede}\ue885\u3271',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 59.56,
+  lodMaxClamp: 72.43,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup98, new Uint32Array(1086), 131, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(18, 191, 578_090_673, 136_591_549);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer24, 244);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let commandEncoder181 = device0.createCommandEncoder({});
+let textureView197 = texture40.createView({dimension: 'cube', arrayLayerCount: 6});
+let computePassEncoder119 = commandEncoder181.beginComputePass();
+try {
+computePassEncoder118.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup82, new Uint32Array(1422), 106, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(295, 78, 8_332_503, 189_131_451);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer69, 5_740);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer131, 200);
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  label: '\u9759\u1589\u{1feee}\u82d3\u9599',
+  layout: bindGroupLayout21,
+  entries: [{binding: 116, resource: textureView150}],
+});
+let commandEncoder182 = device0.createCommandEncoder({});
+let renderPassEncoder64 = commandEncoder182.beginRenderPass({
+  colorAttachments: [{
+  view: textureView158,
+  depthSlice: 133,
+  clearValue: { r: 42.11, g: -518.7, b: -473.7, a: 518.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 369606297,
+});
+try {
+computePassEncoder119.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(7, 347, 6, -2_096_169_883, 846_336_009);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer20, 992);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(1, buffer12);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.prepend(img0);
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 163, resource: textureView163},
+    {binding: 63, resource: {buffer: buffer111, offset: 512, size: 5140}},
+  ],
+});
+let buffer133 = device0.createBuffer({size: 1994, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture232 = device0.createTexture({
+  size: [685, 124, 1],
+  format: 'astc-5x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView198 = texture194.createView({dimension: '2d-array', aspect: 'all'});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder56.setBlendConstant({ r: -950.9, g: -335.2, b: -636.1, a: -976.0, });
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(349, 41, 135, 66_547_044, 544_723_236);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer62, 1_576);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer113, 592);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer39, 0, 563);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+let texture233 = device0.createTexture({
+  size: [24, 10, 43],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView199 = texture80.createView({dimension: '2d', arrayLayerCount: 1});
+try {
+renderPassEncoder23.executeBundles([renderBundle4, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder46.draw(182, 236, 1_336_650_512, 22_060_065);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer72, 2_692);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 356, resource: {buffer: buffer121, offset: 0, size: 872}},
+    {binding: 33, resource: sampler87},
+    {binding: 39, resource: externalTexture8},
+    {binding: 342, resource: sampler32},
+  ],
+});
+let texture234 = device0.createTexture({
+  size: [16, 16, 245],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame10});
+try {
+renderPassEncoder5.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder25.draw(84, 71, 1_349_980_737, 1_010_670_385);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(29, 332, 386, 620_428_935, 624_252_321);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer98, 2_668);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 19872, new DataView(new ArrayBuffer(20754)), 1546, 1388);
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 407, resource: textureView154},
+    {binding: 19, resource: textureView2},
+    {binding: 36, resource: {buffer: buffer42, offset: 0}},
+  ],
+});
+let commandEncoder183 = device0.createCommandEncoder({label: '\u{1f7c3}\u180a\u04a7\uf0d4\u{1f7eb}\u7495'});
+let texture235 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 4},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder120 = commandEncoder183.beginComputePass({});
+let sampler133 = device0.createSampler({
+  label: '\u029a\uf67d\uf176\u{1ff9a}\u{1fabd}\u1aed\u0830\uaa55\u0e7d',
+  addressModeU: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.04,
+  lodMaxClamp: 98.45,
+});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame11});
+try {
+renderPassEncoder9.draw(177, 245, 109_902_773, 3_053_698_396);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise30;
+} catch {}
+let textureView200 = texture206.createView({format: 'r16sint'});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle25 = renderBundleEncoder25.finish({});
+let sampler134 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.17,
+  lodMaxClamp: 70.79,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder33.executeBundles([renderBundle18, renderBundle5, renderBundle19, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(6, 1, 97, 232_409_751, 356_284_606);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer23, 'uint16', 204, 6_729);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer14, 160, 103);
+} catch {}
+try {
+renderPassEncoder61.insertDebugMarker('\u0453');
+} catch {}
+offscreenCanvas2.height = 619;
+let bindGroup120 = device0.createBindGroup({
+  label: '\u0338\ue987\u8cb1\u19d9',
+  layout: bindGroupLayout13,
+  entries: [{binding: 280, resource: {buffer: buffer117, offset: 256, size: 248}}],
+});
+let buffer134 = device0.createBuffer({size: 32, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder184 = device0.createCommandEncoder({label: '\u02e6\u{1fe58}\u4409\u0b0e\u{1fac1}'});
+let textureView201 = texture131.createView({});
+try {
+computePassEncoder118.setBindGroup(2, bindGroup64, new Uint32Array(1432), 15, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder5.draw(9, 256, 853_457_884, 297_001_309);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(33, 172, 60, 485_763_522, 113_570_604);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer117, 3_412);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer114, 'uint16', 5_180, 602);
+} catch {}
+let promise31 = shaderModule3.getCompilationInfo();
+let buffer135 = device0.createBuffer({size: 1801, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture236 = device0.createTexture({
+  size: [96, 40, 1],
+  mipLevelCount: 1,
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView202 = texture216.createView({baseArrayLayer: 1, arrayLayerCount: 4});
+let renderPassEncoder65 = commandEncoder184.beginRenderPass({
+  label: '\u{1f89f}\ub0aa\ue663\u7b53\u00ad\ud350\u{1f796}\u1cb3\uf3e9\u7fed',
+  colorAttachments: [{
+  view: textureView34,
+  depthSlice: 64,
+  clearValue: { r: 926.6, g: 924.0, b: 380.6, a: 234.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup119, new Uint32Array(779), 8, 0);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup56, new Uint32Array(53), 5, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(263, 53, 420_959_919, 1_860_906_276);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(208, 271, 59, 245_024_238, 131_592_435);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer99, 2552, new Float32Array(16275), 248, 348);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let canvas3 = document.createElement('canvas');
+let buffer136 = device0.createBuffer({size: 5961, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 289});
+let textureView203 = texture83.createView({dimension: '3d', baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup112, new Uint32Array(3244), 17, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle6, renderBundle10, renderBundle10, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.draw(56, 132, 404_530_683, 765_838_223);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(21, 6, 11, 314_350_689, 534_145_737);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise28;
+} catch {}
+await gc();
+let texture237 = device0.createTexture({
+  label: '\ub6b9\ub1d1\u0286',
+  size: {width: 192, height: 80, depthOrArrayLayers: 81},
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer43, 1_720); };
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(351, 102, 379, 124_895_098, 476_663_828);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer62, 248);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup107);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer110, 'uint32', 680, 61);
+} catch {}
+let texture238 = device0.createTexture({
+  size: [24, 10, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup75, new Uint32Array(2743), 323, 0);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(3838);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer71, 1_004);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer115, 17_456);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer29, 'uint32', 196, 625);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer15, 0, 3_728);
+} catch {}
+let textureView204 = texture140.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler135 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.21,
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup96);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup108);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(123, 197, 12, 7_725_150, 584_706_020);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer34, 10_464);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer36, 13_300, 939);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer123.unmap();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView205 = texture40.createView({dimension: 'cube', baseArrayLayer: 1, arrayLayerCount: 6});
+let renderBundle26 = renderBundleEncoder27.finish({label: '\u831c\ude1d\ue68b\u05b0\u002a\u1c31\u059f'});
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer101, 7_196);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48_428).fill(148), /* required buffer size: 48_428 */
+{offset: 239, bytesPerRow: 95, rowsPerImage: 125}, {width: 3, height: 8, depthOrArrayLayers: 5});
+} catch {}
+await gc();
+let bindGroup121 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 116, resource: textureView150}]});
+let buffer137 = device0.createBuffer({
+  size: 23332,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 942});
+let renderBundle27 = renderBundleEncoder26.finish({});
+let sampler136 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.34,
+  lodMaxClamp: 43.73,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder25.drawIndexed(0, 84, 2, 154_430_320, 888_713_770);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer34, 4_000);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer32, 712);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(5, buffer97);
+} catch {}
+let textureView206 = texture47.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup92, new Uint32Array(410), 20, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(113, 264, 531_177_070, 532_729_894);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer6, 260);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer81, 10_596);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  label: '\u2eb4\u4f08\ua35a\u3618\u81d2\u0638\udb07\u041e\ud5db\u702d\u{1f75d}',
+  layout: bindGroupLayout17,
+  entries: [{binding: 246, resource: sampler107}],
+});
+let buffer138 = device0.createBuffer({
+  label: '\u0d1b\u003c\u0e4c\u0a4e\u0e5f\u{1f607}\u0295\u45cd\u7a6b\u5136',
+  size: 40579,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView207 = texture111.createView({
+  label: '\uad27\u0d6d\u09aa\u0f80\ub1ee\u{1fd24}\u08b5\ua873\uc60b\u{1fda1}',
+  baseArrayLayer: 3,
+  arrayLayerCount: 4,
+});
+let sampler137 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 45.55,
+  lodMaxClamp: 77.37,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+computePassEncoder74.dispatchWorkgroupsIndirect(buffer23, 1_924);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup108);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer134, 0);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 362,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder185 = device0.createCommandEncoder({});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 1666});
+try {
+renderPassEncoder49.setIndexBuffer(buffer55, 'uint16', 64, 136);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer85, 0);
+} catch {}
+try {
+commandEncoder185.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1104 */
+  offset: 1104,
+  bytesPerRow: 256,
+  buffer: buffer31,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let buffer139 = device0.createBuffer({size: 22193, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder121 = commandEncoder185.beginComputePass({label: '\u{1ffe1}\ue8b5\uce5f\u41b3\u22fa\u16f0\u{1fa09}\u{1faef}\u0c3b'});
+let externalTexture31 = device0.importExternalTexture({label: '\u{1fac6}\u{1fe0c}\u0725\u3c2d\u072b\u03d5\u6fdf\u0997\uf8b5', source: videoFrame9});
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup87, new Uint32Array(2595), 170, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(27, 124, 119_589_370, 300_678_369);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup123 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView93}]});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout11]});
+let buffer140 = device0.createBuffer({size: 3330, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder186 = device0.createCommandEncoder({});
+let renderPassEncoder66 = commandEncoder186.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 83,
+  clearValue: { r: -417.3, g: 862.7, b: 21.39, a: -91.32, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(855, 244, 224, -2_020_033_706, 305_771_733);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer74, 18_484);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer41, 'uint16', 72, 1_168);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer42, 0, 233);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+commandEncoder177.copyBufferToBuffer(buffer40, 3004, buffer79, 348, 208);
+} catch {}
+let commandEncoder187 = device0.createCommandEncoder({});
+let sampler138 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 97.30,
+  lodMaxClamp: 99.79,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder121.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.draw(584, 136, 632_426_544, 1_099_969_730);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(48, 270, 24, 153_833_968, 1_070_993_834);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  multisample: {},
+  fragment: {module: shaderModule7, targets: [{format: 'r16float', writeMask: 0}]},
+  vertex: {
+    module: shaderModule7,
+    buffers: [
+      {
+        arrayStride: 236,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x3', offset: 4, shaderLocation: 2},
+          {format: 'float32', offset: 4, shaderLocation: 3},
+          {format: 'sint32x2', offset: 132, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+let textureView208 = texture3.createView({dimension: '2d-array', mipLevelCount: 2});
+let computePassEncoder122 = commandEncoder177.beginComputePass({});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], stencilReadOnly: true});
+try {
+renderPassEncoder25.draw(79, 163, 213_092_334, 749_459_526);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(23, 31, 7, 536_814_287, 57_673_969);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer72, 760);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer138, 18_952, 4_270);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup28, new Uint32Array(2559), 812, 0);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer41, 'uint32', 488, 6_303);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder187.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 6, y: 2, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 3,
+  origin: {x: 6, y: 5, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let bindGroup124 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 246, resource: sampler10}]});
+let buffer141 = device0.createBuffer({size: 4462, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture239 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder123 = commandEncoder187.beginComputePass({label: '\u05db\u0970\u4378'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+let renderBundle28 = renderBundleEncoder29.finish({});
+try {
+renderPassEncoder58.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer20, 5_248);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer69, 'uint16', 4_452, 1_334);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup30, new Uint32Array(776), 13, 0);
+} catch {}
+try {
+renderPassEncoder51.insertDebugMarker('\u13c2');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer104, 1960, new Float32Array(1783));
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer142 = device0.createBuffer({
+  label: '\u0fc6\u61b4\u{1ff96}\u0227\ubdb1\u100f\u673f',
+  size: 13915,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let sampler139 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.74,
+  lodMaxClamp: 88.81,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup90);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup122);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer93, 'uint16', 26, 135);
+} catch {}
+let arrayBuffer32 = buffer51.getMappedRange(0, 52);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 12, height: 5, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData9,
+  origin: { x: 5, y: 21 },
+  flipY: true,
+}, {
+  texture: texture220,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder();
+let texture240 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder124 = commandEncoder188.beginComputePass();
+try {
+computePassEncoder73.setBindGroup(0, bindGroup8, new Uint32Array(354), 72, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer117, 864); };
+} catch {}
+try {
+renderPassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(7, 54, 0, 221_256_445, 584_020_005);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer36, 744);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer74, 588);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer42, 'uint32', 720, 633);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline2);
+} catch {}
+let buffer143 = device0.createBuffer({size: 3362, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder189 = device0.createCommandEncoder({});
+let textureView209 = texture72.createView({});
+let computePassEncoder125 = commandEncoder189.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup71, new Uint32Array(901), 32, 0);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle12, renderBundle25, renderBundle21, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer24, 32);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer6, 92);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer100, 'uint32', 436, 1_587);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer39, 216, 130);
+} catch {}
+let textureView210 = texture21.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 15});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup115, new Uint32Array(492), 102, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(309, 116, 204_453_211, 639_278_200);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer102, 68);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer61, 172);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+if (!arrayBuffer26.detached) { new Uint8Array(arrayBuffer26).fill(0x55); };
+} catch {}
+let commandEncoder190 = device0.createCommandEncoder({});
+let computePassEncoder126 = commandEncoder190.beginComputePass({});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+let sampler140 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.36,
+  lodMaxClamp: 71.95,
+  compare: 'less',
+});
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer23, 696);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer93, 8);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(2, buffer98, 0, 14_676);
+} catch {}
+try {
+renderBundleEncoder28.insertDebugMarker('\u9183');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer64, 1224, new DataView(new ArrayBuffer(18489)), 1042, 188);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(123).fill(144), /* required buffer size: 123 */
+{offset: 123}, {width: 100, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer29.detached) { new Uint8Array(arrayBuffer29).fill(0x55); };
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup125 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 280, resource: {buffer: buffer121, offset: 768, size: 312}}],
+});
+let buffer144 = device0.createBuffer({size: 35426, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let sampler141 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.19,
+  lodMaxClamp: 80.75,
+  maxAnisotropy: 1,
+});
+let externalTexture32 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup51, new Uint32Array(395), 7, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer20, 852);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(5, buffer6, 0, 48);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(9, 821, 38, 129_805_361, 76_591_153);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(6, buffer90, 0, 3_441);
+} catch {}
+try {
+  await buffer67.mapAsync(GPUMapMode.READ, 0, 1256);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+let commandEncoder191 = device0.createCommandEncoder({});
+let computePassEncoder127 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup108);
+} catch {}
+try {
+computePassEncoder57.setBindGroup(1, bindGroup124, new Uint32Array(308), 49, 0);
+} catch {}
+try {
+renderPassEncoder35.setViewport(0.5160430981442925, 10.416424954565775, 3.3231713408431984, 5.130289322042089, 0.7416328379503121, 0.8189617967784872);
+} catch {}
+try {
+renderPassEncoder34.draw(24, 438, 908_822_239, 475_350_669);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let renderBundle29 = renderBundleEncoder30.finish({label: '\u1776\u0302\u31be\uf7b5\u0b6d\uc58e'});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup95, new Uint32Array(795), 168, 0);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(434, 107, 1_903, 408_148_832, 397_549_288);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer11, 128);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer31, 'uint16', 2_798, 15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture206,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 10},
+  aspect: 'all',
+}, new Uint8Array(12_365).fill(49), /* required buffer size: 12_365 */
+{offset: 611, bytesPerRow: 50, rowsPerImage: 6}, {width: 2, height: 2, depthOrArrayLayers: 40});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let textureView211 = texture144.createView({dimension: '2d-array'});
+let renderBundle30 = renderBundleEncoder28.finish({label: '\u08d3\u{1f6a4}\ua3c2\u5766'});
+try {
+renderPassEncoder62.setBindGroup(1, bindGroup106);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder5.draw(322, 246, 316_068_634, 367_520_434);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(14, 515, 2, 91_847_893, 50_098_548);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer17, 732);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer81, 1_696);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer93, 'uint16', 130, 195);
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  fragment: {module: shaderModule6, entryPoint: 'fragment1', targets: [{format: 'rgba32sint'}]},
+  vertex: {module: shaderModule6, buffers: []},
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: false,
+},
+});
+try {
+computePassEncoder124.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(2, bindGroup101, new Uint32Array(7981), 6_985, 0);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup75, new Uint32Array(2454), 121, 0);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle11, renderBundle23, renderBundle11, renderBundle2, renderBundle2, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer7, 1_156);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(1, buffer135, 0);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame25,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 24, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder();
+let texture241 = device0.createTexture({
+  label: '\u0eb1\ue1f2\u0a08\u6110\u010b',
+  size: [16, 16, 12],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture242 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder128 = commandEncoder192.beginComputePass({});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup91, new Uint32Array(1642), 452, 0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle8, renderBundle1, renderBundle18, renderBundle15, renderBundle23, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(36, 19, 20, 14_864_208, 481_099_609);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer42, 388);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, buffer84, 0, 405);
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 24, resource: textureView135},
+    {binding: 123, resource: {buffer: buffer79, offset: 0}},
+    {binding: 513, resource: sampler3},
+    {binding: 9, resource: textureView207},
+    {binding: 169, resource: textureView54},
+    {binding: 58, resource: textureView76},
+    {binding: 526, resource: textureView185},
+    {binding: 23, resource: {buffer: buffer101, offset: 1024, size: 1988}},
+    {binding: 224, resource: textureView16},
+  ],
+});
+let buffer145 = device0.createBuffer({size: 35820, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture243 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'astc-8x5-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView212 = texture237.createView({dimension: '2d-array', baseArrayLayer: 23, arrayLayerCount: 1});
+try {
+computePassEncoder127.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.draw(666, 652, 1_536_232_409, 229_239_138);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer138, 1_364);
+} catch {}
+let arrayBuffer33 = buffer53.getMappedRange(176, 5836);
+try {
+buffer46.unmap();
+} catch {}
+document.body.append(img0);
+let bindGroup127 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 313, resource: {buffer: buffer32, offset: 256, size: 2140}}],
+});
+let buffer146 = device0.createBuffer({
+  label: '\uc027\u0dff\u3117\u00c1\u1c2b\u7384\u0cc2\u{1f62d}\u81e2\u0ec2\u{1f7fb}',
+  size: 3541,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer24, 116);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer87, 304);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer20, 'uint32', 464, 7_562);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(0, buffer11, 0);
+} catch {}
+let commandEncoder193 = device0.createCommandEncoder({});
+let texture244 = device0.createTexture({
+  label: '\u09fb\u866a\u0737',
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder129 = commandEncoder193.beginComputePass({});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup106, new Uint32Array(294), 43, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(72, 226, 1_115_175_726, 77_403_081);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(4, buffer36, 3_160, 8_009);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer80, 'uint16', 4_672, 42);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer93, 0, 36);
+} catch {}
+try {
+computePassEncoder71.insertDebugMarker('\ufc27');
+} catch {}
+try {
+renderBundleEncoder31.insertDebugMarker('\u5611');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+//let promise33 = adapter0.requestAdapterInfo();
+let bindGroup128 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 19, resource: textureView2},
+    {binding: 407, resource: textureView118},
+    {binding: 36, resource: {buffer: buffer38, offset: 256}},
+  ],
+});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup109, new Uint32Array(4300), 1_141, 0);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer74, 14_140);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer98, 0, 2_800);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer146, 0, 173);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt709', transfer: 'bt1361ExtendedColourGamut'} });
+let shaderModule9 = device0.createShaderModule({
+  label: '\u0a13\u046c\ua0ba\u9536\ua67b\uf667\u659c\ud99e\u0707',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<atomic<i32>, 1>,
+}
+@group(0) @binding(36) var<uniform> buffer147: array<i32, 1>;
+@group(0) @binding(407) var tex12: texture_depth_cube_array;
+@group(0) @binding(19) var tex13: texture_cube_array<f32>;
+struct VertexOutput10 {
+  @location(8) f31: vec4u,
+  @location(0) @interpolate(linear) f32: vec4f,
+  @builtin(position) f33: vec4f,
+  @location(6) @interpolate(linear, centroid) f34: vec3h
+}
+
+@vertex
+fn vertex0(@location(15) @interpolate(flat, center) a0: vec4f) -> VertexOutput10 {
+  var out: VertexOutput10;
+  return out;
+}
+struct FragmentOutput6 {
+  @location(5) f0: vec3f,
+  @location(0) f1: vec3f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = buffer147[0];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder194 = device0.createCommandEncoder();
+let renderPassEncoder67 = commandEncoder194.beginRenderPass({
+  label: '\uec6a\u{1f989}\u9419\u348b',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 44,
+  clearValue: { r: 604.0, g: -307.3, b: -951.3, a: 581.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 148402142,
+});
+let sampler142 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.57,
+  lodMaxClamp: 83.77,
+});
+try {
+computePassEncoder110.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(3, 4, 1, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(695, 289, 79_370_971, 198_828_196);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup105);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup129 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 116, resource: textureView137}]});
+let sampler143 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 91.40,
+  lodMaxClamp: 96.06,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder67.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer109, 'uint32', 752, 323);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer14, 56, 74);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup6, new Uint32Array(103), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer20, 2_376); };
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup129);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup127, new Uint32Array(3750), 543, 0);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(21);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer138, 4_736);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer101, 220);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer31, 'uint32', 6_192, 5_719);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u{1ff5e}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: imageData8,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 20, y: 21, z: 22},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let commandEncoder195 = device0.createCommandEncoder({});
+let renderPassEncoder68 = commandEncoder195.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 23,
+  clearValue: { r: -305.8, g: -430.8, b: 195.9, a: -646.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup108, new Uint32Array(640), 72, 0);
+} catch {}
+try {
+renderPassEncoder35.pushDebugGroup('\ua8e1');
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 3 max align: 1 */
+struct T0 {
+  @align(1) @size(3) f0: array<array<f16, 1>>,
+}
+@group(0) @binding(88) var st2: texture_storage_1d<r32sint, read_write>;
+@group(0) @binding(126) var sam0: sampler_comparison;
+@group(0) @binding(78) var st3: texture_storage_2d_array<rg32uint, read>;
+struct VertexOutput11 {
+  @builtin(position) f35: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput11 {
+  var out: VertexOutput11;
+  if bool(textureLoad(st3, vec2i(), 0)[0]) {
+    var v: vec4f;
+  }
+  return out;
+}
+struct S4 {
+  @location(6) @interpolate(linear, centroid) f0: vec3h
+}
+struct FragmentOutput7 {
+  @location(1) f0: vec2f,
+  @location(0) @interpolate(flat, center) f1: vec2i
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec4f, a1: S4, @location(8) a2: vec4u) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer148 = device0.createBuffer({size: 6559, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder196 = device0.createCommandEncoder({});
+let computePassEncoder130 = commandEncoder196.beginComputePass({});
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup104);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup33, new Uint32Array(340), 103, 0);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer56, 5_136);
+} catch {}
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+try {
+  await promise33;
+} catch {}
+let buffer149 = device0.createBuffer({
+  size: 1831,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture245 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 32},
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture246 = device0.createTexture({
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+let renderBundle32 = renderBundleEncoder32.finish({label: '\u0df8\u0907\u27ad\u91ef\u38d0'});
+try {
+computePassEncoder121.setBindGroup(0, bindGroup93, new Uint32Array(5111), 2_219, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer124, 964);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer87, 448);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer113, 0, 394);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer31.detached) { new Uint8Array(arrayBuffer31).fill(0x55); };
+} catch {}
+try {
+  await promise32;
+} catch {}
+let commandEncoder197 = device0.createCommandEncoder({});
+let textureView213 = texture222.createView({});
+let computePassEncoder131 = commandEncoder197.beginComputePass({});
+try {
+computePassEncoder130.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder34.draw(21, 45, 389_746_112, 885_845_696);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(373, 111, 302, 452_839_936, 1_578_944_161);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer72, 820);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer85, 'uint32', 7_208, 2_473);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder198 = device0.createCommandEncoder({});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup84, new Uint32Array(322), 3, 0);
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(69, 30, 78, -1_797_723_980, 149_786_996);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer71, 296);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 87}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 10, y: 228 },
+  flipY: false,
+}, {
+  texture: texture208,
+  mipLevel: 2,
+  origin: {x: 14, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img1 = await imageWithData(23, 76, '#10101010', '#20202020');
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u{1f6b3}\u5a5b\u{1f7b6}', bindGroupLayouts: []});
+let textureView214 = texture120.createView({dimension: '2d', baseArrayLayer: 13});
+let sampler144 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 64.48,
+  lodMaxClamp: 78.66,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder125.setBindGroup(1, bindGroup116, new Uint32Array(5563), 705, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder25.draw(100, 126, 457_837_009, 38_895_959);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(155, 58, 2, 605_067_002, 1_173_900_070);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder198.insertDebugMarker('\u74bc');
+} catch {}
+let buffer150 = device0.createBuffer({size: 10066, usage: GPUBufferUsage.MAP_WRITE});
+let sampler145 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 31.49,
+  lodMaxClamp: 87.24,
+  compare: 'less-equal',
+});
+let externalTexture33 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder104.setBindGroup(3, bindGroup113);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+renderPassEncoder35.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let imageData26 = new ImageData(76, 36);
+let bindGroup130 = device0.createBindGroup({
+  label: '\ua306\u{1f928}\ua7ab\u{1fdcf}\ufecc\u0f50\u0cf6\u6677\u68b0',
+  layout: bindGroupLayout13,
+  entries: [{binding: 280, resource: {buffer: buffer37, offset: 16384, size: 1952}}],
+});
+let renderPassEncoder69 = commandEncoder198.beginRenderPass({colorAttachments: [{view: textureView39, depthSlice: 22, loadOp: 'load', storeOp: 'store'}]});
+try {
+renderPassEncoder7.drawIndirect(buffer6, 92);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder56.insertDebugMarker('\u9808');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(403).fill(217), /* required buffer size: 403 */
+{offset: 403}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule7,
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    buffers: [
+      {
+        arrayStride: 316,
+        attributes: [
+          {format: 'float32', offset: 96, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 128, shaderLocation: 3},
+          {format: 'sint16x2', offset: 228, shaderLocation: 2},
+          {format: 'sint16x2', offset: 12, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let commandEncoder199 = device0.createCommandEncoder({});
+let texture247 = device0.createTexture({
+  label: '\u9e58\u1b18\uabeb',
+  size: [24, 10, 33],
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder132 = commandEncoder199.beginComputePass({});
+try {
+computePassEncoder69.setBindGroup(2, bindGroup117);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(3, bindGroup107, new Uint32Array(257), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup106, new Uint32Array(3347), 275, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer64, 180, new DataView(new ArrayBuffer(22226)), 6584, 332);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture244,
+  mipLevel: 0,
+  origin: {x: 10, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView215 = texture33.createView({label: '\ud3ae\u0f9f\ucfc9\uc1e5\ue3b1\u0be7\u0e79', arrayLayerCount: 1});
+let sampler146 = device0.createSampler({
+  label: '\u0187\u8a3f\u{1ffbf}\ucd9e\uda27\u7792\u0bb5\u{1ffc4}\u09fd\u49bc',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 84.24,
+  lodMaxClamp: 88.75,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(319, 235, 28, 291_685_743, 109_364_921);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer131, 'uint16', 350, 105);
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 336,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 304,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 145,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 550,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture248 = device0.createTexture({
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture249 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView216 = texture120.createView({dimension: '2d', baseArrayLayer: 3});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup33, new Uint32Array(493), 1, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(210, 173, 663_333_940, 640_952_334);
+} catch {}
+let arrayBuffer34 = buffer94.getMappedRange(104, 3392);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup131 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 376, resource: {buffer: buffer110, offset: 0, size: 67}},
+    {binding: 36, resource: textureView171},
+  ],
+});
+let textureView217 = texture248.createView({});
+let texture250 = device0.createTexture({
+  label: '\u4e50\u0e55\u{1f647}',
+  size: [192],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler147 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.57,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(2, bindGroup105, new Uint32Array(1915), 7, 0);
+} catch {}
+try {
+renderPassEncoder49.draw(74, 86, 401_484_204, 1_207_188_422);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer61, 1_620);
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder();
+let textureView218 = texture2.createView({label: '\u70a8\u{1f933}\u03a6\u{1fff8}\u{1f6dc}'});
+let computePassEncoder133 = commandEncoder200.beginComputePass({});
+try {
+computePassEncoder61.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup7, new Uint32Array(5410), 416, 0);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup76);
+} catch {}
+try {
+renderPassEncoder46.setScissorRect(0, 4, 2, 4);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(2, 25, 4, 356_975_566, 2_022_772_214);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer101, 1_280);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer31, 'uint16', 6_500, 822);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer113);
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder({});
+let textureView219 = texture57.createView({label: '\u{1f975}\udc03\u860e\u6495\u842e\u{1f7b9}\u04e8', dimension: '2d', baseArrayLayer: 17});
+let computePassEncoder134 = commandEncoder201.beginComputePass({});
+try {
+renderPassEncoder8.draw(227, 140, 489_528_453, 2_071_326_429);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer122, 744);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture205,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(123_784).fill(95), /* required buffer size: 123_784 */
+{offset: 170, bytesPerRow: 81, rowsPerImage: 127}, {width: 2, height: 3, depthOrArrayLayers: 13});
+} catch {}
+offscreenCanvas3.height = 14;
+let imageData27 = new ImageData(32, 52);
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 444,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer151 = device0.createBuffer({
+  size: 5741,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder202 = device0.createCommandEncoder();
+let computePassEncoder135 = commandEncoder202.beginComputePass();
+try {
+computePassEncoder120.setBindGroup(0, bindGroup63, new Uint32Array(1840), 193, 0);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(47);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(1, buffer137, 0);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+document.body.append(img1);
+let buffer152 = device0.createBuffer({
+  size: 6058,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder203 = device0.createCommandEncoder({label: '\u9fc9\u09d2\u0f57\u0f22\u0a82\u0f0f\u0480\u2fab\u0eb0\u0f89\ubb4b'});
+let texture251 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder136 = commandEncoder203.beginComputePass({});
+try {
+computePassEncoder136.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer113, 1_144);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer18, 216);
+} catch {}
+try {
+computePassEncoder95.insertDebugMarker('\u007a');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({label: '\u{1f7c4}\ua16e\u{1fa8a}', bindGroupLayouts: []});
+let textureView220 = texture20.createView({label: '\u{1feae}\u00fd\u0462\u654f\ub7a9\u0eb9', aspect: 'all'});
+let texture252 = device0.createTexture({
+  size: [16, 16, 12],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup66, new Uint32Array(4180), 1_979, 0);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 92, 0, 3_922_925, 415_318_910);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte170m', transfer: 'log'} });
+let buffer153 = device0.createBuffer({
+  size: 2920,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture253 = device0.createTexture({
+  label: '\u8689\u{1f939}\u{1ff6b}\u5f06\u{1face}\u7a37\u0106\ub67a\ucc0c',
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer39, 124); };
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup121);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(449, 50, 3_045, 80_402_010, 1_097_342_358);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer151, 1_612);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let bindGroup132 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 85, resource: textureView16}]});
+let buffer154 = device0.createBuffer({
+  size: 19160,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup75, new Uint32Array(121), 7, 0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup76);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(226);
+} catch {}
+try {
+renderPassEncoder35.draw(398, 101, 872_296_891, 45_780_770);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer74, 5_876);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer70, 'uint16', 764, 735);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+  await buffer144.mapAsync(GPUMapMode.WRITE, 0, 840);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup133 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 356, resource: {buffer: buffer81, offset: 2048, size: 764}},
+    {binding: 33, resource: sampler44},
+    {binding: 342, resource: sampler79},
+    {binding: 39, resource: externalTexture1},
+  ],
+});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture254 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 132},
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup84);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle2, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer72, 292);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let buffer155 = device0.createBuffer({
+  label: '\uddce\u{1fa9f}\uabb4\u4f1c\ue218\u{1fbf2}',
+  size: 16485,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let textureView221 = texture56.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 2});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup36, new Uint32Array(1788), 14, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup98, new Uint32Array(2359), 135, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(180, 108, 111_194_639, 1_535_889_418);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer20, 1_336);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer69, 2_924);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer142, 'uint16', 600, 1_548);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView222 = texture68.createView({baseMipLevel: 0});
+let renderPassEncoder70 = commandEncoder204.beginRenderPass({
+  label: '\u{1fa4a}\u{1fc0e}\ude55\u{1f7f4}\uad53\u{1fd6f}\u{1febe}\u23d5\u0a6e',
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: 138.6, g: -780.3, b: -148.2, a: 401.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(542, 70, 292, 965_789_613, 1_042_294_459);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer19, 12);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer36, 3_256);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer137, 'uint32', 1_112, 1_913);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 48, new Float32Array(17740), 228, 16);
+} catch {}
+document.body.append(canvas4);
+let video4 = await videoWithData(76);
+let commandEncoder205 = device0.createCommandEncoder({});
+let computePassEncoder137 = commandEncoder205.beginComputePass({});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+let sampler148 = device0.createSampler({
+  label: '\u06d4\uc693\u4c2a',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.79,
+  lodMaxClamp: 89.63,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer124, 328); };
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup99, new Uint32Array(1743), 442, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+/* target size: 69 max align: 1 */
+struct T0 {
+  @align(1) f0: array<atomic<u32>, 1>,
+  @align(1) f1: vec2h,
+  @align(1) @size(16) f2: array<array<atomic<i32>, 1>, 1>,
+  @align(1) @size(8) f3: atomic<u32>,
+  @align(1) @size(20) f4: vec4f,
+  @align(1) f5: atomic<u32>,
+  @align(1) @size(13) f6: array<f16>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @size(4) f0: f16,
+}
+@group(0) @binding(126) var sam1: sampler_comparison;
+@group(0) @binding(88) var st4: texture_storage_1d<r32float, read_write>;
+@group(0) @binding(78) var st5: texture_storage_2d_array<rg32uint, read>;
+struct FragmentOutput8 {
+  @location(0) f0: vec2f
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+});
+let commandEncoder206 = device0.createCommandEncoder({});
+let texture255 = device0.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder138 = commandEncoder206.beginComputePass({});
+try {
+computePassEncoder138.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(4, 180, 2, 857_825_204, 753_459_317);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer43, 616);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer98, 'uint16', 5_222, 7_833);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(5, buffer72, 528);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup122);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData24,
+  origin: { x: 2, y: 5 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 27, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let buffer156 = device0.createBuffer({
+  size: 10544,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let renderBundle33 = renderBundleEncoder33.finish({});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup74, new Uint32Array(2695), 1_130, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup87);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup133, new Uint32Array(5452), 831, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(767, 141, 112_213_503, 224_532_466);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer7, 3_696);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer44, 'uint16', 1_480, 1_824);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline2);
+} catch {}
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let imageData28 = new ImageData(156, 64);
+let texture256 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 19},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(156, 98, 169, 66_593_669, 762_009_877);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer121, 'uint32', 1_328, 848);
+} catch {}
+try {
+buffer150.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 24, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(221).fill(214), /* required buffer size: 221 */
+{offset: 221, bytesPerRow: 338}, {width: 19, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt2020', transfer: 'bt2020_12bit'} });
+let bindGroup134 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 9, resource: textureView207},
+    {binding: 513, resource: sampler39},
+    {binding: 58, resource: textureView222},
+    {binding: 169, resource: textureView104},
+    {binding: 224, resource: textureView2},
+    {binding: 24, resource: textureView73},
+    {binding: 526, resource: textureView169},
+    {binding: 23, resource: {buffer: buffer3, offset: 1536, size: 980}},
+    {binding: 123, resource: {buffer: buffer93, offset: 0, size: 80}},
+  ],
+});
+let commandEncoder207 = device0.createCommandEncoder({});
+let textureView223 = texture139.createView({dimension: '2d-array'});
+let texture257 = device0.createTexture({size: [96], dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_SRC});
+let textureView224 = texture116.createView({mipLevelCount: 1});
+let renderPassEncoder71 = commandEncoder207.beginRenderPass({colorAttachments: [{view: textureView206, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder62.setScissorRect(45, 1, 20, 25);
+} catch {}
+try {
+renderPassEncoder23.draw(94, 198, 1_403_739_003, 550_352_951);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 329, 2, -649_042_277, 2_051_529_778);
+} catch {}
+try {
+renderPassEncoder60.insertDebugMarker('\u09b6');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup135 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler53}]});
+try {
+computePassEncoder128.setBindGroup(1, bindGroup106);
+} catch {}
+try {
+computePassEncoder125.setBindGroup(2, bindGroup46, new Uint32Array(2756), 667, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer152, 1_352); };
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+let imageData29 = new ImageData(4, 28);
+let bindGroup136 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 376, resource: {buffer: buffer39, offset: 0, size: 11}},
+    {binding: 36, resource: textureView52},
+  ],
+});
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup105, new Uint32Array(958), 7, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle29, renderBundle32, renderBundle29, renderBundle27, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 199.7, g: 983.5, b: -365.7, a: 36.43, });
+} catch {}
+try {
+renderPassEncoder46.draw(55, 8, 2_136_181_261, 518_980_320);
+} catch {}
+let buffer157 = device0.createBuffer({
+  size: 15424,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture258 = device0.createTexture({size: [48], dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_SRC});
+let sampler149 = device0.createSampler({
+  label: '\u063c\u0109\u0529\u0af7\u4ac8\u7ac2\u{1ffda}\ud140\u01d5\u1d9a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.40,
+  lodMaxClamp: 69.57,
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder25.draw(132, 81, 871_398, 512_383_521);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(9, 6, 20, 292_035_371, 864_067_628);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer101, 172);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer72, 520);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(6, buffer103);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer106, 724, new Float32Array(5296), 6, 116);
+} catch {}
+let promise36 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+await gc();
+let offscreenCanvas4 = new OffscreenCanvas(41, 565);
+let commandEncoder208 = device0.createCommandEncoder({});
+let textureView225 = texture168.createView({aspect: 'all'});
+let renderPassEncoder72 = commandEncoder208.beginRenderPass({colorAttachments: [{view: textureView204, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup111, new Uint32Array(407), 102, 0);
+} catch {}
+try {
+computePassEncoder66.dispatchWorkgroups(1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer5, 20); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup15, new Uint32Array(2118), 1_151, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle27, renderBundle29]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer149, 788);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(0, buffer100);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 2112, new Int16Array(22837), 158, 1292);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture241,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas4.getContext('webgpu');
+document.body.append(video2);
+let buffer158 = device0.createBuffer({
+  label: '\u70be\u7f4e\u0d22\ue9de\u{1fd78}\ub54d\u0dc2\ucc22\u{1ff64}\ue832\u0f8a',
+  size: 14155,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture259 = device0.createTexture({
+  size: {width: 16},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler150 = device0.createSampler({
+  label: '\u0acb\u{1fcd5}\u{1f80f}\u{1f875}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 16.44,
+  lodMaxClamp: 86.86,
+});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer5, 160);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer156, 2_908);
+} catch {}
+try {
+texture178.destroy();
+} catch {}
+let arrayBuffer35 = buffer21.getMappedRange(120, 16);
+document.body.prepend(canvas4);
+let buffer159 = device0.createBuffer({
+  label: '\u0225\u{1f966}\u{1feaa}\u0053',
+  size: 3264,
+  usage: GPUBufferUsage.COPY_DST,
+  mappedAtCreation: true,
+});
+let textureView226 = texture13.createView({});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(3, bindGroup76, new Uint32Array(1411), 544, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+renderPassEncoder49.draw(121, 67, 752_104_745, 946_127_394);
+} catch {}
+let commandEncoder209 = device0.createCommandEncoder({label: '\u0770\u0753\u5358'});
+let texture260 = device0.createTexture({size: [48], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler151 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 13.11,
+});
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer72, 336);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer138, 2_724);
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'hlg'} });
+let commandEncoder210 = device0.createCommandEncoder({label: '\u0d86\u6d29\u819e\u0cd2\u34e0\u{1f747}\uda83\u4233'});
+let texture261 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder139 = commandEncoder209.beginComputePass({});
+let renderPassEncoder73 = commandEncoder210.beginRenderPass({
+  colorAttachments: [{
+  view: textureView158,
+  depthSlice: 214,
+  clearValue: { r: -561.2, g: 274.3, b: 126.9, a: -636.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder23.draw(110, 316, 167_294_675, 1_029_398_705);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer20, 8_428);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(4, buffer42, 1_584, 525);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer160 = device0.createBuffer({
+  label: '\u{1fba2}\ua339\u{1ff4a}\u095d\u4fc2\u1822\u{1f75a}\u006c\u0639\u0c38\ua0fa',
+  size: 17460,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 321});
+try {
+computePassEncoder133.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer101, 2_648);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer17, 488);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 17, y: 7, z: 3},
+  aspect: 'all',
+}, new Uint8Array(14_102).fill(202), /* required buffer size: 14_102 */
+{offset: 116, bytesPerRow: 74, rowsPerImage: 47}, {width: 0, height: 2, depthOrArrayLayers: 5});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas5 = document.createElement('canvas');
+let shaderModule12 = device0.createShaderModule({
+  label: '\u2261\u0a7d\uaa8b\u1ca4\ua63f\ufdb6',
+  code: `
+enable f16;
+/* target size: 113 max align: 1 */
+struct T0 {
+  @align(1) @size(12) f0: array<atomic<i32>, 1>,
+  @align(1) @size(40) f1: vec3i,
+  @align(1) @size(16) f2: vec2h,
+  @align(1) f3: u32,
+  @align(1) @size(12) f4: f16,
+  @align(1) f5: u32,
+  @align(1) @size(25) f6: f16,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: array<array<atomic<i32>, 1>, 1>,
+}
+@group(0) @binding(407) var tex14: texture_depth_2d;
+@group(0) @binding(19) var tex15: texture_3d<i32>;
+@group(0) @binding(36) var<uniform> buffer161: array<vec2h, 1>;
+struct VertexOutput12 {
+  @builtin(position) f36: vec4f
+}
+
+@vertex
+fn vertex0(@location(11) @interpolate(perspective, center) a0: vec2h) -> VertexOutput12 {
+  var out: VertexOutput12;
+  _ = buffer161[0];
+  return out;
+}
+struct FragmentOutput9 {
+  @location(0) f0: vec4i,
+  @location(6) f1: vec2u,
+  @location(1) f2: vec2u,
+  @location(2) f3: vec2i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  _ = textureLoad(tex15, vec3i(), 0);
+  if bool(textureLoad(tex14, vec2i(), 0)) {
+    out.f3 = vec2i(bitcast<i32>(textureLoad(tex14, vec2i(), 0)));
+  }
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 177,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup137 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 550, resource: {buffer: buffer78, offset: 1280, size: 2895}},
+    {binding: 304, resource: textureView217},
+    {binding: 145, resource: textureView111},
+    {binding: 76, resource: {buffer: buffer81, offset: 2816, size: 9504}},
+    {binding: 336, resource: textureView78},
+  ],
+});
+let texture262 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture263 = device0.createTexture({
+  size: [96],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let texture264 = gpuCanvasContext3.getCurrentTexture();
+let textureView227 = texture221.createView({label: '\u1549\u06c3', format: 'rgba32sint'});
+try {
+renderPassEncoder46.draw(0, 120, 83_295_697, 735_243_199);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(10, 67, 6, 191_002_469, 710_014_782);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ);
+} catch {}
+document.body.prepend(img0);
+let imageData30 = new ImageData(12, 16);
+let commandEncoder211 = device0.createCommandEncoder();
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 1068});
+let textureView228 = texture262.createView({});
+let computePassEncoder140 = commandEncoder211.beginComputePass({});
+let sampler152 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 40.90,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup65, new Uint32Array(948), 16, 0);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(1, bindGroup78, new Uint32Array(1956), 92, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle2, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer42, 84);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer85, 0, 344);
+} catch {}
+let buffer162 = device0.createBuffer({
+  size: 8557,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(424, 205, 215, 627_883_527, 310_307_948);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 6088, new Int16Array(26307), 6214, 360);
+} catch {}
+document.body.append(img0);
+let texture265 = device0.createTexture({
+  label: '\u{1fcf0}\u01c0\u0a17\u{1f68c}\u23fc\u0ab3\u039e',
+  size: [16],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView229 = texture30.createView({label: '\u0fc8\u99c3\u6b78\u0d4f\u0344\u7911\u0eb0\u2bd0'});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup44, new Uint32Array(1475), 662, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(241, 85, 2_091_919_476, 238_751_811);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(3, 8, 0, 25_396_091, 644_152_357);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer80, 'uint16', 1_640, 4_599);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(4, buffer97, 0, 46);
+} catch {}
+try {
+  await buffer140.mapAsync(GPUMapMode.WRITE, 352, 156);
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+let buffer163 = device0.createBuffer({
+  size: 20574,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle32, renderBundle32, renderBundle27, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(11, 144, 302, 55_672_801, 327_951_581);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer65, 'uint32', 3_380, 2_258);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer111, 4292, new BigUint64Array(4078), 678, 496);
+} catch {}
+let textureView230 = texture200.createView({dimension: '3d', baseArrayLayer: 0});
+let sampler153 = device0.createSampler({
+  label: '\u0cac\u3bfc\uea04\u{1fb13}\u{1fd7e}\ua4f0\u4c2a\u0362\ub64f',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 56.57,
+  maxAnisotropy: 2,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1_462, 12, 652, 139_531_927, 1_854_713_407);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer36 = buffer55.getMappedRange(112, 8);
+try {
+  await promise34;
+} catch {}
+let texture266 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder140.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup111);
+} catch {}
+try {
+renderPassEncoder23.draw(47, 181, 991_263_454, 724_753_211);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(283, 154, 13, 221_367_594, 598_366_579);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer98, 2_132);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(3, buffer138, 1_296);
+} catch {}
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 904});
+let textureView231 = texture26.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer16, 448); };
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup45, new Uint32Array(1796), 37, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer37, 'uint16', 864, 4_541);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(7, buffer100, 0, 302);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(canvas2);
+let buffer164 = device0.createBuffer({size: 23461, usage: GPUBufferUsage.MAP_WRITE});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 365});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup97);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup74, new Uint32Array(660), 14, 0);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer71, 128);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer27, 516);
+} catch {}
+try {
+buffer23.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(4_034).fill(139), /* required buffer size: 4_034 */
+{offset: 366, bytesPerRow: 15, rowsPerImage: 122}, {width: 2, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup92, new Uint32Array(2333), 1_076, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer6, 20);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer74, 'uint16', 16_338, 3_475);
+} catch {}
+let arrayBuffer37 = buffer67.getMappedRange(0, 396);
+try {
+buffer114.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup138 = device0.createBindGroup({
+  label: '\u0f2d\u5ac5\ubd78\u66ad\u0faf\u0ef7\u{1faea}',
+  layout: bindGroupLayout12,
+  entries: [{binding: 408, resource: sampler1}],
+});
+let textureView232 = texture93.createView({label: '\u{1f7ea}\u0768\u8bcf\u3dee', mipLevelCount: 1});
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup17, new Uint32Array(259), 15, 0);
+} catch {}
+try {
+renderPassEncoder34.setScissorRect(0, 2, 9, 2);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer131, 68);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer16, 672);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline1);
+} catch {}
+let gpuCanvasContext9 = canvas5.getContext('webgpu');
+let buffer165 = device0.createBuffer({
+  size: 5764,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture267 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 55},
+  mipLevelCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup30, new Uint32Array(4623), 86, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder23.draw(126, 16, 1_669_181_602, 428_101_371);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer39, 132);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer12, 3_792);
+} catch {}
+let arrayBuffer38 = buffer67.getMappedRange(688, 56);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 46,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup139 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer75, offset: 512, size: 500}}],
+});
+let commandEncoder212 = device0.createCommandEncoder({label: '\u8563\u8a95\ubc10\u666e\u504c\u0da9\u0df8\u1dad\u0c67\u6433'});
+let renderPassEncoder74 = commandEncoder212.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: 811.0, g: 782.7, b: -361.1, a: -483.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler154 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.71,
+  lodMaxClamp: 75.40,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder8.drawIndexed(12, 389, 6, 7_296_830, 686_346_936);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer42, 204);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer63, 24);
+} catch {}
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'gamma22curve'} });
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 41, resource: textureView16},
+    {binding: 89, resource: textureView53},
+    {binding: 5, resource: textureView2},
+  ],
+});
+let buffer166 = device0.createBuffer({
+  label: '\u{1fc73}\u0050\ucf96\u{1ff38}\u8c83\u3ced\u0d07\u097a\u0a01\u3fb8\u405c',
+  size: 21497,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup53, new Uint32Array(265), 14, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(64, 155, 673_470_181, 247_780_952);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer122, 532);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer81, 380);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 76, new Float32Array(13880), 724, 180);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 20, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8Array(5_511).fill(66), /* required buffer size: 5_511 */
+{offset: 182, bytesPerRow: 135, rowsPerImage: 18}, {width: 8, height: 4, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 79}
+*/
+{
+  source: video4,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 9, y: 1, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer167 = device0.createBuffer({size: 27536, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer24, 0);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer71, 652);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer28, 'uint32', 10_300, 944);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline6);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let commandEncoder213 = device0.createCommandEncoder({});
+let computePassEncoder141 = commandEncoder213.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup107);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup54, new Uint32Array(1366), 30, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer122, 560);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer133, 'uint16', 112, 164);
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({});
+let textureView233 = texture259.createView({label: '\u09fd\uccc6\u6115\uc21e'});
+let renderPassEncoder75 = commandEncoder214.beginRenderPass({
+  colorAttachments: [{
+  view: textureView226,
+  depthSlice: 81,
+  clearValue: { r: 517.3, g: -292.1, b: 279.7, a: -871.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 36845558,
+});
+let sampler155 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 73.73,
+  lodMaxClamp: 87.71,
+  compare: 'less-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder77.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.draw(287, 27, 2_286_832_152, 48_457_265);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(108, 100, 9, 421_447_578, 101_218_527);
+} catch {}
+try {
+commandEncoder166.label = '\u{1f827}\ue01b\u04cd\uf737\ub0a6\u140d\ud4e5';
+} catch {}
+let textureView234 = texture4.createView({dimension: '2d-array'});
+try {
+computePassEncoder111.setBindGroup(3, bindGroup95, new Uint32Array(1150), 325, 0);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(1, bindGroup120);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer5, 1_136);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer131, 20);
+} catch {}
+try {
+buffer79.unmap();
+} catch {}
+let commandEncoder215 = device0.createCommandEncoder();
+let texture268 = device0.createTexture({
+  size: [48, 20, 59],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder142 = commandEncoder215.beginComputePass({label: '\udeec\u877d\uaac5\u0dbb\u1e15\ud2fa\u0fee'});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup96, []);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderPassEncoder35.draw(168, 247, 15_356_411, 893_989_183);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer117, 2_024);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer102);
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\u472d');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView235 = texture64.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder141.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.draw(496, 26, 1_402_300_757, 1_185_823_112);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(32, 185, 249, 327_286_682, 230_756_963);
+} catch {}
+let bindGroup141 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView221}]});
+let commandEncoder216 = device0.createCommandEncoder({});
+let textureView236 = texture194.createView({});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup138, new Uint32Array(1678), 117, 0);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(2, 1, 2, 2);
+} catch {}
+try {
+renderPassEncoder34.draw(40, 117, 1_197_851_522, 1_143_836_776);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer116, 3_968);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline6);
+} catch {}
+let bindGroup142 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 28, resource: textureView189}]});
+let commandEncoder217 = device0.createCommandEncoder({});
+let textureView237 = texture194.createView({});
+let texture269 = device0.createTexture({
+  size: [48, 20, 87],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder143 = commandEncoder217.beginComputePass({label: '\ubc5b\u0190'});
+let sampler156 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 94.67});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup114, new Uint32Array(764), 70, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(305);
+} catch {}
+try {
+renderPassEncoder34.draw(170, 16, 730_473_840, 257_847_141);
+} catch {}
+try {
+renderPassEncoder35.drawIndexed(814, 251, 1_084, -1_618_137_292, 1_185_260_231);
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 163, resource: textureView17},
+    {binding: 63, resource: {buffer: buffer110, offset: 256, size: 1120}},
+  ],
+});
+let commandEncoder218 = device0.createCommandEncoder({});
+let textureView238 = texture204.createView({dimension: '3d', format: 'r32sint'});
+let computePassEncoder144 = commandEncoder218.beginComputePass({});
+let renderPassEncoder76 = commandEncoder216.beginRenderPass({
+  colorAttachments: [{
+  view: textureView164,
+  clearValue: { r: 410.8, g: -53.02, b: -332.6, a: 947.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 190179865,
+});
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer113, 3_528);
+} catch {}
+try {
+  await promise36;
+} catch {}
+let bindGroup144 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 36, resource: textureView52}, {binding: 376, resource: {buffer: buffer56, offset: 768}}],
+});
+let commandEncoder219 = device0.createCommandEncoder({});
+let textureView239 = texture33.createView({label: '\u04d5\u{1f986}\u{1fd94}\u{1fd49}\u769f', dimension: '2d'});
+let computePassEncoder145 = commandEncoder219.beginComputePass({});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle34 = renderBundleEncoder34.finish({label: '\u72c7\udf24\u070d\u{1f75e}\u939e\u0b78\uee86\u185c\u{1fd61}'});
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup138);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup143, new Uint32Array(319), 2, 0);
+} catch {}
+try {
+renderPassEncoder53.setStencilReference(1568);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(302, 410, 342, 989_992_047, 35_531_306);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer27, 452);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer152, 976);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer126, 1260, new Float32Array(3389), 785, 588);
+} catch {}
+let imageData31 = new ImageData(32, 16);
+let commandEncoder220 = device0.createCommandEncoder({});
+let texture270 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder8.draw(163, 51, 786_342_413, 537_484_659);
+} catch {}
+try {
+buffer153.unmap();
+} catch {}
+try {
+commandEncoder220.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5882 */
+  offset: 5882,
+  buffer: buffer56,
+}, {
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 1, y: 9, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(76).fill(232), /* required buffer size: 76 */
+{offset: 76}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder44.setBindGroup(2, bindGroup32, new Uint32Array(110), 8, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer72, 708);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer83, 2_536);
+} catch {}
+try {
+querySet30.destroy();
+} catch {}
+let texture271 = device0.createTexture({size: [16], sampleCount: 1, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_DST});
+let textureView240 = texture256.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder146 = commandEncoder220.beginComputePass({});
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.draw(42, 32, 853_607_184, 926_370_972);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer49, 'uint32', 448, 3_591);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(0, buffer103, 0);
+} catch {}
+try {
+computePassEncoder50.pushDebugGroup('\ue342');
+} catch {}
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+let textureView241 = texture40.createView({dimension: 'cube', baseMipLevel: 0, arrayLayerCount: 6});
+let sampler157 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.09,
+  lodMaxClamp: 88.89,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup5, new Uint32Array(1292), 140, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(2_373, 118, 263, 940_429_327, 1_057_074_197);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer163, 2_984);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let imageData32 = new ImageData(76, 32);
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'iec61966-2-1'} });
+let bindGroup145 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 5, resource: textureView16},
+    {binding: 41, resource: textureView2},
+    {binding: 89, resource: textureView12},
+  ],
+});
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12]});
+let texture272 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder146.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer36, 740);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(6, buffer153, 236);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer139, 1676, new Int16Array(3703), 138, 1880);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u94d9\ued82',
+  code: `
+enable f16;
+/* target size: 12 max align: 4 */
+struct T0 {
+  @size(12) f0: array<mat2x2h>,
+}
+@group(0) @binding(408) var sam2: sampler;
+struct VertexOutput13 {
+  @builtin(position) f37: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput13 {
+  var out: VertexOutput13;
+  out.f37 = vec4f(0.2672, 0.3321, 0.8378, 0.09657);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+try {
+computePassEncoder142.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer50, 'uint32', 24, 1);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup71);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8Array(46).fill(47), /* required buffer size: 46 */
+{offset: 46}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup146 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 34, resource: textureView159}]});
+let textureView242 = texture262.createView({label: '\ufac9\u{1fe11}\u0e85\u{1f6f3}\u090a\u0407\ub5bc'});
+let texture273 = device0.createTexture({
+  label: '\u7740\uae3f\u{1f647}\u49d4\u453a\u0646\u0a91\u63d1\u03e8\u4201\u8f40',
+  size: {width: 96, height: 40, depthOrArrayLayers: 110},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup97, []);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(1, bindGroup112, new Uint32Array(193), 41, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer115, 4_292);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer29, 'uint16', 276, 713);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 580, new Int16Array(15231), 935, 20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame32,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+//let promise38 = adapter0.requestAdapterInfo();
+let bindGroup147 = device0.createBindGroup({
+  label: '\u6f27\u0744',
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 33, resource: sampler30},
+    {binding: 39, resource: externalTexture8},
+    {binding: 342, resource: sampler151},
+    {binding: 356, resource: {buffer: buffer50, offset: 0, size: 8}},
+  ],
+});
+let commandEncoder221 = device0.createCommandEncoder({});
+let textureView243 = texture91.createView({dimension: '2d-array', aspect: 'all'});
+let textureView244 = texture108.createView({mipLevelCount: 1});
+let computePassEncoder147 = commandEncoder221.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup28, new Uint32Array(1199), 560, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer131, 180);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(7, buffer19, 0, 81);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup18, new Uint32Array(80), 14, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: img0,
+  origin: { x: 6, y: 2 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise29;
+} catch {}
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroup148 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 34, resource: textureView159}]});
+let renderBundle35 = renderBundleEncoder35.finish({label: '\u7bee\u218f\u{1fec5}\u0251\ud2bf\u76a3\ue821\u7012\u067e\u934c\uac90'});
+let externalTexture34 = device0.importExternalTexture({source: video3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder8.drawIndexed(417, 10, 200, 637_248_968, 56_843_370);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer54, 792);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer110, 'uint16', 56, 2_805);
+} catch {}
+try {
+computePassEncoder50.popDebugGroup();
+} catch {}
+let bindGroup149 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 6, resource: textureView139}]});
+let textureView245 = texture153.createView({label: '\u{1ffa4}\uf0f8\u0f72\u0255\ua31e\u8325\u03e4\u7c05\u06bb', dimension: '2d-array'});
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer149, 28);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer44, 'uint16', 2_864, 387);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline5);
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 34, y: 471 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte170m', transfer: 'hlg'} });
+let buffer168 = device0.createBuffer({
+  size: 29908,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture274 = device0.createTexture({
+  label: '\u8975\u{1f9d2}\u475a\ufc84\u5ae7\ufe83\u0852\u1e01\u032d',
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup84, new Uint32Array(254), 3, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup80, new Uint32Array(88), 51, 0);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(74, 1, 3, 63);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(0, 353, 27, 45_454_930, 746_730_402);
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\ub5f4');
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer25.detached) { new Uint8Array(arrayBuffer25).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u8ebe\ueb4c\ucdc3';
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder9.draw(580, 212, 53_608_952, 177_914_509);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(263, 123, 192, 1_125_718_785, 370_139_365);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer122, 'uint16', 1_094, 2_821);
+} catch {}
+let imageData33 = new ImageData(76, 48);
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  label: '\ub9b7\u737c\u0bac\u8bd2\u2520\u0c48\u0708\u{1f7de}',
+  entries: [
+    {
+      binding: 248,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder222 = device0.createCommandEncoder({});
+let texture275 = device0.createTexture({
+  label: '\u{1f9a7}\u27a7\u{1f702}\u09b4\u{1fb19}',
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(0, bindGroup114);
+} catch {}
+try {
+renderPassEncoder35.draw(210, 159, 655_097_041, 617_470_366);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(9, 72, 32, 147_963_417, 317_356_429);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer116, 488);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer49, 'uint16', 4_164, 1_512);
+} catch {}
+try {
+commandEncoder222.clearBuffer(buffer64, 248, 132);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+  await promise40;
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'gamma28curve'} });
+let buffer169 = device0.createBuffer({size: 12394, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let textureView246 = texture275.createView({
+  label: '\u6b22\u8540\u4689\u0221\u58bc\u46db\u7ef8\u3e0e\u21b7\u0e68\u5f8c',
+  dimension: '2d',
+  baseArrayLayer: 5,
+});
+let textureView247 = texture180.createView({});
+try {
+renderPassEncoder75.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer17, 72);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer104, 2_176);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(1, buffer98, 0, 2_398);
+} catch {}
+try {
+  await promise35;
+} catch {}
+let renderPassEncoder77 = commandEncoder222.beginRenderPass({
+  label: '\u8d31\u011c',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 23,
+  clearValue: { r: 889.9, g: -24.24, b: 543.2, a: -637.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup0, new Uint32Array(1103), 182, 0);
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup6, new Uint32Array(2506), 173, 0);
+} catch {}
+try {
+renderPassEncoder65.setStencilReference(541);
+} catch {}
+try {
+renderPassEncoder9.draw(265, 175, 535_505_171, 534_041_194);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(139, 76, 42, -1_811_146_295, 730_785_102);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer29, 708);
+} catch {}
+let commandEncoder223 = device0.createCommandEncoder();
+let computePassEncoder148 = commandEncoder223.beginComputePass();
+try {
+computePassEncoder67.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle29]);
+} catch {}
+try {
+renderPassEncoder25.draw(126, 629, 650_510_963, 220_875_241);
+} catch {}
+try {
+renderPassEncoder35.drawIndexed(188, 141, 1_730, 98_396_665, 668_672_569);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer34, 148);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer124, 400, 2_709);
+} catch {}
+let textureView248 = texture275.createView({dimension: '2d'});
+let texture276 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 17},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder25.draw(13, 80, 373_820_224, 658_108_209);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer6, 12);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(2, bindGroup113, new Uint32Array(1820), 149, 0);
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+renderPassEncoder72.setScissorRect(0, 1, 6, 1);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 263, 5, 82_613_414, 749_556_106);
+} catch {}
+try {
+buffer151.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer170 = device0.createBuffer({size: 4772, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler158 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 94.58,
+  lodMaxClamp: 97.54,
+  compare: 'never',
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(0, bindGroup116, new Uint32Array(3979), 858, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder57.setViewport(1.7977727258187457, 5.6435641452341265, 11.200098993083078, 0.013747551086239013, 0.9544497677003771, 0.9613150153788047);
+} catch {}
+try {
+renderPassEncoder35.draw(91, 78, 533_686_799, 842_467_824);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: videoFrame28,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 9, y: 21, z: 78},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder();
+let textureView249 = texture261.createView({dimension: 'cube-array', format: 'r16float', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder149 = commandEncoder224.beginComputePass({});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup134, new Uint32Array(1358), 316, 0);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup136);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(180, 330, 14, 673_669_383, 621_893_881);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer104, 916);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup150 = device0.createBindGroup({layout: bindGroupLayout28, entries: [{binding: 310, resource: textureView205}]});
+let commandEncoder225 = device0.createCommandEncoder({});
+let sampler159 = device0.createSampler({addressModeU: 'repeat', minFilter: 'nearest', lodMinClamp: 93.77, lodMaxClamp: 94.10});
+try {
+computePassEncoder114.setBindGroup(2, bindGroup47, new Uint32Array(650), 36, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(348, 313, 119, -1_026_129_626, 87_164_501);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer42, 'uint32', 1_780, 344);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(6, buffer146);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer156, 3872, new BigUint64Array(1634), 354, 16);
+} catch {}
+let texture277 = device0.createTexture({
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView250 = texture60.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let sampler160 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 37.77,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup117, new Uint32Array(4056), 375, 0);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder34.draw(115, 76, 1_097_789_123, 1_314_129_215);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer42, 428);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer122, 1_588);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer55, 'uint32', 88, 1);
+} catch {}
+try {
+commandEncoder225.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1704 */
+  offset: 1704,
+  buffer: buffer115,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder123.pushDebugGroup('\u0798');
+} catch {}
+try {
+renderBundleEncoder36.insertDebugMarker('\u0de7');
+} catch {}
+let buffer171 = device0.createBuffer({size: 13061, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler161 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.43,
+  lodMaxClamp: 43.24,
+});
+try {
+renderPassEncoder46.draw(208, 73, 746_687_010, 1_011_885_395);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(5, 125, 12, 121_361_018, 270_112_093);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer44, 'uint16', 30, 2_739);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer70, 'uint32', 1_804, 62);
+} catch {}
+try {
+computePassEncoder123.popDebugGroup();
+} catch {}
+try {
+renderBundleEncoder36.insertDebugMarker('\u54db');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer167, 4176, new BigUint64Array(6811), 1, 1044);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+try {
+computePassEncoder19.setBindGroup(1, bindGroup98);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -675.3, g: 543.6, b: 229.6, a: 824.0, });
+} catch {}
+try {
+renderPassEncoder23.draw(112, 345, 447_209_800, 49_812_955);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(230, 152, 370, -1_672_239_536, 526_532_132);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer117, 2_748);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer74, 10_168);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer168, 6_708);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup100);
+} catch {}
+let texture278 = device0.createTexture({
+  label: '\ucf97\ue3e5\u50a9\u3c94\u3b4b\u{1fce4}',
+  size: [48, 20, 22],
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder150 = commandEncoder225.beginComputePass({});
+try {
+computePassEncoder150.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup108, new Uint32Array(1354), 1, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(328, 7, 377_139_121, 549_482_420);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer151, 132);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer61, 'uint32', 244, 933);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup110, new Uint32Array(629), 542, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer103, 684);
+} catch {}
+let buffer172 = device0.createBuffer({
+  label: '\ua8c7\u04a3\u{1fa3b}\u155e\u087a\u931f',
+  size: 1576,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler162 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 74.53,
+  lodMaxClamp: 83.42,
+});
+try {
+computePassEncoder100.setBindGroup(2, bindGroup118);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer116, 1_780);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup36, new Uint32Array(481), 32, 0);
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder();
+let renderPassEncoder78 = commandEncoder226.beginRenderPass({
+  colorAttachments: [{
+  view: textureView200,
+  depthSlice: 1,
+  clearValue: { r: -190.0, g: 48.63, b: 35.49, a: -645.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer93, 224); };
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle5, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder5.draw(470, 297, 843_260_548, 473_978_860);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(24, 409, 25, -1_945_458_664, 473_993_947);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer151, 164);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer124, 3_236);
+} catch {}
+try {
+computePassEncoder69.pushDebugGroup('\u8ceb');
+} catch {}
+let promise41 = device0.queue.onSubmittedWorkDone();
+let commandEncoder227 = device0.createCommandEncoder({label: '\ua68c\u5ae0\u026e\u0deb\u{1f782}\u4149\u078a\uc411\u7503\u18ce'});
+let renderPassEncoder79 = commandEncoder227.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: 697.8, g: -342.9, b: -652.1, a: 834.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler163 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 64.41,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder135.setBindGroup(2, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(0, bindGroup97, new Uint32Array(1147), 391, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer168, 1_400);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(2, buffer156, 932, 1_930);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer64, 268, new Int16Array(23589), 2506, 628);
+} catch {}
+document.body.prepend(canvas2);
+canvas3.width = 447;
+let imageData34 = new ImageData(88, 24);
+let buffer173 = device0.createBuffer({size: 11001, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture279 = device0.createTexture({
+  size: [16],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder130.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup54, new Uint32Array(1731), 392, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer165, 308);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer111, 'uint32', 156, 5_738);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer137, 'uint32', 4_104, 1_498);
+} catch {}
+await gc();
+let buffer174 = device0.createBuffer({size: 4131, usage: GPUBufferUsage.MAP_WRITE});
+let texture280 = device0.createTexture({
+  size: [192, 80, 46],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView251 = texture76.createView({});
+let sampler164 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.29,
+  lodMaxClamp: 88.79,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder49.drawIndexed(7, 114, 4, 449_070_388, 150_400_007);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer131, 20);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(3, buffer138);
+} catch {}
+let img2 = await imageWithData(15, 126, '#10101010', '#20202020');
+let textureView252 = texture14.createView({format: 'rg32uint'});
+let renderBundle36 = renderBundleEncoder36.finish({label: '\u{1fb60}\u{1f8e6}\u9b62\u1801\u2c47\u{1fa68}\u{1fc02}'});
+let sampler165 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 76.01,
+  lodMaxClamp: 97.73,
+});
+try {
+renderPassEncoder25.draw(1, 8, 832_864_612, 1_428_059_439);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(2_707, 798, 302, 146_931_359, 761_539_929);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer115, 2_676);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(2, buffer26, 5_440);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder132.setBindGroup(1, bindGroup85, new Uint32Array(1740), 89, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup113, new Uint32Array(2825), 337, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1_365, 186, 121, -1_883_669_796, 843_757_377);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer83, 7_652);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+}, new Uint8Array(123).fill(228), /* required buffer size: 123 */
+{offset: 123, bytesPerRow: 3, rowsPerImage: 62}, {width: 0, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let texture281 = device0.createTexture({
+  size: [48, 20, 174],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView253 = texture194.createView({label: '\u0078\u012f'});
+try {
+computePassEncoder132.setBindGroup(1, bindGroup105, new Uint32Array(484), 197, 0);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(168, 126, 52, -2_106_735_643, 70_789_944);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(7, buffer114, 0, 2_529);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder228 = device0.createCommandEncoder({});
+let querySet32 = device0.createQuerySet({
+  label: '\u7168\u{1f9f1}\u{1f90d}\u99fd\u{1f7c1}\ubc8d\u5005\uc3dd\u8998',
+  type: 'occlusion',
+  count: 677,
+});
+let computePassEncoder151 = commandEncoder228.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer124, 56); };
+} catch {}
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder52.setViewport(7.269827217944336, 9.43965788025866, 0.06152674876222624, 0.09563174561838315, 0.3690526710003703, 0.9727994504316158);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer90, 0, 6_278);
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise38;
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(281, 435);
+let textureView254 = texture41.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+let renderPassEncoder80 = commandEncoder33.beginRenderPass({
+  colorAttachments: [{
+  view: textureView245,
+  clearValue: { r: 950.3, g: -433.6, b: 560.1, a: 989.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder151.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup78);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer129, 'uint32', 1_168, 1_407);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture282 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView255 = texture279.createView({dimension: '1d', arrayLayerCount: 1});
+let sampler166 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 42.88,
+  lodMaxClamp: 81.73,
+  compare: 'never',
+});
+try {
+computePassEncoder89.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup42, new Uint32Array(1602), 58, 0);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -691.2, g: 670.3, b: -605.1, a: 690.4, });
+} catch {}
+try {
+renderPassEncoder46.draw(24, 104, 3_964_747_935, 727_464_302);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(426, 460, 7, 243_556_711, 610_973_592);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData26,
+  origin: { x: 0, y: 13 },
+  flipY: true,
+}, {
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule11,
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule10, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroup151 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer146, offset: 0, size: 696}}],
+});
+let commandEncoder229 = device0.createCommandEncoder({});
+let computePassEncoder152 = commandEncoder229.beginComputePass({});
+let sampler167 = device0.createSampler({
+  label: '\u{1f725}\ude4e\u00fc\uc2c0',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.49,
+  lodMaxClamp: 69.01,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder149.setBindGroup(2, bindGroup129);
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(2, 13, 0, 13_118_671, 1_327_444_141);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer102, 'uint16', 246, 104);
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 16 max align: 16 */
+struct T0 {
+  f0: mat2x2f,
+}
+@group(0) @binding(88) var st6: texture_storage_1d<r32float, read_write>;
+@group(0) @binding(78) var st7: texture_storage_1d<r32float, read>;
+@group(0) @binding(126) var sam3: sampler_comparison;
+
+@fragment
+fn fragment0(@location(8) a0: vec4u, @location(6) @interpolate(flat, centroid) a1: vec3h) -> @location(200) vec4i {
+  var out: vec4i;
+  _ = a1;
+  return out;
+}
+
+@compute @workgroup_size(7, 1, 2)
+fn compute0() {
+}`,
+  sourceMap: {},
+});
+let commandEncoder230 = device0.createCommandEncoder({});
+try {
+commandEncoder230.copyBufferToBuffer(buffer33, 2492, buffer110, 944, 2488);
+} catch {}
+try {
+renderPassEncoder79.pushDebugGroup('\u{1fbe9}');
+} catch {}
+let computePassEncoder153 = commandEncoder230.beginComputePass({});
+let sampler168 = device0.createSampler({
+  label: '\u00b0\u{1fe49}\u{1f8b5}\u0c83\u0f77\u1502',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.090,
+  lodMaxClamp: 90.15,
+});
+try {
+computePassEncoder144.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.draw(1, 0, 209_685_469, 250_463_547);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer17, 372);
+} catch {}
+let bindGroup152 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 28, resource: textureView177}]});
+let commandEncoder231 = device0.createCommandEncoder({});
+let renderPassEncoder81 = commandEncoder231.beginRenderPass({
+  label: '\u0d7c\u0c9a\u28c3\uc0e3\u0f9d\u{1fab6}\u6417\uf5f0\u3039\ub8eb',
+  colorAttachments: [{
+  view: textureView200,
+  depthSlice: 78,
+  clearValue: { r: -662.7, g: 241.6, b: -984.3, a: 799.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup138, new Uint32Array(3797), 299, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder90); computePassEncoder90.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup129, new Uint32Array(462), 4, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer32, 1_388);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(6, buffer103);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas5.getContext('webgpu');
+let bindGroup153 = device0.createBindGroup({
+  label: '\u{1f7c6}\ud63f\u{1f7f2}\u0769\ub145\u{1fea6}',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 115, resource: sampler91},
+    {binding: 71, resource: textureView64},
+    {binding: 348, resource: textureView192},
+    {binding: 125, resource: {buffer: buffer40, offset: 256}},
+    {binding: 129, resource: {buffer: buffer96, offset: 768, size: 52}},
+  ],
+});
+try {
+computePassEncoder136.setBindGroup(0, bindGroup8, new Uint32Array(909), 14, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(55, 122, 496_547_401, 402_574_945);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(26, 14, 10, -1, 425_527_852);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer131, 556);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer101, 168);
+} catch {}
+let arrayBuffer39 = buffer45.getMappedRange(216, 528);
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer175 = device0.createBuffer({
+  size: 50201,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder232 = device0.createCommandEncoder({});
+let sampler169 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.75,
+  maxAnisotropy: 14,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(391, 26, 386, 5_603_219, 117_919_372);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer75, 'uint32', 1_464, 589);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 79}
+*/
+{
+  source: video2,
+  origin: { x: 5, y: 1 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  label: '\ubf5e\u479a\u925f\u0f7f\u{1f6d2}\u{1fcc9}\u0eb5\u6efd\u0837\u16dd\u0232',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<atomic<i32>, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  @align(2) f0: T0,
+}
+/* target size: 4 max align: 4 */
+struct T2 {
+  f0: array<vec2h, 1>,
+}
+@group(0) @binding(36) var st8: texture_storage_2d<rgba16sint, write>;
+@group(0) @binding(376) var<uniform> buffer176: T2;
+struct FragmentOutput10 {
+  @location(1) f0: vec4u,
+  @location(0) @interpolate(flat, center) f1: f32,
+  @location(4) @interpolate(flat) f2: vec2f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  textureStore(st8, vec2i(), vec4i(98, 23, 295, 28));
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u, @builtin(num_workgroups) a1: vec3u) {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder154 = commandEncoder232.beginComputePass({});
+let sampler170 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.78,
+  lodMaxClamp: 67.73,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder154.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup122, new Uint32Array(6688), 183, 0);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(43, 166, 830, 18_598_436, 205_608_570);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer141, 340);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer20, 'uint16', 5_476, 1_190);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer177 = device0.createBuffer({size: 6495, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder233 = device0.createCommandEncoder({});
+let computePassEncoder155 = commandEncoder233.beginComputePass({});
+let sampler171 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.63,
+});
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup85, new Uint32Array(2581), 137, 0);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder25.draw(221, 65, 8_768_993, 1_532_622_535);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(18, 95, 24, 19_951_053, 973_505_898);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer137, 'uint32', 1_816, 1_010);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(5, buffer50, 4);
+} catch {}
+let sampler172 = device0.createSampler({
+  label: '\u4616\u{1f67a}\u{1f700}\u0a67\uf6dd\u8f89\u04c7\u{1fb3f}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.99,
+  lodMaxClamp: 93.23,
+});
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle30]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1_034, 91, 671, 2_948_551, 3_008_115_275);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(5, buffer27, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker('\u1452');
+} catch {}
+let commandEncoder234 = device0.createCommandEncoder({});
+let texture283 = gpuCanvasContext8.getCurrentTexture();
+let renderPassEncoder82 = commandEncoder234.beginRenderPass({
+  colorAttachments: [{
+  view: textureView203,
+  depthSlice: 280,
+  clearValue: { r: -928.9, g: 971.2, b: 12.36, a: -231.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder108.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(2, bindGroup130, new Uint32Array(10000), 3_871, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder7.draw(140, 101, 3_664_513_064, 134_092_415);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(213, 380, 35, 77_171_318, 457_722_558);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer165, 892);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer178 = device0.createBuffer({
+  size: 9785,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture284 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView256 = texture86.createView({
+  label: '\u88b5\u0895\u018a\u9862\u9007\u299f\u{1ffea}\u{1f71d}\u{1fdbd}\u0715\u41bc',
+  format: 'r16float',
+});
+let sampler173 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.38,
+  lodMaxClamp: 91.47,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder25.draw(519, 9, 209_464_926, 1_106_415_760);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer81, 4_896);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer114, 1_688, 616);
+} catch {}
+try {
+  await buffer128.mapAsync(GPUMapMode.WRITE, 0, 860);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture241,
+  mipLevel: 0,
+  origin: {x: 3, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer179 = device0.createBuffer({
+  size: 7992,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture285 = device0.createTexture({
+  size: [48, 20, 154],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler174 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.52,
+  lodMaxClamp: 93.74,
+});
+let externalTexture35 = device0.importExternalTexture({label: '\ud915\uf171\u5ac8\u08a6\u{1fe23}\ua67f\u4812', source: videoFrame20});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup116, []);
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(36, 73, 184, 613_388_062, 31_921_737);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+  await promise39;
+} catch {}
+document.body.prepend(img1);
+let commandEncoder235 = device0.createCommandEncoder({});
+let querySet33 = device0.createQuerySet({label: '\u5e55\u3a29\u1cc9\ue294\u5be5\ub2ee\ub01a\u0904', type: 'occlusion', count: 795});
+let texture286 = device0.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder156 = commandEncoder235.beginComputePass({label: '\u30ad\u5d83\udc66\u0ce7\uef8f\u{1fd25}\u0b7f\u9419\u4759\u{1f976}\u069b'});
+try {
+renderPassEncoder23.draw(32, 130, 289_689_598, 57_887_464);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(0, buffer136);
+} catch {}
+let buffer180 = device0.createBuffer({size: 2644, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+try {
+computePassEncoder156.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer74, 4_344);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer93, 0);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(39).fill(217), /* required buffer size: 39 */
+{offset: 39, rowsPerImage: 23}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup154 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler56}]});
+let commandEncoder236 = device0.createCommandEncoder({});
+let commandBuffer9 = commandEncoder236.finish();
+try {
+renderPassEncoder7.draw(59, 9, 359_885_576, 235_420_470);
+} catch {}
+let arrayBuffer40 = buffer35.getMappedRange(4568, 404);
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let bindGroup155 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 313, resource: {buffer: buffer13, offset: 0, size: 88}}],
+});
+let buffer181 = device0.createBuffer({
+  size: 2552,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup137, new Uint32Array(670), 13, 0);
+} catch {}
+try {
+renderPassEncoder67.setScissorRect(0, 2, 2, 3);
+} catch {}
+try {
+renderPassEncoder8.draw(76, 512, 531_308_789, 440_220_890);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer70, 'uint16', 536, 32);
+} catch {}
+try {
+  await promise41;
+} catch {}
+try {
+computePassEncoder108.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(2, bindGroup136, new Uint32Array(1282), 335, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer20, 3_900);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer19, 36);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer99, 'uint16', 1_820, 2_841);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(2, buffer146, 0, 492);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise31;
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle4, renderBundle0, renderBundle2, renderBundle18, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder9.draw(1_000, 571, 373_176_634, 2_530_836_559);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer63, 228);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer34, 3_316);
+} catch {}
+try {
+renderPassEncoder80.setIndexBuffer(buffer100, 'uint16', 456, 1_168);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(3, buffer39);
+} catch {}
+let arrayBuffer41 = buffer51.getMappedRange(56, 0);
+let buffer182 = device0.createBuffer({
+  size: 16831,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder8.drawIndexed(0, 176, 177, 143_812_787, 72_435_568);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer62, 316);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer42, 'uint16', 330, 102);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 47, y: 21, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  label: '\u0d76\u268e\u8c3f\u0bb2\u018a\u0096\ube0b\uad79\uc218',
+  layout: bindGroupLayout7,
+  entries: [{binding: 36, resource: textureView171}, {binding: 376, resource: {buffer: buffer12, offset: 2304}}],
+});
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer116, 756); };
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderPassEncoder34.draw(83, 53, 149_380_200, 3_027_821_751);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer183 = device0.createBuffer({
+  size: 6878,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup28, new Uint32Array(523), 113, 0);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(2, bindGroup51, new Uint32Array(82), 9, 0);
+} catch {}
+try {
+renderPassEncoder35.draw(512, 6, 148_928_630, 1_399_156_967);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(82, 118, 30, 526_587_502, 72_772_127);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer172, 368);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer43, 5_656);
+} catch {}
+let imageData35 = new ImageData(116, 76);
+let buffer184 = device0.createBuffer({
+  size: 12184,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder237 = device0.createCommandEncoder();
+let renderPassEncoder83 = commandEncoder237.beginRenderPass({
+  colorAttachments: [{view: textureView80, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 185831517,
+});
+let sampler175 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 75.51,
+  lodMaxClamp: 75.75,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer46, 0, 26);
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture287 = device0.createTexture({
+  label: '\u3222\u{1f996}\u{1fe88}\u{1f95d}\u85fa\u6ba4\u0525\u3e8e\u{1f93e}\u{1fc92}',
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView257 = texture60.createView({mipLevelCount: 1});
+try {
+computePassEncoder151.setBindGroup(1, bindGroup123);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(2, bindGroup56, new Uint32Array(1085), 125, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer27, 'uint16', 1_948, 463);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+renderPassEncoder79.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(video4);
+let bindGroup157 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView62}]});
+let buffer185 = device0.createBuffer({
+  size: 7400,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder7.drawIndexed(107, 120, 40, 354_470_676, 57_342_791);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer186 = device0.createBuffer({
+  size: 3137,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder79.setBindGroup(0, bindGroup150, new Uint32Array(2062), 210, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(63, 82, 270, -1_532_007_904, 69_383_464);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer23, 1_960);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer160, 5048, new BigUint64Array(9577), 2438, 140);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture253,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+}, new Uint8Array(90).fill(148), /* required buffer size: 90 */
+{offset: 90}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 269,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 29, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 155,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 398,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 142,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let texture288 = device0.createTexture({
+  size: [192, 80, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView258 = texture73.createView({format: 'rgba32sint', baseArrayLayer: 0, arrayLayerCount: 5});
+let sampler176 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.50,
+  lodMaxClamp: 50.56,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup110, new Uint32Array(592), 132, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup76);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup0, new Uint32Array(5370), 193, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(155, 201, 21, 113_474_879, 109_246_877);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer87, 32);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer16, 'uint16', 1_358, 174);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+try {
+computePassEncoder69.popDebugGroup();
+} catch {}
+let commandEncoder238 = device0.createCommandEncoder();
+let textureView259 = texture24.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 53, arrayLayerCount: 1});
+let texture289 = device0.createTexture({
+  label: '\u0e9c\u40af\u6de4\u57eb\ub4db\ua07b\u0d71\ubad2\u{1fed2}\u7cb5',
+  size: {width: 192, height: 80, depthOrArrayLayers: 37},
+  mipLevelCount: 5,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture137.createView({label: '\u4ac5\u1c51\ua6f5\uefd2\ue58f\u5765\u{1ff36}\u9279', format: 'r16sint'});
+let sampler177 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.086,
+  lodMaxClamp: 77.62,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup117, new Uint32Array(593), 24, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(1_216, 433, 23, 404_058_997, 379_099_645);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer74, 8_140);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer181, 'uint32', 680, 735);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(6, buffer124, 1_780);
+} catch {}
+try {
+buffer61.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas1);
+let buffer187 = device0.createBuffer({
+  label: '\u5d8e\ue9a8',
+  size: 21860,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView261 = texture262.createView({});
+let texture290 = device0.createTexture({size: {width: 96}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView262 = texture256.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder84 = commandEncoder238.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: -312.6, g: -918.8, b: -975.0, a: -619.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 1081009201,
+});
+let sampler178 = device0.createSampler({
+  label: '\u0683\u{1fe9a}\ud314\u0c5f\u78d0\u3529\u{1f78b}\u00c4\u2586',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 69.55,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder9.draw(24, 121, 531_200_989, 922_664_878);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer22, 1_488);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 6, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(114), /* required buffer size: 158 */
+{offset: 158}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture291 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView263 = texture205.createView({label: '\u378e\u{1fc11}'});
+try {
+renderPassEncoder47.executeBundles([renderBundle30]);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer6, 52);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas4,
+  origin: { x: 75, y: 10 },
+  flipY: true,
+}, {
+  texture: texture238,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let texture292 = device0.createTexture({
+  size: [1, 1, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture293 = device0.createTexture({
+  size: [24, 10, 43],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler179 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.65,
+  lodMaxClamp: 98.83,
+  compare: 'equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder9.draw(10, 74, 448_762_943, 540_273_921);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer122, 256);
+} catch {}
+let textureView264 = texture291.createView({label: '\u337a\u{1fedd}\u01a1'});
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup1, new Uint32Array(2324), 142, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer72, 48);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer163, 1_072);
+} catch {}
+let promise43 = device0.queue.onSubmittedWorkDone();
+let bindGroup158 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 513, resource: sampler19},
+    {binding: 58, resource: textureView187},
+    {binding: 23, resource: {buffer: buffer58, offset: 0, size: 3492}},
+    {binding: 9, resource: textureView175},
+    {binding: 24, resource: textureView114},
+    {binding: 169, resource: textureView54},
+    {binding: 224, resource: textureView2},
+    {binding: 123, resource: {buffer: buffer183, offset: 512, size: 144}},
+    {binding: 526, resource: textureView238},
+  ],
+});
+let buffer188 = device0.createBuffer({size: 27585, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder239 = device0.createCommandEncoder({});
+let texture294 = device0.createTexture({
+  label: '\u02ab\uc83c\ucc80\u0830\u08de\u{1fbcd}\u7b12',
+  size: {width: 1, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture295 = device0.createTexture({
+  size: [16, 16, 6],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder157 = commandEncoder239.beginComputePass({});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder90); computePassEncoder90.dispatchWorkgroups(3, 3, 1); };
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(1, bindGroup104);
+} catch {}
+try {
+renderPassEncoder7.draw(150, 269, 20_314_077, 718_117_439);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(21, 88, 2, 258_080_358, 94_660_927);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer23, 2_404);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer48, 'uint32', 7_076, 7_198);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup159 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 963, resource: textureView167},
+    {binding: 178, resource: textureView187},
+    {binding: 3, resource: sampler98},
+    {binding: 114, resource: {buffer: buffer184, offset: 7424}},
+    {binding: 44, resource: textureView31},
+    {binding: 122, resource: textureView16},
+    {binding: 366, resource: {buffer: buffer32, offset: 2816, size: 52}},
+  ],
+});
+let textureView265 = texture288.createView({});
+let texture296 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup118, new Uint32Array(1746), 49, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(56, 4, 391, 398_162_239, 1_428_255_247);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer163, 8_608);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let bindGroup160 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 28, resource: textureView189}]});
+let textureView266 = texture292.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let textureView267 = texture17.createView({
+  label: '\u{1fbfe}\u2aa2\u4e52\u5e9e\u0b70\u1d7f\u9d37\u0dbf\u{1f84e}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+});
+try {
+computePassEncoder120.setBindGroup(3, bindGroup134, []);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup84, new Uint32Array(219), 31, 0);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 242, 7, 369_084_878, 257_084_794);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer187, 2_884);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline2);
+} catch {}
+let imageData36 = new ImageData(20, 44);
+try {
+  //await adapter0.requestAdapterInfo();
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer43, 3_868); };
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup151);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer19, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 2608, new DataView(new ArrayBuffer(13841)), 1569, 532);
+} catch {}
+await gc();
+let texture297 = device0.createTexture({
+  size: [1, 1, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture298 = device0.createTexture({
+  size: [192],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder114.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer115, 3_208);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer61, 'uint32', 748, 33);
+} catch {}
+let bindGroup161 = device0.createBindGroup({
+  label: '\u{1fd11}\uaf83\u490d\u74d3\u07d5\u04a2\u7052\u{1fc4a}',
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer41, offset: 256}}],
+});
+let commandEncoder240 = device0.createCommandEncoder({});
+try {
+computePassEncoder138.setBindGroup(2, bindGroup29, new Uint32Array(218), 53, 0);
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer74, 11_364);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer162, 'uint32', 728, 277);
+} catch {}
+try {
+commandEncoder240.copyBufferToBuffer(buffer130, 5780, buffer171, 772, 1700);
+} catch {}
+let textureView268 = texture288.createView({label: '\u202f\u7b5e', baseMipLevel: 0});
+let texture299 = device0.createTexture({
+  label: '\u0450\u{1fdd1}\u{1f866}\u774a\ub368\u1ab3\ucf86\u870c\u8535\u8829\u357b',
+  size: [48, 20, 86],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float'],
+});
+let textureView269 = texture86.createView({label: '\ue67d\u1a2f\u0f50\u80b6\u83a6\u{1f990}'});
+let renderPassEncoder85 = commandEncoder240.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 100,
+  clearValue: { r: -582.2, g: -206.7, b: 142.1, a: 217.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 273480220,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup119);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(0, bindGroup116, new Uint32Array(1236), 35, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle5, renderBundle24]);
+} catch {}
+let arrayBuffer42 = buffer140.getMappedRange(400, 32);
+let bindGroup162 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 313, resource: {buffer: buffer12, offset: 768, size: 1372}}],
+});
+let buffer189 = device0.createBuffer({
+  label: '\u09d9\u{1ffa1}\u0db9\u0c5f\u6a3d\u81c6',
+  size: 9388,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle33, renderBundle26, renderBundle26, renderBundle36]);
+} catch {}
+try {
+renderPassEncoder25.draw(270, 143, 1_666_799_707, 178_081_692);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer115, 1_576);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer165, 16);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer69, 'uint16', 5_908, 705);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 313, resource: {buffer: buffer153, offset: 256, size: 276}}],
+});
+let buffer190 = device0.createBuffer({
+  size: 10368,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: false});
+let sampler180 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.79,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup73);
+} catch {}
+try {
+renderPassEncoder81.executeBundles([renderBundle20, renderBundle12, renderBundle20, renderBundle21, renderBundle30, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer5, 16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 88, new DataView(new ArrayBuffer(7007)), 1721, 92);
+} catch {}
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55); };
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 96,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder241 = device0.createCommandEncoder({});
+let textureView270 = texture124.createView({});
+let sampler181 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.66,
+  lodMaxClamp: 99.97,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer183, 3_288);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer80, 6_220);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup115, new Uint32Array(689), 131, 0);
+} catch {}
+try {
+buffer180.unmap();
+} catch {}
+let computePassEncoder158 = commandEncoder241.beginComputePass({});
+let renderBundle37 = renderBundleEncoder37.finish({label: '\u0be0\uee89\u3477\u7604\u{1feea}\udff7\u0ed2\u322e\u0bd0\u1dee\u0029'});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup139);
+} catch {}
+try {
+computePassEncoder139.setBindGroup(1, bindGroup101, new Uint32Array(3515), 1_818, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(37, 7, 280, 1_343_165_562, 1_379_042_209);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer80, 4_864);
+} catch {}
+try {
+renderPassEncoder82.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(1, buffer98, 1_052, 1_074);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 4, y: 3, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer191 = device0.createBuffer({size: 8093, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder242 = device0.createCommandEncoder({});
+let computePassEncoder159 = commandEncoder242.beginComputePass({});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder76.beginOcclusionQuery(42);
+} catch {}
+try {
+renderPassEncoder76.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(2, 52, 230_890_899, 722_248_950);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer113, 5_644);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer26);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture176,
+  mipLevel: 0,
+  origin: {x: 136, y: 13, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer192 = device0.createBuffer({size: 12901, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder243 = device0.createCommandEncoder({label: '\u3ff5\u{1fae2}\uec7d\u0a3e\u929c\uac17\u{1f935}\u000c\u{1f7be}\u0bae\u07e3'});
+let textureView271 = texture31.createView({});
+try {
+computePassEncoder144.setBindGroup(3, bindGroup46, new Uint32Array(3856), 790, 0);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(4, buffer181, 0);
+} catch {}
+try {
+buffer155.destroy();
+} catch {}
+let texture300 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  mipLevelCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView272 = texture120.createView({
+  label: '\u127e\ucddf\u8fda\ubb5b\u{1fb4a}\u7837\u0c49\u{1fad9}\uf688\u4ba4',
+  baseArrayLayer: 12,
+  arrayLayerCount: 1,
+});
+let computePassEncoder160 = commandEncoder243.beginComputePass();
+try {
+computePassEncoder63.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer32, 32); };
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup44, new Uint32Array(2224), 521, 0);
+} catch {}
+try {
+renderPassEncoder23.draw(108, 394, 415_189_629, 779_058_869);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(691, 186, 18, 402_930_874, 892_524_184);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer190, 716);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer111, 'uint16', 2_016, 5_564);
+} catch {}
+try {
+buffer133.unmap();
+} catch {}
+let commandEncoder244 = device0.createCommandEncoder();
+let computePassEncoder161 = commandEncoder244.beginComputePass({});
+let sampler182 = device0.createSampler({
+  label: '\u{1fe57}\u04b5\u5f74\u07f4\uc113\ubf32\u{1f719}\u019b\u0cd7\u1ae6',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.270,
+  lodMaxClamp: 89.71,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder104.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder114.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup139);
+} catch {}
+try {
+renderPassEncoder7.draw(193, 119, 1_122_880_448, 1_244_253_148);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(16, 83, 60, 39_220_812, 2_125_063_661);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer16, 220);
+} catch {}
+try {
+commandEncoder176.copyBufferToBuffer(buffer137, 4592, buffer139, 1616, 4360);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData16,
+  origin: { x: 5, y: 4 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 17, y: 5, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder245 = device0.createCommandEncoder({});
+let texture301 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler183 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.71,
+  lodMaxClamp: 51.68,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder161.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup139, new Uint32Array(447), 35, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(723, 313, 173, 76_541_681, 420_536_478);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer138, 3_196);
+} catch {}
+try {
+commandEncoder176.copyBufferToBuffer(buffer46, 628, buffer67, 180, 168);
+} catch {}
+document.body.prepend(video2);
+let renderPassEncoder86 = commandEncoder245.beginRenderPass({
+  colorAttachments: [{view: textureView200, depthSlice: 0, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+});
+let sampler184 = device0.createSampler({
+  label: '\u{1f86d}\u3c55\u75bf\ufad1\u327f\u5e6c\u0182',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.61,
+  maxAnisotropy: 15,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer156, 368); };
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder35.draw(199, 127, 1_969_390_978, 658_349_872);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer27, 304);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer12, 'uint16', 1_740, 868);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder246 = device0.createCommandEncoder({label: '\u01f2\u5c49\u8d9b\u43ee\u045e\uf640\u05f5\uae0e'});
+let renderPassEncoder87 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: -853.3, g: 374.9, b: -679.2, a: 13.81, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler185 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 99.61,
+  lodMaxClamp: 99.87,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder122.setBindGroup(0, bindGroup81, new Uint32Array(1475), 199, 0);
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder23.draw(61, 135, 166_464_996, 28_517_345);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer97, 828);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer28, 'uint32', 1_656, 442);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer42, 0, 1_168);
+} catch {}
+let arrayBuffer43 = buffer190.getMappedRange();
+try {
+commandEncoder246.copyTextureToBuffer({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 224 */
+  offset: 224,
+  bytesPerRow: 256,
+  buffer: buffer192,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData37 = new ImageData(56, 4);
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 238,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer193 = device0.createBuffer({
+  size: 4405,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer72, 236);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(3, buffer70, 88, 946);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView273 = texture152.createView({
+  label: '\u0d70\u5bca\u{1fa96}\u0ff4\u1111\uf1c7\u4ce1\u08c2\u{1fc66}\u8b96\u{1fe29}',
+  baseArrayLayer: 0,
+});
+let texture302 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder162 = commandEncoder246.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder77); computePassEncoder77.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup155);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer29, 304);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer137, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer194 = device0.createBuffer({
+  size: 7858,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder247 = device0.createCommandEncoder({});
+let computePassEncoder163 = commandEncoder247.beginComputePass({});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+let renderBundle38 = renderBundleEncoder38.finish({});
+try {
+computePassEncoder147.setBindGroup(1, bindGroup158);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup113, new Uint32Array(1404), 83, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(560, 40, 621_920_352, 872_957_310);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(4, 44, 85, 195_218_121, 588_086_514);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 7, y: 3, z: 3},
+  aspect: 'all',
+}, new Uint8Array(1_612).fill(228), /* required buffer size: 1_612 */
+{offset: 310, bytesPerRow: 1, rowsPerImage: 62}, {width: 0, height: 0, depthOrArrayLayers: 22});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder248 = device0.createCommandEncoder();
+let computePassEncoder164 = commandEncoder248.beginComputePass({});
+try {
+computePassEncoder138.setBindGroup(1, bindGroup44, new Uint32Array(3275), 83, 0);
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.draw(115, 19, 748_412_672, 1_093_710_833);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 276, 2, 150_580_169, 1_347_257_224);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer87, 80);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer113, 1_748);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer111, 'uint16', 324, 4_090);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder249 = device0.createCommandEncoder({});
+let texture303 = device0.createTexture({
+  label: '\u4a6b\ube53\uc0c2',
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder163.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle23, renderBundle14, renderBundle24, renderBundle14, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer117, 1_552);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer6, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer142, 'uint16', 156, 786);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer15, 0, 8_090);
+} catch {}
+document.body.prepend(canvas2);
+await gc();
+let buffer195 = device0.createBuffer({size: 16836, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let commandBuffer10 = commandEncoder249.finish({label: '\u5ead\u{1fc24}\u{1fee3}\u{1fcf3}\u4bdf'});
+let texture304 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture305 = gpuCanvasContext2.getCurrentTexture();
+let sampler186 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 29.62,
+  lodMaxClamp: 47.24,
+});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame34});
+try {
+computePassEncoder160.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle38, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder11.draw(803, 547, 869_614_822, 321_493_044);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(17, 648, 33, 179_098_901, 522_857_978);
+} catch {}
+let arrayBuffer44 = buffer181.getMappedRange(0, 748);
+try {
+computePassEncoder164.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder7.draw(839, 88, 674_260_178, 34_540_721);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer69, 2_084);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer69, 2_856);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+sampler63.label = '\u828d\u0fd8\u9972\u8baf\u3ea8\u0540\ua16c\u0473';
+} catch {}
+let commandEncoder250 = device0.createCommandEncoder();
+let computePassEncoder165 = commandEncoder250.beginComputePass({});
+let sampler187 = device0.createSampler({
+  label: '\ubcd2\ue25a\udcc8\u06b7\u{1f8c0}\u54c5',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.25,
+  compare: 'less-equal',
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer134, 0); };
+} catch {}
+try {
+computePassEncoder142.end();
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup140);
+} catch {}
+try {
+renderPassEncoder9.draw(16, 13, 298_933_519, 666_287_218);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer20, 'uint32', 3_208, 4_004);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer19, 0, 18);
+} catch {}
+let arrayBuffer45 = buffer48.getMappedRange(144, 164);
+let texture306 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 345},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder40.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(421, 101, 10, 311_753_782, 914_548_245);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer186, 'uint32', 632, 278);
+} catch {}
+try {
+commandEncoder215.resolveQuerySet(querySet22, 62, 234, buffer158, 2816);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture307 = device0.createTexture({
+  size: [48],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture308 = device0.createTexture({
+  size: [24, 10, 43],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder166 = commandEncoder215.beginComputePass({});
+try {
+computePassEncoder165.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder7.draw(111, 19, 179_289_616, 1_602_515_348);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(90, 98, 677, -994_542_858, 554_190_703);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer22, 900);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let texture309 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 8},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture310 = device0.createTexture({
+  size: [24, 10, 43],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler188 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.25,
+  lodMaxClamp: 99.59,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder78.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder11.draw(129, 144, 1_430_510_014, 559_029_782);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(300, 277, 115, 433_276_490, 126_016_749);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer12, 532);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer122, 'uint16', 406, 1_656);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer9, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+await gc();
+let imageData38 = new ImageData(120, 8);
+let buffer196 = device0.createBuffer({size: 18696, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView274 = texture297.createView({});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup116, new Uint32Array(2648), 50, 0);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder60.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder35.draw(321, 477, 908_915_589, 162_418_589);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 21, 1, 170_207_817, 1_521_447_667);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture249,
+  mipLevel: 0,
+  origin: {x: 8, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(387).fill(50), /* required buffer size: 387 */
+{offset: 387, bytesPerRow: 110}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture1.label = '\u0428\u4da9\uebf2\u939d\u{1fa77}\u0e41\u051f\u577b';
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 143,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup164 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 33, resource: sampler137},
+    {binding: 39, resource: externalTexture18},
+    {binding: 356, resource: {buffer: buffer115, offset: 19712}},
+    {binding: 342, resource: sampler36},
+  ],
+});
+let texture311 = device0.createTexture({size: [16], sampleCount: 1, dimension: '1d', format: 'rgba32sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView275 = texture220.createView({mipLevelCount: 1});
+try {
+renderPassEncoder50.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 34, 0, 114_775_819, 148_034_265);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(1, buffer42);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 28, new BigUint64Array(3379), 160, 48);
+} catch {}
+let bindGroup165 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 280, resource: {buffer: buffer163, offset: 14336, size: 2296}}],
+});
+try {
+computePassEncoder90.setBindGroup(1, bindGroup11, new Uint32Array(5859), 162, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup165);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 79, 2, 81_917_692, 604_962_576);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer117, 1_692);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer112, 76);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer12, 'uint16', 416, 2_821);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer184.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame29,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture300,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture312 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 98},
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture313 = device0.createTexture({
+  label: '\u{1fd71}\ue523\u6c7a\u76af\u{1f664}',
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder117.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup87);
+} catch {}
+try {
+renderPassEncoder84.executeBundles([renderBundle33, renderBundle36]);
+} catch {}
+let bindGroup166 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer151, offset: 256, size: 118}}],
+});
+let buffer197 = device0.createBuffer({
+  label: '\u670e\ub056\ufb7b\u2c75\u8605\u{1f987}\u2ecf\u8817\u7d84',
+  size: 23546,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let textureView276 = texture291.createView({});
+try {
+renderPassEncoder64.setViewport(27.78259212512934, 49.5559091771566, 42.56555192994525, 21.862820205244912, 0.6552641107175048, 0.8383580174564023);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer183, 68);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler189 = device0.createSampler({
+  label: '\u5467\ue1f7\u03f3\u{1f658}\u2ff9\u070f\ue3b9\u9c8b\u{1f91f}\u0030\u31e0',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 93.44,
+  lodMaxClamp: 94.05,
+  compare: 'equal',
+});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder27.dispatchWorkgroupsIndirect(buffer152, 1_080);
+} catch {}
+try {
+renderPassEncoder46.draw(9, 101, 207_146_103, 242_109_103);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer40, 'uint32', 696, 1_698);
+} catch {}
+let bindGroup167 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 313, resource: {buffer: buffer117, offset: 1536, size: 524}}],
+});
+let commandEncoder251 = device0.createCommandEncoder({});
+let renderPassEncoder88 = commandEncoder251.beginRenderPass({
+  colorAttachments: [{
+  view: textureView209,
+  clearValue: { r: 236.6, g: -671.4, b: -671.4, a: -74.21, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(171, 400, 66, -2_141_156_291, 159_028_160);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer115, 1_360);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer134, 0);
+} catch {}
+try {
+window.someLabel = sampler33.label;
+} catch {}
+let texture314 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup65, new Uint32Array(297), 10, 0);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle32, renderBundle10, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder9.draw(126, 62, 529_470_884, 211_419_697);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 43, 1, -835_625_449, 1_175_902_570);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer80, 1_364);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer102, 'uint16', 70, 71);
+} catch {}
+try {
+buffer189.unmap();
+} catch {}
+let imageData39 = new ImageData(40, 28);
+let commandEncoder252 = device0.createCommandEncoder({});
+let computePassEncoder167 = commandEncoder252.beginComputePass({});
+try {
+renderPassEncoder35.draw(10, 40, 77_479_744, 486_555_132);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(1, 333, 1, 296_619_093, 343_202_436);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture315 = device0.createTexture({
+  size: [16, 16, 100],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture37 = device0.importExternalTexture({source: video1});
+try {
+computePassEncoder150.setBindGroup(3, bindGroup98);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder60.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.draw(384, 203, 215_359_477, 455_408_190);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer138, 3_912);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer197, 'uint16', 1_156, 6_396);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer111, 1_624, 804);
+} catch {}
+try {
+computePassEncoder86.insertDebugMarker('\u0c20');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let bindGroup168 = device0.createBindGroup({
+  label: '\u8dda\u{1fb0c}\u{1f689}\u0c8d\u0222\u03b2\ue49b\uf0cd\uc895',
+  layout: bindGroupLayout14,
+  entries: [{binding: 85, resource: textureView2}],
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup80, new Uint32Array(51), 2, 0);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 607.8, g: 481.6, b: -823.2, a: -655.8, });
+} catch {}
+try {
+renderPassEncoder34.draw(8, 68, 990_088_465, 81_767_292);
+} catch {}
+let buffer198 = device0.createBuffer({size: 9293, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup113, new Uint32Array(4690), 464, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(192, 82, 19, 123_451_827, 801_094_058);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer22, 704);
+} catch {}
+let arrayBuffer46 = buffer92.getMappedRange(160, 1308);
+try {
+device0.queue.writeBuffer(buffer143, 12, new DataView(new ArrayBuffer(11742)), 3215, 660);
+} catch {}
+try {
+  await promise42;
+} catch {}
+let buffer199 = device0.createBuffer({
+  size: 3070,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder253 = device0.createCommandEncoder({});
+let texture316 = device0.createTexture({size: {width: 192}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder168 = commandEncoder253.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup146);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup142);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup40, new Uint32Array(259), 13, 0);
+} catch {}
+try {
+renderPassEncoder49.draw(62, 177, 741_310_490, 1_395_867_690);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer71, 44);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer71, 516);
+} catch {}
+try {
+  await promise43;
+} catch {}
+let commandEncoder254 = device0.createCommandEncoder({label: '\ue5e3\u40d9\u814d\u5c90\u9bff\u6467\u0dfb\ud33b\u0dbb'});
+let textureView277 = texture97.createView({});
+let renderPassEncoder89 = commandEncoder254.beginRenderPass({
+  colorAttachments: [{
+  view: textureView275,
+  depthSlice: 24,
+  clearValue: { r: -130.8, g: -169.8, b: 855.9, a: -559.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+});
+try {
+renderPassEncoder8.draw(264, 31, 76_525_647, 403_290_030);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer42, 220);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(5, buffer184, 1_248, 829);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder255 = device0.createCommandEncoder({});
+let texture317 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder169 = commandEncoder255.beginComputePass({label: '\u0875\u7040\u{1fef2}\u{1f64b}\u74f1\ub8a7\u0cc8\u02bf'});
+try {
+renderPassEncoder7.draw(39, 46, 705_515_458, 17_363_917);
+} catch {}
+let video5 = await videoWithData(117);
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  label: '\u57b8\u{1ffce}\u0d71\ud7b6\u0a89\u013a\u08c6\u{1ffea}\u{1fb3e}',
+  entries: [
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer200 = device0.createBuffer({
+  label: '\u133f\ua028\u057f\u366d\ud007\uaeca\u13e2\u4e7c\ud483',
+  size: 4453,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+computePassEncoder134.setBindGroup(2, bindGroup44, new Uint32Array(33), 4, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(597, 344, 971_004_107, 403_295_562);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer32, 1_564);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer138, 0, 4_569);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture318 = device0.createTexture({
+  size: {width: 16},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler190 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 8.622,
+  lodMaxClamp: 46.55,
+});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup52, new Uint32Array(101), 8, 0);
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder81.setBindGroup(0, bindGroup148, new Uint32Array(647), 171, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer93, 28);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer6, 224);
+} catch {}
+try {
+  await buffer64.mapAsync(GPUMapMode.READ, 1576, 500);
+} catch {}
+let bindGroup169 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 6, resource: textureView6}]});
+let commandEncoder256 = device0.createCommandEncoder({});
+let texture319 = device0.createTexture({
+  size: [16, 16, 336],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView278 = texture223.createView({});
+let computePassEncoder170 = commandEncoder256.beginComputePass({});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup142);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(1, bindGroup110, new Uint32Array(2923), 33, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup125, []);
+} catch {}
+try {
+renderPassEncoder7.draw(10, 168, 423_141_900, 418_444_722);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer171, 9636, new BigUint64Array(1236), 40, 180);
+} catch {}
+document.body.prepend(video5);
+video2.width = 20;
+let bindGroup170 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer117, offset: 1536, size: 1064}}],
+});
+let commandEncoder257 = device0.createCommandEncoder({label: '\u065d\u0c10'});
+let textureView279 = texture223.createView({mipLevelCount: 1});
+let computePassEncoder171 = commandEncoder257.beginComputePass();
+let sampler191 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.41,
+  lodMaxClamp: 37.13,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup154);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup30, new Uint32Array(1224), 384, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(81, 120, 2_730_966_794, 109_545_502);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(525, 379, 282, 1_243_004_558, 265_608_963);
+} catch {}
+let texture320 = gpuCanvasContext4.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer141, 736);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup32, new Uint32Array(2481), 289, 0);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(169).fill(167), /* required buffer size: 169 */
+{offset: 169}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 12, height: 5, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture220,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup171 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 126, resource: sampler98},
+    {binding: 88, resource: textureView92},
+    {binding: 78, resource: textureView5},
+  ],
+});
+let texture321 = device0.createTexture({
+  label: '\u{1f80f}\u0127\u5a99\u3974\u{1f76c}\u67aa\ua6e3\u{1f641}\u45f6\u0cab',
+  size: [16],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup9, new Uint32Array(65), 14, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder77); computePassEncoder77.dispatchWorkgroupsIndirect(buffer104, 1_684); };
+} catch {}
+try {
+renderPassEncoder34.draw(269, 259, 1_231_285_811, 337_589_935);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer117, 4_788);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer199, 1_528);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer154, 'uint16', 766, 1_089);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(4, buffer103, 0);
+} catch {}
+let arrayBuffer47 = buffer26.getMappedRange(1744, 748);
+let texture322 = device0.createTexture({size: [48], dimension: '1d', format: 'r16float', usage: GPUTextureUsage.COPY_SRC});
+let sampler192 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.22,
+  lodMaxClamp: 49.17,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder171.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.draw(38, 55, 230_914_416, 621_614_061);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer24, 240);
+} catch {}
+let bindGroup172 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 36, resource: textureView171}, {binding: 376, resource: {buffer: buffer40, offset: 0}}],
+});
+let buffer201 = device0.createBuffer({
+  size: 60,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView280 = texture263.createView({});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup113, new Uint32Array(1277), 416, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle34]);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer72, 368);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer190, 'uint16', 2_188, 561);
+} catch {}
+try {
+  await promise44;
+} catch {}
+let bindGroup173 = device0.createBindGroup({
+  label: '\u092c\u{1fc6d}\u3496\u077f\u4d01\uee47\u{1fad5}\u09bd\u632a\uf601',
+  layout: bindGroupLayout12,
+  entries: [{binding: 408, resource: sampler182}],
+});
+let buffer202 = device0.createBuffer({size: 15366, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder258 = device0.createCommandEncoder({});
+let computePassEncoder172 = commandEncoder258.beginComputePass({});
+let sampler193 = device0.createSampler({lodMinClamp: 92.22, lodMaxClamp: 97.72});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup56, new Uint32Array(2545), 826, 0);
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder23.draw(57, 191, 303_903_257, 1_056_792_410);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer117, 176);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer114, 'uint32', 6_048, 3_260);
+} catch {}
+document.body.append(video3);
+let bindGroup174 = device0.createBindGroup({layout: bindGroupLayout37, entries: [{binding: 238, resource: textureView16}]});
+let commandEncoder259 = device0.createCommandEncoder();
+let computePassEncoder173 = commandEncoder259.beginComputePass({});
+try {
+renderPassEncoder46.drawIndexed(98, 31, 1_246, 1_462_269, 1_025_901_342);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer34, 4_912);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer41, 'uint32', 1_116, 1_562);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.append(canvas5);
+let textureView281 = texture58.createView({dimension: '2d-array', format: 'astc-12x12-unorm', mipLevelCount: 1});
+try {
+computePassEncoder144.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(1, bindGroup88, new Uint32Array(222), 14, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(3, 1); };
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup16, new Uint32Array(1010), 350, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(14, 6, 62, -2_096_992_050, 376_653_478);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer138, 4_996);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer181, 'uint32', 640, 964);
+} catch {}
+try {
+renderPassEncoder51.insertDebugMarker('\u{1f978}');
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let sampler194 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.21,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder170.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+renderPassEncoder7.draw(144, 133, 184_876_518, 1_121_598_662);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer189, 1_828);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer44, 2_652);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer154, 'uint32', 488, 598);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u490f\u1b0e\ud1df\u{1ffc2}\u{1f6fc}',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: array<f32, 1>,
+}
+/* target size: 4 max align: 4 */
+struct T1 {
+  f0: u32,
+}
+@group(0) @binding(19) var tex17: texture_depth_2d;
+@group(0) @binding(36) var<uniform> buffer203: T0;
+@group(0) @binding(407) var tex16: texture_cube<u32>;
+struct FragmentOutput11 {
+  @location(0) @interpolate(flat, sample) f0: i32,
+  @builtin(sample_mask) f1: u32,
+  @location(4) @interpolate(flat, sample) f2: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  return out;
+}
+struct FragmentOutput12 {
+  @location(0) f0: i32
+}
+
+@fragment
+fn fragment1() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  return out;
+}
+struct FragmentOutput13 {
+  @location(0) f0: f32,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment2() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u) {
+  _ = buffer203.f0[0];
+  _ = buffer203;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup175 = device0.createBindGroup({
+  label: '\u65d0\u1b80\ub462\u{1fb17}\u0fd8\u0345\u3bf4\u{1ff5d}\u{1f81f}\uc20e',
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 513, resource: sampler40},
+    {binding: 23, resource: {buffer: buffer84, offset: 1536, size: 608}},
+    {binding: 58, resource: textureView49},
+    {binding: 526, resource: textureView263},
+    {binding: 9, resource: textureView207},
+    {binding: 24, resource: textureView109},
+    {binding: 224, resource: textureView16},
+    {binding: 169, resource: textureView54},
+    {binding: 123, resource: {buffer: buffer12, offset: 256, size: 2264}},
+  ],
+});
+let commandEncoder260 = device0.createCommandEncoder();
+let computePassEncoder174 = commandEncoder260.beginComputePass();
+try {
+renderPassEncoder46.draw(246, 127, 1_227_377_501, 1_440_674_172);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(36, 478, 78, 357_392_588, 472_464_834);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(3, buffer55, 60, 139);
+} catch {}
+let querySet34 = device0.createQuerySet({label: '\ua6ef\u5194\u0316\ub0a7\u{1f6c3}\u{1fba0}', type: 'occlusion', count: 851});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(4); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroupsIndirect(buffer117, 1_000); };
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup158);
+} catch {}
+try {
+renderPassEncoder46.draw(598, 154, 151_332_947, 122_007_227);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(143, 233, 85, 452_553_308, 2_275_135_828);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer72, 680);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 8, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {
+      binding: 276,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 99,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let textureView282 = texture288.createView({dimension: '2d-array'});
+let textureView283 = texture302.createView({format: 'rg8unorm'});
+try {
+computePassEncoder174.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder35.draw(267, 24, 340_194_525, 347_818_724);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer157, 1772, new Float32Array(7591), 357, 0);
+} catch {}
+document.body.prepend(img1);
+let bindGroup176 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 261, resource: textureView191}]});
+let commandEncoder261 = device0.createCommandEncoder({});
+let textureView284 = texture309.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let renderPassEncoder90 = commandEncoder261.beginRenderPass({
+  label: '\ud92f\u{1ffc5}\ufba4\u{1fb80}\u66ca\u0f9d\u0450\u3da5',
+  colorAttachments: [{
+  view: textureView138,
+  clearValue: { r: -769.6, g: 822.4, b: 184.6, a: 883.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 596952032,
+});
+try {
+computePassEncoder156.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer29, 208);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(4, buffer183, 0, 579);
+} catch {}
+let arrayBuffer48 = buffer190.getMappedRange(10368, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(68_220).fill(70), /* required buffer size: 68_220 */
+{offset: 54, bytesPerRow: 142, rowsPerImage: 80}, {width: 3, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let promise45 = device0.queue.onSubmittedWorkDone();
+let bindGroup177 = device0.createBindGroup({layout: bindGroupLayout27, entries: [{binding: 33, resource: textureView63}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer190, 2_248); };
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup151, new Uint32Array(819), 80, 0);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer49 = buffer45.getMappedRange(744, 228);
+try {
+  await promise45;
+} catch {}
+//let promise46 = adapter0.requestAdapterInfo();
+let textureView285 = texture85.createView({label: '\u{1fe14}\u01a4\u0b3d\u8c1b', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 34});
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup29, new Uint32Array(918), 250, 0);
+} catch {}
+try {
+renderPassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer112, 4_928);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer41, 'uint32', 464, 424);
+} catch {}
+try {
+renderPassEncoder90.setPipeline(pipeline2);
+} catch {}
+let bindGroup178 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 19, resource: textureView2},
+    {binding: 407, resource: textureView163},
+    {binding: 36, resource: {buffer: buffer133, offset: 1792, size: 96}},
+  ],
+});
+let pipelineLayout25 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout35]});
+try {
+computePassEncoder107.setBindGroup(2, bindGroup53, new Uint32Array(509), 116, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer54, 5_648); };
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup26, new Uint32Array(970), 153, 0);
+} catch {}
+try {
+renderPassEncoder23.draw(45, 545, 852_858_192, 344_142_499);
+} catch {}
+let buffer204 = device0.createBuffer({
+  size: 11030,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder262 = device0.createCommandEncoder({});
+let textureView286 = texture124.createView({baseMipLevel: 0});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup100, new Uint32Array(41), 0, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.draw(50, 58, 1_095_971_300, 944_434_544);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer122, 'uint16', 238, 1_337);
+} catch {}
+try {
+renderPassEncoder90.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder262.copyBufferToBuffer(buffer55, 0, buffer197, 7384, 40);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video1);
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'film', transfer: 'gamma22curve'} });
+try {
+computePassEncoder125.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder11.draw(193, 97, 1_859_076_694, 166_802_547);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer81, 1_332);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 174}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 33, y: 12, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData40 = new ImageData(8, 16);
+let textureView287 = texture77.createView({});
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder90.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder262.clearBuffer(buffer181);
+} catch {}
+try {
+  await promise46;
+} catch {}
+let imageData41 = new ImageData(12, 28);
+let buffer205 = device0.createBuffer({size: 9404, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture323 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder175 = commandEncoder262.beginComputePass({});
+try {
+computePassEncoder128.setBindGroup(0, bindGroup78, new Uint32Array(586), 5, 0);
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(2, bindGroup43, new Uint32Array(2633), 158, 0);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(41, 93, 265, 35_904_084, 169_860_536);
+} catch {}
+try {
+renderPassEncoder88.setIndexBuffer(buffer15, 'uint16', 6_200, 28_254);
+} catch {}
+try {
+if (!arrayBuffer39.detached) { new Uint8Array(arrayBuffer39).fill(0x55); };
+} catch {}
+let bindGroup179 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 28, resource: textureView177}]});
+let buffer206 = device0.createBuffer({
+  size: 1521,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture324 = gpuCanvasContext10.getCurrentTexture();
+try {
+computePassEncoder164.setBindGroup(0, bindGroup126);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder34.draw(417, 630, 49_747_074, 347_980_067);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer136, 300);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer36, 296);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer44, 'uint32', 168, 896);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 665, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(58).fill(236), /* required buffer size: 58 */
+{offset: 58}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup180 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView93}]});
+let commandEncoder263 = device0.createCommandEncoder({});
+let renderPassEncoder91 = commandEncoder263.beginRenderPass({colorAttachments: [{view: textureView155, depthSlice: 137, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder161.setBindGroup(1, bindGroup171, []);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup59, new Uint32Array(56), 2, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(37, 516, 196_088_330, 221_383_427);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer187, 4_232);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer46.detached) { new Uint8Array(arrayBuffer46).fill(0x55); };
+} catch {}
+let commandEncoder264 = device0.createCommandEncoder({});
+let renderPassEncoder92 = commandEncoder264.beginRenderPass({
+  colorAttachments: [{
+  view: textureView155,
+  depthSlice: 189,
+  clearValue: { r: 803.5, g: -273.7, b: 928.3, a: 253.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 217861251,
+});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup80, new Uint32Array(149), 48, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder136); computePassEncoder136.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(256, 20, 78, 230_819_233, 446_702_212);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer61, 344);
+} catch {}
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 27});
+try {
+computePassEncoder90.dispatchWorkgroupsIndirect(buffer165, 1_340);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(21, 337, 51, 304_569_076, 316_604_265);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer122, 1_296);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+document.body.append(canvas0);
+let buffer207 = device0.createBuffer({
+  size: 10540,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder265 = device0.createCommandEncoder({});
+let texture325 = device0.createTexture({
+  label: '\u{1fcdb}\u024b\u4b73\u3b31\u{1fd67}\u07c9\u{1f976}\u098a\udb03\u{1fa28}',
+  size: [24],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder176 = commandEncoder265.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder77); computePassEncoder77.dispatchWorkgroupsIndirect(buffer19, 8); };
+} catch {}
+try {
+renderPassEncoder49.draw(22, 145, 229_160_941, 460_979_887);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer146, 364);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer193, 2_472);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer49, 'uint32', 388, 1_772);
+} catch {}
+let imageData42 = new ImageData(52, 32);
+let bindGroup181 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 126, resource: sampler189},
+    {binding: 78, resource: textureView11},
+    {binding: 88, resource: textureView63},
+  ],
+});
+let textureView288 = texture26.createView({});
+try {
+computePassEncoder176.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup75, new Uint32Array(677), 238, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle17, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(114, 151, 193, -2_055_608_714, 55_186_018);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer29, 68);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer187, 'uint32', 13_992, 6_036);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline0);
+} catch {}
+let commandEncoder266 = device0.createCommandEncoder({});
+let computePassEncoder177 = commandEncoder266.beginComputePass({});
+try {
+computePassEncoder134.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder58.beginOcclusionQuery(241);
+} catch {}
+let videoFrame39 = new VideoFrame(imageBitmap2, {timestamp: 0});
+try {
+commandEncoder265.label = '\u{1f958}\u0ea3\u28e1\u002f\u{1fba6}\u5c17\ufdfc\u1614\ud904';
+} catch {}
+let pipelineLayout26 = device0.createPipelineLayout({label: '\u7abb\u{1f8b9}\u07d6\ub7dc\u0896\u{1fa1f}', bindGroupLayouts: []});
+let texture326 = device0.createTexture({
+  size: [48, 20, 188],
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler195 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.16,
+  lodMaxClamp: 91.79,
+  compare: 'never',
+});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup103, new Uint32Array(883), 257, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer24, 152); };
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.draw(255, 178, 847_761_105, 45_121_962);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1_150, 15, 15, 475_916_135, 471_336_047);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer98, 5_592);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+let sampler196 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.54,
+  lodMaxClamp: 48.88,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup105, new Uint32Array(1515), 1_052, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup168, new Uint32Array(274), 38, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer29, 44);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer6, 176);
+} catch {}
+try {
+computePassEncoder88.insertDebugMarker('\u35c3');
+} catch {}
+let texture327 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 9},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u7cb0\u95a2\ubaf8\u{1fc70}\u004b\u0377\u02ac\u{1ff3c}\u{1fc0f}\u031d\u02ca',
+  colorFormats: ['r16sint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder158.setBindGroup(1, bindGroup99, new Uint32Array(4045), 853, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(56, 130, 467_682_912, 3_420_074);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(56, 242, 17, 257_449_927, 562_042_726);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer16, 372);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(2, buffer190, 4_660, 104);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 696, new BigUint64Array(832), 11, 108);
+} catch {}
+let promise47 = device0.queue.onSubmittedWorkDone();
+let videoFrame40 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'gamma28curve'} });
+let shaderModule17 = device0.createShaderModule({
+  label: '\udce6\u69d5\u0007',
+  code: `
+enable f16;
+/* target size: 44 max align: 4 */
+struct T0 {
+  @size(8) f0: f16,
+  @align(1) f1: array<array<array<i32, 1>, 1>, 1>,
+  @size(4) f2: f16,
+  @size(28) f3: array<array<f16, 1>, 3>,
+}
+@group(0) @binding(407) var tex18: texture_2d<i32>;
+@group(0) @binding(36) var<uniform> buffer208: array<f32, 1>;
+@group(0) @binding(19) var tex19: texture_depth_cube_array;
+struct VertexOutput14 {
+  @builtin(position) f38: vec4f
+}
+
+@vertex
+fn vertex0(@location(1) @interpolate(linear) a0: f32) -> VertexOutput14 {
+  var out: VertexOutput14;
+  return out;
+}
+struct FragmentOutput14 {
+  @location(0) @interpolate(flat) f0: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = buffer208[0];
+  _ = buffer208[0];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer209 = device0.createBuffer({size: 7772, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture328 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder175.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer152, 2_164);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(buffer48, 'uint32', 11_012, 1_494);
+} catch {}
+let bindGroup182 = device0.createBindGroup({layout: bindGroupLayout27, entries: [{binding: 33, resource: textureView277}]});
+let texture329 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture330 = gpuCanvasContext7.getCurrentTexture();
+let textureView289 = texture198.createView({baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+renderPassEncoder8.draw(135, 195, 389_436_705, 373_190_091);
+} catch {}
+let textureView290 = texture237.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 3, arrayLayerCount: 1});
+try {
+computePassEncoder140.setBindGroup(2, bindGroup162);
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(1, bindGroup157, new Uint32Array(557), 10, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer18, 2_704);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer102, 44);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(1, bindGroup47, new Uint32Array(1040), 81, 0);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(6, buffer63, 204, 16);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let pipelineLayout27 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0]});
+let texture331 = device0.createTexture({
+  size: [24, 10, 55],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle39 = renderBundleEncoder39.finish({});
+let sampler197 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.65,
+  compare: 'less',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup112);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup28, new Uint32Array(1265), 330, 0);
+} catch {}
+try {
+renderPassEncoder46.draw(601, 97, 370_702_049, 89_617_375);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer29, 28);
+} catch {}
+try {
+renderPassEncoder88.setIndexBuffer(buffer183, 'uint16', 1_082, 908);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer182, 0);
+} catch {}
+try {
+  await promise47;
+} catch {}
+try {
+externalTexture20.label = '\u4c00\u2ad9\u4d70\u029f\u5fa6\ufdf2\u6f06\u7044\u3427\u{1f82b}\u0a57';
+} catch {}
+try {
+computePassEncoder82.setBindGroup(2, bindGroup138, new Uint32Array(1383), 855, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroupsIndirect(buffer168, 652); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup99, []);
+} catch {}
+try {
+renderPassEncoder76.setViewport(33.917025567079165, 45.253813488468914, 57.83492869193466, 10.876812456191034, 0.4358512400231277, 0.7492936932283922);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer39, 272);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer17, 3_500);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer194, 'uint32', 976, 611);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(303).fill(100), /* required buffer size: 303 */
+{offset: 303}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas1.height = 799;
+try {
+adapter0.label = '\u9230\uaf9e';
+} catch {}
+let sampler198 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.50,
+  lodMaxClamp: 64.83,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder31.setIndexBuffer(buffer180, 'uint32', 180, 640);
+} catch {}
+let bindGroup183 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 265, resource: {buffer: buffer194, offset: 3840, size: 276}}],
+});
+try {
+computePassEncoder152.setBindGroup(3, bindGroup172, []);
+} catch {}
+try {
+computePassEncoder147.setBindGroup(1, bindGroup80, new Uint32Array(1234), 138, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle1, renderBundle18, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer93, 24);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer80, 1_112);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer19, 'uint16', 80, 137);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 738});
+try {
+renderPassEncoder52.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder7.draw(240, 5, 1_246_205_842, 36_139_455);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer18, 356);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let arrayBuffer50 = buffer2.getMappedRange(0, 8);
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55); };
+} catch {}
+let texture332 = device0.createTexture({
+  size: [192, 80, 31],
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler199 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.19,
+  lodMaxClamp: 50.56,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder118.setBindGroup(1, bindGroup138);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup24, new Uint32Array(4671), 966, 0);
+} catch {}
+try {
+renderPassEncoder58.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.draw(524, 231, 626_567_598, 948_121_063);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(322, 194, 327, 283_482_760, 223_632_120);
+} catch {}
+document.body.append(img0);
+let videoFrame41 = new VideoFrame(video2, {timestamp: 0});
+let bindGroup184 = device0.createBindGroup({
+  label: '\u0b74\u3720\u992e\u1753\u{1f66d}\u01db\uc212\u{1f894}',
+  layout: bindGroupLayout29,
+  entries: [{binding: 362, resource: textureView2}],
+});
+let buffer210 = device0.createBuffer({
+  size: 3538,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder23.drawIndexed(109, 48, 77, -2_015_446_953, 4_246_958_668);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte432', transfer: 'smpte240m'} });
+let buffer211 = device0.createBuffer({
+  label: '\u3608\ua8f9\u{1fcd2}\u065a\u0b60\ud92a\ucd48\uf6db\ub282',
+  size: 9100,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture333 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder30.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(0, bindGroup4, new Uint32Array(5058), 8, 0);
+} catch {}
+try {
+computePassEncoder74.dispatchWorkgroupsIndirect(buffer16, 356);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup30, new Uint32Array(5664), 1_643, 0);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder26.setViewport(162.67431957058415, 60.60799317423576, 13.908654155388746, 14.55441594966305, 0.2046551890606617, 0.210459059522782);
+} catch {}
+try {
+renderPassEncoder9.draw(134, 140, 1_739_409_885, 1_244_959_203);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer151, 2_620);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(7, buffer182, 188);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer12, 1_004); };
+} catch {}
+try {
+renderPassEncoder7.draw(74, 28, 233_657_206, 161_553_176);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer19, 56);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer36, 704);
+} catch {}
+document.body.prepend(img2);
+let buffer212 = device0.createBuffer({
+  size: 1021,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder118.setBindGroup(3, bindGroup133, new Uint32Array(2220), 315, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(79, 128, 2_992_954_704, 493_748_107);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(76, 132, 2, 1_537_436_010, 166_306_445);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer69, 1_680);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+window.someLabel = externalTexture21.label;
+} catch {}
+let bindGroup185 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 89, resource: textureView12},
+    {binding: 5, resource: textureView2},
+    {binding: 41, resource: textureView2},
+  ],
+});
+let texture334 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 18},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler200 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.43,
+  lodMaxClamp: 98.47,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup113, new Uint32Array(4183), 571, 0);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder46.draw(269, 30, 57_067_682, 408_866_330);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer62, 3_028);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer63);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 2464, new Float32Array(10529), 455, 264);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(3, bindGroup155);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(2, bindGroup182, new Uint32Array(1768), 653, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer62, 3_100);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer12, 860);
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer137, 'uint16', 184, 434);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline1);
+} catch {}
+try {
+if (!arrayBuffer31.detached) { new Uint8Array(arrayBuffer31).fill(0x55); };
+} catch {}
+let imageData43 = new ImageData(44, 12);
+let bindGroup186 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 13, resource: textureView2}, {binding: 444, resource: textureView209}],
+});
+let buffer213 = device0.createBuffer({size: 1002, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture335 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture336 = gpuCanvasContext1.getCurrentTexture();
+let textureView291 = texture231.createView({aspect: 'all', format: 'r16float'});
+try {
+computePassEncoder124.setBindGroup(1, bindGroup182);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder63.setViewport(163.25705633534352, 43.32213445614541, 16.754737368346643, 31.753142393030124, 0.19068620235381062, 0.4129913045528415);
+} catch {}
+try {
+renderPassEncoder25.draw(105, 201, 1_031_659_685, 1_424_701_195);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer31, 'uint16', 7_482, 5_981);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline2);
+} catch {}
+await gc();
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 410});
+try {
+computePassEncoder93.setBindGroup(3, bindGroup137);
+} catch {}
+try {
+renderPassEncoder50.setViewport(10.332524840670628, 5.458531934215952, 4.259056391508585, 0.17390682206198949, 0.24355199291695484, 0.8129827820859291);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(36, 2, 234, 550_643_822, 486_894_536);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer201, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+let texture337 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 174},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler201 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 5.982,
+  lodMaxClamp: 16.95,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder127.setBindGroup(2, bindGroup127);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder90); computePassEncoder90.dispatchWorkgroupsIndirect(buffer5, 128); };
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(470, 705, 89, 371_345_453, 975_731_425);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer63, 224);
+} catch {}
+try {
+if (!arrayBuffer27.detached) { new Uint8Array(arrayBuffer27).fill(0x55); };
+} catch {}
+let sampler202 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.94,
+  lodMaxClamp: 83.51,
+  maxAnisotropy: 15,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer5, 80); };
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture318,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(268).fill(78), /* required buffer size: 268 */
+{offset: 268}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData44 = new ImageData(28, 52);
+let buffer214 = device0.createBuffer({size: 9038, usage: GPUBufferUsage.COPY_DST});
+let texture338 = device0.createTexture({
+  size: [24, 10, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView292 = texture267.createView({dimension: '2d', baseArrayLayer: 13});
+try {
+renderPassEncoder89.executeBundles([renderBundle26, renderBundle26, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder46.draw(41, 143, 66_312_970, 466_001_692);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(15, 161, 10, 135_864_316, 371_604_943);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer20, 2_788);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer36, 2_080);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroup187 = device0.createBindGroup({layout: bindGroupLayout32, entries: [{binding: 177, resource: textureView228}]});
+let texture339 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup78, new Uint32Array(270), 56, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer104, 68);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer43, 1_392);
+} catch {}
+try {
+renderPassEncoder87.insertDebugMarker('\uf5c0');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let bindGroup188 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 163, resource: textureView47},
+    {binding: 63, resource: {buffer: buffer206, offset: 0, size: 444}},
+  ],
+});
+let textureView293 = texture128.createView({arrayLayerCount: 2});
+try {
+computePassEncoder102.setBindGroup(1, bindGroup101, []);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup111, new Uint32Array(1168), 794, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer178, 3_624);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup189 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 78, resource: textureView11},
+    {binding: 126, resource: sampler110},
+    {binding: 88, resource: textureView277},
+  ],
+});
+let texture340 = device0.createTexture({
+  size: [96],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup108, []);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup65, new Uint32Array(20), 4, 0);
+} catch {}
+try {
+renderPassEncoder88.setViewport(1.2258509270319218, 8.361193604018064, 7.167583248726717, 1.5620223128008832, 0.15504330531359922, 0.8317727605776623);
+} catch {}
+try {
+renderPassEncoder25.draw(94, 59, 1_020_649_143, 136_517_294);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer187, 1_568);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView294 = texture92.createView({label: '\u0aa4\u{1f612}', aspect: 'all'});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup29, new Uint32Array(566), 48, 0);
+} catch {}
+try {
+renderPassEncoder60.setViewport(0.8006593373315267, 5.810781566393132, 8.448433791371786, 2.942860627445467, 0.4877834406047832, 0.6824674012196978);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(385, 108, 292, 7_569_876, 1_243_241_900);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer36, 2_892);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer185, 'uint16', 434, 634);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData45 = new ImageData(8, 48);
+let bindGroup190 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView91}]});
+let buffer215 = device0.createBuffer({size: 6916, usage: GPUBufferUsage.STORAGE});
+let texture341 = gpuCanvasContext5.getCurrentTexture();
+let textureView295 = texture22.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3});
+try {
+renderPassEncoder92.executeBundles([renderBundle13, renderBundle38, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer34, 4_268);
+} catch {}
+try {
+renderPassEncoder91.setVertexBuffer(3, buffer124, 0);
+} catch {}
+document.body.prepend(video4);
+let buffer216 = device0.createBuffer({
+  size: 3383,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView296 = texture306.createView({mipLevelCount: 1});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup103, new Uint32Array(3109), 237, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(133, 105, 233, -2_124_251_238, 2_306_912_625);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer113, 1_880);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer210, 276, new Float32Array(3464), 805, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(2_494).fill(115), /* required buffer size: 2_494 */
+{offset: 26, bytesPerRow: 7, rowsPerImage: 117}, {width: 2, height: 2, depthOrArrayLayers: 4});
+} catch {}
+let textureView297 = texture49.createView({dimension: '3d'});
+try {
+computePassEncoder67.dispatchWorkgroupsIndirect(buffer180, 368);
+} catch {}
+try {
+renderPassEncoder9.draw(6, 100, 2_920_641_937, 1_917_323_836);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer29, 168);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer191, 'uint32', 956, 1_061);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(0, bindGroup181, new Uint32Array(151), 47, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(49, 427, 39, 479_483_615, 83_956_301);
+} catch {}
+try {
+renderPassEncoder75.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(0, buffer97, 0, 584);
+} catch {}
+let promise48 = device0.queue.onSubmittedWorkDone();
+let buffer217 = device0.createBuffer({
+  label: '\ucc10\u0ae3\u7a5b\u915a\u2bb1\uae59',
+  size: 2767,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup49, new Uint32Array(2841), 78, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer131, 32);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer172, 480);
+} catch {}
+try {
+computePassEncoder100.setBindGroup(3, bindGroup17, new Uint32Array(75), 1, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(126, 167, 539_975_273, 202_933_545);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer27, 2_068);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture342 = gpuCanvasContext4.getCurrentTexture();
+let textureView298 = texture231.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder11.drawIndexed(34, 335, 31, 2_147_483_647, 433_427_935);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer71, 1_588);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+canvas1.height = 2763;
+let video6 = await videoWithData(53);
+let texture343 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView299 = texture228.createView({
+  label: '\u0dac\u2195\u{1fa2f}\u2c91\u0ec8\ud109\uc069\u0112\u07d5\u6369\u135d',
+  mipLevelCount: 1,
+  baseArrayLayer: 18,
+  arrayLayerCount: 1,
+});
+let sampler203 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.85,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder39.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer71, 540);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer93, 168);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let bindGroup191 = device0.createBindGroup({
+  layout: bindGroupLayout35,
+  entries: [
+    {binding: 116, resource: {buffer: buffer74, offset: 15616, size: 3359}},
+    {binding: 38, resource: textureView268},
+    {binding: 155, resource: textureView273},
+    {binding: 142, resource: textureView274},
+    {binding: 20, resource: {buffer: buffer0, offset: 0, size: 504}},
+    {binding: 269, resource: {buffer: buffer3, offset: 768}},
+    {binding: 29, resource: {buffer: buffer29, offset: 512, size: 1836}},
+    {binding: 1, resource: textureView264},
+    {binding: 398, resource: textureView55},
+    {binding: 31, resource: textureView60},
+  ],
+});
+let texture344 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup60, new Uint32Array(6786), 426, 0);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(9, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(78, 140, 819_367_096, 2_156_450_573);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer65, 6_532);
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  label: '\u0647\uf307\u4fc4\u4626\u62f0\ub2ed\uc587\ubb74',
+  layout: bindGroupLayout33,
+  entries: [{binding: 46, resource: sampler50}],
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(0, buffer92, 452, 1_055);
+} catch {}
+try {
+texture211.destroy();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 176, new BigUint64Array(121));
+} catch {}
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 729,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer218 = device0.createBuffer({
+  size: 7086,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder170.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise48;
+} catch {}
+let canvas6 = document.createElement('canvas');
+let bindGroup193 = device0.createBindGroup({
+  label: '\u14ef\u{1f774}\ud7ff\u0187',
+  layout: bindGroupLayout41,
+  entries: [
+    {binding: 36, resource: textureView273},
+    {binding: 729, resource: {buffer: buffer137, offset: 1280, size: 214}},
+  ],
+});
+let texture345 = device0.createTexture({
+  size: [96, 40, 83],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder49.draw(48, 75, 1_675_973_211, 110_954_946);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(425, 22, 145, -1_927_862_521, 137_714_199);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer37, 1_656);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(4, buffer129, 6_776, 3_323);
+} catch {}
+try {
+querySet26.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup194 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 408, resource: sampler70}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup170);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer193, 108);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer78, 0, 2_999);
+} catch {}
+try {
+buffer163.unmap();
+} catch {}
+await gc();
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder80.setViewport(136.75783296557046, 22.976674378653783, 3.1804245709745733, 51.4791318017336, 0.5063870732502893, 0.6331613737564439);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(11, 64, 215, -2_085_013_959, 367_761_851);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer136, 132);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(5, buffer89, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(20).fill(170), /* required buffer size: 20 */
+{offset: 20}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup195 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView62}]});
+let renderBundle40 = renderBundleEncoder40.finish({});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(3, bindGroup87, new Uint32Array(531), 25, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup86, new Uint32Array(34), 5, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(61, 52, 460_790_442, 1_011_073_914);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(299, 251, 33, 759_540_977, 1_267_919_167);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup193, new Uint32Array(107), 7, 0);
+} catch {}
+try {
+renderPassEncoder54.beginOcclusionQuery(42);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(64, 296, 138, 101_961_347, 499_368_763);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer194, 'uint32', 4, 190);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer106, 1460, new Int16Array(4562), 93, 0);
+} catch {}
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 419,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 136,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup196 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 52, resource: textureView45},
+    {binding: 202, resource: textureView192},
+    {binding: 243, resource: {buffer: buffer199, offset: 0, size: 216}},
+    {binding: 999, resource: textureView172},
+  ],
+});
+let texture346 = device0.createTexture({
+  size: [96, 40, 174],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView300 = texture37.createView({});
+try {
+computePassEncoder151.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder152.setBindGroup(2, bindGroup194, new Uint32Array(378), 96, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle4, renderBundle31, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder50.setScissorRect(3, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(147, 48, 1_469_655_401, 157_752_748);
+} catch {}
+let texture347 = device0.createTexture({
+  label: '\uf550\u9f87\u{1f724}\u{1ffab}',
+  size: {width: 48, height: 20, depthOrArrayLayers: 87},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture348 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder83.setScissorRect(9, 5, 0, 2);
+} catch {}
+try {
+renderPassEncoder65.setViewport(31.939912343429015, 0.0076272043017455715, 0.41567426207229546, 12.70790353481278, 0.8234145520813324, 0.9675574455827671);
+} catch {}
+try {
+renderPassEncoder8.draw(14, 92, 207_001_260, 247_975_497);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture335,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView301 = texture346.createView({arrayLayerCount: 1});
+let textureView302 = texture213.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup86, new Uint32Array(762), 192, 0);
+} catch {}
+try {
+renderPassEncoder46.draw(39, 101, 535_619_071, 1_878_468_452);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(118, 145, 50, 693_863_890, 766_950_672);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer81, 1_120);
+} catch {}
+try {
+renderPassEncoder91.setIndexBuffer(buffer19, 'uint16', 20, 3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup197 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 34, resource: textureView131}]});
+let textureView303 = texture347.createView({});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup94);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer80, 4_768);
+} catch {}
+try {
+renderPassEncoder81.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(4_294_967_295, undefined, 0, 1_191_659_581);
+} catch {}
+let texture349 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView304 = texture105.createView({
+  label: '\ue05b\u9359\ub1b5\ub376\u09df\ucc6e',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+  baseArrayLayer: 3,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder66.dispatchWorkgroupsIndirect(buffer74, 756);
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(0, bindGroup177, new Uint32Array(1114), 74, 0);
+} catch {}
+try {
+renderPassEncoder65.setBlendConstant({ r: -249.4, g: -641.8, b: -987.7, a: -842.5, });
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(14, 181, 146, -2_008_081_819, 49_626_688);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer201, 4);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer190, 148);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer98, 'uint16', 1_588, 1_594);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline6);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let texture350 = device0.createTexture({size: {width: 96}, dimension: '1d', format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView305 = texture52.createView({label: '\ufad0\u807e\u6a89\ub242\u7c6e\u{1faa5}\ue17b\u0dae\u8ae4\u{1fc71}'});
+try {
+renderPassEncoder82.setBindGroup(2, bindGroup84);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(28);
+} catch {}
+try {
+renderPassEncoder69.setViewport(6.193033078373631, 7.342449872994417, 15.022881494956486, 0.34968941798207803, 0.31617279339447246, 0.6655302511869982);
+} catch {}
+try {
+renderPassEncoder49.draw(117, 39, 367_511_470, 2_005_358_097);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer36, 3_556);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer152, 440);
+} catch {}
+try {
+computePassEncoder166.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+computePassEncoder136.setBindGroup(2, bindGroup137, new Uint32Array(387), 19, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer84, 420); };
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup134, new Uint32Array(984), 411, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle39]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(86, 32, 96, 561_324_406, 1_326_097_756);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer134, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer131, 240);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: videoFrame36,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture176,
+  mipLevel: 0,
+  origin: {x: 27, y: 38, z: 154},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer219 = device0.createBuffer({
+  size: 21084,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView306 = texture7.createView({});
+try {
+renderPassEncoder82.setBindGroup(3, bindGroup186);
+} catch {}
+try {
+renderPassEncoder84.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(139, 479, 190, 589_928_106, 148_357_384);
+} catch {}
+try {
+renderPassEncoder82.setPipeline(pipeline6);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let texture351 = gpuCanvasContext7.getCurrentTexture();
+try {
+computePassEncoder92.setBindGroup(1, bindGroup186);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup152, new Uint32Array(5008), 1_299, 0);
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.draw(31, 76, 1_079_765_300, 267_909_411);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer193, 3_288);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer31, 'uint32', 1_632, 346);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline4);
+} catch {}
+offscreenCanvas3.width = 1979;
+let texture352 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 72},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup126);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(2, bindGroup97, new Uint32Array(489), 60, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(26, 131, 1_173_292_932, 75_044_569);
+} catch {}
+let texture353 = device0.createTexture({
+  size: [24, 10, 43],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView307 = texture162.createView({baseArrayLayer: 22, arrayLayerCount: 3});
+let externalTexture38 = device0.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.draw(590, 91, 861_574_037, 321_810_621);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(103, 53, 44, 242_027_614, 417_972_834);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer112, 5_288);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(2, buffer93, 0, 1);
+} catch {}
+let arrayBuffer51 = buffer51.getMappedRange(64, 4);
+document.body.prepend(video0);
+let texture354 = device0.createTexture({
+  size: [16, 16, 53],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder54.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder49.draw(250, 326, 940_660_038, 204_285_955);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(586, 97, 1_111, 34_569_205, 4_286_404);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer165, 904);
+} catch {}
+let sampler204 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  lodMaxClamp: 92.22,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder11.draw(73, 553, 370_671_600, 1_328_269_534);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(11, 17, 288, -2_089_392_653, 249_305_417);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer80, 2_132);
+} catch {}
+let gpuCanvasContext11 = canvas6.getContext('webgpu');
+let bindGroup198 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 127, resource: textureView93}]});
+let texture355 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler205 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.79,
+  lodMaxClamp: 88.62,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup143);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder36.beginOcclusionQuery(153);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer71, 780);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer69, 'uint16', 104, 648);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(2, buffer43, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 17, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(42).fill(245), /* required buffer size: 42 */
+{offset: 42, bytesPerRow: 17}, {width: 1, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let texture356 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint']});
+let sampler206 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.75,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder110.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroupsIndirect(buffer63, 232); };
+} catch {}
+try {
+renderPassEncoder85.setBindGroup(1, bindGroup147, new Uint32Array(2994), 47, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer93, 16);
+} catch {}
+try {
+renderPassEncoder82.setVertexBuffer(5, buffer39);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup175, new Uint32Array(3081), 633, 0);
+} catch {}
+let bindGroup199 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer122, offset: 1024, size: 952}}],
+});
+let textureView308 = texture61.createView({dimension: '2d', arrayLayerCount: 1});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup125);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup129, new Uint32Array(415), 94, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(58, 85, 1_003_751_633, 805_711_082);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer181, 'uint16', 0, 129);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup7, new Uint32Array(407), 244, 0);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer206, 'uint32', 336, 908);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(3, buffer18, 1_124);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let textureView309 = texture347.createView({});
+let texture357 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder166.setBindGroup(1, bindGroup185);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(8, 120, 2, 902_402_364, 267_520_181);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer74, 1_808);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(3, buffer193);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer12, 'uint32', 440, 748);
+} catch {}
+try {
+renderBundleEncoder41.insertDebugMarker('\uad70');
+} catch {}
+let buffer220 = device0.createBuffer({
+  label: '\u{1fbc5}\u4c41\u03df',
+  size: 15293,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture358 = device0.createTexture({size: [16, 16, 12], format: 'r16sint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let textureView310 = texture157.createView({mipLevelCount: 1});
+try {
+renderPassEncoder65.end();
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(558, 60, 76, 234_532_890, 90_125_861);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer199, 524);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(6, buffer90, 6_528);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(2, buffer193);
+} catch {}
+let arrayBuffer52 = buffer92.getMappedRange(2192, 96);
+try {
+renderPassEncoder70.pushDebugGroup('\ue833');
+} catch {}
+try {
+renderPassEncoder70.popDebugGroup();
+} catch {}
+document.body.append(video2);
+let renderBundle41 = renderBundleEncoder41.finish({});
+try {
+computePassEncoder177.setBindGroup(1, bindGroup184);
+} catch {}
+try {
+renderPassEncoder49.draw(71, 181, 593_175_624, 1_070_775_399);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer152, 604);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture359 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder177.setBindGroup(1, bindGroup135, new Uint32Array(515), 99, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer113, 1_172); };
+} catch {}
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder85.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder8.draw(697, 232, 104_936_459, 161_245_108);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(78, 65, 157, 693_717_348, 1_020_794_642);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer6, 8);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise49 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder107.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup22, new Uint32Array(2932), 1_442, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer69, 4_632);
+} catch {}
+try {
+if (!arrayBuffer50.detached) { new Uint8Array(arrayBuffer50).fill(0x55); };
+} catch {}
+let bindGroup200 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer75, offset: 0, size: 752}}],
+});
+let sampler207 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 86.82,
+  lodMaxClamp: 96.11,
+});
+try {
+computePassEncoder155.setPipeline(pipeline3);
+} catch {}
+try {
+buffer165.destroy();
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer221 = device0.createBuffer({
+  label: '\u7076\u{1fa16}\uae86\u1b5c\u0b0b\u03f7\uecb3',
+  size: 20391,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture360 = device0.createTexture({
+  label: '\u8d5b\u319c\u0c0e',
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder133.setBindGroup(3, bindGroup152);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer207, 80);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer39, 'uint16', 12, 7);
+} catch {}
+try {
+if (!arrayBuffer45.detached) { new Uint8Array(arrayBuffer45).fill(0x55); };
+} catch {}
+let querySet38 = device0.createQuerySet({label: '\u064a\u01df', type: 'occlusion', count: 173});
+let sampler208 = device0.createSampler({
+  label: '\u{1f9c6}\u{1ff15}\uc351\u9110\u0b3b\u{1f759}\u01ab\u{1fcb3}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.32,
+  maxAnisotropy: 11,
+});
+let externalTexture39 = device0.importExternalTexture({source: video5, colorSpace: 'srgb'});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup151);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(2, bindGroup66, new Uint32Array(3359), 122, 0);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(142, 556, 39, 305_793_425, 16_473_263);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer29, 496);
+} catch {}
+try {
+renderPassEncoder90.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup60, []);
+} catch {}
+try {
+renderPassEncoder71.setScissorRect(6, 0, 5, 4);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(233, 158, 225, 182_833_566, 1_518_161_799);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer202, 2_804);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture361 = device0.createTexture({size: [192], dimension: '1d', format: 'rgba32sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView311 = texture160.createView({});
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer131, 192);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer202);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+externalTexture7.label = '\u0cbc\u33a7\u5922\u12cd';
+} catch {}
+let bindGroup201 = device0.createBindGroup({
+  label: '\ub3da\u{1f8d9}\u{1f641}\u2b2e\u0fa8\ubb99',
+  layout: bindGroupLayout26,
+  entries: [{binding: 63, resource: {buffer: buffer62, offset: 1792}}, {binding: 163, resource: textureView163}],
+});
+let buffer222 = device0.createBuffer({
+  label: '\uc605\u2d56\u759f\uddbe\u372b',
+  size: 2514,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let externalTexture40 = device0.importExternalTexture({source: video6});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup178);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder92.end();
+} catch {}
+try {
+renderPassEncoder49.draw(465, 107, 90_574_620, 2_377_641_535);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer83, 2_224);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(3, buffer70, 96, 3_335);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 48, new Float32Array(19296), 6534, 448);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 20, y: 17, z: 27},
+  aspect: 'all',
+}, new Uint8Array(2_181_752).fill(162), /* required buffer size: 2_181_752 */
+{offset: 367, bytesPerRow: 645, rowsPerImage: 57}, {width: 40, height: 19, depthOrArrayLayers: 60});
+} catch {}
+try {
+  await promise49;
+} catch {}
+let bindGroup202 = device0.createBindGroup({layout: bindGroupLayout14, entries: [{binding: 85, resource: textureView16}]});
+try {
+computePassEncoder89.setBindGroup(2, bindGroup121, new Uint32Array(76), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder88.executeBundles([renderBundle0, renderBundle14, renderBundle0, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(14, 374, 33, -2_048_237_732, 294_674_488);
+} catch {}
+let arrayBuffer53 = buffer35.getMappedRange(3016, 292);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture238,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture5.label = '\u0071\u{1fa2a}\u1984\u0685\u8079';
+} catch {}
+let textureView312 = texture353.createView({mipLevelCount: 1});
+let sampler209 = device0.createSampler({
+  label: '\u{1f708}\u04db\ubbd2\u05de\u0d9d\u8f93\u{1f8aa}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 97.28,
+  lodMaxClamp: 99.60,
+});
+try {
+renderPassEncoder46.draw(155, 110, 1_513_530_677, 231_487_470);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(124, 233, 40, 274_286_349, 897_169_997);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(1, buffer11, 48, 1_919);
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'film', transfer: 'bt2020_12bit'} });
+try {
+adapter0.label = '\u797d\u{1f99b}\u0fc3\u9846\ud32e\ue2a8\ua232';
+} catch {}
+let textureView313 = texture13.createView({format: 'rgba32sint', mipLevelCount: 1});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup98);
+} catch {}
+try {
+computePassEncoder175.setBindGroup(0, bindGroup60, new Uint32Array(585), 70, 0);
+} catch {}
+try {
+renderPassEncoder87.end();
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(184, 30, 355, -1_714_565_195, 28_787_754);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer16, 140);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(1, buffer212);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData33,
+  origin: { x: 1, y: 7 },
+  flipY: false,
+}, {
+  texture: texture284,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule12, constants: {}}});
+try {
+if (!arrayBuffer32.detached) { new Uint8Array(arrayBuffer32).fill(0x55); };
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let sampler210 = device0.createSampler({
+  label: '\u301c\u8d37\u81f4\u09fe\u0d7e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.294,
+  lodMaxClamp: 53.49,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder157.setBindGroup(3, bindGroup11, new Uint32Array(5034), 1_502, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer63, 368); };
+} catch {}
+try {
+renderPassEncoder8.draw(36, 177, 159_730_223, 159_746_859);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(307, 414, 14, 876_346_303, 463_567_647);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer194, 756);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer217);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 5, y: 7, z: 0},
+  aspect: 'all',
+}, new Uint8Array(13).fill(127), /* required buffer size: 13 */
+{offset: 13}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let bindGroupLayout43 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 11,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer223 = device0.createBuffer({size: 5061, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView314 = texture168.createView({dimension: '2d-array'});
+try {
+renderPassEncoder85.setBlendConstant({ r: 894.8, g: -403.3, b: 277.0, a: -109.8, });
+} catch {}
+try {
+renderPassEncoder62.setViewport(178.66249930576458, 8.18232164574173, 4.614212473272844, 41.95766326938654, 0.4777210988885301, 0.6950512685195003);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer81, 4_996);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer70, 244);
+} catch {}
+let buffer224 = device0.createBuffer({
+  label: '\u{1f712}\u{1fb03}\uf2c7\u7654',
+  size: 4148,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture362 = device0.createTexture({
+  size: [96, 40, 174],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup131);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer44, 2_840);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer112, 7_624);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer183, 'uint32', 1_524, 377);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer198, 956, new DataView(new ArrayBuffer(16723)), 620, 1596);
+} catch {}
+document.body.append(canvas5);
+let buffer225 = device0.createBuffer({size: 616, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer187, 1_960); };
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(70, 87, 3, -1_872_211_816, 1_721_409_341);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer225, 228);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer6, 168);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 57, y: 29 },
+  flipY: false,
+}, {
+  texture: texture238,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup203 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 407, resource: textureView248},
+    {binding: 36, resource: {buffer: buffer74, offset: 7936, size: 47}},
+    {binding: 19, resource: textureView16},
+  ],
+});
+let buffer226 = device0.createBuffer({size: 1259, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let texture363 = device0.createTexture({
+  size: [24, 10, 1],
+  sampleCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup127);
+} catch {}
+try {
+renderPassEncoder46.draw(207, 55, 1_326_558_803, 550_954_573);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(218, 186, 603, 677_583_297, 533_096_613);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer97, 512);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer27, 272);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer225, 104);
+} catch {}
+let img3 = await imageWithData(3, 135, '#10101010', '#20202020');
+let texture364 = device0.createTexture({size: [96, 40, 174], dimension: '3d', format: 'r16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+try {
+renderPassEncoder34.draw(221, 402, 810_020_509, 245_878_815);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer74, 6_504);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer65, 'uint32', 152, 200);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(4, buffer43, 0, 1_602);
+} catch {}
+let arrayBuffer54 = buffer144.getMappedRange(8, 108);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: videoFrame33,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture331,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video7 = await videoWithData(107);
+try {
+computePassEncoder60.setBindGroup(2, bindGroup171, new Uint32Array(3899), 413, 0);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(412, 14, 72, 237_210_529, 1_033_065_496);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer80, 6_320);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer102, 104);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(0, buffer16, 0, 52);
+} catch {}
+let arrayBuffer55 = buffer137.getMappedRange(0, 4668);
+try {
+device0.queue.writeBuffer(buffer57, 36, new Float32Array(4528), 335, 44);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 11, y: 31 },
+  flipY: false,
+}, {
+  texture: texture176,
+  mipLevel: 0,
+  origin: {x: 38, y: 39, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 8, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let texture365 = device0.createTexture({
+  size: [192, 80, 92],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder168.setBindGroup(1, bindGroup110, new Uint32Array(2228), 204, 0);
+} catch {}
+try {
+renderPassEncoder49.draw(206, 267, 827_249_786, 1_456_235_822);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer87, 788);
+} catch {}
+try {
+renderPassEncoder88.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(1, buffer36, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData46 = new ImageData(4, 12);
+let bindGroup204 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 5, resource: textureView16},
+    {binding: 41, resource: textureView2},
+    {binding: 89, resource: textureView53},
+  ],
+});
+let buffer227 = device0.createBuffer({
+  size: 38371,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture366 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 25},
+  mipLevelCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup97, new Uint32Array(2140), 194, 0);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(55);
+} catch {}
+try {
+renderPassEncoder46.draw(102, 433, 215_755_125, 777_066_564);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer102, 72);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer49, 'uint16', 524, 5_881);
+} catch {}
+let arrayBuffer56 = buffer219.getMappedRange(6704);
+let buffer228 = device0.createBuffer({
+  size: 14624,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let texture367 = gpuCanvasContext11.getCurrentTexture();
+let textureView315 = texture61.createView({arrayLayerCount: 2});
+try {
+renderPassEncoder58.beginOcclusionQuery(81);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer138, 12_100);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer206, 4, 190);
+} catch {}
+try {
+computePassEncoder38.pushDebugGroup('\u0a61');
+} catch {}
+let textureView316 = texture108.createView({label: '\u04f1\u{1f61f}\u{1ff76}\u{1fee5}\u12b0\u361b\uf1d0\u{1ffac}', baseMipLevel: 0});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup109, new Uint32Array(2400), 29, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle20]);
+} catch {}
+try {
+renderPassEncoder25.draw(188, 470, 209_865_034, 78_756_530);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer36, 9_492);
+} catch {}
+try {
+buffer61.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+let textureView317 = texture260.createView({label: '\u091a\u21b9\u08e2\ub866\u7363\u59a9\u{1fd1a}\u{1f9aa}\u46ee'});
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup158, new Uint32Array(1186), 59, 0);
+} catch {}
+try {
+renderPassEncoder58.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle15, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer97, 344);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer121, 'uint16', 1_284, 57);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 1243});
+let texture368 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 1},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture369 = gpuCanvasContext9.getCurrentTexture();
+try {
+computePassEncoder110.setBindGroup(1, bindGroup22, new Uint32Array(564), 139, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer83, 244); };
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer226, 192);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer152, 960);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture229,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(185).fill(63), /* required buffer size: 185 */
+{offset: 185, rowsPerImage: 7}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 139}
+*/
+{
+  source: canvas0,
+  origin: { x: 1, y: 84 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 36, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let textureView318 = texture254.createView({dimension: '2d', baseArrayLayer: 20});
+let sampler211 = device0.createSampler({
+  label: '\u9f41\u7b28\u039a\u52fc\u15a4\u0ea4\uaa3d',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.49,
+  lodMaxClamp: 88.32,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup130, new Uint32Array(237), 57, 0);
+} catch {}
+try {
+renderPassEncoder88.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer87, 240);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer187, 'uint32', 616, 998);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(6, buffer184, 3_080, 932);
+} catch {}
+let sampler212 = device0.createSampler({
+  label: '\ud90b\u0d88\u{1f7d0}\u0490\u00df\u842a\ue639\ua182\u085b\u0a98',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 20.53,
+  lodMaxClamp: 48.42,
+  compare: 'less',
+});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup146);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(3, bindGroup129, new Uint32Array(2875), 440, 0);
+} catch {}
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle37]);
+} catch {}
+try {
+renderPassEncoder11.draw(118, 72, 1_162_998_413, 1_514_190_181);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(11, 227, 34, 598_021_769, 377_042_477);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer186, 564);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer36, 1_900);
+} catch {}
+try {
+  await buffer132.mapAsync(GPUMapMode.WRITE, 760, 60);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let texture370 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder7.drawIndexed(165, 153, 95, 82_726_246, 292_561_764);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer178, 692);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer9, 0);
+} catch {}
+document.body.append(video5);
+let textureView319 = texture289.createView({
+  label: '\u643e\u0a11\u0715\u07dd\u0190\u012f\udf18',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+try {
+renderPassEncoder49.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder38.draw(59, 5, 1_122_501_790, 395_427_792);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer117, 2_388);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer209, 972, 927);
+} catch {}
+await gc();
+try {
+externalTexture36.label = '\ud02f\u70b2\u9ff2\u0b28\u389e\u2366\u01f9';
+} catch {}
+let bindGroup205 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer183, offset: 256, size: 1884}}],
+});
+let buffer229 = device0.createBuffer({
+  size: 200,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture371 = device0.createTexture({
+  size: [16, 16, 12],
+  mipLevelCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView320 = texture197.createView({});
+try {
+computePassEncoder172.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer22, 1_936); };
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder8.draw(64, 143, 739_504_241, 904_911_236);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer27, 'uint32', 3_432, 439);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 96, y: 6, z: 4},
+  aspect: 'all',
+}, new Uint8Array(1_123).fill(236), /* required buffer size: 1_123 */
+{offset: 157, bytesPerRow: 53}, {width: 3, height: 19, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer230 = device0.createBuffer({
+  size: 9091,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView321 = texture162.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 4});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup205);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(0, bindGroup59, new Uint32Array(292), 2, 0);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(0, bindGroup119, new Uint32Array(1657), 101, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(287, 352, 104, 1_262_955_706, 646_377_342);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(2, bindGroup138);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup66, new Uint32Array(1042), 336, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer98, 2_396);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer112, 44);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer50, 'uint32', 4, 6);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline5);
+} catch {}
+let sampler213 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.57,
+  lodMaxClamp: 43.34,
+});
+try {
+renderPassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder7.draw(26, 472, 1_792_325_913, 1_293_432_909);
+} catch {}
+try {
+renderPassEncoder38.drawIndexed(166, 23, 290, 681_037_996, 1_288_051_863);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer141, 1_656);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let bindGroup206 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 41, resource: textureView2},
+    {binding: 5, resource: textureView16},
+    {binding: 89, resource: textureView60},
+  ],
+});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup112, new Uint32Array(810), 268, 0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(29.09796860808409, 19.804784772083636, 15.03630899666442, 0.17923332747158804, 0.4741807107978142, 0.665254123963933);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(803, 226, 82, 188_185_893, 1_145_606_209);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer97, 360);
+} catch {}
+try {
+renderPassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video2);
+let texture372 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture373 = gpuCanvasContext4.getCurrentTexture();
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer17, 1_556);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer186, 'uint16', 894, 209);
+} catch {}
+//let promise50 = adapter0.requestAdapterInfo();
+let texture374 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder89.executeBundles([renderBundle37]);
+} catch {}
+try {
+renderPassEncoder25.draw(83, 274, 1_318_602_176, 370_976_306);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer131, 204);
+} catch {}
+let buffer231 = device0.createBuffer({
+  size: 18360,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder105.setBindGroup(2, bindGroup170);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup98, new Uint32Array(2938), 687, 0);
+} catch {}
+try {
+renderPassEncoder86.beginOcclusionQuery(39);
+} catch {}
+try {
+renderPassEncoder86.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.draw(65, 94, 1_674_174_876, 1_250_283_984);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer178, 188);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline1);
+} catch {}
+let bindGroup207 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 6, resource: textureView45}]});
+let textureView322 = texture55.createView({mipLevelCount: 1});
+let sampler214 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.63,
+  lodMaxClamp: 65.99,
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder80.setBindGroup(1, bindGroup63, new Uint32Array(4869), 842, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(2_299, 228, 875, 206_611_221, 1_167_378_853);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer186, 908);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer57 = buffer211.getMappedRange(280, 2480);
+try {
+computePassEncoder38.popDebugGroup();
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 24 max align: 8 */
+struct T0 {
+  @size(24) f0: array<atomic<u32>>,
+}
+@group(0) @binding(88) var st9: texture_storage_1d<r32float, read_write>;
+@group(0) @binding(126) var sam4: sampler_comparison;
+@group(0) @binding(78) var st10: texture_storage_1d<rg32uint, read>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0() {
+}`,
+  sourceMap: {},
+});
+let texture375 = device0.createTexture({
+  size: {width: 48, height: 20, depthOrArrayLayers: 21},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup140, new Uint32Array(803), 273, 0);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle14, renderBundle2, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder51.setViewport(0.17399309150104791, 6.807147470279121, 8.955782372998808, 0.47920538381279276, 0.556332275253215, 0.9857948745671871);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(345, 317, 66, 200_692_637, 73_582_260);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer117, 4_488);
+} catch {}
+try {
+renderPassEncoder91.setPipeline(pipeline6);
+} catch {}
+document.body.append(video4);
+let bindGroup208 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [
+    {binding: 39, resource: externalTexture11},
+    {binding: 33, resource: sampler72},
+    {binding: 356, resource: {buffer: buffer213, offset: 0, size: 192}},
+    {binding: 342, resource: sampler4},
+  ],
+});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer151, 1_964);
+} catch {}
+try {
+renderPassEncoder38.drawIndirect(buffer190, 4_832);
+} catch {}
+let arrayBuffer58 = buffer45.getMappedRange(1008, 768);
+try {
+buffer7.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let bindGroup209 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 6, resource: textureView6}]});
+let textureView323 = texture142.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler215 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.551,
+  lodMaxClamp: 37.87,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup138, new Uint32Array(851), 57, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(681, 1, 345_005_224, 118_830_688);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer199, 216);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer62, 472);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(2, buffer223, 0);
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteSt4281', transfer: 'log'} });
+try {
+renderPassEncoder46.draw(65, 81, 306_183_384, 3_497_987_862);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let textureView324 = texture120.createView({baseArrayLayer: 11, arrayLayerCount: 8});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup179);
+} catch {}
+try {
+renderPassEncoder89.setIndexBuffer(buffer230, 'uint32', 48, 719);
+} catch {}
+let bindGroup210 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 444, resource: textureView209}, {binding: 13, resource: textureView16}],
+});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({colorFormats: ['r16float']});
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder46.draw(167, 146, 275_883_346, 441_500_122);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(135, 148, 45, 400_112_750, 110_662_827);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer44, 'uint16', 558, 1_258);
+} catch {}
+try {
+computePassEncoder113.pushDebugGroup('\u0183');
+} catch {}
+let pipelineLayout28 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer232 = device0.createBuffer({size: 16580, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+try {
+renderPassEncoder46.draw(61, 58, 120_980_395, 241_427_859);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer61, 'uint32', 44, 108);
+} catch {}
+try {
+buffer74.unmap();
+} catch {}
+let bindGroup211 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 116, resource: textureView137}]});
+let textureView325 = texture6.createView({baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 1});
+let textureView326 = texture275.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 2});
+let renderBundle42 = renderBundleEncoder42.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder77); computePassEncoder77.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(686, 39, 461, 493_090_952, 3_170_747_190);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(7_033).fill(167), /* required buffer size: 7_033 */
+{offset: 79, bytesPerRow: 114, rowsPerImage: 60}, {width: 0, height: 2, depthOrArrayLayers: 2});
+} catch {}
+let sampler216 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.02,
+  lodMaxClamp: 25.95,
+  maxAnisotropy: 7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer27, 372); };
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle42, renderBundle29, renderBundle13, renderBundle35, renderBundle29, renderBundle13, renderBundle42, renderBundle13, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder49.draw(281, 36, 1_569_148_969, 491_203_888);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(4, 650, 82, 277_572_709, 3_595_541_363);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer27, 40);
+} catch {}
+let bindGroup212 = device0.createBindGroup({
+  label: '\u0b2a\u521b\u00d0',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 407, resource: textureView326},
+    {binding: 19, resource: textureView16},
+    {binding: 36, resource: {buffer: buffer220, offset: 1280, size: 2467}},
+  ],
+});
+try {
+renderPassEncoder25.drawIndexed(2, 110, 2, 174_838_922, 2_819_702_719);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer22, 112);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer152, 88);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(0, buffer116);
+} catch {}
+try {
+window.someLabel = externalTexture25.label;
+} catch {}
+let texture376 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 21},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView327 = texture86.createView({dimension: '2d-array'});
+try {
+renderPassEncoder23.draw(86, 151, 692_100_346, 427_061_385);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(2, 37, 5, 318_615_900, 265_608_649);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer71, 20);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+let videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte240m', transfer: 'logSqrt'} });
+let sampler217 = device0.createSampler({
+  label: '\u{1fa77}\u0196\u{1ffe0}\u010a\u0764\u0cbf\u2cad\u{1f632}\u{1ffa3}\uac7d\u0325',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.82,
+  lodMaxClamp: 88.93,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder33.setBlendConstant({ r: 857.7, g: 849.0, b: -871.0, a: -811.4, });
+} catch {}
+try {
+renderPassEncoder25.draw(131, 319, 1_352_318_620, 759_281_461);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer216, 'uint32', 1_604, 620);
+} catch {}
+document.body.append(video2);
+let textureView328 = texture255.createView({label: '\u{1ff60}\ue2ad\u{1fc8d}\u{1fa14}\u{1f7bd}\u{1fcbe}\u68c2\u40f7\u96fd', aspect: 'all'});
+try {
+renderPassEncoder7.drawIndexed(268, 327, 21, 490_502_764, 814_980_122);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer32, 1_824);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer206, 'uint16', 126, 77);
+} catch {}
+try {
+  await promise50;
+} catch {}
+let texture377 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView329 = texture128.createView({
+  label: '\u0e62\u284a\u3667\u{1f812}\u0eff\u0789\u029c\u0307\ude7c\u0556',
+  baseArrayLayer: 1,
+  arrayLayerCount: 3,
+});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup205);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup162, new Uint32Array(210), 18, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(168, 41, 315_015_269, 398_727_549);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer207, 848);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer34, 3_416);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer163, 'uint16', 6_442, 3_039);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline5);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame43,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture241,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55); };
+} catch {}
+let sampler218 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 71.46,
+  lodMaxClamp: 71.51,
+});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup143);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(3, bindGroup64, new Uint32Array(4868), 1_874, 0);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture309,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(442).fill(121), /* required buffer size: 442 */
+{offset: 442, bytesPerRow: 135}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 146, y: 14 },
+  flipY: true,
+}, {
+  texture: texture195,
+  mipLevel: 1,
+  origin: {x: 20, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 31, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img3);
+try {
+computePassEncoder6.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle38, renderBundle38, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder38.drawIndexedIndirect(buffer104, 1_268);
+} catch {}
+try {
+if (!arrayBuffer44.detached) { new Uint8Array(arrayBuffer44).fill(0x55); };
+} catch {}
+let imageData47 = new ImageData(36, 28);
+let buffer233 = device0.createBuffer({
+  size: 8608,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture378 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder72.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder23.draw(594, 130, 864_556_396, 171_061_604);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer187, 60);
+} catch {}
+try {
+computePassEncoder113.popDebugGroup();
+} catch {}
+let bindGroup213 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 999, resource: textureView164},
+    {binding: 202, resource: textureView147},
+    {binding: 243, resource: {buffer: buffer204, offset: 1024, size: 1916}},
+    {binding: 52, resource: textureView45},
+  ],
+});
+let texture379 = gpuCanvasContext10.getCurrentTexture();
+try {
+computePassEncoder151.setBindGroup(1, bindGroup196, new Uint32Array(752), 36, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer226, 424);
+} catch {}
+let texture380 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 328},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder11.draw(66, 318, 1_413_502_565, 705_690_500);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+renderPassEncoder49.draw(126, 85, 811_347_638, 1_411_972_025);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer152, 24);
+} catch {}
+try {
+if (!arrayBuffer42.detached) { new Uint8Array(arrayBuffer42).fill(0x55); };
+} catch {}
+document.body.append(video7);
+let bindGroup214 = device0.createBindGroup({
+  label: '\u7ca5\u098c\u0d43\u0ae9',
+  layout: bindGroupLayout36,
+  entries: [{binding: 96, resource: textureView64}],
+});
+try {
+computePassEncoder137.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder61.setBlendConstant({ r: 938.5, g: 548.8, b: 772.4, a: 891.0, });
+} catch {}
+try {
+renderPassEncoder46.draw(144, 43, 425_522_657, 107_825_043);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer42, 776);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer38.detached) { new Uint8Array(arrayBuffer38).fill(0x55); };
+} catch {}
+let buffer234 = device0.createBuffer({
+  size: 2161,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let querySet40 = device0.createQuerySet({type: 'occlusion', count: 836});
+let sampler219 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.97,
+});
+try {
+renderPassEncoder7.drawIndexed(209, 22, 836, 366_873_535, 101_281_191);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer168, 512);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer87, 776);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(4_294_967_294, undefined, 0, 984_116_515);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer235 = device0.createBuffer({
+  size: 11968,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let externalTexture41 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+computePassEncoder111.setBindGroup(2, bindGroup174, new Uint32Array(2304), 273, 0);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup189);
+} catch {}
+try {
+renderPassEncoder63.setViewport(26.420059926142486, 63.33022049839563, 106.71708485948426, 10.161481747103945, 0.13394022499136204, 0.5439022931703057);
+} catch {}
+try {
+renderPassEncoder38.draw(223, 240, 256_250_408, 231_742_437);
+} catch {}
+try {
+renderPassEncoder38.drawIndexedIndirect(buffer233, 2_404);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer133, 'uint16', 852, 50);
+} catch {}
+let texture381 = device0.createTexture({
+  label: '\uae39\u0a43',
+  size: {width: 192, height: 80, depthOrArrayLayers: 349},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView330 = texture308.createView({mipLevelCount: 1});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup177);
+} catch {}
+try {
+renderPassEncoder8.draw(17, 101, 68_099_506, 141_302_019);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(0, 301, 0, 499_623_102, 4_045_606_002);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer149, 124);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(0, buffer84, 0);
+} catch {}
+let videoFrame46 = new VideoFrame(videoFrame13, {timestamp: 0});
+let bindGroup215 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler193}]});
+let buffer236 = device0.createBuffer({
+  size: 7558,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderPassEncoder67.end();
+} catch {}
+try {
+renderPassEncoder8.draw(252, 9, 952_802_010, 1_628_778_345);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer165, 720);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(1, bindGroup117);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup44, new Uint32Array(765), 472, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 19, y: 84 },
+  flipY: true,
+}, {
+  texture: texture331,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup216 = device0.createBindGroup({layout: bindGroupLayout32, entries: [{binding: 177, resource: textureView261}]});
+let renderBundle43 = renderBundleEncoder43.finish({});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup63, new Uint32Array(441), 12, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup131);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle27, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(120, 222, 458, 423_464_226, 157_435_836);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer199, 96);
+} catch {}
+try {
+  //await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup217 = device0.createBindGroup({
+  label: '\ub327\u09c2\u09d7\ucfef\u5081\u03ed\u8ef8\u6a51\ub7b9',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 129, resource: {buffer: buffer142, offset: 768, size: 1132}},
+    {binding: 125, resource: {buffer: buffer146, offset: 0, size: 504}},
+    {binding: 71, resource: textureView300},
+    {binding: 115, resource: sampler133},
+    {binding: 348, resource: textureView192},
+  ],
+});
+let buffer237 = device0.createBuffer({
+  size: 258,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler220 = device0.createSampler({
+  label: '\u0a91\u27c5\u08ca\uadf8',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 31.70,
+  compare: 'always',
+});
+try {
+renderPassEncoder73.setBindGroup(2, bindGroup1, new Uint32Array(1720), 256, 0);
+} catch {}
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle31, renderBundle19, renderBundle31, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder23.draw(345, 89, 151_853_786, 285_698_553);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer98, 772);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(1, buffer172);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 139}
+*/
+{
+  source: video2,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 26, y: 25, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup112);
+} catch {}
+try {
+renderPassEncoder89.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder46.draw(63, 42, 64_291_266, 946_346_694);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline4);
+} catch {}
+try {
+buffer205.unmap();
+} catch {}
+let videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt2020', transfer: 'iec61966-2-1'} });
+let bindGroup218 = device0.createBindGroup({layout: bindGroupLayout28, entries: [{binding: 310, resource: textureView241}]});
+let buffer238 = device0.createBuffer({
+  size: 968,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let texture382 = device0.createTexture({
+  size: [48, 20, 1],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder154.setBindGroup(3, bindGroup120);
+} catch {}
+try {
+renderPassEncoder38.drawIndexed(186, 483, 395, 791_285_076, 114_637_236);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer42, 684);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer163, 'uint32', 124, 2_867);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer239 = device0.createBuffer({size: 597, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 927});
+let texture383 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler221 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.39,
+});
+try {
+computePassEncoder139.setBindGroup(1, bindGroup152);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup10, new Uint32Array(2096), 258, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer42, 1_544);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder86.setVertexBuffer(6, buffer100);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture362,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(334_386).fill(102), /* required buffer size: 334_386 */
+{offset: 234, bytesPerRow: 117, rowsPerImage: 56}, {width: 16, height: 0, depthOrArrayLayers: 52});
+} catch {}
+let texture384 = device0.createTexture({
+  size: [16, 16, 12],
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16float', 'r16float'],
+});
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup95, []);
+} catch {}
+try {
+renderPassEncoder89.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.draw(472, 0, 349_394_411, 271_028_997);
+} catch {}
+try {
+renderPassEncoder38.drawIndexed(161, 653, 203, 106_220_636, 620_590_845);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer225, 144);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let bindGroup219 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 106, resource: textureView102}]});
+let buffer240 = device0.createBuffer({
+  label: '\ubb29\u0150\u{1fff4}\u3691\u6e3a\u{1f842}\u{1f60e}\u{1fbd1}\u6785\u{1fb47}',
+  size: 4701,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder174.setBindGroup(2, bindGroup87, new Uint32Array(564), 119, 0);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline2);
+} catch {}
+let bindGroup220 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [{binding: 444, resource: textureView8}, {binding: 13, resource: textureView16}],
+});
+let buffer241 = device0.createBuffer({size: 17706, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let texture385 = device0.createTexture({size: [48, 20, 87], dimension: '3d', format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView331 = texture279.createView({dimension: '1d', baseMipLevel: 0});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup53, new Uint32Array(125), 10, 0);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(1, bindGroup71, new Uint32Array(1175), 8, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(10, 480, 17_418_758, 81_096_548);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(2, 239, 3, 29_200_580, 1_902_240_915);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer224, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer154, 'uint16', 916, 1_430);
+} catch {}
+document.body.append(canvas0);
+let bindGroup221 = device0.createBindGroup({
+  label: '\ub927\u{1f63c}\u{1fdcd}\u0717\u0adc\u{1fe0d}\u0db4\u091a\uc11d\ufeaa\u{1f8db}',
+  layout: bindGroupLayout18,
+  entries: [{binding: 34, resource: textureView159}],
+});
+let textureView332 = texture126.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder93); computePassEncoder93.dispatchWorkgroupsIndirect(buffer61, 292); };
+} catch {}
+try {
+renderPassEncoder59.end();
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer5, 1_484);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer193);
+} catch {}
+try {
+buffer212.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture362,
+  mipLevel: 0,
+  origin: {x: 10, y: 9, z: 17},
+  aspect: 'all',
+}, new Uint8Array(31_079).fill(119), /* required buffer size: 31_079 */
+{offset: 213, bytesPerRow: 44, rowsPerImage: 87}, {width: 11, height: 6, depthOrArrayLayers: 9});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: imageData14,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture331,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+computePassEncoder113.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 44, y: 4 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer242 = device0.createBuffer({
+  size: 1686,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture386 = device0.createTexture({
+  label: '\uc2b7\ua953',
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder116.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+buffer137.unmap();
+} catch {}
+let bindGroupLayout44 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 239,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let bindGroup222 = device0.createBindGroup({layout: bindGroupLayout37, entries: [{binding: 238, resource: textureView16}]});
+let textureView333 = texture294.createView({format: 'depth24plus'});
+try {
+renderPassEncoder46.drawIndexed(448, 254, 184, 421_513_949, 108_659_861);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let bindGroup223 = device0.createBindGroup({layout: bindGroupLayout44, entries: [{binding: 239, resource: textureView333}]});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup142, new Uint32Array(158), 17, 0);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder90.beginOcclusionQuery(4);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle29]);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer131, 64);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(3, buffer153);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+renderPassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder90.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.draw(114, 215, 77_784_239, 431_439_402);
+} catch {}
+try {
+renderPassEncoder88.setVertexBuffer(1, buffer89, 0, 49);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup224 = device0.createBindGroup({
+  label: '\u8958\uc9a0\u789e\u{1fd43}\u72e8\u795f',
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 336, resource: textureView300},
+    {binding: 76, resource: {buffer: buffer79, offset: 256}},
+    {binding: 304, resource: textureView217},
+    {binding: 550, resource: {buffer: buffer199, offset: 256, size: 363}},
+    {binding: 145, resource: textureView256},
+  ],
+});
+let texture387 = device0.createTexture({
+  size: [96, 40, 174],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer224, 144);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline1);
+} catch {}
+let texture388 = gpuCanvasContext9.getCurrentTexture();
+try {
+computePassEncoder126.setBindGroup(0, bindGroup112);
+} catch {}
+try {
+computePassEncoder152.setBindGroup(2, bindGroup204, new Uint32Array(1944), 391, 0);
+} catch {}
+try {
+renderPassEncoder46.draw(165, 125, 1_623_147_366, 877_866_247);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(408, 35, 49, 364_102_158, 225_722_481);
+} catch {}
+let buffer243 = device0.createBuffer({
+  size: 1124,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView334 = texture140.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer124, 1_328); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup62, new Uint32Array(5466), 103, 0);
+} catch {}
+try {
+renderPassEncoder91.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(6, buffer106, 196, 268);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(4_887).fill(124), /* required buffer size: 4_887 */
+{offset: 119, bytesPerRow: 99, rowsPerImage: 8}, {width: 2, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+document.body.append(video2);
+let bindGroup225 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 70, resource: textureView137}]});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup106);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder7.draw(119, 337, 1_267_715_100, 2_377_320_081);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer194, 1_196);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer11);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(4, buffer11, 0);
+} catch {}
+let videoFrame48 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let bindGroup226 = device0.createBindGroup({layout: bindGroupLayout29, entries: [{binding: 362, resource: textureView319}]});
+let textureView335 = texture199.createView({baseArrayLayer: 0});
+let renderBundle44 = renderBundleEncoder44.finish({});
+let sampler222 = device0.createSampler({label: '\u0759\u{1fc10}\ubfeb\u7bd4', addressModeW: 'mirror-repeat', lodMaxClamp: 26.75});
+try {
+computePassEncoder162.setBindGroup(3, bindGroup216);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle23, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer62, 508);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(7, buffer240, 1_724);
+} catch {}
+try {
+  await shaderModule9.getCompilationInfo();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 139}
+*/
+{
+  source: imageData0,
+  origin: { x: 5, y: 2 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 3, y: 8, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer244 = device0.createBuffer({
+  size: 14536,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let querySet42 = device0.createQuerySet({label: '\u{1f8fa}\u{1fb19}\u8f09\u138c\uc2b1\u75fc\ufd18', type: 'occlusion', count: 97});
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup183);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.draw(111, 247, 3_414_412_362, 850_328_837);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(429, 133, 317, 87_386_523, 447_756_513);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer32, 880);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer123, 1792, new BigUint64Array(9193), 2114, 20);
+} catch {}
+try {
+if (!arrayBuffer50.detached) { new Uint8Array(arrayBuffer50).fill(0x55); };
+} catch {}
+await gc();
+let buffer245 = device0.createBuffer({size: 15992, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder49.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder88.setBindGroup(1, bindGroup40);
+} catch {}
+let bindGroup227 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [
+    {binding: 24, resource: textureView243},
+    {binding: 169, resource: textureView254},
+    {binding: 58, resource: textureView222},
+    {binding: 513, resource: sampler29},
+    {binding: 9, resource: textureView175},
+    {binding: 224, resource: textureView2},
+    {binding: 123, resource: {buffer: buffer221, offset: 1792, size: 1544}},
+    {binding: 526, resource: textureView169},
+    {binding: 23, resource: {buffer: buffer168, offset: 2304}},
+  ],
+});
+let texture389 = device0.createTexture({size: [192, 80, 349], dimension: '3d', format: 'rgba32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler223 = device0.createSampler({
+  label: '\u0c40\u04db\u44b1\u604b\u7ffb\u02f5\u{1fb4e}\u1b5d',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMinClamp: 2.775,
+  lodMaxClamp: 60.97,
+  compare: 'equal',
+});
+try {
+computePassEncoder128.setBindGroup(1, bindGroup209);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(2, bindGroup199, new Uint32Array(1587), 115, 0);
+} catch {}
+try {
+computePassEncoder74.dispatchWorkgroups(1, 4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup197, new Uint32Array(934), 94, 0);
+} catch {}
+try {
+renderPassEncoder21.draw(76, 274, 4_294_967_295, 666_429_525);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroupLayout45 = device0.createBindGroupLayout({
+  label: '\u6758\u99c7\u4494\u0860\u048a\ud979\uaec1',
+  entries: [
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView336 = texture6.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroupsIndirect(buffer172, 140); };
+} catch {}
+try {
+renderPassEncoder11.draw(686, 123, 1_212_233_170, 373_697_134);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer193, 288);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer91, 'uint32', 988, 221);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer100.unmap();
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(239, 45);
+let buffer246 = device0.createBuffer({
+  size: 14028,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture390 = device0.createTexture({
+  size: [96, 40, 174],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView337 = texture72.createView({baseMipLevel: 0});
+try {
+computePassEncoder163.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder90); computePassEncoder90.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(2, bindGroup168);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(52);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle15, renderBundle8, renderBundle15, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(3, 385, 7, 173_437_079, 13_031_997);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer97, 228);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer114, 'uint32', 4_004, 5_146);
+} catch {}
+try {
+renderPassEncoder86.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(3, buffer84, 0, 448);
+} catch {}
+let imageData48 = new ImageData(32, 64);
+let bindGroup228 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 63, resource: {buffer: buffer198, offset: 256, size: 148}},
+    {binding: 163, resource: textureView172},
+  ],
+});
+try {
+renderPassEncoder46.draw(104, 82, 635_304_556, 68_723_182);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer244, 2_812);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4, buffer42, 1_724);
+} catch {}
+let videoFrame49 = videoFrame38.clone();
+let textureView338 = texture210.createView({baseArrayLayer: 0});
+let sampler224 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.521,
+  lodMaxClamp: 22.65,
+});
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer37, 1_120);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img1);
+let textureView339 = texture277.createView({label: '\u96f7\u06e1'});
+let sampler225 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 53.32,
+  lodMaxClamp: 90.42,
+  compare: 'greater',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer34, 1_380); };
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup204);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer93, 124);
+} catch {}
+let arrayBuffer59 = buffer55.getMappedRange(104, 0);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup229 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 34, resource: textureView159}]});
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 1004});
+let texture391 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup64);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(108, 39, 1_490, 39_623_088, 218_365_182);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer109, 'uint16', 796, 97);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+  label: '\u047f\u03d4\u0d69',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule13, constants: {}},
+});
+let bindGroup230 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 313, resource: {buffer: buffer225, offset: 256}}]});
+let buffer247 = device0.createBuffer({
+  size: 11960,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(2, bindGroup138, new Uint32Array(2287), 56, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1_342, 40, 251, 590_852_696, 54_856_479);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer146, 0);
+} catch {}
+try {
+texture390.destroy();
+} catch {}
+let textureView340 = texture238.createView({dimension: '2d'});
+try {
+renderPassEncoder21.draw(162, 180, 868_760_690, 58_187_335);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(30, 93, 48, 566_426_473, 564_470_575);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer12, 1_076);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer224, 272);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise51 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let texture392 = device0.createTexture({
+  label: '\u1919\u{1fbb3}\u69fc\u137c\ub7b5\u0ca1\u{1f7e7}\u07dc\u96c2\u77a5\u{1f97d}',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView341 = texture392.createView({});
+let sampler226 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.59,
+  lodMaxClamp: 92.10,
+  compare: 'equal',
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder78.setBindGroup(3, bindGroup56, []);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup174, new Uint32Array(328), 102, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(84, 67, 193_427_434, 1_115_002_617);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup231 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 408, resource: sampler103}]});
+let buffer248 = device0.createBuffer({
+  size: 5030,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView342 = texture195.createView({aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup194, new Uint32Array(2974), 773, 0);
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer39, 'uint16', 228, 426);
+} catch {}
+let arrayBuffer60 = buffer159.getMappedRange(376, 760);
+try {
+if (!arrayBuffer31.detached) { new Uint8Array(arrayBuffer31).fill(0x55); };
+} catch {}
+document.body.append(canvas6);
+let bindGroup232 = device0.createBindGroup({
+  label: '\u0b88\u5190\u07fc\u{1fb30}\u1139\u{1fe69}\u8711',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 115, resource: sampler62},
+    {binding: 129, resource: {buffer: buffer47, offset: 0}},
+    {binding: 125, resource: {buffer: buffer190, offset: 256}},
+    {binding: 71, resource: textureView64},
+    {binding: 348, resource: textureView112},
+  ],
+});
+try {
+computePassEncoder112.setBindGroup(1, bindGroup96);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 676, new Float32Array(1548), 678, 20);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas6.getContext('webgpu');
+let bindGroup233 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 49, resource: sampler118}]});
+let pipelineLayout29 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView343 = texture306.createView({format: 'rg16uint', mipLevelCount: 1});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup92, []);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(91, 97, 111, 191_106_467, 21_319_071);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer74, 'uint32', 13_440, 5_643);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+renderPassEncoder88.setIndexBuffer(buffer93, 'uint32', 208, 44);
+} catch {}
+let arrayBuffer61 = buffer128.getMappedRange(448, 116);
+let sampler227 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 74.29,
+  lodMaxClamp: 83.02,
+});
+try {
+computePassEncoder127.setBindGroup(1, bindGroup168, new Uint32Array(1293), 78, 0);
+} catch {}
+try {
+renderPassEncoder64.setBlendConstant({ r: -614.9, g: 371.0, b: -505.7, a: 794.3, });
+} catch {}
+try {
+renderPassEncoder11.draw(289, 39, 591_393_917, 354_455_766);
+} catch {}
+let buffer249 = device0.createBuffer({
+  size: 963,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture393 = device0.createTexture({
+  label: '\u83cb\u7028\u3572',
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView344 = texture167.createView({});
+try {
+renderPassEncoder21.draw(63, 24, 535_219_816, 377_465_662);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer237, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer180, 528);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer149, 1_808);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer98, 1_372);
+} catch {}
+let sampler228 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.57,
+  lodMaxClamp: 92.49,
+});
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup141, new Uint32Array(3746), 1_279, 0);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(6, 200, 1, 72_877_290, 1_088_979_575);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer224, 712);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer40, 'uint32', 228, 266);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(2, buffer241);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler229 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 46.96,
+  lodMaxClamp: 55.12,
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup222);
+} catch {}
+try {
+renderPassEncoder34.draw(93, 0, 486_602_145, 821_340_570);
+} catch {}
+try {
+renderPassEncoder25.drawIndexedIndirect(buffer112, 964);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(2, buffer84, 428, 440);
+} catch {}
+document.body.append(img3);
+let bindGroup234 = device0.createBindGroup({
+  label: '\ud9e9\uf643\u5935\u{1fc66}\u5584',
+  layout: bindGroupLayout18,
+  entries: [{binding: 34, resource: textureView147}],
+});
+let texture394 = device0.createTexture({size: [24, 10, 1], format: 'rgba32sint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup160);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(24, 724, 48, -2_111_770_402, 707_371_418);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer168, 1_184);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer66, 'uint32', 232, 642);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(0, buffer156);
+} catch {}
+let textureView345 = texture52.createView({aspect: 'all', baseMipLevel: 0});
+let sampler230 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.24,
+});
+try {
+computePassEncoder130.setBindGroup(0, bindGroup101, new Uint32Array(1419), 191, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup138);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 45, 9, -1_466_317_478, 55_120_987);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 608, new DataView(new ArrayBuffer(11825)), 1633, 156);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame40,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture315,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 36},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData49 = new ImageData(32, 44);
+let bindGroup235 = device0.createBindGroup({
+  layout: bindGroupLayout42,
+  entries: [
+    {binding: 127, resource: textureView309},
+    {binding: 114, resource: textureView301},
+    {binding: 43, resource: textureView147},
+    {binding: 136, resource: {buffer: buffer122, offset: 256, size: 864}},
+    {binding: 419, resource: textureView207},
+    {binding: 46, resource: sampler1},
+  ],
+});
+try {
+computePassEncoder112.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([renderBundle20, renderBundle39]);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(295, 328, 372, -957_890_936, 154_921_317);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer240, 808);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture315,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 23},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture395 = gpuCanvasContext11.getCurrentTexture();
+let textureView346 = texture288.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup217, new Uint32Array(618), 103, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup97, new Uint32Array(4646), 960, 0);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(60, 707, 147, 964_200_261, 144_833_672);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer207, 'uint32', 788, 1_582);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder66.insertDebugMarker('\ufb3e');
+} catch {}
+let bindGroup236 = device0.createBindGroup({
+  label: '\u{1fda1}\u0bb2\u063a',
+  layout: bindGroupLayout32,
+  entries: [{binding: 177, resource: textureView261}],
+});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(2, bindGroup9, new Uint32Array(1055), 100, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup204, new Uint32Array(4490), 86, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(79, 105, 1_508_715_017, 351_198_721);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer6, 132);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer96, 'uint32', 1_044, 504);
+} catch {}
+let textureView347 = texture123.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer32, 368);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer207, 840);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(6, buffer235, 128, 1_308);
+} catch {}
+let arrayBuffer62 = buffer55.getMappedRange(0, 12);
+let videoFrame50 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt709', transfer: 'bt1361ExtendedColourGamut'} });
+let textureView348 = texture294.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 0});
+let sampler231 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 53.04,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder11.drawIndexed(22, 63, 32, -1_935_389_043, 1_793_700_396);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer32, 156);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer240, 656);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline5);
+} catch {}
+await gc();
+let texture396 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 14},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler232 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.43,
+  lodMaxClamp: 77.52,
+  compare: 'less',
+  maxAnisotropy: 8,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder86.setBindGroup(3, bindGroup86);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder34.draw(35, 192, 161_413_207, 466_987_459);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer237, 28);
+} catch {}
+try {
+renderPassEncoder80.setVertexBuffer(2, buffer19, 64, 125);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer241, 8420, new Int16Array(25397), 3229, 492);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 139}
+*/
+{
+  source: videoFrame47,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 12, y: 3, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet44 = device0.createQuerySet({type: 'occlusion', count: 45});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup87);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer62, 500);
+} catch {}
+try {
+renderPassEncoder86.setVertexBuffer(2, buffer102, 592, 399);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(2, bindGroup233, new Uint32Array(2047), 163, 0);
+} catch {}
+try {
+renderPassEncoder46.draw(46, 277, 916_849_541, 81_837_730);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.append(video0);
+let texture397 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup82, new Uint32Array(2622), 345, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(13, 179, 9, 770_270_503, 544_287_027);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer226, 536);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer204, 'uint16', 1_906, 2_104);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup187);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline0);
+} catch {}
+let pipelineLayout30 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture398 = device0.createTexture({
+  label: '\ucdd0\u0a23\u7054\u5f98\u{1fb35}\u{1fab9}\u03fc\ud193\uc5c2',
+  size: [192, 80, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle45 = renderBundleEncoder45.finish({});
+try {
+computePassEncoder135.setBindGroup(2, bindGroup1, new Uint32Array(441), 59, 0);
+} catch {}
+try {
+renderPassEncoder84.setScissorRect(2, 0, 6, 1);
+} catch {}
+try {
+renderPassEncoder46.draw(93, 200, 154_076_447, 261_267_518);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(137, 21, 132, -2_092_351_878, 14_613_843);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer83, 1_812);
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer28, 'uint32', 1_000, 661);
+} catch {}
+let texture399 = device0.createTexture({
+  size: [96, 40, 174],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler233 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 99.08,
+  lodMaxClamp: 99.99,
+});
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+renderPassEncoder80.setVertexBuffer(4, buffer27, 2_044, 51);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+window.someLabel = externalTexture40.label;
+} catch {}
+try {
+texture295.label = '\u2e97\ufba1\u{1f801}\u050a\u5ee3\u07c5\u74bb\u0746\u097d';
+} catch {}
+let buffer250 = device0.createBuffer({size: 2515, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let texture400 = gpuCanvasContext4.getCurrentTexture();
+let sampler234 = device0.createSampler({
+  label: '\u30a7\u3665\ua0c8\u049b\u9814\u{1fcaf}\ua743\u0dd4\uce51',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.032,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+renderPassEncoder85.setBindGroup(0, bindGroup203);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer191, 'uint16', 734, 676);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer114, 0, 15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer110, 908, new DataView(new ArrayBuffer(11589)), 3397, 464);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup237 = device0.createBindGroup({
+  layout: bindGroupLayout42,
+  entries: [
+    {binding: 136, resource: {buffer: buffer69, offset: 0}},
+    {binding: 46, resource: sampler186},
+    {binding: 43, resource: textureView2},
+    {binding: 419, resource: textureView208},
+    {binding: 127, resource: textureView309},
+    {binding: 114, resource: textureView312},
+  ],
+});
+let textureView349 = texture338.createView({dimension: '2d-array'});
+let sampler235 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.88,
+  lodMaxClamp: 72.39,
+});
+try {
+renderPassEncoder56.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder49.draw(21, 182, 577_758_882, 612_020_544);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(534, 43, 237, 66_353_874, 36_899_815);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer189, 1_092);
+} catch {}
+let buffer251 = device0.createBuffer({size: 33304, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture401 = gpuCanvasContext9.getCurrentTexture();
+try {
+computePassEncoder85.setBindGroup(3, bindGroup213, new Uint32Array(2336), 168, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup231, []);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup65, new Uint32Array(6445), 1_671, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(291, 372, 1_083_507_230, 66_701_505);
+} catch {}
+try {
+renderPassEncoder38.drawIndexed(190, 25, 351, -1_838_118_075, 180_872_967);
+} catch {}
+try {
+renderPassEncoder38.drawIndirect(buffer219, 1_104);
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer184, 'uint32', 2_196, 743);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline7);
+} catch {}
+try {
+  await promise51;
+} catch {}
+let bindGroup238 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 163, resource: textureView154},
+    {binding: 63, resource: {buffer: buffer115, offset: 3840, size: 5252}},
+  ],
+});
+let textureView350 = texture20.createView({});
+let sampler236 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 44.86,
+  lodMaxClamp: 89.89,
+});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup220);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer217, 'uint32', 880, 282);
+} catch {}
+let arrayBuffer63 = buffer219.getMappedRange(1640, 728);
+try {
+if (!arrayBuffer55.detached) { new Uint8Array(arrayBuffer55).fill(0x55); };
+} catch {}
+let bindGroup239 = device0.createBindGroup({layout: bindGroupLayout36, entries: [{binding: 96, resource: textureView300}]});
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder69.setScissorRect(0, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(70, 286, 456_278_578, 287_658_530);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer172, 24);
+} catch {}
+let imageData50 = new ImageData(96, 44);
+try {
+window.someLabel = externalTexture38.label;
+} catch {}
+let textureView351 = texture222.createView({});
+let sampler237 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.99,
+  lodMaxClamp: 80.06,
+  compare: 'always',
+  maxAnisotropy: 11,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer54, 1_864);
+} catch {}
+try {
+computePassEncoder175.setBindGroup(3, bindGroup74, new Uint32Array(2193), 55, 0);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup130);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup186, new Uint32Array(2251), 13, 0);
+} catch {}
+try {
+renderPassEncoder25.draw(64, 20, 305_453_822, 752_154_227);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(0, 132, 8, 352_921_370, 793_729_103);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer136, 260);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline1);
+} catch {}
+document.body.append(video5);
+await gc();
+let bindGroup240 = device0.createBindGroup({
+  label: '\u05dc\u0188\u90c8\u{1ff60}\u{1f7d1}\u2908',
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 550, resource: {buffer: buffer45, offset: 768}},
+    {binding: 76, resource: {buffer: buffer40, offset: 0, size: 1532}},
+    {binding: 304, resource: textureView217},
+    {binding: 145, resource: textureView111},
+    {binding: 336, resource: textureView64},
+  ],
+});
+let texture402 = device0.createTexture({
+  size: {width: 24, height: 10, depthOrArrayLayers: 43},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView352 = texture197.createView({});
+let sampler238 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.44,
+  lodMaxClamp: 18.95,
+  compare: 'less',
+});
+try {
+computePassEncoder120.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder85.drawIndexed(0, 15, 2, 744_255_951, 1_374_109_642);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer246, 3_588);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer18, 'uint32', 604, 844);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: canvas2,
+  origin: { x: 31, y: 5 },
+  flipY: true,
+}, {
+  texture: texture176,
+  mipLevel: 0,
+  origin: {x: 10, y: 2, z: 108},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let texture403 = device0.createTexture({size: [24, 10, 1], format: 'r16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler239 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 62.98,
+  lodMaxClamp: 66.72,
+});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup237, new Uint32Array(5634), 2_297, 0);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(0, bindGroup127, new Uint32Array(1612), 172, 0);
+} catch {}
+try {
+renderPassEncoder85.draw(45, 264, 1_440_245_001, 1_037_955_704);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer187, 1_064);
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  label: '\u069b\u{1f83f}\u9714\u6c8c\u0146',
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  @align(1) f0: array<atomic<u32>>,
+}
+/* target size: 16 max align: 16 */
+struct T1 {
+  @align(4) f0: mat2x3h,
+}
+/* target size: 50 max align: 2 */
+struct T2 {
+  @size(50) f0: T0,
+}
+@group(0) @binding(89) var tex20: texture_1d<u32>;
+@group(0) @binding(41) var tex21: texture_depth_cube_array;
+@group(0) @binding(5) var tex22: texture_cube_array<u32>;
+
+@fragment
+fn fragment0(@location(0) a0: vec4f) -> @location(200) @interpolate(perspective) vec3f {
+  var out: vec3f;
+  out /= a0.gag;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup241 = device0.createBindGroup({layout: bindGroupLayout36, entries: [{binding: 96, resource: textureView33}]});
+try {
+renderPassEncoder70.setBindGroup(2, bindGroup29, new Uint32Array(893), 108, 0);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([renderBundle21, renderBundle12, renderBundle12, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder85.drawIndexed(2, 105, 0, 75_072_417, 116_914_393);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer152, 272);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer122, 2_892);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer240, 'uint16', 600, 204);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(4, buffer43, 0, 6_816);
+} catch {}
+try {
+  await shaderModule6.getCompilationInfo();
+} catch {}
+let bindGroup242 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 265, resource: {buffer: buffer37, offset: 1024, size: 9588}}],
+});
+let buffer252 = device0.createBuffer({size: 5456, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX, mappedAtCreation: true});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({colorFormats: ['r16float'], stencilReadOnly: false});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup217);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer44, 580);
+} catch {}
+try {
+renderPassEncoder86.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+renderPassEncoder80.end();
+} catch {}
+try {
+renderPassEncoder46.draw(176, 47, 69_657_347, 1_116_227_406);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer233, 392);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(1, bindGroup87, new Uint32Array(1660), 626, 0);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(0, buffer14, 0);
+} catch {}
+let texture404 = device0.createTexture({
+  size: [24, 10, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView353 = texture98.createView({});
+let externalTexture42 = device0.importExternalTexture({source: video7});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup106);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup34, new Uint32Array(249), 43, 0);
+} catch {}
+try {
+renderPassEncoder81.setViewport(3.4068487982095075, 4.446364273754467, 0.28677299491028646, 8.697908512984188, 0.11487577053954268, 0.6551704033408217);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(4_294_967_295, undefined, 0, 495_140_982);
+} catch {}
+let arrayBuffer64 = buffer53.getMappedRange(6016, 8);
+let bindGroup243 = device0.createBindGroup({
+  layout: bindGroupLayout42,
+  entries: [
+    {binding: 114, resource: textureView312},
+    {binding: 127, resource: textureView303},
+    {binding: 136, resource: {buffer: buffer221, offset: 17152, size: 252}},
+    {binding: 43, resource: textureView37},
+    {binding: 46, resource: sampler20},
+    {binding: 419, resource: textureView321},
+  ],
+});
+try {
+computePassEncoder153.setBindGroup(1, bindGroup205, new Uint32Array(257), 10, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(2, 2, 1); };
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7, renderBundle7, renderBundle27, renderBundle35, renderBundle7, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer185, 1_372);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6_215).fill(11), /* required buffer size: 6_215 */
+{offset: 7, bytesPerRow: 31, rowsPerImage: 66}, {width: 2, height: 3, depthOrArrayLayers: 4});
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+/* target size: 19 max align: 1 */
+struct T0 {
+  @align(1) f0: f16,
+  @align(1) f1: atomic<u32>,
+  @align(1) @size(13) f2: array<array<atomic<i32>, 1>, 1>,
+}
+@group(0) @binding(41) var tex24: texture_1d<i32>;
+@group(0) @binding(5) var tex25: texture_depth_2d;
+@group(0) @binding(89) var tex23: texture_1d<u32>;
+struct S5 {
+  @location(1) f0: vec3h,
+  @location(13) @interpolate(linear) f1: vec2h,
+  @location(12) f2: vec4u,
+  @builtin(vertex_index) f3: u32,
+  @location(6) @interpolate(flat) f4: vec2h,
+  @location(3) f5: u32,
+  @location(10) f6: vec2h,
+  @location(9) @interpolate(flat, sample) f7: vec3i,
+  @location(15) @interpolate(flat) f8: vec4u,
+  @location(4) f9: vec3i,
+  @builtin(instance_index) f10: u32,
+  @location(5) @interpolate(flat) f11: f32,
+  @location(2) @interpolate(perspective, sample) f12: vec2f,
+  @location(7) f13: vec2i,
+  @location(14) @interpolate(linear) f14: vec3f
+}
+
+@vertex
+fn vertex0(a0: S5, @location(0) a1: vec4i, @location(8) @interpolate(flat, center) a2: f16, @location(11) @interpolate(flat, centroid) a3: vec2h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = a2;
+  _ = a0.f9;
+  _ = a0.f4;
+  _ = textureLoad(tex24, 0, 0);
+  if bool(a0.f3) {
+    out = bitcast<vec4f>(a0.f9.bbgb);
+  }
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(local_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u) {
+  if bool(textureLoad(tex23, 0, 0)[1]) {
+    return;
+  }
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup244 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer12, offset: 1280, size: 6121}}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer39, 144); };
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer69, 'uint16', 3_894, 691);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView354 = texture182.createView({});
+try {
+computePassEncoder174.setBindGroup(2, bindGroup146, new Uint32Array(93), 41, 0);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(3, bindGroup94, new Uint32Array(151), 35, 0);
+} catch {}
+try {
+renderPassEncoder25.drawIndexed(6, 199, 1, 702_623_085, 286_369_464);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer189, 524);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer6, 156);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer31, 'uint32', 12_788, 2_157);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(3, buffer43, 5_200, 638);
+} catch {}
+let arrayBuffer65 = buffer201.getMappedRange(24, 0);
+try {
+buffer222.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 36, new BigUint64Array(491));
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder74.setBindGroup(3, bindGroup157);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(0, bindGroup54, new Uint32Array(2610), 1_850, 0);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(2, bindGroup140);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(3, bindGroup141, new Uint32Array(2432), 783, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(36, 66, 765_510_261, 104_932_803);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(159, 63, 45, -2_026_882_883, 2_180_625_247);
+} catch {}
+try {
+renderPassEncoder38.drawIndexedIndirect(buffer224, 840);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer93, 28);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer234, 'uint16', 542, 233);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(5, buffer14);
+} catch {}
+try {
+computePassEncoder166.pushDebugGroup('\u7b6c');
+} catch {}
+document.body.append(canvas1);
+await gc();
+let videoFrame51 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+try {
+renderPassEncoder76.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup180, new Uint32Array(885), 159, 0);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer201, 4);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline4);
+} catch {}
+try {
+  await buffer177.mapAsync(GPUMapMode.WRITE, 0, 1380);
+} catch {}
+try {
+computePassEncoder166.popDebugGroup();
+} catch {}
+let bindGroup245 = device0.createBindGroup({
+  label: '\u{1fec1}\u75fb\u{1f735}\u056a\u396e\u0fc3\u01eb\u0c8d\ue724\u6564',
+  layout: bindGroupLayout34,
+  entries: [{binding: 248, resource: textureView248}],
+});
+let renderBundle46 = renderBundleEncoder46.finish({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup206);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder136); computePassEncoder136.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder88.end();
+} catch {}
+try {
+renderPassEncoder38.draw(69, 74, 1_289_427_792, 683_283_442);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(34, 343, 60, 191_405_591, 115_585_581);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer138, 8_712);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer48, 'uint32', 6_112, 2_232);
+} catch {}
+let arrayBuffer66 = buffer181.getMappedRange(752, 156);
+try {
+commandEncoder140.resolveQuerySet(querySet38, 11, 15, buffer187, 11264);
+} catch {}
+let computePassEncoder178 = commandEncoder140.beginComputePass();
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup0, new Uint32Array(1288), 50, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer168, 9_352);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer187, 9_316);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup211);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup10, new Uint32Array(58), 15, 0);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline1);
+} catch {}
+let bindGroup246 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 63, resource: {buffer: buffer71, offset: 768, size: 200}},
+    {binding: 163, resource: textureView337},
+  ],
+});
+let texture405 = device0.createTexture({
+  size: [192],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let textureView355 = texture243.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler240 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.62,
+  lodMaxClamp: 97.24,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder178.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup194, new Uint32Array(678), 82, 0);
+} catch {}
+try {
+renderPassEncoder38.drawIndexedIndirect(buffer235, 804);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer96, 'uint16', 4_576, 2_483);
+} catch {}
+let buffer253 = device0.createBuffer({
+  label: '\u1a91\u058d\u0024\u0576\u0cfe',
+  size: 24520,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView356 = texture24.createView({
+  label: '\u8676\u{1f72a}\u5bb0\u5207\u04ed\ubd43\u9c98\u{1fded}\ud308\u{1f651}\u09d3',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 30,
+});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup184, new Uint32Array(957), 44, 0);
+} catch {}
+try {
+computePassEncoder15.dispatchWorkgroups(2);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(3, bindGroup56, new Uint32Array(3566), 572, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(39, 69, 138, 54_608_300, 881_668_990);
+} catch {}
+try {
+renderPassEncoder34.drawIndexedIndirect(buffer186, 1_228);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer97, 760, 320);
+} catch {}
+try {
+  await buffer196.mapAsync(GPUMapMode.READ, 0, 1928);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup165, new Uint32Array(525), 103, 0);
+} catch {}
+try {
+renderPassEncoder38.drawIndexedIndirect(buffer163, 3_880);
+} catch {}
+try {
+renderPassEncoder85.drawIndirect(buffer168, 2_256);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer44, 'uint32', 3_116, 1_548);
+} catch {}
+try {
+renderPassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder119.insertDebugMarker('\u{1fb30}');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup247 = device0.createBindGroup({layout: bindGroupLayout33, entries: [{binding: 46, resource: sampler207}]});
+let buffer254 = device0.createBuffer({
+  label: '\u8706\u9cbb\u095a\u{1fc54}\u9b2c\u020d\uf2ac\u470f\u0864\u9e41\u0fde',
+  size: 5932,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture406 = device0.createTexture({
+  size: [192, 80, 349],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView357 = texture103.createView({label: '\u0fe6\u94ac', dimension: '2d', baseArrayLayer: 3});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup162, []);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer98, 2_464);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline7);
+} catch {}
+let buffer255 = device0.createBuffer({size: 26635, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder11.draw(263, 76, 25_782_024, 657_274_710);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer146, 528);
+} catch {}
+try {
+renderPassEncoder11.draw(68, 17, 621_613_108, 298_056_882);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer163, 784);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer39, 96);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline2);
+} catch {}
+document.body.prepend(img2);
+video4.height = 84;
+let bindGroup248 = device0.createBindGroup({
+  label: '\u232f\uc67a\u{1fc76}\u{1f82d}\u0c8d\u065f\uf773\u{1ff37}',
+  layout: bindGroupLayout8,
+  entries: [{binding: 8, resource: {buffer: buffer240, offset: 0, size: 348}}],
+});
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+renderPassEncoder86.setBindGroup(3, bindGroup38, new Uint32Array(2258), 318, 0);
+} catch {}
+try {
+renderPassEncoder49.draw(97, 29, 911_861_942, 2_402_358_839);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(714, 104, 406, 390_247_814, 236_981_199);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer224, 288);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer157, 'uint16', 132, 1_735);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline1);
+} catch {}
+offscreenCanvas0.width = 2761;
+let renderPassEncoder93 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 27,
+  clearValue: { r: 613.0, g: -150.2, b: 776.5, a: 922.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+});
+let sampler241 = device0.createSampler({
+  label: '\uc3b8\u55fb\uf616\u0ea0\u5052\u942d\u26da',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 5,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer199, 480); };
+} catch {}
+try {
+renderPassEncoder85.drawIndexed(225, 67, 180, 235_216_649, 270_142_265);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer19, 120);
+} catch {}
+let texture407 = device0.createTexture({
+  label: '\ue344\u013a',
+  size: {width: 48, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup134);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle29, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer115, 5336, new DataView(new ArrayBuffer(4609)), 698, 352);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 7},
+  aspect: 'all',
+}, new Uint8Array(46).fill(25), /* required buffer size: 46 */
+{offset: 46, bytesPerRow: 207}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 80, depthOrArrayLayers: 349}
+*/
+{
+  source: imageData46,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture208,
+  mipLevel: 0,
+  origin: {x: 6, y: 13, z: 30},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder144.label = '\u005c\u1a74\u{1f62c}\ub2a5\u9007\u89d9\u0e4f\uef4e\u{1fefe}\u{1fe56}';
+} catch {}
+let texture408 = device0.createTexture({
+  label: '\uf707\ucb42\u5342\u0cc4\u{1fb06}\u0464\ub327',
+  size: {width: 48},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler242 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.83,
+  lodMaxClamp: 98.85,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder66.beginOcclusionQuery(69);
+} catch {}
+await gc();
+//let promise52 = adapter0.requestAdapterInfo();
+try {
+computePassEncoder159.setBindGroup(1, bindGroup49, new Uint32Array(933), 128, 0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup74, new Uint32Array(4956), 2_253, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndirect(buffer189, 1_712);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(6, buffer90, 0, 3_744);
+} catch {}
+try {
+computePassEncoder83.setBindGroup(1, bindGroup196);
+} catch {}
+try {
+renderPassEncoder11.draw(73, 59, 1_571_985_668, 91_476_798);
+} catch {}
+try {
+  await buffer150.mapAsync(GPUMapMode.WRITE, 816, 2528);
+} catch {}
+document.body.prepend(img0);
+let texture409 = device0.createTexture({
+  size: [24, 10, 43],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView358 = texture2.createView({label: '\u45b0\u0a74\u09e5\uf529', baseArrayLayer: 0, arrayLayerCount: 1});
+let sampler243 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.57,
+  lodMaxClamp: 97.41,
+});
+try {
+computePassEncoder111.setBindGroup(0, bindGroup198);
+} catch {}
+try {
+renderPassEncoder49.draw(33, 20, 948_113_995, 728_804_926);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(542, 15, 43, 427_500_548, 2_317_313_970);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer187, 4_056);
+} catch {}
+let buffer256 = device0.createBuffer({
+  label: '\u{1fe88}\u{1f9dd}\u081e\u207d\ub722\u0630',
+  size: 11816,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture410 = device0.createTexture({size: {width: 48}, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup131);
+} catch {}
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle17, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder85.draw(140, 2, 218_006_085, 386_953_732);
+} catch {}
+try {
+renderPassEncoder34.drawIndexed(363, 84, 117, -1_905_299_910, 111_978_586);
+} catch {}
+document.body.append(canvas6);
+let textureView359 = texture237.createView({baseArrayLayer: 4, arrayLayerCount: 2});
+let sampler244 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.99,
+  lodMaxClamp: 83.06,
+});
+try {
+computePassEncoder107.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup101, new Uint32Array(1191), 133, 0);
+} catch {}
+try {
+renderPassEncoder63.setScissorRect(138, 41, 2, 30);
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(454);
+} catch {}
+try {
+renderPassEncoder38.drawIndexed(134, 199, 81, 1_474_640_901, 2_316_426_279);
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(3, buffer183);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+computePassEncoder86.label = '\u633f\u{1f880}\ua2bb';
+} catch {}
+try {
+renderPassEncoder49.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(13, 61, 61, 262_688_915, 1_566_769_025);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(3, buffer90, 0, 6_874);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer134, 0, new Float32Array(7510), 890, 0);
+} catch {}
+let buffer257 = device0.createBuffer({size: 13487, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler245 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.84,
+  lodMaxClamp: 84.04,
+  compare: 'greater-equal',
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup200, new Uint32Array(665), 12, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(69, 269, 17, 57_813_015, 1_309_696_994);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer199, 896);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer39, 988);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(0, bindGroup195, new Uint32Array(63), 4, 0);
+} catch {}
+try {
+renderPassEncoder88.executeBundles([renderBundle31]);
+} catch {}
+try {
+renderPassEncoder85.drawIndirect(buffer84, 644);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer230, 2_856, 2_245);
+} catch {}
+let texture411 = device0.createTexture({
+  size: {width: 24},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+  await promise52;
+} catch {}
+let texture412 = device0.createTexture({
+  label: '\u5468\udb27\u0022\u{1fe5f}\ue822\u22e1\u505b',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup47, new Uint32Array(1036), 121, 0);
+} catch {}
+try {
+renderPassEncoder89.beginOcclusionQuery(36);
+} catch {}
+try {
+renderPassEncoder89.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer226, 92);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer61, 248);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture288,
+  mipLevel: 0,
+  origin: {x: 59, y: 26, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(122), /* required buffer size: 93 */
+{offset: 93, bytesPerRow: 70}, {width: 7, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let texture413 = device0.createTexture({
+  size: [24, 10, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup184, new Uint32Array(140), 105, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(238, 103, 193, 99_772_662, 1_045_129_627);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer40, 'uint16', 2_884, 198);
+} catch {}
+let pipelineLayout31 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer258 = device0.createBuffer({
+  label: '\u631a\u3765\u0f69\u{1f8de}\u0db1\u3512\uc431\u59bb\u0698\u0ea2\u0762',
+  size: 118,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder113.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(2, bindGroup141);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup129, new Uint32Array(343), 60, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(595, 36, 122, 133_510_084, 411_238_482);
+} catch {}
+try {
+renderPassEncoder34.drawIndirect(buffer36, 2_596);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer242, 12, new Float32Array(23442), 403, 200);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 20, depthOrArrayLayers: 87}
+*/
+{
+  source: imageData43,
+  origin: { x: 15, y: 9 },
+  flipY: false,
+}, {
+  texture: texture208,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView360 = texture3.createView({aspect: 'depth-only', format: 'depth24plus', mipLevelCount: 1});
+try {
+computePassEncoder38.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.draw(769, 44, 186_517_172, 28_255_944);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer81, 3_272);
+} catch {}
+try {
+renderPassEncoder38.drawIndirect(buffer136, 1_516);
+} catch {}
+let arrayBuffer67 = buffer48.getMappedRange(608, 1124);
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture228,
+  mipLevel: 1,
+  origin: {x: 4, y: 1, z: 4},
+  aspect: 'all',
+}, new Uint8Array(17_643).fill(229), /* required buffer size: 17_643 */
+{offset: 207, bytesPerRow: 128, rowsPerImage: 8}, {width: 14, height: 1, depthOrArrayLayers: 18});
+} catch {}
+let bindGroup249 = device0.createBindGroup({layout: bindGroupLayout38, entries: [{binding: 143, resource: textureView7}]});
+let buffer259 = device0.createBuffer({
+  size: 8752,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let texture414 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder136); computePassEncoder136.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder34.draw(492, 902, 574_387_704, 63_392_477);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer172, 176);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout46 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 161, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture415 = device0.createTexture({
+  label: '\u{1f637}\u{1f85f}\u7850\ub8d8\u0758\ucc98\ua960\u{1fb2c}\u1b34\u8d50\uac07',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder46.drawIndirect(buffer81, 7_740);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline0);
+} catch {}
+let buffer260 = device0.createBuffer({
+  label: '\uca35\u0c4b\u{1fc5c}\u1ad3\u031c\u{1f657}\u{1f9a7}\uf02e',
+  size: 35907,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture416 = device0.createTexture({size: [192, 80, 1], format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let textureView361 = texture269.createView({label: '\ubdff\u2223\u37a4', arrayLayerCount: 1});
+let sampler246 = device0.createSampler({
+  label: '\ub6eb\ufed8\u25b0\u0d79\u3a43\u{1ff3e}\uccc7',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.78,
+  lodMaxClamp: 98.18,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup29, new Uint32Array(540), 85, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(64, 162, 46, 300_358_775, 344_129_625);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer235, 3_556);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(6, buffer153, 1_744, 271);
+} catch {}
+let arrayBuffer68 = buffer219.getMappedRange(2952, 480);
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder123.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroupsIndirect(buffer178, 984); };
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup178, new Uint32Array(52), 1, 0);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(130);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer89, 0);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup42, new Uint32Array(1996), 318, 0);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup210, new Uint32Array(1710), 500, 0);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder34.draw(91, 555, 55_599_538, 550_976_872);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer224, 552);
+} catch {}
+try {
+renderPassEncoder25.drawIndirect(buffer93, 232);
+} catch {}
+try {
+renderPassEncoder48.insertDebugMarker('\u5ce6');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer234, 452, new DataView(new ArrayBuffer(5774)), 209, 764);
+} catch {}
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 137});
+let textureView362 = texture291.createView({aspect: 'all', format: 'rg32float'});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup176);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup8, new Uint32Array(1719), 120, 0);
+} catch {}
+try {
+renderPassEncoder23.draw(120, 310, 1_424_762_819, 162_633_363);
+} catch {}
+try {
+renderPassEncoder85.drawIndexed(120, 68, 53, -1_988_335_466, 1_335_671_875);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer73, 0, 451);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer261 = device0.createBuffer({
+  size: 27044,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder38.drawIndexed(129, 5, 11, 154_180_347, 334_309_207);
+} catch {}
+try {
+renderPassEncoder63.drawIndexedIndirect(buffer23, 328);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+let bindGroup250 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 300, resource: {buffer: buffer207, offset: 256, size: 1381}}],
+});
+let texture417 = device0.createTexture({
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView363 = texture64.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder126.setBindGroup(2, bindGroup210);
+} catch {}
+try {
+renderPassEncoder77.setScissorRect(0, 2, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer18, 1_616);
+} catch {}
+try {
+renderPassEncoder82.setVertexBuffer(5, buffer204);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(757).fill(240), /* required buffer size: 757 */
+{offset: 315, bytesPerRow: 149, rowsPerImage: 109}, {width: 72, height: 15, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(img0);
+let imageBitmap4 = await createImageBitmap(videoFrame10);
+let bindGroup251 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 246, resource: sampler238}]});
+let texture418 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup136);
+} catch {}
+try {
+computePassEncoder72.setBindGroup(2, bindGroup189, new Uint32Array(944), 76, 0);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup73, new Uint32Array(355), 30, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer190, 1_208);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer18, 'uint32', 796, 31);
+} catch {}
+try {
+renderPassEncoder88.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+let videoFrame52 = new VideoFrame(canvas1, {timestamp: 0});
+let bindGroup252 = device0.createBindGroup({layout: bindGroupLayout33, entries: [{binding: 46, resource: sampler132}]});
+let querySet46 = device0.createQuerySet({type: 'occlusion', count: 370});
+let sampler247 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.87,
+  lodMaxClamp: 78.58,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder169.setBindGroup(3, bindGroup125);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup118, new Uint32Array(192), 79, 0);
+} catch {}
+try {
+renderPassEncoder38.drawIndexed(13, 77, 13, 153_837_045, 1_432_781_111);
+} catch {}
+try {
+renderPassEncoder38.drawIndexedIndirect(buffer19, 32);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(6, buffer183, 892, 1_223);
+} catch {}
+let texture419 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder77.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(2, 0, 10, 1);
+} catch {}
+try {
+renderPassEncoder71.drawIndirect(buffer141, 16);
+} catch {}
+try {
+renderPassEncoder89.setIndexBuffer(buffer48, 'uint16', 2_348, 6_731);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(6, buffer248);
+} catch {}
+try {
+buffer129.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer194, 472, new Float32Array(6556), 31, 40);
+} catch {}
+let textureView364 = texture180.createView({format: 'r16float'});
+let externalTexture43 = device0.importExternalTexture({source: video2});
+try {
+renderPassEncoder85.setBindGroup(2, bindGroup200);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup222, new Uint32Array(1983), 18, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder11.draw(147, 268, 912_284_261, 3_636_159_974);
+} catch {}
+try {
+renderPassEncoder46.drawIndexedIndirect(buffer199, 256);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer136, 'uint16', 1_352, 726);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(7, buffer235, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer250, 72, new DataView(new ArrayBuffer(18968)), 114, 168);
+} catch {}
+let videoFrame53 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'iec6196624'} });
+let bindGroup253 = device0.createBindGroup({layout: bindGroupLayout36, entries: [{binding: 96, resource: textureView33}]});
+let texture420 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder21.drawIndirect(buffer234, 944);
+} catch {}
+let bindGroupLayout47 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 224,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 280, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup193, new Uint32Array(751), 437, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup160);
+} catch {}
+try {
+buffer134.unmap();
+} catch {}
+try {
+computePassEncoder134.insertDebugMarker('\u{1f93f}');
+} catch {}
+//let promise53 = adapter0.requestAdapterInfo();
+let bindGroup254 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 407, resource: textureView118},
+    {binding: 36, resource: {buffer: buffer175, offset: 2816, size: 3056}},
+    {binding: 19, resource: textureView16},
+  ],
+});
+let buffer262 = device0.createBuffer({size: 5236, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture421 = device0.createTexture({
+  size: {width: 192, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder82.setBindGroup(3, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder49.draw(51, 310, 331_210_836, 205_003_460);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(9, 91, 9, -1_644_987_259, 1_532_081_911);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer237, 12);
+} catch {}
+try {
+renderPassEncoder38.drawIndirect(buffer244, 304);
+} catch {}
+try {
+renderPassEncoder91.setIndexBuffer(buffer91, 'uint16', 48, 832);
+} catch {}
+let arrayBuffer69 = buffer35.getMappedRange(4976, 96);
+try {
+device0.queue.writeTexture({
+  texture: texture358,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(187).fill(86), /* required buffer size: 187 */
+{offset: 33, bytesPerRow: 74}, {width: 3, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise53;
+} catch {}
+document.body.append(img0);
+let buffer263 = device0.createBuffer({size: 4460, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer185, 220); };
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup126);
+} catch {}
+try {
+renderPassEncoder71.drawIndexed(237, 10, 21, -2_029_713_459, 196_329_825);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer237, 24);
+} catch {}
+try {
+renderPassEncoder63.drawIndirect(buffer151, 408);
+} catch {}
+try {
+renderPassEncoder90.setIndexBuffer(buffer204, 'uint16', 2_376, 243);
+} catch {}
+try {
+buffer131.unmap();
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture387,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(266_438).fill(225), /* required buffer size: 266_438 */
+{offset: 50, bytesPerRow: 79, rowsPerImage: 102}, {width: 0, height: 7, depthOrArrayLayers: 34});
+} catch {}
+try {
+if (!arrayBuffer44.detached) { new Uint8Array(arrayBuffer44).fill(0x55); };
+} catch {}
+let bindGroup255 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 407, resource: textureView318},
+    {binding: 19, resource: textureView2},
+    {binding: 36, resource: {buffer: buffer221, offset: 0, size: 2908}},
+  ],
+});
+let sampler248 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'nearest'});
+try {
+renderPassEncoder77.setBindGroup(3, bindGroup108);
+} catch {}
+try {
+renderPassEncoder7.draw(254, 108, 817_189_302, 3_638_646_891);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer217);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer170, 444, new DataView(new ArrayBuffer(4869)), 146, 156);
+} catch {}
+let imageData51 = new ImageData(44, 120);
+try {
+externalTexture13.label = '\u487f\u02f7\u{1fd22}\uc791';
+} catch {}
+let texture422 = device0.createTexture({
+  size: {width: 96, height: 40, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView365 = texture300.createView({label: '\u{1fa7b}\u10ff\u{1fc95}\u02a3', dimension: '2d-array', format: 'rg8unorm', arrayLayerCount: 1});
+try {
+computePassEncoder171.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+computePassEncoder159.setBindGroup(0, bindGroup15, new Uint32Array(717), 52, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroupsIndirect(buffer138, 3_960); };
+} catch {}
+try {
+renderPassEncoder8.draw(43, 22, 1_982_904_732, 395_417_040);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer186, 204);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(6, buffer43, 720, 1_052);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas2);
+let buffer264 = device0.createBuffer({
+  label: '\u1601\u035b\u0341\u0804',
+  size: 4007,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture423 = device0.createTexture({
+  label: '\u{1faec}\u2765\udf2e\u0322\u{1f652}\u9bed\u9c5c',
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder175.setBindGroup(0, bindGroup212);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup26, new Uint32Array(2027), 132, 0);
+} catch {}
+try {
+renderPassEncoder46.drawIndexed(347, 10, 319, -2_058_030_273, 592_333_225);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer99, 'uint16', 2_008, 2_423);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(1, buffer206, 116, 92);
+} catch {}
+let texture424 = device0.createTexture({
+  size: [24, 10, 17],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture44 = device0.importExternalTexture({label: '\u079a\u{1fe8b}\u57cd\u209c\u07b4\u{1f689}\u033b\u0eee\u0be5\u77ee', source: videoFrame28});
+try {
+renderPassEncoder63.draw(134, 16, 1_295_147_410, 33_482_485);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer6, 32);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer244, 300);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer108, 'uint16', 1_948, 4_928);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer214, 660, new Float32Array(34438), 221, 148);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 10, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData18,
+  origin: { x: 31, y: 3 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame54 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'film', transfer: 'logSqrt'} });
+let texture425 = device0.createTexture({
+  size: [192, 80, 1],
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture426 = device0.createTexture({
+  size: [48, 20, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView366 = texture53.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder88.setScissorRect(0, 1, 3, 2);
+} catch {}
+try {
+renderPassEncoder25.draw(203, 217, 1_399_006_487, 1_769_788_566);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer98, 3_008);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(2, buffer166, 7_452, 71);
+} catch {}
+let sampler249 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.45,
+  lodMaxClamp: 48.90,
+});
+try {
+renderPassEncoder50.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder71.draw(21, 289, 277_610_511, 270_358_877);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer93, 128);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer70 = buffer196.getMappedRange(0, 196);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData44,
+  origin: { x: 1, y: 7 },
+  flipY: true,
+}, {
+  texture: texture195,
+  mipLevel: 1,
+  origin: {x: 22, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let sampler250 = device0.createSampler({
+  label: '\u{1ff9c}\u9635\u{1fed3}\uc82a\u0e82',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.010,
+  lodMaxClamp: 48.97,
+});
+try {
+renderPassEncoder34.drawIndexed(148, 58, 516, 222_204_815, 34_062_501);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer6, 60);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer187, 'uint32', 868, 4_874);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(1, bindGroup112, new Uint32Array(271), 78, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup24, new Uint32Array(1372), 244, 0);
+} catch {}
+try {
+renderPassEncoder21.draw(3, 28, 111_498_580, 335_740_343);
+} catch {}
+try {
+renderPassEncoder85.drawIndexedIndirect(buffer81, 2_000);
+} catch {}
+try {
+renderPassEncoder71.drawIndirect(buffer61, 608);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer85);
+} catch {}
+let arrayBuffer71 = buffer26.getMappedRange(2496, 3412);
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer265 = device0.createBuffer({
+  size: 4606,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup171, new Uint32Array(141), 29, 0);
+} catch {}
+try {
+renderPassEncoder81.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer19, 'uint16', 28, 58);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroup256 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 19, resource: textureView360},
+    {binding: 36, resource: {buffer: buffer47, offset: 512}},
+    {binding: 407, resource: textureView358},
+  ],
+});
+let sampler251 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  lodMinClamp: 83.92,
+  lodMaxClamp: 85.19,
+});
+try {
+computePassEncoder100.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(94, 79, 175, -1_640_772_804, 294_803_365);
+} catch {}
+try {
+renderPassEncoder78.setPipeline(pipeline2);
+} catch {}
+let bindGroup257 = device0.createBindGroup({
+  label: '\ub4d2\u0aec\u478d\ue223\u{1fda4}\ucb8e\uc654\u0619\u266d',
+  layout: bindGroupLayout9,
+  entries: [{binding: 261, resource: textureView76}],
+});
+let textureView367 = texture280.createView({dimension: '2d', baseArrayLayer: 7});
+try {
+computePassEncoder139.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder157.setBindGroup(1, bindGroup114, new Uint32Array(64), 1, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup250);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer20, 11_444);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer27, 'uint32', 2_428, 206);
+} catch {}
+try {
+renderPassEncoder77.pushDebugGroup('\u0279');
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture328,
+  mipLevel: 0,
+  origin: {x: 66, y: 25, z: 0},
+  aspect: 'all',
+}, new Uint8Array(451).fill(182), /* required buffer size: 451 */
+{offset: 451, bytesPerRow: 417, rowsPerImage: 68}, {width: 45, height: 52, depthOrArrayLayers: 0});
+} catch {}
+videoFrame0.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame31.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame51.close();
+videoFrame52.close();
+videoFrame53.close();
+videoFrame54.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1032,6 +1032,7 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<RenderBundl
         incrementDrawCount(renderBundle.drawCount());
 
         for (RenderBundleICBWithResources* icb in renderBundle.renderBundlesResources()) {
+            commandEncoder = renderCommandEncoder();
 
             if (id<MTLDepthStencilState> depthStencilState = icb.depthStencilState)
                 [commandEncoder setDepthStencilState:depthStencilState];


### PR DESCRIPTION
#### 871feed41fae902600f7a4f0469bc060d305d806
<pre>
[WebGPU] executeBundles may attempt to encode commands on invalid encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=279453">https://bugs.webkit.org/show_bug.cgi?id=279453</a>
<a href="https://rdar.apple.com/135707950">rdar://135707950</a>

Reviewed by Dan Glastonbury.

We need to reset the command encoder in the for loop as a validation
error would cause us to stop encoding commands.

* LayoutTests/fast/webgpu/nocrash/fuzz-279453-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-279453.html: Added.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/283455@main">https://commits.webkit.org/283455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/954acac067ea8febd8d473fc91f38be0ff6dd637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16878 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53163 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11769 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72003 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60486 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2070 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41450 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42525 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->