### PR TITLE
[WebGPU] Use the async version of newLibraryWithSource

### DIFF
--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -83,19 +83,41 @@ id<MTLLibrary> ShaderModule::createLibrary(id<MTLDevice> device, const String& m
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     options.fastMathEnabled = YES;
 ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
-    // FIXME(PERFORMANCE): Run the asynchronous version of this
-    id<MTLLibrary> library = [device newLibraryWithSource:msl options:options error:error];
-    if (error && *error) {
-        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to compile the shader source, generated metal:\n%@", (NSString*)msl] }];
-#ifndef NDEBUG
+    
+    // Use a dispatch semaphore to wait for the async operation to complete
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    
+    __block id<MTLLibrary> resultLibrary = nil;
+    __block NSError* resultError = nil;
+    
+    [device newLibraryWithSource:msl options:options completionHandler:^(id<MTLLibrary> library, NSError* libraryError) {
+        if (library) {
+            resultLibrary = library;
+            library.label = label;
+        }
+        
+        if (libraryError) {
+            resultError = libraryError;
+        }
+        
+        dispatch_semaphore_signal(semaphore);
+    }];
+    
+    // Wait for the async operation to complete
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    
+    if (error && resultError) {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
-        WTFLogAlways("MSL compilation error: %@", [*error localizedDescription]);
+#ifdef NDEBUG
+        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to compile the shader source, generated metal:\n%@", (NSString*)msl] }];
+#else
+        WTFLogAlways("MSL compilation error: %@", [resultError localizedDescription]);
+        *error = resultError;
 #endif
         return nil;
     }
-    library.label = label;
-    return library;
+    
+    return resultLibrary;
 }
 
 static RefPtr<ShaderModule> earlyCompileShaderModule(Device& device, std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&& checkResult, const WGPUShaderModuleDescriptor& suppliedHints, String&& label)


### PR DESCRIPTION
<pre>[WebGPU] Use the async version of newLibraryWithSource
https://bugs.webkit.org/show_bug.cgi?id=279464

Reviewed by NOBODY (OOPS!).

This fixes the performance problem in WebGPU.

* Source/WebGPU/WebGPU/ShaderModule.mm: (WebGPU::ShaderModule::createLibrary): Use async version of newLibraryWithSource.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ef75a517c8213ddad3b5a4c1b0d4bcba4faf73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94535 "10 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14127 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3924 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45051 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14425 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22555 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29456 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97537 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/14425 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/3924 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52471 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/14425 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/3924 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44374 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/14425 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/3924 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101598 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21591 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/22555 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81139 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21841 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/3924 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80513 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/3924 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14813 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21568 "Hash 52ef75a5 for PR 33418 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26699 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21247 "Hash 52ef75a5 for PR 33418 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24710 "Hash 52ef75a5 for PR 33418 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22985 "Hash 52ef75a5 for PR 33418 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->