### PR TITLE
Implement iframe sandboxing with site isolation

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7548,7 +7548,10 @@ void Document::initSecurityContext()
     // In the common case, create the security context from the currently
     // loading URL with a fresh content security policy.
     setCookieURL(m_url);
-    enforceSandboxFlags(m_frame->loader().effectiveSandboxFlags());
+
+    // Flags from CSP will be added when the response is received, but should not be carried over to the frame's next document.
+    enforceSandboxFlags(m_frame->sandboxFlagsFromSandboxAttributeNotCSP());
+
     setReferrerPolicy(m_frame->loader().effectiveReferrerPolicy());
 
     if (shouldEnforceContentDispositionAttachmentSandbox())

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -109,6 +109,8 @@ WindowProxy* HTMLFrameOwnerElement::contentWindow() const
 void HTMLFrameOwnerElement::setSandboxFlags(SandboxFlags flags)
 {
     m_sandboxFlags = flags;
+    if (m_contentFrame)
+        m_contentFrame->updateSandboxFlags(flags, Frame::NotifyUIProcess::Yes);
 }
 
 bool HTMLFrameOwnerElement::isKeyboardFocusable(KeyboardEvent* event) const

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -808,7 +808,7 @@ std::optional<CrossOriginOpenerPolicyEnforcementResult> DocumentLoader::doCrossO
 
     auto currentCoopEnforcementResult = CrossOriginOpenerPolicyEnforcementResult::from(m_frame->document()->url(), m_frame->document()->securityOrigin(), m_frame->document()->crossOriginOpenerPolicy(), m_triggeringAction.requester(), openerURL);
 
-    auto newCoopEnforcementResult = WebCore::doCrossOriginOpenerHandlingOfResponse(*m_frame->document(), response, m_triggeringAction.requester(), m_contentSecurityPolicy.get(), frameLoader()->effectiveSandboxFlags(), m_request.httpReferrer(), frameLoader()->stateMachine().isDisplayingInitialEmptyDocument(), currentCoopEnforcementResult);
+    auto newCoopEnforcementResult = WebCore::doCrossOriginOpenerHandlingOfResponse(*m_frame->document(), response, m_triggeringAction.requester(), m_contentSecurityPolicy.get(), m_frame->effectiveSandboxFlags(), m_request.httpReferrer(), frameLoader()->stateMachine().isDisplayingInitialEmptyDocument(), currentCoopEnforcementResult);
     if (!newCoopEnforcementResult) {
         cancelMainResourceLoad(frameLoader()->cancelledError(m_request));
         return std::nullopt;
@@ -1149,7 +1149,7 @@ void DocumentLoader::continueAfterContentPolicy(PolicyAction policy)
         if (ResourceLoader* mainResourceLoader = this->mainResourceLoader())
             InspectorInstrumentation::continueWithPolicyDownload(*m_frame, mainResourceLoader->identifier(), *this, m_response);
 
-        if (!frameLoader()->effectiveSandboxFlags().contains(SandboxFlag::Downloads)) {
+        if (!m_frame->effectiveSandboxFlags().contains(SandboxFlag::Downloads)) {
             // When starting the request, we didn't know that it would result in download and not navigation. Now we know that main document URL didn't change.
             // Download may use this knowledge for purposes unrelated to cookies, notably for setting file quarantine data.
             frameLoader()->setOriginalURLForDownloadRequest(m_request);
@@ -2241,7 +2241,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
         return !(flags.contains(SandboxFlag::Origin)) && !(flags.contains(SandboxFlag::Scripts));
     };
 
-    if (!m_canUseServiceWorkers || !isSandboxingAllowingServiceWorkerFetchHandling(frameLoader()->effectiveSandboxFlags()))
+    if (!m_canUseServiceWorkers || !isSandboxingAllowingServiceWorkerFetchHandling(m_frame->effectiveSandboxFlags()))
         mainResourceLoadOptions.serviceWorkersMode = ServiceWorkersMode::None;
     else {
         // The main navigation load will trigger the registration of the client.

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -600,6 +600,10 @@ void EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navig
 {
 }
 
+void EmptyFrameLoaderClient::updateSandboxFlags(SandboxFlags)
+{
+}
+
 void EmptyFrameLoaderClient::broadcastMainFrameURLChangeToOtherProcesses(const URL&)
 {
 }
@@ -1213,9 +1217,12 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         adoptRef(*new EmptyBackForwardClient),
         CookieJar::create(adoptRef(*new EmptyStorageSessionProvider)),
         makeUniqueRef<EmptyProgressTrackerClient>(),
-        CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)> { [] (auto&) {
-            return makeUniqueRef<EmptyFrameLoaderClient>();
-        } },
+        PageConfiguration::LocalMainFrameCreationParameters {
+            CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)> { [] (auto&) {
+                return makeUniqueRef<EmptyFrameLoaderClient>();
+            } },
+            SandboxFlags::all(),
+        },
         FrameIdentifier::generate(),
         nullptr,
         makeUniqueRef<DummySpeechRecognitionProvider>(),

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -96,6 +96,7 @@ private:
     void dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&) final;
     void dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&) final;
     void dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse& redirectResponse, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, IsPerformingHTTPFallback, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&) final;
+    void updateSandboxFlags(SandboxFlags) final;
     void broadcastMainFrameURLChangeToOtherProcesses(const URL&) final;
     void cancelPolicyCheck() final;
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4048,9 +4048,6 @@ void FrameLoader::continueLoadAfterNewWindowPolicy(const ResourceRequest& reques
         return;
 
     CheckedRef mainFrameLoader = mainFrame->loader();
-    SandboxFlags sandboxFlags = frame->loader().effectiveSandboxFlags();
-    if (sandboxFlags.contains(SandboxFlag::PropagatesToAuxiliaryBrowsingContexts))
-        mainFrameLoader->forceSandboxFlags(sandboxFlags);
 
     if (!isBlankTargetFrameName(frameName))
         mainFrame->tree().setSpecifiedName(frameName);
@@ -4526,16 +4523,6 @@ void FrameLoader::dispatchGlobalObjectAvailableInAllWorlds()
         m_client->dispatchGlobalObjectAvailable(world);
 }
 
