### PR TITLE
[scroll-animations] Add ScrollTimeline and ViewTimeline to AnimationTimelinesController

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline generates and resolves finish promises and events assert_false: Animation is not finished before starting expected false got true
+FAIL View timeline generates and resolves finish promises and events assert_true: Animation is finished after passing end expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
 FAIL animation.progress reflects the progress of a scroll animation as a number between 0 and 1 assert_equals: The progress is null since the currentTime is unresolved. expected (object) null but got (undefined) undefined
-TIMEOUT animation.progress reflects the overall progress of a scroll animation with multiple iterations. Test timed out
-NOTRUN animation.progress reflects the overall progress of a scroll animation that uses a view-timeline.
-NOTRUN progresss of a view-timeline is bounded between 0 and 1.
+FAIL animation.progress reflects the overall progress of a scroll animation with multiple iterations. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+FAIL animation.progress reflects the overall progress of a scroll animation that uses a view-timeline. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"
+FAIL progresss of a view-timeline is bounded between 0 and 1. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2887,6 +2887,9 @@ imported/w3c/web-platform-tests/svg/text/reftests/text-inline-size-101.svg [ Ski
 imported/w3c/web-platform-tests/svg/text/reftests/text-multiline-001.svg [ Skip ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-multiline-002.svg [ Skip ]
 
+imported/w3c/web-platform-tests/scroll-animations/ [ Skip ]
+imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html [ Skip ]
+
 # webkit.org/b/278316
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_nowrap_wrapped.html

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ScrollTimeline.h"
 
+#include "AnimationTimelinesController.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSScrollValue.h"
 #include "CSSValuePool.h"
@@ -73,6 +74,8 @@ ScrollTimeline::ScrollTimeline(ScrollTimelineOptions&& options)
     : m_source(WTFMove(options.source))
     , m_axis(options.axis)
 {
+    if (m_source)
+        m_source->protectedDocument()->ensureTimelinesController().addTimeline(*this);
 }
 
 ScrollTimeline::ScrollTimeline(const AtomString& name, ScrollAxis axis)

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ViewTimeline.h"
 
+#include "AnimationTimelinesController.h"
 #include "CSSNumericFactory.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPrimitiveValueMappings.h"
@@ -76,6 +77,8 @@ ViewTimeline::ViewTimeline(ViewTimelineOptions&& options)
     , m_startOffset(CSSNumericFactory::px(0))
     , m_endOffset(CSSNumericFactory::px(0))
 {
+    if (m_subject)
+        m_subject->protectedDocument()->ensureTimelinesController().addTimeline(*this);
 }
 
 ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, ViewTimelineInsets&& insets)


### PR DESCRIPTION
#### b882778806909f1e15c33ae623356f662e7ac061
<pre>
[scroll-animations] Add ScrollTimeline and ViewTimeline to AnimationTimelinesController
<a href="https://bugs.webkit.org/show_bug.cgi?id=279468">https://bugs.webkit.org/show_bug.cgi?id=279468</a>
<a href="https://rdar.apple.com/135751833">rdar://135751833</a>

Reviewed by Antoine Quint.

Add newly created ScrollTimeline and ViewTimeline objects to AnimationTimelinesController.

* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::ScrollTimeline):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::ViewTimeline):

Canonical link: <a href="https://commits.webkit.org/283500@main">https://commits.webkit.org/283500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4bcfbcdf6896a79a70d4fd4785bfa6e5e494885

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53291 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72179 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60931 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8585 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2196 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10071 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41625 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->