### PR TITLE
REGRESSION (283132@main): [visionOS] Unable to start drags over web content

### DIFF
--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
@@ -45,9 +45,6 @@ struct TextIndicatorData;
 
 namespace WebKit {
 
-using DragPreparationBlock = BOOL(^)(void);
-using AddDragItemBlock = BOOL(^)(NSArray<UIDragItem *> *);
-
 struct DragSourceState {
     OptionSet<WebCore::DragSourceAction> action;
     CGRect dragPreviewFrameInRootViewCoordinates { CGRectZero };
@@ -71,7 +68,7 @@ public:
     bool anyActiveDragSourceContainsSelection() const;
 
     // These helper methods are unique to UIDragInteraction.
-    void prepareForDragSession(id<UIDragSession>, DragPreparationBlock);
+    void prepareForDragSession(id <UIDragSession>, dispatch_block_t completionHandler);
     void dragSessionWillBegin();
     void stageDragItem(const WebCore::DragItem&, UIImage *);
     bool hasStagedDragSource() const;
@@ -82,7 +79,7 @@ public:
     UITargetedDragPreview *previewForCancelling(UIDragItem *, UIView *contentView, UIView *previewContainer);
     void dragSessionWillDelaySetDownAnimation(dispatch_block_t completion);
     bool shouldRequestAdditionalItemForDragSession(id <UIDragSession>) const;
-    void dragSessionWillRequestAdditionalItem(AddDragItemBlock);
+    void dragSessionWillRequestAdditionalItem(void (^completion)(NSArray <UIDragItem *> *));
 
     void dropSessionDidEnterOrUpdate(id <UIDropSession>, const WebCore::DragData&);
     void dropSessionDidExit() { m_dropSession = nil; }
@@ -95,8 +92,8 @@ public:
     bool isPerformingDrop() const { return m_isPerformingDrop; }
     id<UIDragSession> dragSession() const { return m_dragSession.get(); }
     id<UIDropSession> dropSession() const { return m_dropSession.get(); }
-    BlockPtr<BOOL()> takeDragStartCompletionBlock() { return std::exchange(m_dragStartCompletionBlock, { }); }
-    BlockPtr<BOOL(NSArray<UIDragItem *> *)> takeAddDragItemCompletionBlock() { return std::exchange(m_addDragItemCompletionBlock, { }); }
+    BlockPtr<void()> takeDragStartCompletionBlock() { return WTFMove(m_dragStartCompletionBlock); }
+    BlockPtr<void(NSArray<UIDragItem *> *)> takeAddDragItemCompletionBlock() { return WTFMove(m_addDragItemCompletionBlock); }
     RetainPtr<UIView> takePreviewViewForDragCancel() { return std::exchange(m_previewViewForDragCancel, { }); }
 
     void addDefaultDropPreview(UIDragItem *, UITargetedDragPreview *);
@@ -117,8 +114,8 @@ private:
     bool m_isPerformingDrop { false };
     RetainPtr<id <UIDragSession>> m_dragSession;
     RetainPtr<id <UIDropSession>> m_dropSession;
-    BlockPtr<BOOL()> m_dragStartCompletionBlock;
-    BlockPtr<BOOL(NSArray<UIDragItem *> *)> m_addDragItemCompletionBlock;
+    BlockPtr<void()> m_dragStartCompletionBlock;
+    BlockPtr<void(NSArray<UIDragItem *> *)> m_addDragItemCompletionBlock;
     RetainPtr<UIView> m_previewViewForDragCancel;
 
     std::optional<DragSourceState> m_stagedDragSource;

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -186,7 +186,7 @@ bool DragDropInteractionState::anyActiveDragSourceContainsSelection() const
     return false;
 }
 
-void DragDropInteractionState::prepareForDragSession(id<UIDragSession> session, DragPreparationBlock completionHandler)
+void DragDropInteractionState::prepareForDragSession(id<UIDragSession> session, dispatch_block_t completionHandler)
 {
     m_dragSession = session;
     m_dragStartCompletionBlock = completionHandler;
@@ -332,7 +332,7 @@ bool DragDropInteractionState::shouldRequestAdditionalItemForDragSession(id <UID
     return m_dragSession == session && !m_addDragItemCompletionBlock && !m_dragStartCompletionBlock;
 }
 
-void DragDropInteractionState::dragSessionWillRequestAdditionalItem(AddDragItemBlock completion)
+void DragDropInteractionState::dragSessionWillRequestAdditionalItem(void (^completion)(NSArray <UIDragItem *> *))
 {
     clearStagedDragSource();
     m_addDragItemCompletionBlock = completion;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10049,7 +10049,7 @@ static BOOL shouldEnableDragInteractionForPolicy(_WKDragInteractionPolicy policy
 
 - (void)_didHandleDragStartRequest:(BOOL)started
 {
-    auto savedCompletionBlock = _dragDropInteractionState.takeDragStartCompletionBlock();
+    BlockPtr<void()> savedCompletionBlock = _dragDropInteractionState.takeDragStartCompletionBlock();
     ASSERT(savedCompletionBlock);
 
     RELEASE_LOG(DragAndDrop, "Handling drag start request (started: %d, completion block: %p)", started, savedCompletionBlock.get());
@@ -10525,11 +10525,18 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
     return dataOwner;
 }
 
-#if USE(BROWSERENGINEKIT)
+- (void)_dragInteraction:(UIDragInteraction *)interaction itemsForAddingToSession:(id<UIDragSession>)session withTouchAtPoint:(CGPoint)point completion:(void(^)(NSArray<UIDragItem *> *))completion
+{
+    if (!_dragDropInteractionState.shouldRequestAdditionalItemForDragSession(session)) {
+        completion(@[ ]);
+        return;
+    }
 
-#pragma mark - BEDragInteractionDelegate
+    _dragDropInteractionState.dragSessionWillRequestAdditionalItem(completion);
+    _page->requestAdditionalItemsForDragSession(WebCore::roundedIntPoint(point), WebCore::roundedIntPoint(point), self._allowedDragSourceActions);
+}
 
-- (void)dragInteraction:(BEDragInteraction *)interaction prepareDragSession:(id<UIDragSession>)session completion:(BOOL(^)(void))completion
+- (void)_dragInteraction:(UIDragInteraction *)interaction prepareForSession:(id<UIDragSession>)session completion:(dispatch_block_t)completion
 {
     RELEASE_LOG(DragAndDrop, "Preparing for drag session: %p", session);
     if (self.currentDragOrDropSession) {
@@ -10560,19 +10567,6 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
     prepareForSession(WebKit::ProceedWithTextSelectionInImage::No);
 #endif
 }
-
-- (void)dragInteraction:(BEDragInteraction *)interaction itemsForAddingToSession:(id<UIDragSession>)session forTouchAtPoint:(CGPoint)point completion:(BOOL(^)(NSArray<UIDragItem *> *))completion
-{
-    if (!_dragDropInteractionState.shouldRequestAdditionalItemForDragSession(session)) {
-        completion(@[ ]);
-        return;
-    }
-
-    _dragDropInteractionState.dragSessionWillRequestAdditionalItem(completion);
-    _page->requestAdditionalItemsForDragSession(WebCore::roundedIntPoint(point), WebCore::roundedIntPoint(point), self._allowedDragSourceActions);
-}
-
-#endif // USE(BROWSERENGINEKIT)
 
 - (NSArray<UIDragItem *> *)dragInteraction:(UIDragInteraction *)interaction itemsForBeginningSession:(id<UIDragSession>)session
 {
@@ -10705,6 +10699,26 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 {
     [existingLocalDragSessionContext(session) cleanUpTemporaryDirectories];
 }
+
+#if USE(BROWSERENGINEKIT)
+
+#pragma mark - BEDragInteractionDelegate
+
+- (void)dragInteraction:(BEDragInteraction *)interaction prepareDragSession:(id<UIDragSession>)session completion:(BOOL(^)(void))completion
+{
+    [self _dragInteraction:interaction prepareForSession:session completion:[completion = makeBlockPtr(completion)] {
+        completion();
+    }];
+}
+
+- (void)dragInteraction:(BEDragInteraction *)interaction itemsForAddingToSession:(id<UIDragSession>)session forTouchAtPoint:(CGPoint)point completion:(BOOL(^)(NSArray<UIDragItem *> *))completion
+{
+    [self _dragInteraction:interaction itemsForAddingToSession:session withTouchAtPoint:point completion:[completion = makeBlockPtr(completion)](NSArray<UIDragItem *> *items) {
+        completion(items);
+    }];
+}
+
+#endif // USE(BROWSERENGINEKIT)
 
 #pragma mark - UIDropInteractionDelegate
 

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -141,6 +141,12 @@ WTF_EXTERN_C_END
 @interface UITextInputTraits : NSObject <UITextInputTraits, UITextInputTraits_Private, NSCopying>
 @end
 
+@protocol UIDragInteractionDelegate_ForWebKitOnly<UIDragInteractionDelegate>
+@optional
+- (void)_dragInteraction:(UIDragInteraction *)interaction prepareForSession:(id<UIDragSession>)session completion:(void(^)(void))completion;
+- (void)_dragInteraction:(UIDragInteraction *)interaction itemsForAddingToSession:(id<UIDragSession>)session withTouchAtPoint:(CGPoint)point completion:(void(^)(NSArray<UIDragItem *> *))completion;
+@end
+
 @class WebEvent;
 
 @protocol UITextInputPrivate <UITextInput, UITextInputTraits_Private>

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -35,7 +35,6 @@
 #import "TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
 #import "WKWebViewConfigurationExtras.h"
-#import <BrowserEngineKit/BrowserEngineKit.h>
 #import <Contacts/Contacts.h>
 #import <MapKit/MapKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -50,6 +49,10 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/Seconds.h>
 #import <wtf/SoftLinking.h>
+
+#if USE(BROWSERENGINEKIT)
+#import <BrowserEngineKit/BrowserEngineKit.h>
+#endif
 
 SOFT_LINK_FRAMEWORK(Contacts)
 SOFT_LINK_CLASS(Contacts, CNMutableContact)
@@ -1579,9 +1582,13 @@ TEST(DragAndDropTests, UnresponsivePageDoesNotHangUI)
 
     // The test passes if we can prepare for a drag session without timing out.
     auto dragSession = adoptNS([[MockDragSession alloc] init]);
+#if USE(BROWSERENGINEKIT)
     [[webView dragInteractionDelegate] dragInteraction:[webView dragInteraction] prepareDragSession:dragSession.get() completion:^{
         return NO;
     }];
+#else
+    [(id<UIDragInteractionDelegate_ForWebKitOnly>)[webView dragInteractionDelegate] _dragInteraction:[webView dragInteraction] prepareForSession:dragSession.get() completion:^{ }];
+#endif
 }
 
 TEST(DragAndDropTests, WebItemProviderPasteboardLoading)

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -72,9 +72,14 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 
 @interface WKWebView (DragAndDropTesting)
 - (id<UIDropInteractionDelegate>)dropInteractionDelegate;
-- (id<BEDragInteractionDelegate>)dragInteractionDelegate;
 - (UIDropInteraction *)dropInteraction;
+#if USE(BROWSERENGINEKIT)
+- (id<BEDragInteractionDelegate>)dragInteractionDelegate;
 - (BEDragInteraction *)dragInteraction;
+#else
+- (id<UIDragInteractionDelegate>)dragInteractionDelegate;
+- (UIDragInteraction *)dragInteraction;
+#endif
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### b6a6f030b2287e57e7a3af51ca05fd999771ac95
<pre>
REGRESSION (283132@main): [visionOS] Unable to start drags over web content
<a href="https://bugs.webkit.org/show_bug.cgi?id=279482">https://bugs.webkit.org/show_bug.cgi?id=279482</a>
<a href="https://rdar.apple.com/135758350">rdar://135758350</a>

Reviewed by Abrar Rahman Protyasha.

In 283132@main, I attempted to fix the build after UIKit removed support for the legacy drag
interaction SPI delegate, which was previously used before transitioning to BrowserEngineKit.
However, visionOS and Catalyst both still use this legacy codepath, and are now broken as a result
of that change.

To fix this, we revert the `Source/` changes in 283132@main, such that we&apos;re still compatible with
both legacy and BrowserEngineKit drag interaction codepaths, and additionally make the drag and drop
simulator in `Tools/` robust in both cases where BrowserEngineKit is used, or the legacy codepath is
used.

* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
(WebKit::DragDropInteractionState::BlockPtr&lt;void):
(WebKit::DragDropInteractionState::BlockPtr&lt;BOOL): Deleted.
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::prepareForDragSession):
(WebKit::DragDropInteractionState::dragSessionWillRequestAdditionalItem):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _didHandleDragStartRequest:]):
(-[WKContentView _dragInteraction:itemsForAddingToSession:withTouchAtPoint:completion:]):
(-[WKContentView _dragInteraction:prepareForSession:completion:]):
(-[WKContentView dragInteraction:prepareDragSession:completion:]):
(-[WKContentView dragInteraction:itemsForAddingToSession:forTouchAtPoint:completion:]):

Completely revert all changes to the `Source/` directory in 283132@main.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::TEST(DragAndDropTests, UnresponsivePageDoesNotHangUI)):
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[WKWebView dragInteractionDelegate]):
(-[DragAndDropSimulator runFrom:to:additionalItemRequestLocations:]):
(-[DragAndDropSimulator _sendQueuedAdditionalItemRequest]):

Adjust the codepaths that were modified in 283132@main, such that we preserve the non-
BrowserEngineKit test infrastructure as well as the new BrowserEngineKit path, depending on whether
`USE(BROWSERENGINEKIT)` is enabled.

Canonical link: <a href="https://commits.webkit.org/283463@main">https://commits.webkit.org/283463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/088b1ea1219a6dc9cd4801c66e76eb1980c6de7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53226 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11840 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33879 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15854 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/60736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72104 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60864 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2136 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->