-SandboxFlags FrameLoader::effectiveSandboxFlags() const
-{
-    SandboxFlags flags = m_forcedSandboxFlags;
-    if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent()))
-        flags.add(parentFrame->document()->sandboxFlags());
-    if (RefPtr ownerElement = m_frame->ownerElement())
-        flags.add(ownerElement->sandboxFlags());
-    return flags;
-}
-
 void FrameLoader::didChangeTitle(DocumentLoader* loader)
 {
     m_client->didChangeTitle(loader);
@@ -4693,11 +4680,6 @@ RefPtr<Frame> createWindow(LocalFrame& openerFrame, FrameLoadRequest&& request, 
         return nullptr;
 
     Ref frame = page->mainFrame();
-
-    if (isDocumentSandboxed(openerFrame, SandboxFlag::PropagatesToAuxiliaryBrowsingContexts)) {
-        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
-            localFrame->checkedLoader()->forceSandboxFlags(openerFrame.document()->sandboxFlags());
-    }
 
     if (!isBlankTargetFrameName(request.frameName()))
         frame->tree().setSpecifiedName(request.frameName());

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -252,11 +252,6 @@ public:
     void dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&);
     void dispatchDidClearWindowObjectsInAllWorlds();
 
-    // The following sandbox flags will be forced, regardless of changes to
-    // the sandbox attribute of any parent frames.
-    void forceSandboxFlags(SandboxFlags flags) { m_forcedSandboxFlags.add(flags); }
-    WEBCORE_EXPORT SandboxFlags effectiveSandboxFlags() const;
-
     bool checkIfFormActionAllowedByCSP(const URL&, bool didReceiveRedirectResponse, const URL& preRedirectURL) const;
 
     void resetMultipleFormSubmissionProtection();
@@ -515,8 +510,6 @@ private:
     bool m_currentNavigationHasShownBeforeUnloadConfirmPanel { false };
 
     bool m_loadsSynchronously { false };
-
-    SandboxFlags m_forcedSandboxFlags;
 
     RefPtr<FrameNetworkingContext> m_networkingContext;
 

--- a/Source/WebCore/loader/FrameLoaderClient.h
+++ b/Source/WebCore/loader/FrameLoaderClient.h
@@ -38,14 +38,17 @@ class ResourceRequest;
 class ResourceResponse;
 
 enum class PolicyDecisionMode;
+enum class SandboxFlag : uint16_t;
 
 enum class IsPerformingHTTPFallback : bool { No, Yes };
 
 using FramePolicyFunction = CompletionHandler<void(PolicyAction)>;
+using SandboxFlags = OptionSet<SandboxFlag>;
 
 class FrameLoaderClient {
 public:
     virtual void dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse& redirectResponse, FormState*, const String& clientRedirectSourceForHistory, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool hasOpener, IsPerformingHTTPFallback, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&) = 0;
+    virtual void updateSandboxFlags(SandboxFlags) = 0;
     virtual ~FrameLoaderClient() = default;
 };
 

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -236,7 +236,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
         CheckedRef frameLoader = frame->loader();
         switch (policyAction) {
         case PolicyAction::Download:
-            if (!frameLoader->effectiveSandboxFlags().contains(SandboxFlag::Downloads)) {
+            if (!frame->effectiveSandboxFlags().contains(SandboxFlag::Downloads)) {
                 frameLoader->setOriginalURLForDownloadRequest(request);
                 frameLoader->client().startDownload(request, suggestedFilename);
             } else if (RefPtr document = frame->document())
@@ -288,7 +288,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     auto clientRedirectSourceForHistory = documentLoader ? documentLoader->clientRedirectSourceForHistory() : String();
     auto navigationID = documentLoader ? documentLoader->navigationID() : std::nullopt;
     bool hasOpener = !!frame->opener();
-    auto sandboxFlags = frameLoader->effectiveSandboxFlags();
+    auto sandboxFlags = frame->effectiveSandboxFlags();
     auto isPerformingHTTPFallback = frameLoader->isHTTPFallbackInProgress() ? IsPerformingHTTPFallback::Yes : IsPerformingHTTPFallback::No;
 
     if (isInitialEmptyDocumentLoad) {
@@ -329,7 +329,7 @@ void PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigationAction, Re
 
         switch (policyAction) {
         case PolicyAction::Download:
-            if (!frame->loader().effectiveSandboxFlags().contains(SandboxFlag::Downloads))
+            if (!frame->effectiveSandboxFlags().contains(SandboxFlag::Downloads))
                 frame->checkedLoader()->client().startDownload(request);
             else if (RefPtr document = frame->document())
                 document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Not allowed to download due to sandboxing"_s);

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -302,4 +302,10 @@ std::optional<OwnerPermissionsPolicyData> Frame::ownerPermissionsPolicy() const
     return OwnerPermissionsPolicyData { WTFMove(documentOrigin), WTFMove(documentPolicy), WTFMove(containerPolicy) };
 }
 
+void Frame::updateSandboxFlags(SandboxFlags flags, NotifyUIProcess notifyUIProcess)
+{
+    if (notifyUIProcess == NotifyUIProcess::Yes)
+        loaderClient().updateSandboxFlags(flags);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -52,6 +52,9 @@ class WeakPtrImplWithEventTargetData;
 class WindowProxy;
 
 enum class AdvancedPrivacyProtections : uint16_t;
+enum class SandboxFlag : uint16_t;
+
+using SandboxFlags = OptionSet<SandboxFlag>;
 
 class Frame : public ThreadSafeRefCounted<Frame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<Frame> {
 public:
@@ -114,6 +117,9 @@ public:
     virtual String customUserAgentAsSiteSpecificQuirks() const = 0;
     virtual String customNavigatorPlatform() const = 0;
     virtual OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const = 0;
+
+    enum class NotifyUIProcess : bool { No, Yes };
+    virtual void updateSandboxFlags(SandboxFlags, NotifyUIProcess);
 
     WEBCORE_EXPORT RenderWidget* ownerRenderer() const; // Renderer for the element that contains this frame.
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -157,13 +157,14 @@ static const LocalFrame& rootFrame(const LocalFrame& frame)
     return frame;
 }
 
-LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, HTMLFrameOwnerElement* ownerElement, Frame* parent, Frame* opener)
+LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags sandboxFlags, HTMLFrameOwnerElement* ownerElement, Frame* parent, Frame* opener)
     : Frame(page, identifier, FrameType::Local, ownerElement, parent, opener)
     , m_loader(makeUniqueRef<FrameLoader>(*this, clientCreator(*this)))
     , m_script(makeUniqueRef<ScriptController>(*this))
     , m_pageZoomFactor(parentPageZoomFactor(this))
     , m_textZoomFactor(parentTextZoomFactor(this))
     , m_rootFrame(WebCore::rootFrame(*this))
+    , m_sandboxFlags(sandboxFlags)
     , m_eventHandler(makeUniqueRef<EventHandler>(*this))
 {
     ProcessWarming::initializeNames();
@@ -191,19 +192,19 @@ void LocalFrame::init()
     checkedLoader()->init();
 }
 
-Ref<LocalFrame> LocalFrame::createMainFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, Frame* opener)
+Ref<LocalFrame> LocalFrame::createMainFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, Frame* opener)
 {
-    return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, nullptr, nullptr, opener));
+    return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, effectiveSandboxFlags, nullptr, nullptr, opener));
 }
 
-Ref<LocalFrame> LocalFrame::createSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, HTMLFrameOwnerElement& ownerElement)
+Ref<LocalFrame> LocalFrame::createSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, HTMLFrameOwnerElement& ownerElement)
 {
-    return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, &ownerElement, ownerElement.document().frame(), nullptr));
+    return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, effectiveSandboxFlags, &ownerElement, ownerElement.document().frame(), nullptr));
 }
 
-Ref<LocalFrame> LocalFrame::createProvisionalSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, Frame& parent)
+Ref<LocalFrame> LocalFrame::createProvisionalSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, Frame& parent)
 {
-    return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, nullptr, &parent, nullptr));
+    return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, effectiveSandboxFlags, nullptr, &parent, nullptr));
 }
 
 LocalFrame::~LocalFrame()
@@ -1348,6 +1349,20 @@ OptionSet<AdvancedPrivacyProtections> LocalFrame::advancedPrivacyProtections() c
     if (auto* documentLoader = loader().activeDocumentLoader())
         return documentLoader->advancedPrivacyProtections();
     return { };
