### PR TITLE
Unable to zoom out all the way on one specific encrypted PDF

### DIFF
--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -160,6 +160,12 @@ public:
         return fromRaw(lhs.m_storage | rhs.m_storage);
     }
 
+    constexpr OptionSet& operator|=(const OptionSet& other)
+    {
+        add(other);
+        return *this;
+    }
+
     constexpr friend OptionSet operator&(OptionSet lhs, OptionSet rhs)
     {
         return fromRaw(lhs.m_storage & rhs.m_storage);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -133,8 +133,8 @@ public:
     virtual double scaleFactor() const = 0;
     virtual void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin) = 0;
 
-    virtual CGFloat minScaleFactor() const { return 0.25; }
-    virtual CGFloat maxScaleFactor() const { return 5; }
+    virtual double minScaleFactor() const { return 0.25; }
+    virtual double maxScaleFactor() const { return 5; }
 
     bool isLocked() const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -105,7 +105,12 @@ public:
     // This is the scale that scales the largest page or pair of pages up or down to fit the available width.
     float scale() const { return m_scale; }
 
-    void updateLayout(WebCore::IntSize pluginSize, ShouldUpdateAutoSizeScale);
+    enum class LayoutUpdateChange : uint8_t {
+        PageGeometries = 1 << 0,
+        DocumentBounds = 1 << 1,
+    };
+
+    OptionSet<LayoutUpdateChange> updateLayout(WebCore::IntSize pluginSize, ShouldUpdateAutoSizeScale);
     WebCore::FloatSize contentsSize() const;
     WebCore::FloatSize scaledContentsSize() const;
 
@@ -130,6 +135,8 @@ public:
         WebCore::FloatRect cropBox;
         WebCore::FloatRect layoutBounds;
         WebCore::IntDegrees rotation { 0 };
+
+        friend bool operator==(const PageGeometry&, const PageGeometry&) = default;
     };
 
     std::optional<PageGeometry> geometryForPage(RetainPtr<PDFPage>) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -207,6 +207,9 @@ public:
 
     void setPDFDisplayModeForTesting(const String&) final;
 
+    double minScaleFactor() const final;
+    double maxScaleFactor() const final;
+
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }
@@ -624,6 +627,11 @@ private:
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
     std::unique_ptr<PDFDataDetectorOverlayController> m_dataDetectorOverlayController;
 #endif
+
+    // FIXME: We should rationalize these with the values in ViewGestureController.
+    // For now, we'll leave them differing as they do in PDFPlugin.
+    static constexpr double minimumZoomScale = 0.2;
+    static constexpr double maximumZoomScale = 6.0;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, RepaintRequirement);

--- a/Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp
@@ -89,6 +89,20 @@ TEST(WTF_OptionSet, Or)
     EXPECT_TRUE(((set | set2) == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
 }
 
+TEST(WTF_OptionSet, OrAssignment)
+{
+    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
+
+    set |= { };
+    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+
+    set |= { ExampleFlags::A };
+    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+
+    set |= { ExampleFlags::C, ExampleFlags::D };
+    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
+}
+
 TEST(WTF_OptionSet, Minus)
 {
     OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };


### PR DESCRIPTION
#### 13d7a93baa0ccbb274c0e1f825602af133f2e0fa
<pre>
Unable to zoom out all the way on one specific encrypted PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=279490">https://bugs.webkit.org/show_bug.cgi?id=279490</a>
<a href="https://rdar.apple.com/135716681">rdar://135716681</a>

Reviewed by Tim Horton.

This patch revisits the issue originally addressed by 282007@main, which
is that for a class of encrypted PDF documents, we don&apos;t have accurate
page geometry before the document is unlocked. As such, document layout
updates may settle at the wrong initial scale / anchor position for such
documents, resulting in symptoms reported in this bug and in bug 277812.

This patch:
- Adjusts the condition from 282007@main: having a page count doesn&apos;t
  mean we have accurate page geometry, so we reset scale when unlocking
  assuming we don&apos;t.

- Returns an option set informing what changes to the document layout
  were made in PDFDocumentLayout::updateLayout(). If the option set
  isn&apos;t empty, that implies we did not have accurate page geometry on
  previous layout updates, and as such we should reset scale and ignore
  any previously determined anchor positions.

- Overrides UnifiedPDFPlugin::[min/max]ScaleFactor() to return the
  minimum/maximum zoom scales defined for the plugin, respectively. This
  aligns the HUD zoom limits with the pinch zoom limits.

- Adds an operator|= to WTF::OptionSet for ease of updating the option
  set in UnifiedPDFPlugin::updateLayout().

* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::operator|=):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::minScaleFactor const):
(WebKit::PDFPluginBase::maxScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::updateLayout):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):
(WebKit::UnifiedPDFPlugin::maxScaleFactor const):
(WebKit::UnifiedPDFPlugin::scaleForActualSize const):
(WebKit::UnifiedPDFPlugin::updateLayout):
* Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp:
(TestWebKitAPI::TEST(WTF_OptionSet, OrAssignment)):

Canonical link: <a href="https://commits.webkit.org/283487@main">https://commits.webkit.org/283487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94baa5e754a5fcd7f0a31c9291800589f30160ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53247 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15876 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59504 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72126 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65635 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14643 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2152 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87402 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41572 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15368 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42649 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->