### PR TITLE
[macOS Release] 2 tests in media/video are flaky failure (failing in EWS)

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2390,10 +2390,6 @@ webkit.org/b/276624 fast/dynamic/layer-hit-test-crash.html [ Pass Failure ]
 
 webkit.org/b/276906 imported/w3c/web-platform-tests/IndexedDB/storage-buckets.https.any.worker.html [ Pass Failure ]
 
-# webkit.org/b/278239 [macOS Release] 2 tests in media/video are flaky failure (failing in EWS)
-[ Release ] media/video-playsinline.html [ Pass Failure ]
-[ Release ] media/video-webkit-playsinline.html [ Pass Failure ]
-
 # webkit.org/b/278318 [macOS Debug] ASSERTION FAILED: m_wrapper on media/video-playsinline.html, also flaky failure in Release
 [ Debug ] media/video-playsinline.html [ Pass Crash ]
 

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -27,6 +27,51 @@ const maxNonLiveDuration = 604800; // 604800 seconds == 1 week
 
 class MediaController
 {
+    static EmptyRanges = {
+        get length() { return 0; },
+        start: function(index) { return undefined; },
+        end: function(index) { return undefined; },
+    }
+
+    static NullMedia = {
+        get audioTracks() { return []; },
+        get autoplay() { return false; },
+        get buffered() { return EmptyRanges; },
+        get controls() { return false; },
+        get currentTime() { return 0; },
+        set currentTime(time) { },
+        get defaultPlaybackRate() { return 1; },
+        set defaultPlaybackRate(rate) { },
+        get duration() { return 0; },
+        get error() { return null; },
+        get muted() { return false; },
+        set muted(muted) { },
+        get networkState() { return HTMLMediaElement.NETWORK_NO_SOURCE; },
+        get paused() { return false; },
+        get playbackRate() { return 1; },
+        set playbackRate(rate) { },
+        get played() { return EmptyRanges; },
+        get readyState() { return HTMLMediaElement.HAVE_NOTHING; },
+        get seekable() { return EmptyRanges; },
+        get textTracks() { return []; },
+        get videoTracks() { return []; },
+        get volume() { return 1; },
+        set volume(volume) { },
+        get webkitCurrentPlaybackTargetIsWireless() { return false; },
+        get webkitPresentationMode() { return "inline"; },
+        get webkitSupportsFullscreen() { return false; },
+
+        pause: function() { },
+        play: function() { },
+        fastSeek: function(time) { },
+        requestPictureInPicture: function() { },
+        webkitEnterFullscreen: function() { },
+        webkitExitFullscreen: function() { },
+        webkitSetPresentationMode: function(mode) { },
+        webkitShowPlaybackTargetPicker: function() { },
+        webkitSupportsPresentationMode: function(mode) { return false; },
+    };
+
     constructor(shadowRoot, media, host)
     {
         this.shadowRootWeakRef = new WeakRef(shadowRoot);
@@ -71,7 +116,7 @@ class MediaController
     // Public
     get media()
     {
-        return this.mediaWeakRef ? this.mediaWeakRef.deref() : null;
+        return this.mediaWeakRef.deref() ?? MediaController.NullMedia;
     }
 
     get shadowRoot()


### PR DESCRIPTION
#### 5304ae18190803982983e1acef7f5a6c4f095d21
<pre>
[macOS Release] 2 tests in media/video are flaky failure (failing in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=278239">https://bugs.webkit.org/show_bug.cgi?id=278239</a>
<a href="https://rdar.apple.com/134069680">rdar://134069680</a>

Reviewed by Eric Carlson.

In 277196@main, MediaController was modified to hold a WeakRef pointing to the controller&apos;s
media element. But the rest of the modern-media-controls code is written in a way to expect
this.mediaController.media to always be non-Null. Rather than edit every place where
this.mediaController.media is accessed to null-check the result, return a NullMedia object
which exposes the same interface as HTMLMediaElement in the case where the media object
has been GCd.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.EmptyRanges.prototype.get length):
(MediaController.EmptyRanges.start):
(MediaController.EmptyRanges.end):
(MediaController.NullMedia.prototype.get audioTracks):
(MediaController.NullMedia.prototype.get autoplay):
(MediaController.NullMedia.prototype.get buffered):
(MediaController.NullMedia.prototype.get controls):
(MediaController.NullMedia.prototype.get currentTime):
(MediaController.NullMedia.prototype.set currentTime):
(MediaController.NullMedia.prototype.get defaultPlaybackRate):
(MediaController.NullMedia.prototype.set defaultPlaybackRate):
(MediaController.NullMedia.prototype.get duration):
(MediaController.NullMedia.prototype.get error):
(MediaController.NullMedia.prototype.get muted):
(MediaController.NullMedia.prototype.set muted):
(MediaController.NullMedia.prototype.get networkState):
(MediaController.NullMedia.prototype.get paused):
(MediaController.NullMedia.prototype.get playbackRate):
(MediaController.NullMedia.prototype.set playbackRate):
(MediaController.NullMedia.prototype.get played):
(MediaController.NullMedia.prototype.get readyState):
(MediaController.NullMedia.prototype.get seekable):
(MediaController.NullMedia.prototype.get textTracks):
(MediaController.NullMedia.prototype.get videoTracks):
(MediaController.NullMedia.prototype.get volume):
(MediaController.NullMedia.prototype.set volume):
(MediaController.NullMedia.prototype.get webkitCurrentPlaybackTargetIsWireless):
(MediaController.NullMedia.prototype.get webkitPresentationMode):
(MediaController.NullMedia.prototype.get webkitSupportsFullscreen):
(MediaController.NullMedia.pause):
(MediaController.NullMedia.play):
(MediaController.NullMedia.fastSeek):
(MediaController.NullMedia.requestPictureInPicture):
(MediaController.NullMedia.webkitEnterFullscreen):
(MediaController.NullMedia.webkitExitFullscreen):
(MediaController.NullMedia.webkitSetPresentationMode):
(MediaController.NullMedia.webkitShowPlaybackTargetPicker):
(MediaController.NullMedia.webkitSupportsPresentationMode):
(MediaController.prototype.get media):

Canonical link: <a href="https://commits.webkit.org/283488@main">https://commits.webkit.org/283488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de5ecb6962953307fd86ab8cc0a109c8e5b51cc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70360 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53199 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14807 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14645 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2109 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41510 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42587 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->