+}
+
+SandboxFlags LocalFrame::effectiveSandboxFlags() const
+{
+    auto effectiveSandboxFlags = m_sandboxFlags;
+    if (RefPtr document = this->document())
+        effectiveSandboxFlags.add(document->sandboxFlags());
+    return effectiveSandboxFlags;
+}
+
+void LocalFrame::updateSandboxFlags(SandboxFlags flags, NotifyUIProcess notifyUIProcess)
+{
+    Frame::updateSandboxFlags(flags, notifyUIProcess);
+    m_sandboxFlags = flags;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -98,7 +98,10 @@ class SecurityOrigin;
 class VisiblePosition;
 class Widget;
 
+enum class SandboxFlag : uint16_t;
 enum class WindowProxyProperty : uint8_t;
+
+using SandboxFlags = OptionSet<SandboxFlag>;
 
 struct SimpleRange;
 
@@ -118,9 +121,9 @@ using NodeQualifier = Function<Node* (const HitTestResult&, Node* terminationNod
 class LocalFrame final : public Frame {
 public:
     using ClientCreator = CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)>;
-    WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, Frame* opener);
-    WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement&);
-    WEBCORE_EXPORT static Ref<LocalFrame> createProvisionalSubframe(Page&, ClientCreator&&, FrameIdentifier, Frame& parent);
+    WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, Frame* opener);
+    WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, HTMLFrameOwnerElement&);
+    WEBCORE_EXPORT static Ref<LocalFrame> createProvisionalSubframe(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, Frame& parent);
 
     WEBCORE_EXPORT void init();
 #if PLATFORM(IOS_FAMILY)
@@ -319,13 +322,17 @@ public:
     String customNavigatorPlatform() const final;
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
 
+    WEBCORE_EXPORT SandboxFlags effectiveSandboxFlags() const;
+    SandboxFlags sandboxFlagsFromSandboxAttributeNotCSP() { return m_sandboxFlags; }
+    WEBCORE_EXPORT void updateSandboxFlags(SandboxFlags, NotifyUIProcess) final;
+
 protected:
     void frameWasDisconnectedFromOwner() const final;
 
 private:
     friend class NavigationDisabler;
 
-    LocalFrame(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Frame* opener);
+    LocalFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, HTMLFrameOwnerElement*, Frame* parent, Frame* opener);
 
     void dropChildren();
 
@@ -387,6 +394,7 @@ private:
     FloatSize m_overrideScreenSize;
 
     const WeakRef<const LocalFrame> m_rootFrame;
