### PR TITLE
[WebPrivacy] Reduce code duplication in helper classes used to manage remotely updatable lists

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -522,9 +522,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     // FIXME: Filter by process's site when site isolation is enabled
-    parameters.storageAccessUserAgentStringQuirksData = StorageAccessUserAgentStringQuirkController::shared().cachedQuirks();
+    parameters.storageAccessUserAgentStringQuirksData = StorageAccessUserAgentStringQuirkController::shared().cachedListData();
 
-    for (auto&& entry : StorageAccessPromptQuirkController::shared().cachedQuirks()) {
+    for (auto&& entry : StorageAccessPromptQuirkController::shared().cachedListData()) {
         if (!entry.triggerPages.isEmpty()) {
             for (auto&& page : entry.triggerPages)
                 parameters.storageAccessPromptQuirksDomains.add(RegistrableDomain { page });
@@ -556,7 +556,7 @@ void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationPara
     parameters.ftpEnabled = [defaults objectForKey:WebPreferencesKey::ftpEnabledKey()] && [defaults boolForKey:WebPreferencesKey::ftpEnabledKey()];
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::shared().cachedQuirks();
+    parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::shared().cachedListData();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -219,7 +219,7 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 #endif
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::shared().cachedQuirks();
+    parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::shared().cachedListData();
 #endif
 
     WebProcessPool::platformInitializeNetworkProcess(parameters);
@@ -265,7 +265,7 @@ NetworkProcessProxy::NetworkProcessProxy()
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     m_storageAccessPromptQuirksDataUpdateObserver = StorageAccessPromptQuirkController::shared().observeUpdates([weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->send(Messages::NetworkProcess::UpdateStorageAccessPromptQuirks(StorageAccessPromptQuirkController::shared().cachedQuirks()), 0);
+            protectedThis->send(Messages::NetworkProcess::UpdateStorageAccessPromptQuirks(StorageAccessPromptQuirkController::shared().cachedListData()), 0);
     });
 #endif
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -88,9 +88,9 @@ namespace WebKit {
 
 class DownloadProxy;
 class DownloadProxyMap;
+class ListDataObserver;
 class WebPageProxy;
 class WebUserContentControllerProxy;
-class StorageAccessPromptQuirkObserver;
 
 enum class BackgroundFetchChange : uint8_t;
 enum class LoadedWebArchive : bool;
@@ -436,7 +436,7 @@ private:
 #endif
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    RefPtr<StorageAccessPromptQuirkObserver> m_storageAccessPromptQuirksDataUpdateObserver;
+    RefPtr<ListDataObserver> m_storageAccessPromptQuirksDataUpdateObserver;
 #endif
 
     struct UploadActivity {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1603,7 +1603,7 @@ void WebPageProxy::initializeWebPage(const Site& site)
     process->addVisitedLinkStoreUser(visitedLinkStore(), internals().identifier);
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    m_needsInitialLinkDecorationFilteringData = LinkDecorationFilteringController::shared().cachedStrings().isEmpty();
+    m_needsInitialLinkDecorationFilteringData = LinkDecorationFilteringController::shared().cachedListData().isEmpty();
     m_shouldUpdateAllowedQueryParametersForAdvancedPrivacyProtections = cachedAllowedQueryParametersForAdvancedPrivacyProtections().isEmpty();
 #endif
 }
@@ -7344,7 +7344,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
 
     auto shouldWaitForInitialLinkDecorationFilteringData = ShouldWaitForInitialLinkDecorationFilteringData::No;
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    if (LinkDecorationFilteringController::shared().cachedStrings().isEmpty())
+    if (LinkDecorationFilteringController::shared().cachedListData().isEmpty())
         shouldWaitForInitialLinkDecorationFilteringData = ShouldWaitForInitialLinkDecorationFilteringData::Yes;
     else if (m_needsInitialLinkDecorationFilteringData)
         sendCachedLinkDecorationFilteringData();
@@ -7882,7 +7882,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
         newPage->m_shouldSuppressSOAuthorizationInNextNavigationPolicyDecision = true;
 #endif
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-        newPage->m_needsInitialLinkDecorationFilteringData = LinkDecorationFilteringController::shared().cachedStrings().isEmpty();
+        newPage->m_needsInitialLinkDecorationFilteringData = LinkDecorationFilteringController::shared().cachedListData().isEmpty();
         newPage->m_shouldUpdateAllowedQueryParametersForAdvancedPrivacyProtections = cachedAllowedQueryParametersForAdvancedPrivacyProtections().isEmpty();
 #endif
     };
@@ -10835,7 +10835,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #endif
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    parameters.linkDecorationFilteringData = LinkDecorationFilteringController::shared().cachedStrings();
+    parameters.linkDecorationFilteringData = LinkDecorationFilteringController::shared().cachedListData();
     parameters.allowedQueryParametersForAdvancedPrivacyProtections = cachedAllowedQueryParametersForAdvancedPrivacyProtections();
 #endif
 
@@ -14211,18 +14211,18 @@ void WebPageProxy::sendCachedLinkDecorationFilteringData()
     if (!hasRunningProcess())
         return;
 
-    if (LinkDecorationFilteringController::shared().cachedStrings().isEmpty())
+    if (LinkDecorationFilteringController::shared().cachedListData().isEmpty())
         return;
 
     m_needsInitialLinkDecorationFilteringData = false;
-    send(Messages::WebPage::SetLinkDecorationFilteringData(LinkDecorationFilteringController::shared().cachedStrings()));
+    send(Messages::WebPage::SetLinkDecorationFilteringData(LinkDecorationFilteringController::shared().cachedListData()));
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 }
 
 void WebPageProxy::waitForInitialLinkDecorationFilteringData(WebFramePolicyListenerProxy& listener)
 {
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    LinkDecorationFilteringController::shared().updateStrings([listener = Ref { listener }] {
+    LinkDecorationFilteringController::shared().updateList([listener = Ref { listener }] {
         listener->didReceiveInitialLinkDecorationFilteringData();
     });
 #else

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -402,7 +402,7 @@ class DrawingAreaProxy;
 class GamepadData;
 class GeolocationPermissionRequestManagerProxy;
 class LayerTreeContext;
-class LinkDecorationFilteringDataObserver;
+class ListDataObserver;
 class MediaCapability;
 class MediaKeySystemPermissionRequestManagerProxy;
 class MediaSessionCoordinatorProxyPrivate;
@@ -3621,7 +3621,7 @@ private:
     bool m_isLockdownModeExplicitlySet { false };
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    RefPtr<LinkDecorationFilteringDataObserver> m_linkDecorationFilteringDataUpdateObserver;
+    RefPtr<ListDataObserver> m_linkDecorationFilteringDataUpdateObserver;
     bool m_needsInitialLinkDecorationFilteringData { true };
     bool m_shouldUpdateAllowedQueryParametersForAdvancedPrivacyProtections { false };
     OptionSet<WebCore::AdvancedPrivacyProtections> m_advancedPrivacyProtectionsPolicies;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -318,13 +318,13 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
     m_storageAccessUserAgentStringQuirksDataUpdateObserver = StorageAccessUserAgentStringQuirkController::shared().observeUpdates([weakThis = WeakPtr { *this }] {
         // FIXME: Filter by process's site when site isolation is enabled
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateStorageAccessUserAgentStringQuirks(StorageAccessUserAgentStringQuirkController::shared().cachedQuirks()));
+            protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateStorageAccessUserAgentStringQuirks(StorageAccessUserAgentStringQuirkController::shared().cachedListData()));
     });
 
     m_storageAccessPromptQuirksDataUpdateObserver = StorageAccessPromptQuirkController::shared().observeUpdates([weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get()) {
             HashSet<WebCore::RegistrableDomain> domainSet;
-            for (auto&& entry : StorageAccessPromptQuirkController::shared().cachedQuirks()) {
+            for (auto&& entry : StorageAccessPromptQuirkController::shared().cachedListData()) {
                 if (!entry.triggerPages.isEmpty()) {
                     for (auto&& page : entry.triggerPages)
                         domainSet.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(page.string()));
@@ -336,9 +336,9 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
             protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateDomainsWithStorageAccessQuirks(domainSet));
         }
     });
-    if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
+    if (StorageAccessPromptQuirkController::shared().cachedListData().isEmpty())
         StorageAccessPromptQuirkController::shared().initialize();
-    if (StorageAccessUserAgentStringQuirkController::shared().cachedQuirks().isEmpty())
+    if (StorageAccessUserAgentStringQuirkController::shared().cachedListData().isEmpty())
         StorageAccessUserAgentStringQuirkController::shared().initialize();
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -116,9 +116,6 @@ namespace WebKit {
 
 class LockdownModeObserver;
 class PerActivityStateCPUUsageSampler;
-#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-class StorageAccessUserAgentStringQuirkObserver;
-#endif
 class SuspendedPageProxy;
 class UIGamepad;
 class WebAutomationSession;
@@ -132,6 +129,10 @@ struct GPUProcessCreationParameters;
 struct NetworkProcessCreationParameters;
 struct WebProcessCreationParameters;
 struct WebProcessDataStoreParameters;
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+class ListDataObserver;
+#endif
 
 #if PLATFORM(COCOA)
 int networkProcessLatencyQOS();
@@ -910,8 +911,8 @@ private:
 #endif
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    RefPtr<StorageAccessUserAgentStringQuirkObserver> m_storageAccessUserAgentStringQuirksDataUpdateObserver;
-    RefPtr<StorageAccessPromptQuirkObserver> m_storageAccessPromptQuirksDataUpdateObserver;
+    RefPtr<ListDataObserver> m_storageAccessUserAgentStringQuirksDataUpdateObserver;
+    RefPtr<ListDataObserver> m_storageAccessPromptQuirksDataUpdateObserver;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1347,7 +1347,7 @@ void WebsiteDataStore::setStorageAccessPromptQuirkForTesting(String&& topFrameDo
     } };
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    StorageAccessPromptQuirkController::shared().setCachedQuirksForTesting(WTFMove(quirk));
+    StorageAccessPromptQuirkController::shared().setCachedListDataForTesting(WTFMove(quirk));
 #else
     protectedNetworkProcess()->send(Messages::NetworkProcess::UpdateStorageAccessPromptQuirks(WTFMove(quirk)), 0);
 #endif
@@ -1872,7 +1872,7 @@ void WebsiteDataStore::didAllowPrivateTokenUsageByThirdPartyForTesting(bool wasA
 void WebsiteDataStore::setUserAgentStringQuirkForTesting(const String& domain, const String& userAgentString, CompletionHandler<void()>&& completionHandler)
 {
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    StorageAccessUserAgentStringQuirkController::shared().setCachedQuirksForTesting({ { WebCore::RegistrableDomain::uncheckedCreateFromHost(domain), userAgentString } });
+    StorageAccessUserAgentStringQuirkController::shared().setCachedListDataForTesting({ { WebCore::RegistrableDomain::uncheckedCreateFromHost(domain), userAgentString } });
 #endif
     completionHandler();
 }


### PR DESCRIPTION
#### 617326575536554ba7faf2a1f95788f6714f38c1
<pre>
[WebPrivacy] Reduce code duplication in helper classes used to manage remotely updatable lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=279469">https://bugs.webkit.org/show_bug.cgi?id=279469</a>

Reviewed by Charlie Wolfe and Abrar Rahman Protyasha.

Ahead of making further changes in this area, clean up the following helper classes to consolidate
(currently) duplicated code underneath common base classes. See below for more details.

No change in behavior.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
(WebKit::ListDataObserver::create):
(WebKit::ListDataObserver::ListDataObserver):

We currently have 3 nearly-identical classes, that all fulfill the same purpose of wrapping a
callback in a weakly-held C++ object:

- LinkDecorationFilteringDataObserver
- StorageAccessPromptQuirkObserver
- StorageAccessUserAgentStringQuirkObserver

Simply consolidate these three into a single class: `WebKit::ListDataObserver`.

(WebKit::ListDataController::shared):
(WebKit::ListDataController::setCachedListDataForTesting):
(WebKit::ListDataController::cachedListData const):
(WebKit::ListDataController::setCachedListData):
(WebKit::ListDataController::didUpdateCachedListData):

Add two helper classes:

1.  `ListDataControllerBase`, a virtual, non-templated class which implements `observeUpdates()` and
    `initialize()`.

2.  `ListDataController&lt;S, T&gt;`, a templated class which derives from `ListDataControllerBase` and
    exposes getters and setters for the backing `T m_cachedListData`.

This split between non-templated and templated classes allows us to keep the implementations of
`observeUpdates` and `initialize` in the C++ source (rather than an inline header), which is
necessary since the implementation of `observeUpdates` calls into ObjC code but this header is
included in C++ sources.

(WebKit::LinkDecorationFilteringController::cachedListData const):
(WebKit::LinkDecorationFilteringDataObserver::create): Deleted.
(WebKit::LinkDecorationFilteringDataObserver::invokeCallback): Deleted.
(WebKit::LinkDecorationFilteringDataObserver::LinkDecorationFilteringDataObserver): Deleted.
(WebKit::LinkDecorationFilteringController::cachedStrings const): Deleted.
(WebKit::StorageAccessPromptQuirkObserver::create): Deleted.
(WebKit::StorageAccessPromptQuirkObserver::invokeCallback): Deleted.
(WebKit::StorageAccessPromptQuirkObserver::StorageAccessPromptQuirkObserver): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkObserver::create): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkObserver::invokeCallback): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkObserver::StorageAccessUserAgentStringQuirkObserver): Deleted.
(WebKit::StorageAccessPromptQuirkController::cachedQuirks const): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::cachedQuirks const): Deleted.
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(-[WKWebPrivacyNotificationListener initWithType:callback:]):
(-[WKWebPrivacyNotificationListener dealloc]):
(-[WKWebPrivacyNotificationListener didUpdate:]):

