### PR TITLE
_getTextFragmentMatchWithCompletionHandler returns an empty string instead of nil when there is no text fragment match

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3916,7 +3916,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 {
     THROW_IF_SUSPENDED;
     _page->getTextFragmentMatch([completionHandler = makeBlockPtr(completionHandler)](const String& textFragmentMatch) {
-        completionHandler(textFragmentMatch);
+        completionHandler(nsStringNilIfNull(textFragmentMatch));
     });
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextFragments.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextFragments.mm
@@ -45,6 +45,10 @@ TEST(WebKit, GetTextFragmentMatch)
 
         __block bool isDone;
         [webView _getTextFragmentMatchWithCompletionHandler:^(NSString *string) {
+            // Explicitly test for null, because EXPECT_WK_STREQ coalesces null
+            // to an empty string, and we want to be specific here.
+            if (!expectedResult)
+                EXPECT_NULL(string);
             EXPECT_WK_STREQ(string, expectedResult);
             isDone = true;
         }];


### PR DESCRIPTION
#### 3dc0842188b37a5261d7732440526e83b38962f7
<pre>
_getTextFragmentMatchWithCompletionHandler returns an empty string instead of nil when there is no text fragment match
<a href="https://bugs.webkit.org/show_bug.cgi?id=279488">https://bugs.webkit.org/show_bug.cgi?id=279488</a>
<a href="https://rdar.apple.com/135775793">rdar://135775793</a>

Reviewed by Richard Robinson.

The intent of _getTextFragmentMatchWithCompletionHandler is that it returns nil
if there is no text fragment match, but String -&gt; NSString conversion coalesces
the null String to an empty NSString instead of nil. Fix this.

Sadly, while I added a test for this, EXPECT_WK_STREQ *also* does coalescing that
made the test falsely pass. Add an extra test condition for actually-nil.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _getTextFragmentMatchWithCompletionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextFragments.mm:
(TEST(WebKit, GetTextFragmentMatch)):

Canonical link: <a href="https://commits.webkit.org/283471@main">https://commits.webkit.org/283471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268afd41d04b46955cfa667d49dc51746aee1b66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53235 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38848 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14843 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2137 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41558 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->