+    SandboxFlags m_sandboxFlags;
     UniqueRef<EventHandler> m_eventHandler;
     HashSet<RegistrableDomain> m_storageAccessExceptionDomains;
 };

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -85,7 +85,7 @@ PageConfiguration::PageConfiguration(
     Ref<BackForwardClient>&& backForwardClient,
     Ref<CookieJar>&& cookieJar,
     UniqueRef<ProgressTrackerClient>&& progressTrackerClient,
-    ClientCreatorForMainFrame&& clientCreatorForMainFrame,
+    MainFrameCreationParameters&& mainFrameCreationParameters,
     FrameIdentifier mainFrameIdentifier,
     RefPtr<Frame>&& mainFrameOpener,
     UniqueRef<SpeechRecognitionProvider>&& speechRecognitionProvider,
@@ -119,7 +119,7 @@ PageConfiguration::PageConfiguration(
     , progressTrackerClient(WTFMove(progressTrackerClient))
     , backForwardClient(WTFMove(backForwardClient))
     , cookieJar(WTFMove(cookieJar))
-    , clientCreatorForMainFrame(WTFMove(clientCreatorForMainFrame))
+    , mainFrameCreationParameters(WTFMove(mainFrameCreationParameters))
     , mainFrameIdentifier(WTFMove(mainFrameIdentifier))
     , mainFrameOpener(WTFMove(mainFrameOpener))
     , cacheStorageProvider(WTFMove(cacheStorageProvider))

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -95,12 +95,19 @@ class ValidationMessageClient;
 class VisitedLinkStore;
 class WebRTCProvider;
 
+enum class SandboxFlag : uint16_t;
+using SandboxFlags = OptionSet<SandboxFlag>;
+
 class PageConfiguration {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PageConfiguration, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(PageConfiguration);
 public:
 
-    using ClientCreatorForMainFrame = std::variant<CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)>, CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>>;
+    struct LocalMainFrameCreationParameters {
+        CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)> clientCreator;
+        SandboxFlags effectiveSandboxFlags;
+    };
+    using MainFrameCreationParameters = std::variant<LocalMainFrameCreationParameters, CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>>;
 
     WEBCORE_EXPORT PageConfiguration(
         std::optional<PageIdentifier>,
@@ -113,7 +120,7 @@ public:
         Ref<BackForwardClient>&&,
         Ref<CookieJar>&&,
         UniqueRef<ProgressTrackerClient>&&,
-        ClientCreatorForMainFrame&&,
+        MainFrameCreationParameters&&,
         FrameIdentifier mainFrameIdentifier,
         RefPtr<Frame>&& mainFrameOpener,
         UniqueRef<SpeechRecognitionProvider>&&,
@@ -166,7 +173,7 @@ public:
     Ref<CookieJar> cookieJar;
     std::unique_ptr<ValidationMessageClient> validationMessageClient;
 
-    ClientCreatorForMainFrame clientCreatorForMainFrame;
+    MainFrameCreationParameters mainFrameCreationParameters;
 
     FrameIdentifier mainFrameIdentifier;
     RefPtr<Frame> mainFrameOpener;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -490,7 +490,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
         localMainFrame->setView(LocalFrameView::create(*localMainFrame));
         localMainFrame->init();
         CheckedRef loader = localMainFrame->loader();
-        loader->forceSandboxFlags(SandboxFlags::all());
+        ASSERT(localMainFrame->effectiveSandboxFlags() == SandboxFlags::all());
 
         RefPtr frameView = localMainFrame->view();
         frameView->setCanHaveScrollbars(false); // SVG Images will always synthesize a viewBox, if it's not available, and thus never see scrollbars.

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -475,6 +475,7 @@ def types_that_cannot_be_forward_declared():
         'WebCore::PointerID',
         'WebCore::RenderingMode',
         'WebCore::RenderingPurpose',
+        'WebCore::SandboxFlags',
         'WebCore::ScriptExecutionContextIdentifier',
         'WebCore::ScrollingNodeID',
         'WebCore::ServiceWorkerOrClientData',

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -37,7 +37,6 @@
 #include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <WebCore/ResourceRequest.h>
-#include <WebCore/SandboxFlags.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
 #include <WebCore/SubstituteData.h>
 
@@ -45,6 +44,8 @@ OBJC_CLASS NSDictionary;
 
 namespace WebCore {
 class SharedBuffer;
+enum class SandboxFlag : uint16_t;
+using SandboxFlags = OptionSet<SandboxFlag>;
 }
 
 namespace WebKit {

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
@@ -27,10 +27,16 @@
 
 #include <WebCore/LayerHostingContextIdentifier.h>
 
+namespace WebCore {
+enum class SandboxFlag : uint16_t;
+using SandboxFlags = OptionSet<SandboxFlag>;
+}
+
 namespace WebKit {
 
 struct ProvisionalFrameCreationParameters {
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier;
+    WebCore::SandboxFlags effectiveSandboxFlags;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
@@ -22,4 +22,5 @@
 
 struct WebKit::ProvisionalFrameCreationParameters {
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier;
+    WebCore::SandboxFlags effectiveSandboxFlags;
 };

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -84,9 +84,9 @@
 #include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
 #endif
 
-namespace IPC {
-class Decoder;
-class Encoder;
+namespace WebCore {
+enum class SandboxFlag : uint16_t;
+using SandboxFlags = OptionSet<SandboxFlag>;
 }
 
 namespace WebKit {
@@ -325,6 +325,7 @@ struct WebPageCreationParameters {
     std::optional<RemotePageParameters> remotePageParameters { };
     std::optional<WebCore::FrameIdentifier> openerFrameIdentifier { };
     WebCore::FrameIdentifier mainFrameIdentifier;
+    WebCore::SandboxFlags initialSandboxFlags;
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     Vector<WebCore::LinkDecorationFilteringData> linkDecorationFilteringData { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -249,6 +249,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     std::optional<WebKit::RemotePageParameters> remotePageParameters;
     std::optional<WebCore::FrameIdentifier> openerFrameIdentifier;
     WebCore::FrameIdentifier mainFrameIdentifier;
+    WebCore::SandboxFlags initialSandboxFlags;
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     Vector<WebCore::LinkDecorationFilteringData> linkDecorationFilteringData;

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -135,7 +135,6 @@ public:
     WebCore::LockBackForwardList lockBackForwardList() const { return m_lastNavigationAction.lockBackForwardList; }
 
     WTF::String clientRedirectSourceForHistory() const { return m_lastNavigationAction.clientRedirectSourceForHistory; }
-    WebCore::SandboxFlags effectiveSandboxFlags() const { return m_lastNavigationAction.effectiveSandboxFlags; }
     std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy() const { return m_lastNavigationAction.ownerPermissionsPolicy; }
 
     void setLastNavigationAction(const WebKit::NavigationActionData& navigationAction) { m_lastNavigationAction = navigationAction; }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -123,6 +123,16 @@ void PageConfiguration::setOpenerInfo(std::optional<OpenerInfo>&& info)
 
 bool PageConfiguration::OpenerInfo::operator==(const OpenerInfo&) const = default;
 
+WebCore::SandboxFlags PageConfiguration::initialSandboxFlags() const
+{
+    return m_data.initialSandboxFlags;
+}
+
+void PageConfiguration::setInitialSandboxFlags(WebCore::SandboxFlags sandboxFlags)
+{
+    m_data.initialSandboxFlags = sandboxFlags;
+}
+
 WebProcessPool& PageConfiguration::processPool() const
 {
     return m_data.processPool.get();

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -52,6 +52,11 @@ OBJC_PROTOCOL(_UIClickInteractionDriving);
 #include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
 #endif
 
+namespace WebCore {
+enum class SandboxFlag : uint16_t;
+using SandboxFlags = OptionSet<SandboxFlag>;
+}
+
 namespace WebKit {
 class BrowsingContextGroup;
 class VisitedLinkStore;
@@ -111,6 +116,9 @@ public:
     };
     const std::optional<OpenerInfo>& openerInfo() const;
     void setOpenerInfo(std::optional<OpenerInfo>&&);
+
+    WebCore::SandboxFlags initialSandboxFlags() const;
+    void setInitialSandboxFlags(WebCore::SandboxFlags);
 
     WebKit::WebProcessPool& processPool() const;
     void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
@@ -488,6 +496,7 @@ private:
         RefPtr<WebKit::WebPageGroup> pageGroup;
         WeakPtr<WebKit::WebPageProxy> relatedPage;
         std::optional<OpenerInfo> openerInfo;
+        WebCore::SandboxFlags initialSandboxFlags;
         WeakPtr<WebKit::WebPageProxy> pageToCloneSessionStorageFrom;
         WeakPtr<WebKit::WebPageProxy> alternateWebViewForNavigationGestures;
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2547,8 +2547,9 @@ void webkitWebViewBaseCreateWebPage(WebKitWebViewBase* webkitWebViewBase, Ref<AP
     priv->pageProxy->setIntrinsicDeviceScaleFactor(gtk_widget_get_scale_factor(GTK_WIDGET(webkitWebViewBase)));
     priv->acceleratedBackingStore = AcceleratedBackingStore::create(*priv->pageProxy);
 
-    auto& openerInfo = priv->pageProxy->configuration().openerInfo();
-    priv->pageProxy->initializeWebPage(openerInfo ? openerInfo->site : Site(aboutBlankURL()));
+    auto& pageConfiguration = priv->pageProxy->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    priv->pageProxy->initializeWebPage(openerInfo ? openerInfo->site : Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 
     if (priv->displayID)
         priv->pageProxy->windowScreenDidChange(priv->displayID);

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
@@ -286,8 +286,9 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
 
     wpe_view_backend_initialize(m_backend);
 
-    auto& openerInfo = m_pageProxy->configuration().openerInfo();
-    m_pageProxy->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()));
+    auto& pageConfiguration = m_pageProxy->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    m_pageProxy->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 
     viewsVector().append(this);
 }

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -128,8 +128,9 @@ ViewPlatform::ViewPlatform(WPEDisplay* display, const API::PageConfiguration& co
     m_pageProxy->windowScreenDidChange(m_displayID);
     m_backingStore = AcceleratedBackingStoreDMABuf::create(*m_pageProxy, m_wpeView.get());
 
-    auto& openerInfo = m_pageProxy->configuration().openerInfo();
-    m_pageProxy->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()));
+    auto& pageConfiguration = m_pageProxy->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    m_pageProxy->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 }
 
 ViewPlatform::~ViewPlatform()

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -44,7 +44,10 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProc
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
 {
     process().markProcessAsRecentlyUsed();
-    process().send(Messages::WebPage::CreateProvisionalFrame({ frame.layerHostingContextIdentifier() }, frame.frameID()), frame.page()->webPageIDInProcess(process()));
+    process().send(Messages::WebPage::CreateProvisionalFrame(ProvisionalFrameCreationParameters {
+        frame.layerHostingContextIdentifier(),
+        frame.effectiveSandboxFlags()
+    }, frame.frameID()), frame.page()->webPageIDInProcess(process()));
 }
 
 ProvisionalFrameProxy::~ProvisionalFrameProxy()

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -117,7 +117,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     } else if (m_page->preferences().siteIsolationEnabled())
         m_mainFrame = m_page->mainFrame();
     else {
-        m_mainFrame = WebFrameProxy::create(protectedPage(), m_frameProcess, FrameIdentifier::generate(), WebFrameProxy::IsMainFrame::Yes);
+        m_mainFrame = WebFrameProxy::create(protectedPage(), m_frameProcess, FrameIdentifier::generate(), previousMainFrame->effectiveSandboxFlags(), WebFrameProxy::IsMainFrame::Yes);
 
         // Restore the main frame's committed URL as some clients may rely on it until the next load is committed.
         m_mainFrame->frameLoadState().setURL(previousMainFrame->url());
@@ -248,7 +248,10 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             m_mainFrame = existingRemotePageProxy->page()->mainFrame();
             m_messageReceiverRegistration.stopReceivingMessages();
             m_messageReceiverRegistration.transferMessageReceivingFrom(existingRemotePageProxy->messageReceiverRegistration(), *this);
-            send(Messages::WebPage::CreateProvisionalFrame({ }, m_mainFrame->frameID()));
+            send(Messages::WebPage::CreateProvisionalFrame(ProvisionalFrameCreationParameters {
+                std::nullopt,
+                m_mainFrame->effectiveSandboxFlags(),
+            }, m_mainFrame->frameID()));
             m_needsCookieAccessAddedInNetworkProcess = true;
             registerWithInspectorController = false; // FIXME: <rdar://121240770> This is a hack. There seems to be a bug in our interaction with WebPageInspectorController.
         }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -208,6 +208,7 @@ enum class ReasonForDismissingAlternativeText : uint8_t;
 enum class ReloadOption : uint8_t;
 enum class RenderAsTextFlag : uint16_t;
 enum class RouteSharingPolicy : uint8_t;
+enum class SandboxFlag : uint16_t;
 enum class ScreenOrientationType : uint8_t;
 enum class ScrollGranularity : uint8_t;
 enum class ScrollIsAnimated : bool;
@@ -349,6 +350,7 @@ using PlatformLayerIdentifier = ProcessQualified<ObjectIdentifier<PlatformLayerI
 using PlaybackTargetClientContextIdentifier = LegacyNullableObjectIdentifier<PlaybackTargetClientContextIdentifierType>;
 using PointerID = uint32_t;
 using ResourceLoaderIdentifier = LegacyNullableAtomicObjectIdentifier<ResourceLoader>;
+using SandboxFlags = OptionSet<SandboxFlag>;
 using ScrollingNodeID = ProcessQualified<LegacyNullableObjectIdentifier<ScrollingNodeIDType>>;
 using SleepDisablerIdentifier = LegacyNullableObjectIdentifier<SleepDisablerIdentifierType>;
 using UserMediaRequestIdentifier = LegacyNullableObjectIdentifier<UserMediaRequestIdentifierType>;
@@ -806,7 +808,7 @@ public:
 
     void setPageLoadStateObserver(std::unique_ptr<PageLoadStateObserverBase>&&);
 
-    void initializeWebPage(const WebCore::Site&);
+    void initializeWebPage(const WebCore::Site&, WebCore::SandboxFlags);
     void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
 
     WeakPtr<SecKeyProxyStore> secKeyProxyStore(const WebCore::AuthenticationChallenge&);
@@ -2563,7 +2565,7 @@ private:
     void requestPointerLock();
 #endif
 
-    void didCreateSubframe(IPC::Connection&, WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, const String& frameName);
+    void didCreateSubframe(IPC::Connection&, WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, const String& frameName, WebCore::SandboxFlags);
 
     void didStartProvisionalLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, URL&&, URL&& unreachableURL, const UserData&, WallTime);
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, WebCore::ResourceRequest&&, const UserData&);
@@ -2599,6 +2601,7 @@ private:
 #endif
 
     void updateRemoteFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
+    void updateSandboxFlags(IPC::Connection&, WebCore::FrameIdentifier, WebCore::SandboxFlags);
 
     void didDestroyNavigation(WebCore::NavigationIdentifier);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -119,7 +119,7 @@ messages -> WebPageProxy {
     EndNetworkRequestsForPageLoadTiming(WebCore::FrameIdentifier frameID, WallTime timestamp)
 
     # Frame lifetime messages
-    DidCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String frameName)
+    DidCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String frameName, WebCore::SandboxFlags sandboxFlags)
 
     # Frame load messages
     DidStartProvisionalLoadForFrame(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::ResourceRequest request, std::optional<WebCore::NavigationIdentifier> navigationID, URL url, URL unreachableURL, WebKit::UserData userData, WallTime timestamp)
@@ -143,7 +143,7 @@ messages -> WebPageProxy {
     DidChangeMainDocument(WebCore::FrameIdentifier frameID)
     DidExplicitOpenForFrame(WebCore::FrameIdentifier frameID, URL url, String mimeType)
     DidDestroyNavigation(WebCore::NavigationIdentifier navigationID)
-
+    UpdateSandboxFlags(WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags)
     UpdateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize size)
 
     MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture, double minScale, double maxScale)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -264,8 +264,9 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     ASSERT(_pageClient);
 
     _page = processPool.createWebPage(*_pageClient, WTFMove(configuration));
-    auto& openerInfo = _page->configuration().openerInfo();
-    _page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()));
+    auto& pageConfiguration = _page->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    _page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 
     [self _updateRuntimeProtocolConformanceIfNeeded];
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1308,8 +1308,9 @@ WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWeb
 
     m_page->setAddsVisitedLinks(processPool.historyClient().addsVisitedLinks());
 