Refactor `WKWebPrivacyNotificationListener` so that it takes a single callback block and resource
type, and only calls the callback if the notification&apos;s resource type matches. This is much cleaner
than enumerating every single list type as a member, but only using a single member for any given
listener instance.

(WebKit::ListDataControllerBase::observeUpdates):
(WebKit::ListDataControllerBase::initialize):
(WebKit::LinkDecorationFilteringController::resourceType const):
(WebKit::LinkDecorationFilteringController::updateList):
(WebKit::requestLinkDecorationFilteringData):
(WebKit::StorageAccessPromptQuirkController::resourceType const):
(WebKit::StorageAccessPromptQuirkController::didUpdateCachedListData):
(WebKit::StorageAccessPromptQuirkController::updateList):
(WebKit::StorageAccessUserAgentStringQuirkController::resourceType const):
(WebKit::StorageAccessUserAgentStringQuirkController::updateList):
(WebKit::RestrictedOpenerDomainsController::RestrictedOpenerDomainsController):
(WebKit::RestrictedOpenerDomainsController::update):
(WebKit::TrackerAddressLookupInfo::populateIfNeeded):
(WebKit::TrackerDomainLookupInfo::populateIfNeeded):
(WebKit::canUseWebPrivacyFramework): Deleted.
(WebKit::resourceDataChangedNotificationName): Deleted.
(WebKit::notificationUserInfoResourceTypeKey): Deleted.

