### PR TITLE
Deleting content immediately before a `<picture>` unexpectedly removes `<source>`s

### DIFF
--- a/LayoutTests/editing/deleting/delete-picture-expected.txt
+++ b/LayoutTests/editing/deleting/delete-picture-expected.txt
@@ -1,0 +1,16 @@
+Test deletion of <picture>.
+
+Initial state:
+| "Test"
+| <picture>
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <img>
+|     src=""
+| <#selection-caret>
+
+After deletion:
+| "Test<#selection-caret>"

--- a/LayoutTests/editing/deleting/delete-picture.html
+++ b/LayoutTests/editing/deleting/delete-picture.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable>Test<picture><source srcset="resources/apple.gif" media="(min-width: 600px)"/><source srcset="resources/mozilla.gif"/><img src=""></picture></div>
+<script>
+
+Markup.description('Test deletion of <picture>.');
+
+var editor = document.querySelector('#editor');
+window.getSelection().setBaseAndExtent(editor, 2, editor, 2);
+Markup.dump(editor, 'Initial state');
+
+document.execCommand('Delete');
+Markup.dump(editor, 'After deletion');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/delete-text-before-picture-expected.txt
+++ b/LayoutTests/editing/deleting/delete-text-before-picture-expected.txt
@@ -1,0 +1,24 @@
+Test text deletion before <picture>.
+
+Initial state:
+| "Test"
+| <picture>
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <#selection-caret>
+|   <img>
+|     src=""
+
+After deletion:
+| "Tes<#selection-caret>"
+| <picture>
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <img>
+|     src=""

--- a/LayoutTests/editing/deleting/delete-text-before-picture.html
+++ b/LayoutTests/editing/deleting/delete-text-before-picture.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable>Test<picture><source srcset="resources/apple.gif" media="(min-width: 600px)"/><source srcset="resources/mozilla.gif"/><img src=""></picture></div>
+<script>
+
+Markup.description('Test text deletion before <picture>.');
+
+var picture = document.querySelector('picture');
+window.getSelection().setBaseAndExtent(picture, 2, picture, 2);
+Markup.dump(editor, 'Initial state');
+
+document.execCommand('Delete');
+Markup.dump(editor, 'After deletion');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 1d56845bb42e19b8f4574231e668b34c8a2e2aa8
<pre>
Deleting content immediately before a `&lt;picture&gt;` unexpectedly removes `&lt;source&gt;`s
<a href="https://bugs.webkit.org/show_bug.cgi?id=279467">https://bugs.webkit.org/show_bug.cgi?id=279467</a>
<a href="https://rdar.apple.com/128100106">rdar://128100106</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

`&lt;picture&gt;` elements may contain one or more `&lt;source&gt;` elements (which are not
rendered) and an `&lt;img&gt;` element. When making selections around a `&lt;picture&gt;`
element, the selection is anchored before or after the `&lt;img&gt;` child.

Consequently, when the selection is visually before a `&lt;picture&gt;` element, and
deletion is performed, all `&lt;source&gt;` elements before the selection are also
removed. This is incorrect, as the `&lt;picture&gt;` element and all its children should
be left intact.

Fix by avoiding removal of nodes that have a parent node which cannot have
children for editing. Only the direct parent is checked, since traversal is
performed in document order.

A longer term solution would be to (again) experiment with making
`canContainRangeEndPoint` return `false` for `HTMLPictureElement`. That change would
solve this issue by ensuring the selection could never be inside a `&lt;picture&gt;`.
However, that change is much higher risk, and also causes other selection related
issues, which need to be investigated independently.

* LayoutTests/editing/deleting/delete-picture-expected.txt: Added.
* LayoutTests/editing/deleting/delete-picture.html: Added.

Test already working behavior to delete a `&lt;picture&gt; element.

* LayoutTests/editing/deleting/delete-text-before-picture-expected.txt: Added.
* LayoutTests/editing/deleting/delete-text-before-picture.html: Added.

Test the issue fixed by this patch.

* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::handleGeneralDelete):

Canonical link: <a href="https://commits.webkit.org/283457@main">https://commits.webkit.org/283457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1deebd29ff820eff6da99e85c36ee7f9cae8d21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53189 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11805 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14785 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60515 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60820 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8476 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10052 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->