-    auto& openerInfo = m_page->configuration().openerInfo();
-    m_page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()));
+    auto& pageConfiguration = m_page->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    m_page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 
     registerDraggedTypes();
 

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -57,8 +57,9 @@ PlayStationWebView::PlayStationWebView(struct wpe_view_backend* backend, const A
 
     wpe_view_backend_initialize(m_backend);
 
-    auto& openerInfo = m_page->configuration().openerInfo();
-    m_page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()));
+    auto& pageConfiguration = m_page->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    m_page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 }
 
 #else
@@ -76,8 +77,9 @@ PlayStationWebView::PlayStationWebView(const API::PageConfiguration& conf)
     auto& pool = configuration->processPool();
     m_page = pool.createWebPage(*m_pageClient, WTFMove(configuration));
 
-    auto& openerInfo = m_page->configuration().openerInfo();
-    m_page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()));
+    auto& pageConfiguration = m_page->configuration();
+    auto& openerInfo = pageConfiguration.openerInfo();
+    m_page->initializeWebPage(openerInfo ? openerInfo->site : WebCore::Site(aboutBlankURL()), pageConfiguration.initialSandboxFlags());
 }
 
 #endif // USE(WPE_BACKEND_PLAYSTATION)

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -233,13 +233,14 @@ WebView::WebView(RECT rect, const API::PageConfiguration& configuration, HWND pa
     // status into account. <http://webkit.org/b/54104>
     ASSERT(m_isVisible == static_cast<bool>(::GetWindowLong(m_window, GWL_STYLE) & WS_VISIBLE));
 
-    auto pageConfiguration = configuration.copy();
+    Ref pageConfiguration = configuration.copy();
     pageConfiguration->preferences().setAllowTestOnlyIPC(pageConfiguration->allowTestOnlyIPC());
     WebProcessPool& processPool = pageConfiguration->processPool();
     m_page = processPool.createWebPage(*m_pageClient, WTFMove(pageConfiguration));
 
-    auto& openerInfo = m_page->configuration().openerInfo();
-    m_page->initializeWebPage(openerInfo ? openerInfo->site : Site(aboutBlankURL()));
+    auto& configurationFromPage = m_page->configuration();
+    auto& openerInfo = configurationFromPage.openerInfo();
+    m_page->initializeWebPage(openerInfo ? openerInfo->site : Site(aboutBlankURL()), configurationFromPage.initialSandboxFlags());
 
     m_page->setIntrinsicDeviceScaleFactor(deviceScaleFactorForWindow(m_window));
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -515,7 +515,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     loadParameters.isCrossOriginOpenerPolicyEnabled = document && document->settings().crossOriginOpenerPolicyEnabled();
     loadParameters.isDisplayingInitialEmptyDocument = frame && frame->loader().stateMachine().isDisplayingInitialEmptyDocument();
     if (frame)
-        loadParameters.effectiveSandboxFlags = frame->loader().effectiveSandboxFlags();
+        loadParameters.effectiveSandboxFlags = frame->sandboxFlagsFromSandboxAttributeNotCSP();
     if (auto* openerFrame = frame ? dynamicDowncast<LocalFrame>(frame->opener()) : nullptr) {
         if (auto openerDocument = openerFrame->document())
             loadParameters.openerURL = openerDocument->url();

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -180,9 +180,11 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         auto loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, effectiveUserAgent);
         if (contextData.serviceWorkerPageIdentifier)
             loaderClientForMainFrame->setServiceWorkerPageIdentifier(*contextData.serviceWorkerPageIdentifier);
-        pageConfiguration.clientCreatorForMainFrame = CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = WTFMove(loaderClientForMainFrame)] (auto&) mutable {
-            return WTFMove(client);
-        } };
+        pageConfiguration.mainFrameCreationParameters = PageConfiguration::LocalMainFrameCreationParameters {
+            CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = WTFMove(loaderClientForMainFrame)] (auto&) mutable {
+                return WTFMove(client);
+            } }, SandboxFlags { }
+        };
 
 #if !RELEASE_LOG_DISABLED
         auto serviceWorkerIdentifier = contextData.serviceWorkerIdentifier;

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -112,9 +112,9 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
 #endif
     pageConfiguration.storageProvider = makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt());
 