Remove several workarounds that are no longer necessary, since we dropped support for macOS Monterey
on trunk.

(-[WKWebPrivacyNotificationListener init]): Deleted.
(-[WKWebPrivacyNotificationListener listenForLinkFilteringDataChanges:]): Deleted.
(-[WKWebPrivacyNotificationListener listenForStorageAccessPromptQuirkChanges:]): Deleted.
(-[WKWebPrivacyNotificationListener listenForStorageAccessUserAgentStringQuirkChanges:]): Deleted.
(-[WKWebPrivacyNotificationListener listenForRestrictedOpenerDomainsChanges:]): Deleted.
(WebKit::LinkDecorationFilteringController::shared): Deleted.
(WebKit::LinkDecorationFilteringController::observeUpdates): Deleted.
(WebKit::LinkDecorationFilteringController::setCachedStrings): Deleted.
(WebKit::LinkDecorationFilteringController::updateStrings): Deleted.
(WebKit::StorageAccessPromptQuirkController::shared): Deleted.
(WebKit::StorageAccessPromptQuirkController::observeUpdates): Deleted.
(WebKit::StorageAccessPromptQuirkController::setCachedQuirks): Deleted.
(WebKit::StorageAccessPromptQuirkController::setCachedQuirksForTesting): Deleted.
(WebKit::StorageAccessPromptQuirkController::initialize): Deleted.
(WebKit::StorageAccessPromptQuirkController::updateQuirks): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::shared): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::observeUpdates): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::setCachedQuirks): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::setCachedQuirksForTesting): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::initialize): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::updateQuirks): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::platformInitializeNetworkProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
(WebKit::NetworkProcessProxy::NetworkProcessProxy):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::sendCachedLinkDecorationFilteringData):
(WebKit::WebPageProxy::waitForInitialLinkDecorationFilteringData):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setStorageAccessPromptQuirkForTesting):
(WebKit::WebsiteDataStore::setUserAgentStringQuirkForTesting):

Canonical link: <a href="https://commits.webkit.org/283464@main">https://commits.webkit.org/283464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77bbd9b5189346896620c7c3c4ef2a0cd1fdc8c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53217 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11829 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38829 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72091 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14627 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2130 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41537 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->