### PR TITLE
Only use WKKeyedCoder for encoding when secure coding class is not specified

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -55,6 +55,8 @@ _test_receiver_names = [
     'TestWithStreamServerConnectionHandle',
     'TestWithEnabledBy',
     'TestWithEnabledIf',
+    'TestWithEnabledByAndConjunction',
+    'TestWithEnabledByOrConjunction',
 ]
 
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -103,6 +103,7 @@ class LayerProperties;
 class CoreIPCAVOutputContext;
 #endif
 class CoreIPCNSSomeFoundationType;
+class CoreIPCclass NSSomeOtherFoundationType;
 #if ENABLE(DATA_DETECTION)
 class CoreIPCDDScannerResult;
 #endif
@@ -304,6 +305,11 @@ template<> struct ArgumentCoder<WebKit::CoreIPCAVOutputContext> {
 template<> struct ArgumentCoder<WebKit::CoreIPCNSSomeFoundationType> {
     static void encode(Encoder&, const WebKit::CoreIPCNSSomeFoundationType&);
     static std::optional<WebKit::CoreIPCNSSomeFoundationType> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::CoreIPCclass NSSomeOtherFoundationType> {
+    static void encode(Encoder&, const WebKit::CoreIPCclass NSSomeOtherFoundationType&);
+    static std::optional<WebKit::CoreIPCclass NSSomeOtherFoundationType> decode(Decoder&);
 };
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
@@ -32,6 +32,7 @@
 OBJC_CLASS AVOutputContext;
 #endif
 OBJC_CLASS NSSomeFoundationType;
+OBJC_CLASS class NSSomeOtherFoundationType;
 #if ENABLE(DATA_DETECTION)
 OBJC_CLASS DDScannerResult;
 #endif
@@ -88,6 +89,24 @@ private:
     RetainPtr<NSArray> m_OptionalArrayKey;
     RetainPtr<NSDictionary> m_DictionaryKey;
     RetainPtr<NSDictionary> m_OptionalDictionaryKey;
+};
+
+class CoreIPCclass NSSomeOtherFoundationType {
+public:
+    CoreIPCclass NSSomeOtherFoundationType(class NSSomeOtherFoundationType *);
+    CoreIPCclass NSSomeOtherFoundationType(const RetainPtr<class NSSomeOtherFoundationType>& object)
+        : CoreIPCclass NSSomeOtherFoundationType(object.get()) { }
+
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCclass NSSomeOtherFoundationType, void>;
+
+    CoreIPCclass NSSomeOtherFoundationType(
+        RetainPtr<NSDictionary>&&
+    );
+
+    RetainPtr<NSDictionary> m_DictionaryKey;
 };
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -172,6 +172,8 @@
 #include "TestWithStreamServerConnectionHandleMessages.h" // NOLINT
 #include "TestWithEnabledByMessages.h" // NOLINT
 #include "TestWithEnabledIfMessages.h" // NOLINT
+#include "TestWithEnabledByAndConjunctionMessages.h" // NOLINT
+#include "TestWithEnabledByOrConjunctionMessages.h" // NOLINT
 
 namespace IPC {
 
@@ -384,6 +386,10 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(globalObject, decoder);
     case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
         return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled>(globalObject, decoder);
     default:
         break;
     }
@@ -1122,6 +1128,14 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
             { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s, ASCIILiteral(), false },
         };

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -32,6 +32,8 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
     { "TestWithCVPixelBuffer_SendCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
 #endif
+    { "TestWithEnabledByAndConjunction_AlwaysEnabled"_s, ReceiverName::TestWithEnabledByAndConjunction, false, false },
+    { "TestWithEnabledByOrConjunction_AlwaysEnabled"_s, ReceiverName::TestWithEnabledByOrConjunction, false, false },
     { "TestWithEnabledBy_AlwaysEnabled"_s, ReceiverName::TestWithEnabledBy, false, false },
     { "TestWithEnabledBy_ConditionallyEnabled"_s, ReceiverName::TestWithEnabledBy, false, false },
     { "TestWithEnabledBy_ConditionallyEnabledAnd"_s, ReceiverName::TestWithEnabledBy, false, false },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -33,21 +33,23 @@ namespace IPC {
 enum class ReceiverName : uint8_t {
     TestWithCVPixelBuffer = 1
     , TestWithEnabledBy = 2
-    , TestWithEnabledIf = 3
-    , TestWithIfMessage = 4
-    , TestWithImageData = 5
-    , TestWithLegacyReceiver = 6
-    , TestWithSemaphore = 7
-    , TestWithStream = 8
-    , TestWithStreamBatched = 9
-    , TestWithStreamBuffer = 10
-    , TestWithStreamServerConnectionHandle = 11
-    , TestWithSuperclass = 12
-    , TestWithoutAttributes = 13
-    , TestWithoutUsingIPCConnection = 14
-    , IPC = 15
-    , AsyncReply = 16
-    , Invalid = 17
+    , TestWithEnabledByAndConjunction = 3
+    , TestWithEnabledByOrConjunction = 4
+    , TestWithEnabledIf = 5
+    , TestWithIfMessage = 6
+    , TestWithImageData = 7
+    , TestWithLegacyReceiver = 8
+    , TestWithSemaphore = 9
+    , TestWithStream = 10
+    , TestWithStreamBatched = 11
+    , TestWithStreamBuffer = 12
+    , TestWithStreamServerConnectionHandle = 13
+    , TestWithSuperclass = 14
+    , TestWithoutAttributes = 15
+    , TestWithoutUsingIPCConnection = 16
+    , IPC = 17
+    , AsyncReply = 18
+    , Invalid = 19
 };
 
 enum class MessageName : uint16_t {
@@ -55,6 +57,8 @@ enum class MessageName : uint16_t {
     TestWithCVPixelBuffer_ReceiveCVPixelBuffer,
     TestWithCVPixelBuffer_SendCVPixelBuffer,
 #endif
+    TestWithEnabledByAndConjunction_AlwaysEnabled,
+    TestWithEnabledByOrConjunction_AlwaysEnabled,
     TestWithEnabledBy_AlwaysEnabled,
     TestWithEnabledBy_ConditionallyEnabled,
     TestWithEnabledBy_ConditionallyEnabledAnd,

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -406,6 +406,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         { "NSSomeFoundationType"_s, {
             { "WebKit::CoreIPCNSSomeFoundationType"_s, "wrapper"_s }
         } },
+        { "WebKit::CoreIPCclass NSSomeOtherFoundationType"_s, {
+            { "RetainPtr<NSDictionary>"_s , "DictionaryKey"_s },
+        } },
+        { "class NSSomeOtherFoundationType"_s, {
+            { "WebKit::CoreIPCclass NSSomeOtherFoundationType"_s, "wrapper"_s }
+        } },
 #if ENABLE(DATA_DETECTION)
         { "WebKit::CoreIPCDDScannerResult"_s, {
             { "RetainPtr<NSString>"_s , "StringKey"_s },

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -248,6 +248,10 @@ webkit_secure_coding NSSomeFoundationType {
     OptionalDictionaryKey: Dictionary?
 }
 
+[SupportWKKeyedCoder] webkit_secure_coding class NSSomeOtherFoundationType {
+    DictionaryKey: Dictionary
+}
+
 #if ENABLE(DATA_DETECTION)
 # Test a comment
 secure_coding_headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -236,6 +236,35 @@ std::optional<WebKit::CoreIPCNSSomeFoundationType> ArgumentCoder<WebKit::CoreIPC
     };
 }
 
+void ArgumentCoder<WebKit::CoreIPCclass NSSomeOtherFoundationType>::encode(Encoder& encoder, const WebKit::CoreIPCclass NSSomeOtherFoundationType& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_DictionaryKey)>, RetainPtr<NSDictionary>>);
+    struct ShouldBeSameSizeAsclass NSSomeOtherFoundationType : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCclass NSSomeOtherFoundationType>, false> {
+        RetainPtr<NSDictionary> DictionaryKey;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsclass NSSomeOtherFoundationType) == sizeof(WebKit::CoreIPCclass NSSomeOtherFoundationType));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::CoreIPCclass NSSomeOtherFoundationType, m_DictionaryKey)
+    >::value);
+
+    encoder << instance.m_DictionaryKey;
+}
+
+std::optional<WebKit::CoreIPCclass NSSomeOtherFoundationType> ArgumentCoder<WebKit::CoreIPCclass NSSomeOtherFoundationType>::decode(Decoder& decoder)
+{
+    auto DictionaryKey = decoder.decode<RetainPtr<NSDictionary>>();
+    if (!DictionaryKey)
+        return std::nullopt;
+
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::CoreIPCclass NSSomeOtherFoundationType {
+            WTFMove(*DictionaryKey)
+        }
+    };
+}
+
 #if ENABLE(DATA_DETECTION)
 void ArgumentCoder<WebKit::CoreIPCDDScannerResult>::encode(Encoder& encoder, const WebKit::CoreIPCDDScannerResult& instance)
 {


### PR DESCRIPTION
#### 8b4884931b2c0f8412cff37d9b8ae7724736b2f2
<pre>
Only use WKKeyedCoder for encoding when secure coding class is not specified
<a href="https://bugs.webkit.org/show_bug.cgi?id=279457">https://bugs.webkit.org/show_bug.cgi?id=279457</a>
<a href="https://rdar.apple.com/135631932">rdar://135631932</a>

Reviewed by Alex Christensen.

The existing implementation expects _webKitPropertyListData to return a dictionary that matches the declaration in
existing CoreIPC*.serialization.in file, when _webKitPropertyListData selector exists. However, a class could add
support for _webKitPropertyListData independently, and the result may not match the existing declaration, which could
lead to breakage in existing WebKit clients. To avoid such issue, now we only allow to use WKKeyedCoder for types that
have WKKeyedCoder support and do not specify secure coding class. When a class adds implementation for
_webKitPropertyListData, the WKKeyedCoder coding will still be in use, and we could explicitly enable the new encoding
format by updating CoreIPC*.serialization.in file and specifying secure encoding class later.

Also, update tests with new auto-generated files.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_webkit_secure_coding_impl):
(generate_webkit_secure_coding_impl.is):
* Source/WebKit/Scripts/webkit/messages_unittest.py:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::dictionaryForWebKitSecureCodingTypeFromWKKeyedCoder):
(WebKit::dictionaryForWebKitSecureCodingType):
(WebKit::CoreIPCAVOutputContext::toID const):
(WebKit::CoreIPCNSSomeFoundationType::toID const):
(WebKit::NSSomeOtherFoundationType):
(WebKit::NSSomeOtherFoundationType::toID const):
(WebKit::CoreIPCDDScannerResult::toID const):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::messageArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::NSSomeOtherFoundationType&gt;::encode):
(IPC::NSSomeOtherFoundationType&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/283566@main">https://commits.webkit.org/283566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1e641584fc6f2b35ba74aa908d39ed900cce3d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17670 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53325 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11918 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33986 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/66049 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38946 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72273 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14677 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60654 "Found 1 new test failure: webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60976 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2254 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41719 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->