-    pageConfiguration.clientCreatorForMainFrame = CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, m_userAgent)] (auto&) mutable {
+    pageConfiguration.mainFrameCreationParameters = WebCore::PageConfiguration::LocalMainFrameCreationParameters { CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, m_userAgent)] (auto&) mutable {
         return WTFMove(client);
-    } };
+    } }, WebCore::SandboxFlags { } };
 
     Ref page = WebCore::Page::create(WTFMove(pageConfiguration));
     if (m_preferencesStore) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -345,7 +345,7 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& win
         WebCore::LockHistory::No,
         WebCore::LockBackForwardList::No,
         { }, /* clientRedirectSourceForHistory */
-        { }, /* effectiveSandboxFlags */
+        frame.effectiveSandboxFlags(),
         std::nullopt, /* ownerPermissionsPolicy */
         navigationAction.privateClickMeasurement(),
         { }, /* advancedPrivacyProtections */

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -207,4 +207,10 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     });
 }
 
+void WebFrameLoaderClient::updateSandboxFlags(SandboxFlags sandboxFlags)
+{
+    if (RefPtr webPage = m_frame->page())
+        webPage->send(Messages::WebPageProxy::UpdateSandboxFlags(m_frame->frameID(), sandboxFlags));
+}
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -66,6 +66,7 @@ protected:
     WebFrameLoaderClient(Ref<WebFrame>&&, ScopeExit<Function<void()>>&& frameInvalidator);
 
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::IsPerformingHTTPFallback, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&);
+    void updateSandboxFlags(WebCore::SandboxFlags);
 
     Ref<WebFrame> m_frame;
     ScopeExit<Function<void()>> m_frameInvalidator;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -490,7 +490,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         WebCore::LockHistory::No,
         WebCore::LockBackForwardList::No,
         { }, /* clientRedirectSourceForHistory */
-        { }, /* effectiveSandboxFlags */
+        m_localFrame->effectiveSandboxFlags(),
         std::nullopt, /* ownerPermissionsPolicy */
         std::nullopt, /* privateClickMeasurement */
         { }, /* advancedPrivacyProtections */
@@ -968,7 +968,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         WebCore::LockHistory::No,
         WebCore::LockBackForwardList::No,
         { }, /* clientRedirectSourceForHistory */
-        { }, /* effectiveSandboxFlags */
+        m_localFrame->effectiveSandboxFlags(),
         std::nullopt, /* ownerPermissionsPolicy */
         navigationAction.privateClickMeasurement(),
         { }, /* advancedPrivacyProtections */
@@ -1008,6 +1008,11 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Na
     FormState* formState, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, IsPerformingHTTPFallback isPerformingHTTPFallback, WebCore::SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {
     WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTFMove(hitTestResult), hasOpener, isPerformingHTTPFallback, sandboxFlags, policyDecisionMode, WTFMove(function));
+}
+
+void WebLocalFrameLoaderClient::updateSandboxFlags(WebCore::SandboxFlags sandboxFlags)
+{
+    WebFrameLoaderClient::updateSandboxFlags(sandboxFlags);
 }
 
 void WebLocalFrameLoaderClient::cancelPolicyCheck()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -130,6 +130,7 @@ private:
     void dispatchDecidePolicyForResponse(const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, const String&, WebCore::FramePolicyFunction&&) final;
     void dispatchDecidePolicyForNewWindowAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, WebCore::FormState*, const String& frameName, std::optional<WebCore::HitTestResult>&&, WebCore::FramePolicyFunction&&) final;
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::IsPerformingHTTPFallback, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&) final;
+    void updateSandboxFlags(WebCore::SandboxFlags) final;
     void cancelPolicyCheck() final;
     
     void dispatchUnableToImplementPolicy(const WebCore::ResourceError&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -167,6 +167,11 @@ void WebRemoteFrameClient::dispatchDecidePolicyForNavigationAction(const Navigat
     WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTFMove(hitTestResult), hasOpener, isPerformingHTTPFallback, sandboxFlags, policyDecisionMode, WTFMove(function));
 }
 
+void WebRemoteFrameClient::updateSandboxFlags(WebCore::SandboxFlags sandboxFlags)
+{
+    WebFrameLoaderClient::updateSandboxFlags(sandboxFlags);
+}
+
 void WebRemoteFrameClient::applyWebsitePolicies(WebsitePoliciesData&& websitePolicies)
 {
     RefPtr coreFrame = m_frame->coreRemoteFrame();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -56,7 +56,7 @@ private:
     void unfocus() final;
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::IsPerformingHTTPFallback, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&) final;
-
+    void updateSandboxFlags(WebCore::SandboxFlags) final;
 };
 
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -137,6 +137,7 @@ private:
     void dispatchDecidePolicyForResponse(const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, const String&, WebCore::FramePolicyFunction&&) final;
     void dispatchDecidePolicyForNewWindowAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, WebCore::FormState*, const WTF::String& frameName, std::optional<WebCore::HitTestResult>&&, WebCore::FramePolicyFunction&&) final;
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::IsPerformingHTTPFallback, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&) final;
+    void updateSandboxFlags(WebCore::SandboxFlags) { }
     void broadcastMainFrameURLChangeToOtherProcesses(const URL&) final { }
     void cancelPolicyCheck() final;
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -309,9 +309,14 @@ WebView *getWebView(WebFrame *webFrame)
     WebView *webView = kit(&page);
 
     RetainPtr<WebFrame> frame = adoptNS([[self alloc] _initWithWebFrameView:frameView webView:webView]);
+
+    auto effectiveSandboxFlags = ownerElement.sandboxFlags();
+    if (RefPtr parentLocalFrame = ownerElement.document().frame())
+        effectiveSandboxFlags.add(parentLocalFrame->effectiveSandboxFlags());
+
     auto coreFrame = WebCore::LocalFrame::createSubframe(page, [frame] (auto&) {
         return makeUniqueRef<WebFrameLoaderClient>(frame.get());
-    }, WebCore::FrameIdentifier::generate(), ownerElement);
+    }, WebCore::FrameIdentifier::generate(), effectiveSandboxFlags, ownerElement);
     frame->_private->coreFrame = coreFrame.ptr();
 
     coreFrame.get().tree().setSpecifiedName(name);

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1512,11 +1512,14 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         BackForwardList::create(self),
         WebCore::CookieJar::create(storageProvider.copyRef()),
         makeUniqueRef<WebProgressTrackerClient>(self),
