### PR TITLE
[JSC] Add fast path for `Iterator.prototype.toArray`

### DIFF
--- a/JSTests/microbenchmarks/iterator-prototype-toArray-for-array.js
+++ b/JSTests/microbenchmarks/iterator-prototype-toArray-for-array.js
@@ -1,0 +1,6 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+var a1 = new Array(1024);
+a1.fill(99);
+for (var i = 0; i < 1e2; ++i)
+    var a2 = Iterator.prototype.toArray.call(a1);

--- a/JSTests/stress/iterator-prototype-toArray-empty.js
+++ b/JSTests/stress/iterator-prototype-toArray-empty.js
@@ -1,0 +1,102 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let source = new Array(0);
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 0);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42;
+    source[1] = 43;
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 42);
+    shouldBe(result[1], 43);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42.195;
+    source[1] = 43.195;
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 42.195);
+    shouldBe(result[1], 43.195);
+}
+
+{
+    let source = new Array(6);
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42;
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], 42);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42.195;
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], 42.195);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "string");
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    $vm.ensureArrayStorage(source);
+    source[1000] = "Hello";
+    let result = Iterator.prototype.toArray.call(source);
+    shouldBe(result.length, 1001);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "string");
+        else if (i === 1000)
+            shouldBe(result[i], "Hello");
+        else
+            shouldBe(result[i], undefined);
+    }
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -108,15 +108,6 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
     return std::pair { SpeciesConstructResult::CreatedObject, newObject };
 }
 
-ALWAYS_INLINE JSValue getProperty(JSGlobalObject* globalObject, JSObject* object, uint64_t index)
-{
-    if (JSValue result = object->tryGetIndexQuickly(index))
-        return result;
-
-    // Don't return undefined if the property is not found.
-    return object->getIfPropertyExists(globalObject, index);
-}
-
 ALWAYS_INLINE void setLength(JSGlobalObject* globalObject, VM& vm, JSObject* obj, uint64_t value)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -324,4 +324,13 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
     }
 }
 
+ALWAYS_INLINE JSValue getProperty(JSGlobalObject* globalObject, JSObject* object, uint64_t index)
+{
+    if (JSValue result = object->tryGetIndexQuickly(index))
+        return result;
+
+    // Don't return undefined if the property is not found.
+    return object->getIfPropertyExists(globalObject, index);
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -138,7 +138,13 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncToArray, (JSGlobalObject* globalObject
     if (!thisValue.isObject())
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.toArray requires that |this| be an Object."_s);
 
-    // FIXME: Add a fast path when thisValue is a fast array
+    if (getIterationMode(vm, globalObject, thisValue) == IterationMode::FastArray) {
+        JSArray* array = tryCloneArrayFromFast(globalObject, thisValue);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (array)
+            return JSValue::encode(array);
+    }
+
     MarkedArgumentBuffer value;
     forEachInIteratorProtocol(globalObject, thisValue, [&value, &scope](VM&, JSGlobalObject* globalObject, JSValue nextItem) {
         value.append(nextItem);


### PR DESCRIPTION
#### 4cd20629601f53916b5afc75bf2c3bac83980f66
<pre>
[JSC] Add fast path for `Iterator.prototype.toArray`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279489">https://bugs.webkit.org/show_bug.cgi?id=279489</a>

Reviewed by Yusuke Suzuki.

This patch adds a fast path for `Iterator.prototype.toArray.call(Array)`. It uses the same logic as
the already existing fast path for `Array.from(Array)`[1].

With this patch, performance on microbenchmarks improves by approximately 2.3x.

                                              TipOfTree                  Patched

iterator-prototype-toArray-for-array        0.7119+-0.0159     ^      0.3019+-0.0052        ^ definitely 2.3578x faster

Even though this patch shares some code with `Array.from`, there are no performance regressions.

                                TipOfTree                  Patched

array-from-array              0.3007+-0.0145            0.2976+-0.0057          might be 1.0103x faster
array-from-arraylike         29.8513+-0.4606     ^     29.1788+-0.1179        ^ definitely 1.0230x faster

[1]: <a href="https://commits.webkit.org/269690@main">https://commits.webkit.org/269690@main</a>

* JSTests/microbenchmarks/iterator-prototype-toArray-for-array.js: Added.
* JSTests/stress/iterator-prototype-toArray-empty.js: Added.
(shouldBe):
(throw.new.Error):
(else.shouldBe):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendOne):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::moveElements): Deleted.
(JSC::clearElement): Deleted.
(JSC::copyElements): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::getProperty): Deleted.
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::clearElement):
* Source/JavaScriptCore/runtime/JSArray.h:
(JSC::moveArrayElements):
(JSC::clearElement):
(JSC::copyArrayElements):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::getProperty):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/283672@main">https://commits.webkit.org/283672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1929fa557b3d0a733b57487c8104a7cc69a3563f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18136 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17919 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16490 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60117 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66248 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61207 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61282 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9001 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42185 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15491 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->