### PR TITLE
Crash in NetworkManager::onGatheredNetworks() under std::sort

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -352,7 +352,7 @@ static bool hasNetworkChanged(const RTCNetwork& a, const RTCNetwork& b)
     return !isEqual(a.prefix, b.prefix) || a.prefixLength != b.prefixLength || a.type != b.type || a.scopeID != b.scopeID || !isEqual(a.ips, b.ips);
 }
 
-static int sortNetworks(const RTCNetwork& a, const RTCNetwork& b)
+static bool sortNetworks(const RTCNetwork& a, const RTCNetwork& b)
 {
     if (a.type != b.type)
         return a.type < b.type;
@@ -363,7 +363,7 @@ static int sortNetworks(const RTCNetwork& a, const RTCNetwork& b)
     if (precedenceA != precedenceB)
         return precedenceA < precedenceB;
 
-    return codePointCompare(StringView { std::span(a.description.data(), a.description.size()) }, StringView { std::span(b.description.data(), b.description.size()) });
+    return codePointCompare(StringView { std::span(a.description.data(), a.description.size()) }, StringView { std::span(b.description.data(), b.description.size()) }) < 0;
 }
 
 void NetworkManager::onGatheredNetworks(RTCNetwork::IPAddress&& ipv4, RTCNetwork::IPAddress&& ipv6, HashMap<String, RTCNetwork>&& networkMap)


### PR DESCRIPTION
#### 82eeb087cdbf9fcc12ed1d0134c325689c24f11d
<pre>
Crash in NetworkManager::onGatheredNetworks() under std::sort
<a href="https://bugs.webkit.org/show_bug.cgi?id=279487">https://bugs.webkit.org/show_bug.cgi?id=279487</a>
<a href="https://rdar.apple.com/133707018">rdar://133707018</a>

Reviewed by Youenn Fablet and Darin Adler.

The `compare` function passed to std::sort() needs to satisfy the strict weak ordering
rule:
- <a href="https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings">https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings</a>

```
Input:                      Test:     Result
a is equivalent to b:       a &lt; b     false
a is equivalent to b        b &lt; a     false

a is less than b            a &lt; b     true
a is less than b            b &lt; a     false

b is less than a            a &lt; b     false
b is less than a            b &lt; a     true
```

If the function doesn&apos;t satisfy this rule, the behavior is undefined and he can lead
to crashes.

The function we are passing to std::sort() is `sortNetworks()`. The first issue is that
it returns an `int` instead of a `bool`, which means that std::sort() will implicitly
convert the return value to a bool internally.

Then the implementation would rely on codePointCompare() internally which would return:
-1 if a &lt; b, 0 if a == b, and 1 if a &gt; b.

For both `a &lt; b` and `b &lt; a`, the result value (-1 and 1) would get implicitly converted
to `true` and thus the sortNetworks() did NOT obey the strict weak ordering rule.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::sortNetworks):

Canonical link: <a href="https://commits.webkit.org/283477@main">https://commits.webkit.org/283477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0d45179acd5bab9f3d34281f0acc84373097f1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53231 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11844 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38843 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10329 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2138 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41554 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->