### PR TITLE
Add support for nativeMessaging with NSExtension messages.

### DIFF
--- a/Source/WTF/wtf/CallbackAggregator.h
+++ b/Source/WTF/wtf/CallbackAggregator.h
@@ -70,7 +70,7 @@ using MainRunLoopCallbackAggregator = CallbackAggregatorOnThread<DestructionThre
 
 template<typename> class EagerCallbackAggregator;
 template <typename Out, typename... In>
-class EagerCallbackAggregator<Out(In...)> : public RefCounted<EagerCallbackAggregator<Out(In...)>> {
+class EagerCallbackAggregator<Out(In...)> : public ThreadSafeRefCounted<EagerCallbackAggregator<Out(In...)>> {
 public:
     template<typename CallableType, class = typename std::enable_if<std::is_rvalue_reference<CallableType&&>::value>::type>
     static Ref<EagerCallbackAggregator> create(CallableType&& callback, In... defaultArgs)
@@ -88,7 +88,7 @@ public:
     ~EagerCallbackAggregator()
     {
         if (m_callback)
-            std::apply(m_callback, m_defaultArgs);
+            std::apply(m_callback, WTFMove(m_defaultArgs));
     }
 
 private:

--- a/Source/WTF/wtf/WeakObjCPtr.h
+++ b/Source/WTF/wtf/WeakObjCPtr.h
@@ -107,6 +107,8 @@ private:
 #endif
 };
 
+template<typename T> WeakObjCPtr(T) -> WeakObjCPtr<std::remove_pointer_t<T>>;
+
 #ifdef __OBJC__
 template<typename T>
 RetainPtr<typename WeakObjCPtr<T>::ValueType> WeakObjCPtr<T>::get() const

--- a/Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h
@@ -27,10 +27,11 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
-#include <Foundation/NSPrivateDecls.h>
+#import <Foundation/NSExtension.h>
+#import <Foundation/NSPrivateDecls.h>
 
 #if PLATFORM(IOS_FAMILY)
-#include <Foundation/NSDistributedNotificationCenter.h>
+#import <Foundation/NSDistributedNotificationCenter.h>
 #endif
 
 #else
@@ -48,6 +49,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)postNotificationName:(NSNotificationName)aName object:(nullable NSString *)anObject userInfo:(nullable NSDictionary *)aUserInfo;
 @end
 #endif
+
+@interface NSExtension : NSObject
++ (NSExtension *)extensionWithIdentifier:(NSString *)bundleIdentifier error:(NSError **)error;
+- (void)beginExtensionRequestWithInputItems:(NSArray *)inputItems completion:(void (^)(id <NSCopying>, NSError *))handler;
+- (void)cancelExtensionRequestWithIdentifier:(id <NSCopying>)requestIdentifier;
+@property (copy, NS_NONATOMIC_IOSONLY) void (^requestCompletionBlock)(id <NSCopying>, NSArray *);
+@property (copy, NS_NONATOMIC_IOSONLY) void (^requestCancellationBlock)(id <NSCopying>, NSError *);
+@property (copy, NS_NONATOMIC_IOSONLY) void (^requestInterruptionBlock)(id <NSCopying>);
+@end
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -1087,6 +1087,9 @@ void WebExtensionAction::popupSizeDidChange()
 
 void WebExtensionAction::closePopup()
 {
+    if (!popupPresented())
+        return;
+
     ASSERT(hasPopupWebView());
 
     RELEASE_LOG_DEBUG(Extensions, "Popup closed");

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -204,6 +204,7 @@ public:
 
     Ref<API::Data> serializeLocalization();
 
+    NSBundle *bundle() const { return m_bundle.get(); }
     SecStaticCodeRef bundleStaticCode() const;
     NSData *bundleHash() const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -508,6 +508,8 @@ public:
     void runOpenPanel(WKWebView *, WKOpenPanelParameters *, void (^)(NSArray *));
 #endif
 
+    void sendNativeMessage(const String& applicationID, id message, CompletionHandler<void(Expected<RetainPtr<id>, WebExtensionError>&&)>&&);
+
     void addInjectedContent(WebUserContentControllerProxy&);
     void removeInjectedContent(WebUserContentControllerProxy&);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -29,6 +29,7 @@
 
 #include "APIObject.h"
 #include "WebExtensionPortChannelIdentifier.h"
+#include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 
 OBJC_CLASS NSError;
@@ -38,7 +39,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 
-class WebExtensionMessagePort : public API::ObjectImpl<API::Object::Type::WebExtensionMessagePort> {
+class WebExtensionMessagePort : public API::ObjectImpl<API::Object::Type::WebExtensionMessagePort>, public CanMakeWeakPtr<WebExtensionMessagePort> {
     WTF_MAKE_NONCOPYABLE(WebExtensionMessagePort);
 
 public:
@@ -66,11 +67,11 @@ public:
     WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
     WebExtensionContext* extensionContext() const;
 
-    void disconnect(Error);
+    void disconnect(Error = std::nullopt);
     void reportDisconnection(Error);
     bool isDisconnected() const;
 
-    void sendMessage(id message, CompletionHandler<void(Error)>&&);
+    void sendMessage(id message, CompletionHandler<void(Error)>&& = { });
     void receiveMessage(id message, Error);
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### a4a63949921ef119388c9e154b743ad928ebf47f
<pre>
Add support for nativeMessaging with NSExtension messages.
<a href="https://webkit.org/b/262081">https://webkit.org/b/262081</a>
<a href="https://rdar.apple.com/problem/116022628">rdar://problem/116022628</a>

Reviewed by Brian Weinstein.

If the app does not implement WKWebExtensionControllerDelegate methods for native messages, fall back to
sending them directly via NSExtension to align with Safari’s behavior.

Manual testing performed with various extensions like 1Password and Userscripts. API tests were not added due
to challenges with testing bundle loading and NSExtension.

* Source/WTF/wtf/CallbackAggregator.h:
(WTF::EagerCallbackAggregator): Use ThreadSafeRefCounted so it can be used in threaded code, like NSExtension blocks.
* Source/WTF/wtf/WeakObjCPtr.h: Added template to allow making a WeakObjCPtr without a type like RetainPtr.
* Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h: Added NSExtension.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::sendNativeMessage): Added. Added NSExtension fallback.
(WebKit::WebExtensionContext::runtimeSendNativeMessage): Refactored into sendNativeMessage().
(WebKit::WebExtensionContext::runtimeConnectNative): Fallback to using sendNativeMessage.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::closePopup): Drive-by ASSERT fix I was hitting with Userscripts.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::WebExtensionMessagePort::remove): Protect this since removeNativePort() might drop the last reference.
(WebKit::WebExtensionMessagePort::sendMessage): Made completionHandler optional.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::bundle const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h:

Canonical link: <a href="https://commits.webkit.org/283446@main">https://commits.webkit.org/283446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d9be46894de5be498feba7bf2b3cc7fda8e01e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66311 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16921 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15797 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59425 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72046 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65555 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60819 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8473 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87322 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10047 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15353 "Found 4 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->