-        CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
-            return makeUniqueRef<WebFrameLoaderClient>();
-        } },
+        WebCore::PageConfiguration::LocalMainFrameCreationParameters {
+            CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
+                return makeUniqueRef<WebFrameLoaderClient>();
+            } },
+            WebCore::SandboxFlags { } // Set by updateSandboxFlags after instantiation.
+        },
         WebCore::FrameIdentifier::generate(),
-        nullptr, // Opener may be set by setOpenerForWebKitLegacy.
+        nullptr, // Opener may be set by setOpenerForWebKitLegacy after instantiation.
         makeUniqueRef<WebCore::DummySpeechRecognitionProvider>(),
         makeUniqueRef<WebCore::MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),
@@ -1775,11 +1778,14 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         BackForwardList::create(self),
         WebCore::CookieJar::create(storageProvider.copyRef()),
         makeUniqueRef<WebProgressTrackerClient>(self),
-        CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
-            return makeUniqueRef<WebFrameLoaderClient>();
-        } },
+        WebCore::PageConfiguration::LocalMainFrameCreationParameters {
+            CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
+                return makeUniqueRef<WebFrameLoaderClient>();
+            } },
+            WebCore::SandboxFlags { } // Set by updateSandboxFlags after instantiation.
+        },
         WebCore::FrameIdentifier::generate(),
-        nullptr, // Opener may be set by setOpenerForWebKitLegacy.
+        nullptr, // Opener may be set by setOpenerForWebKitLegacy after instantiation.
         makeUniqueRef<WebCore::DummySpeechRecognitionProvider>(),
         makeUniqueRef<WebCore::MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -402,6 +402,7 @@ TEST(SiteIsolation, BasicPostMessageWindowOpen)
 
 struct WebViewAndDelegates {
     RetainPtr<TestWKWebView> webView;
+    RetainPtr<TestMessageHandler> messageHandler;
     RetainPtr<TestNavigationDelegate> navigationDelegate;
     RetainPtr<TestUIDelegate> uiDelegate;
 };
@@ -3169,39 +3170,33 @@ TEST(SiteIsolation, ThemeColor)
     Util::runFor(0.1_s);
 }
 
