### PR TITLE
[scroll-animations] Move some functions from DocumentTimeline to AnimationTimeline

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "AnimationTimeline.h"
 
+#include "AnimationTimelinesController.h"
 #include "KeyframeEffect.h"
 #include "KeyframeEffectStack.h"
 #include "StyleResolver.h"
@@ -80,6 +81,34 @@ std::optional<double> AnimationTimeline::bindingsCurrentTime()
     if (!time)
         return std::nullopt;
     return secondsToWebAnimationsAPITime(*time);
+}
+
+void AnimationTimeline::detachFromDocument()
+{
+    Ref<AnimationTimeline> protectedThis(*this);
+    if (CheckedPtr controller = this->controller())
+        controller->removeTimeline(*this);
+
+    auto& animationsToRemove = m_animations;
+    while (!animationsToRemove.isEmpty())
+        animationsToRemove.first()->remove();
+}
+
+void AnimationTimeline::suspendAnimations()
+{
+    for (const auto& animation : m_animations)
+        animation->setSuspended(true);
+}
+
+void AnimationTimeline::resumeAnimations()
+{
+    for (const auto& animation : m_animations)
+        animation->setSuspended(false);
+}
+
+bool AnimationTimeline::animationsAreSuspended() const
+{
+    return controller() && controller()->animationsAreSuspended();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class AnimationTimelinesController;
 class WebAnimation;
 
 class AnimationTimeline : public RefCounted<AnimationTimeline>, public CanMakeWeakPtr<AnimationTimeline> {
@@ -51,6 +52,17 @@ public:
 
     std::optional<double> bindingsCurrentTime();
     virtual std::optional<Seconds> currentTime() { return m_currentTime; }
+
+    virtual void detachFromDocument();
+
+    enum class ShouldUpdateAnimationsAndSendEvents : bool { No, Yes };
+    virtual ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() { return ShouldUpdateAnimationsAndSendEvents::No; }
+
+    virtual void suspendAnimations();
+    virtual void resumeAnimations();
+    bool animationsAreSuspended() const;
+
+    virtual AnimationTimelinesController* controller() const { return nullptr; }
 
 protected:
     AnimationTimeline();

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -35,6 +35,7 @@
 
 namespace WebCore {
 
+class AnimationTimelinesController;
 class AnimationEventBase;
 class CustomEffectCallback;
 class Document;
@@ -65,22 +66,20 @@ public:
     void transitionDidComplete(Ref<CSSTransition>&&);
 
     void animationAcceleratedRunningStateDidChange(WebAnimation&);
-    void detachFromDocument();
+    void detachFromDocument() override;
 
     void enqueueAnimationEvent(AnimationEventBase&);
     bool hasPendingAnimationEventForAnimation(const WebAnimation&) const;
     
-    enum class ShouldUpdateAnimationsAndSendEvents : bool { No, Yes };
-    ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents();
+    ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
     void removeReplacedAnimations();
     AnimationEvents prepareForPendingAnimationEventsDispatch();
     void documentDidUpdateAnimationsAndSendEvents();
     void styleOriginatedAnimationsWereCreated();
 
     WEBCORE_EXPORT Seconds animationInterval() const;
-    void suspendAnimations();
-    void resumeAnimations();
-    bool animationsAreSuspended() const;
+    void suspendAnimations() override;
+    void resumeAnimations() override;
     WEBCORE_EXPORT unsigned numberOfActiveAnimationsForTesting() const;
     WEBCORE_EXPORT Vector<std::pair<String, double>> acceleratedAnimationsForElement(Element&) const;    
     WEBCORE_EXPORT unsigned numberOfAnimationTimelineInvalidationsForTesting() const;
@@ -94,7 +93,7 @@ private:
 
     bool isDocumentTimeline() const final { return true; }
 
-    AnimationTimelinesController* controller() const;
+    AnimationTimelinesController* controller() const override;
     void applyPendingAcceleratedAnimations();
     void scheduleInvalidationTaskIfNeeded();
     void scheduleAnimationResolution();

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -124,4 +124,18 @@ Ref<CSSValue> ScrollTimeline::toCSSValue(const RenderStyle&) const
     return CSSScrollValue::create(CSSPrimitiveValue::create(scroller), CSSPrimitiveValue::create(toCSSValueID(m_axis)));
 }
 
+AnimationTimelinesController* ScrollTimeline::controller() const
+{
+    if (m_source)
+        return &m_source->document().ensureTimelinesController();
+    return nullptr;
+}
+
+AnimationTimeline::ShouldUpdateAnimationsAndSendEvents ScrollTimeline::documentWillUpdateAnimationsAndSendEvents()
+{
+    if (m_source && m_source->isConnected())
+        return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::Yes;
+    return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::No;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 
+class AnimationTimelinesController;
 class CSSScrollValue;
 class Element;
 class RenderStyle;
@@ -53,6 +54,10 @@ public:
 
     virtual void dump(TextStream&) const;
     virtual Ref<CSSValue> toCSSValue(const RenderStyle&) const;
+
+    AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
+
+    AnimationTimelinesController* controller() const override;
 
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -124,4 +124,18 @@ Ref<CSSValue> ViewTimeline::toCSSValue(const RenderStyle& style) const
     );
 }
 
+AnimationTimelinesController* ViewTimeline::controller() const
+{
+    if (m_subject)
+        return &m_subject->document().ensureTimelinesController();
+    return nullptr;
+}
+
+AnimationTimeline::ShouldUpdateAnimationsAndSendEvents ViewTimeline::documentWillUpdateAnimationsAndSendEvents()
+{
+    if (m_subject && m_subject->isConnected())
+        return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::Yes;
+    return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::No;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -56,6 +56,8 @@ public:
     const CSSNumericValue& startOffset() const { return m_startOffset.get(); }
     const CSSNumericValue& endOffset() const { return m_endOffset.get(); }
     const ViewTimelineInsets& insets() const { return m_insets; }
+    AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
+    AnimationTimelinesController* controller() const override;
 
 private:
     explicit ViewTimeline(ViewTimelineOptions&& = { });


### PR DESCRIPTION
#### e4d5fc8e99945e2e1e6aed054d54fddb399c1a47
<pre>
[scroll-animations] Move some functions from DocumentTimeline to AnimationTimeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=279466">https://bugs.webkit.org/show_bug.cgi?id=279466</a>
<a href="https://rdar.apple.com/135748611">rdar://135748611</a>

Reviewed by Antoine Quint.

Move some functions on DocumentTimeline to the AnimationTimeline superclass.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::detachFromDocument):
(WebCore::AnimationTimeline::suspendAnimations):
(WebCore::AnimationTimeline::resumeAnimations):
(WebCore::AnimationTimeline::animationsAreSuspended const):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::documentWillUpdateAnimationsAndSendEvents):
(WebCore::AnimationTimeline::controller const):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::detachFromDocument):
(WebCore::DocumentTimeline::suspendAnimations):
(WebCore::DocumentTimeline::resumeAnimations):
(WebCore::DocumentTimeline::animationsAreSuspended const): Deleted.
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::ScrollTimeline):
(WebCore::ScrollTimeline::controller const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::ViewTimeline):

Canonical link: <a href="https://commits.webkit.org/283574@main">https://commits.webkit.org/283574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add33a2e927d0c5fe14fdc5d8ee96cbad31c1b27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53416 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/12004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15080 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60747 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61082 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8741 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2360 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10116 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->