### PR TITLE
AX: The accessibility tree doesn't update when selection is cleared

### DIFF
--- a/LayoutTests/accessibility/mac/dynamic-selection-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-selection-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we update the accessibility tree when selected text changes dynamically.
+
+PASS: webArea.stringForTextMarkerRange(selectedRange) === 'bar baz'
+PASS: webArea.stringForTextMarkerRange(selectedRange) === 'two three'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo bar baz One two three

--- a/LayoutTests/accessibility/mac/dynamic-selection.html
+++ b/LayoutTests/accessibility/mac/dynamic-selection.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+Foo <span id="span-one">bar baz</span>
+One <span id="span-two">two three</span>
+
+<script>
+var output = "This test ensures we update the accessibility tree when selected text changes dynamically.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var selectedRange;
+    setTimeout(async function() {
+        selectedRange = await selectElementTextById("span-one", webArea);
+        output += expect("webArea.stringForTextMarkerRange(selectedRange)", "'bar baz'");
+
+        selectedRange = await selectElementTextById("span-two", webArea);
+        output += expect("webArea.stringForTextMarkerRange(selectedRange)", "'two three'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -266,6 +266,31 @@ async function waitForFocus(id) {
     return focusedElement;
 }
 
+// Selects text within the element with the given ID, and returns the global selected `TextMarkerRange` after doing so.
+// Optionally takes the AccessibilityUIElement associated with the web area as an argument. If not passed, we'll
+// retrieve it in the function.
+async function selectElementTextById(id, axWebArea) {
+    const webArea = axWebArea ? axWebArea : accessibilityController.rootElement.childAtIndex(0);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+
+    await waitFor(() => {
+        const selectedRange = webArea.selectedTextMarkerRange();
+        return webArea.textMarkerRangeLength(selectedRange) == 0;
+    });
+
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById(id));
+    selection.addRange(range);
+
+    let selectedRange;
+    await waitFor(() => {
+        selectedRange = webArea.selectedTextMarkerRange();
+        return webArea.textMarkerRangeLength(selectedRange) > 0;
+    });
+    return selectedRange;
+}
+
 function evalAndReturn(expression) {
     if (typeof expression !== "string")
         debug("FAIL: evalAndReturn() expects a string argument");


### PR DESCRIPTION
#### c726e39c4422ee5635c91936773212032cc1c2e7
<pre>
AX: The accessibility tree doesn&apos;t update when selection is cleared
<a href="https://bugs.webkit.org/show_bug.cgi?id=279484">https://bugs.webkit.org/show_bug.cgi?id=279484</a>
<a href="https://rdar.apple.com/135768164">rdar://135768164</a>

Reviewed by Andres Gonzalez.

Prior to this patch, we never updated the isolated tree when selection
was cleared, only when it was changed from one node to another. This
meant that we would serve stale data for the AXSelectedTextMarkerRangeAttribute
API.

* LayoutTests/accessibility/mac/dynamic-selection-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-selection.html: Added.
* LayoutTests/resources/accessibility-helper.js:
* Source/WebCore/editing/mac/FrameSelectionMac.mm:
(WebCore::FrameSelection::notifyAccessibilityForSelectionChange):

Canonical link: <a href="https://commits.webkit.org/283506@main">https://commits.webkit.org/283506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48dfb7deb6bbd3c7687d0ef4f91e94dd97eea783

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53297 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11895 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14911 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14625 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60624 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/scale-and-rotate-both-specified-on-animation-keyframes.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-skew.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-translate.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-animated-001.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60938 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2203 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41636 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->