+static WebViewAndDelegates makeWebViewAndDelegates(HTTPServer& server)
+{
+    RetainPtr messageHandler = adoptNS([TestMessageHandler new]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration.get());
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    return {
+        WTFMove(webView),
+        WTFMove(messageHandler),
+        WTFMove(navigationDelegate),
+        WTFMove(uiDelegate)
+    };
+};
+
 TEST(SiteIsolation, SandboxFlags)
 {
     NSString *checkAlertJS = @"alert('alerted');window.open('https://example.com/opened');window.webkit.messageHandlers.testHandler.postMessage('testHandler')";
 
     HTTPServer server({
-        { "/example"_s, { "<iframe sandbox='allow-scripts' id='testiframe' src='https://webkit.org/iframe'></iframe><div id='testdiv'></div>"_s } },
+        { "/example"_s, { "<iframe sandbox='allow-scripts' id='testiframe' src='https://webkit.org/iframe'></iframe>"_s } },
         { "/iframe"_s, { "hi"_s } },
         { "/check-when-loaded"_s, { [NSString stringWithFormat:@"<script>onload = ()=>{ %@ }</script>", checkAlertJS] } },
         { "/csp-forbids-alert"_s, { { { "Content-Security-Policy"_s, "sandbox allow-scripts"_s } }, "<script>alert('alerted');window.webkit.messageHandlers.testHandler.postMessage('testHandler')</script>"_s } },
         { "/opened"_s, { "hi"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
-
-    struct WebViewAndDelegates {
-        RetainPtr<TestWKWebView> webView;
-        RetainPtr<TestMessageHandler> messageHandler;
-        RetainPtr<TestNavigationDelegate> navigationDelegate;
-        RetainPtr<TestUIDelegate> uiDelegate;
-    };
-
-    auto makeWebViewAndDelegates = [&] {
-        RetainPtr messageHandler = adoptNS([TestMessageHandler new]);
-        RetainPtr configuration = server.httpsProxyConfiguration();
-        [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration.get(), CGRectZero, false); // FIXME: Make all these tests pass with site isolation on.
-        RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
-        [webView setUIDelegate:uiDelegate.get()];
-        return WebViewAndDelegates {
-            WTFMove(webView),
-            WTFMove(messageHandler),
-            WTFMove(navigationDelegate),
-            WTFMove(uiDelegate)
-        };
-    };
 
     bool receivedMessage { false };
     bool receivedAlert { false };
@@ -3212,7 +3207,8 @@ TEST(SiteIsolation, SandboxFlags)
         receivedOpen = false;
     };
 
-    auto webViewAndDelegates = makeWebViewAndDelegates();
+    WebViewAndDelegates openedWebViewAndDelegates;
+    auto webViewAndDelegates = makeWebViewAndDelegates(server);
     RetainPtr webView = webViewAndDelegates.webView;
     webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
     [webViewAndDelegates.messageHandler addMessage:@"testHandler" withHandler:[&] {
@@ -3226,6 +3222,20 @@ TEST(SiteIsolation, SandboxFlags)
     auto returnNilOpenedView = [&] (WKWebViewConfiguration *, WKNavigationAction *, WKWindowFeatures *) -> WKWebView * {
         receivedOpen = true;
         return nil;
+    };
+    auto returnNonNilOpenedView = [&] (WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) -> WKWebView * {
+        EXPECT_FALSE(openedWebViewAndDelegates.webView);
+        openedWebViewAndDelegates = WebViewAndDelegates {
+            adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]),
+            nil,
+            adoptNS([TestNavigationDelegate new]),
+            uiDelegate
+        };
+        openedWebViewAndDelegates.webView.get().UIDelegate = uiDelegate.get();
+        openedWebViewAndDelegates.webView.get().navigationDelegate = openedWebViewAndDelegates.navigationDelegate.get();
+        [openedWebViewAndDelegates.navigationDelegate allowAnyTLSCertificate];
+        receivedOpen = true;
+        return openedWebViewAndDelegates.webView.get();
     };
     uiDelegate.get().createWebViewWithConfiguration = returnNilOpenedView;
 
@@ -3271,20 +3281,7 @@ TEST(SiteIsolation, SandboxFlags)
     EXPECT_TRUE(receivedOpen);
 
     reset();
-    WebViewAndDelegates openedWebViewAndDelegates;
-    uiDelegate.get().createWebViewWithConfiguration = [&] (WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) -> WKWebView * {
-        openedWebViewAndDelegates = WebViewAndDelegates {
-            adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]),
-            nil,
-            adoptNS([TestNavigationDelegate new]),
-            uiDelegate
-        };
-        openedWebViewAndDelegates.webView.get().UIDelegate = uiDelegate.get();
-        openedWebViewAndDelegates.webView.get().navigationDelegate = openedWebViewAndDelegates.navigationDelegate.get();
-        [openedWebViewAndDelegates.navigationDelegate allowAnyTLSCertificate];
-        receivedOpen = true;
-        return openedWebViewAndDelegates.webView.get();
-    };
+    uiDelegate.get().createWebViewWithConfiguration = returnNonNilOpenedView;
     [webView evaluateJavaScript:@"i.sandbox = 'allow-scripts allow-popups'; i.src = 'https://apple.com/check-when-loaded'" completionHandler:nil];
     while (!openedWebViewAndDelegates.webView)
         Util::spinRunLoop();
@@ -3299,6 +3296,80 @@ TEST(SiteIsolation, SandboxFlags)
     Util::run(&receivedMessage);
     EXPECT_FALSE(receivedAlert);
     EXPECT_TRUE(receivedOpen);
+
+    reset();
+    uiDelegate.get().createWebViewWithConfiguration = returnNonNilOpenedView;
+    openedWebViewAndDelegates.webView = nil;
+    [webView evaluateJavaScript:@"i.sandbox = 'allow-scripts allow-popups allow-popups-to-escape-sandbox'; i.src = 'https://apple.com/check-when-loaded'" completionHandler:nil];
+    while (!openedWebViewAndDelegates.webView)
+        Util::spinRunLoop();
+    [openedWebViewAndDelegates.navigationDelegate waitForDidFinishNavigation];
+    Util::run(&receivedMessage);
+    EXPECT_FALSE(receivedAlert);
+    EXPECT_TRUE(receivedOpen);
+
+    reset();
+    uiDelegate.get().createWebViewWithConfiguration = returnNilOpenedView;
+    [openedWebViewAndDelegates.webView evaluateJavaScript:checkAlertJS completionHandler:nil];
+    Util::run(&receivedMessage);
+    EXPECT_TRUE(receivedAlert);
+    EXPECT_TRUE(receivedOpen);
+}
+
+TEST(SiteIsolation, SandboxFlagsDuringNavigation)
+{
+    bool receivedIframe2Request { false };
+    HTTPServer server { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+        while (true) {
+            auto path = HTTPServer::parsePath(co_await connection.awaitableReceiveHTTPRequest());
+            if (path == "/example"_s) {
+                co_await connection.awaitableSend(HTTPResponse("<iframe sandbox='allow-scripts' id='testiframe' src='https://webkit.org/iframe1'></iframe>"_s).serialize());
+                continue;
+            }
+            if (path == "/iframe1"_s) {
+                co_await connection.awaitableSend(HTTPResponse("hi"_s).serialize());
+                continue;
+            }
+            if (path == "/iframe2"_s) {
+                receivedIframe2Request = true;
+                // Never respond.
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    }, HTTPServer::Protocol::HttpsProxy };
+
+    NSString *checkAlertJS = @"alert('alerted');window.webkit.messageHandlers.testHandler.postMessage('testHandler')";
+
+    bool receivedMessage { false };
+    bool receivedAlert { false };
+    auto reset = [&] {
+        receivedMessage = false;
+        receivedAlert = false;
+        receivedIframe2Request = false;
+    };
+
+    auto webViewAndDelegates = makeWebViewAndDelegates(server);
+    RetainPtr webView = webViewAndDelegates.webView;
+    webViewAndDelegates.uiDelegate.get().runJavaScriptAlertPanelWithMessage = [&](WKWebView *, NSString *alert, WKFrameInfo *, void (^completionHandler)()) {
+        receivedAlert = true;
+        completionHandler();
+    };
+    [webViewAndDelegates.messageHandler addMessage:@"testHandler" withHandler:[&] {
+        receivedMessage = true;
+    }];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [webViewAndDelegates.navigationDelegate waitForDidFinishNavigation];
+    [webView evaluateJavaScript:checkAlertJS inFrame:[webView firstChildFrame] completionHandler:nil];
+    Util::run(&receivedMessage);
+    EXPECT_FALSE(receivedAlert);
+
+    reset();
+    [webView evaluateJavaScript:@"let i = document.getElementById('testiframe'); i.sandbox = 'allow-scripts allow-modals'; i.src='https://webkit.org/iframe2'" completionHandler:nil];
+    Util::run(&receivedIframe2Request);
+    [webView evaluateJavaScript:checkAlertJS inFrame:[webView firstChildFrame] completionHandler:nil];
+    Util::run(&receivedMessage);
+    EXPECT_FALSE(receivedAlert);
 }
 
 }


### PR DESCRIPTION
#### 973d3a5d7447506b2193a201c9efb92ac0fbd8c3
<pre>
Implement iframe sandboxing with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=279460">https://bugs.webkit.org/show_bug.cgi?id=279460</a>
<a href="https://rdar.apple.com/135438611">rdar://135438611</a>

Reviewed by Charlie Wolfe.

To implement iframe sandboxing with site isolation, the state needs
to be sent to the UI process, stored on the WebFrameProxy, then sent
to the web content process when a LocalFrame is constructed, then
updated as needed.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::initSecurityContext):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::setSandboxFlags):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::doCrossOriginOpenerHandlingOfResponse):
(WebCore::DocumentLoader::continueAfterContentPolicy):
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::updateSandboxFlags):
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::createWindow):
(WebCore::FrameLoader::effectiveSandboxFlags const): Deleted.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/FrameLoaderClient.h:
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
(WebCore::PolicyChecker::checkNewWindowPolicy):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::updateEffectiveSandboxFlags):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::createMainFrame):
(WebCore::LocalFrame::createSubframe):
(WebCore::LocalFrame::createProvisionalSubframe):
(WebCore::LocalFrame::updateEffectiveSandboxFlags):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::createMainFrame):
(WebCore::Page::Page):
* Source/WebCore/page/PageConfiguration.cpp:
(WebCore::PageConfiguration::PageConfiguration):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::dataChanged):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.h:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::clientRedirectSourceForHistory const):
(API::Navigation::effectiveSandboxFlags const): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::initialSandboxFlags const):
(API::PageConfiguration::setInitialSandboxFlags):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseCreateWebPage):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::ViewLegacy):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::ViewPlatform):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::didCreateSubframe):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::create):
(WebKit::WebFrameProxy::effectiveSandboxFlags const):
(WebKit::WebFrameProxy::updateSandboxFlags):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::updateSandboxFlags):
(WebKit::WebPageProxy::decidePolicyForNavigationActionSync):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
(WebKit::m_backend):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::WebView):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::updateSandboxFlags):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebKit::WebLocalFrameLoaderClient::updateSandboxFlags):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::updateSandboxFlags):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::createProvisionalFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::mainFrameCreationParameters):
(WebKit::m_textAnimationController):
(WebKit::WebPage::loadRequest):
(WebKit::clientCreatorForMainFrame): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
(WebFrameLoaderClient::updateSandboxFlags):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchCreatePage):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame _createFrameWithPage:frameName:frameView:ownerElement:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView initSimpleHTMLDocumentWithStyle:frame:preferences:groupName:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::makeWebViewAndDelegates):
(TestWebKitAPI::TEST(SiteIsolation, SandboxFlags)):
(TestWebKitAPI::TEST(SiteIsolation, SandboxFlagsDuringNavigation)):

Canonical link: <a href="https://commits.webkit.org/283667@main">https://commits.webkit.org/283667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf478246b852815ae5db63f84ac48a71ac887ab9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53704 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12149 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34225 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/66431 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15294 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72655 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2553 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->