### PR TITLE
[JSC] Implement `Iterator.prototype.forEach` from Iterator Helpers Proposal

### DIFF
--- a/JSTests/stress/iterator-prototype-forEach.js
+++ b/JSTests/stress/iterator-prototype-forEach.js
@@ -1,0 +1,168 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function sameArray(a, b) {
+    sameValue(JSON.stringify(a), JSON.stringify(b));
+}
+
+function shouldThrow(fn, error, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+    }
+}
+
+{
+    class Iter extends Iterator {
+        i = 1;
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        }
+    }
+    const iter = new Iter();
+    const result = [];
+    iter.forEach((item, i) => { result.push([item, i]); });
+    sameArray(result, [[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]]);
+}
+
+{
+    const iter = {
+        i: 1,
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        },
+    };
+    const result = [];
+    Iterator.prototype.forEach.call(iter, (item, i) => { result.push([item, i]); });
+    sameArray(result, [[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]]);
+}
+
+{
+    let nextGetCount = 0;
+    class Iter extends Iterator {
+        get next() {
+            nextGetCount++;
+            let i = 1;
+            return function() {
+                if (i > 5)
+                    return { value: i, done: true }
+                return { value: i++, done: false }
+            }
+        };
+    };
+    const iter = new Iter();
+    const result = [];
+    sameValue(nextGetCount, 0);
+    iter.forEach((item, i) => { result.push([item, i]); });
+    sameValue(nextGetCount, 1);
+    sameArray(result, [[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]]);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+        yield 4;
+        yield 5;
+    }
+    const iter = gen();
+    const result = [];
+    iter.forEach((item, i) => { result.push([item, i]); });
+    sameArray(result, [[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.forEach === Iterator.prototype.forEach);
+    const result = [];
+    iter.forEach((item, i) => { result.push([item, i]); });
+    sameArray(result, [[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const result = [];
+    Iterator.prototype.forEach.call(arr, (item, i) => { result.push([item, i]); });
+    sameArray(result, [[1, 0], [2, 1], [3, 2], [4, 3], [5, 4]]);
+}
+
+{
+    const invalidIterators = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    for (const invalidIterator of invalidIterators) {
+        shouldThrow(function () {
+            Iterator.prototype.forEach.call(invalidIterator);
+        }, TypeError, "Iterator.prototype.forEach requires that |this| be an Object.");
+    }
+}
+
+{
+    const invalidCallbacks = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidCallback of invalidCallbacks) {
+        shouldThrow(function () {
+            Iterator.prototype.forEach.call(validIter, invalidCallback);
+        }, TypeError, "Iterator.prototype.forEach requires the callback argument to be callable.");
+    }
+}
+
+{
+    const iter = {};
+    shouldThrow(function () {
+        Iterator.prototype.forEach.call(iter, () => {});
+    }, TypeError, "Type error");
+}
+
+{
+    const iter = { next() { return 3; }};
+    shouldThrow(function () {
+        Iterator.prototype.forEach.call(iter, () => {});
+    }, TypeError, "Iterator result interface is not an object.")
+}
+
+{
+    class MyError extends Error {}
+    shouldThrow(function() {
+        const validIter = (function* gen() { yield 1; })();
+        validIter.forEach((item, i) => {
+            sameValue(item, 1);
+            sameValue(i, 0);
+            throw new MyError("my error");
+        });
+    }, MyError, "my error");
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -517,66 +517,6 @@ test/built-ins/Iterator/prototype/flatMap/underlying-iterator-closed-in-parallel
 test/built-ins/Iterator/prototype/flatMap/underlying-iterator-closed.js:
   default: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(() => [])', 'iterator.flatMap' is undefined)"
   strict mode: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(() => [])', 'iterator.flatMap' is undefined)"
-test/built-ins/Iterator/prototype/forEach/callable.js:
-  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
-test/built-ins/Iterator/prototype/forEach/fn-args.js:
-  default: "TypeError: iter.forEach is not a function. (In 'iter.forEach((v, count) => {"
-  strict mode: "TypeError: iter.forEach is not a function. (In 'iter.forEach((v, count) => {"
-test/built-ins/Iterator/prototype/forEach/fn-called-for-each-yielded-value.js:
-  default: "TypeError: g().forEach is not a function. (In 'g().forEach((value, count) => {"
-  strict mode: "TypeError: g().forEach is not a function. (In 'g().forEach((value, count) => {"
-test/built-ins/Iterator/prototype/forEach/fn-this.js:
-  default: "TypeError: iter.forEach is not a function. (In 'iter.forEach(function (v, count) {"
-  strict mode: "TypeError: iter.forEach is not a function. (In 'iter.forEach(function (v, count) {"
-test/built-ins/Iterator/prototype/forEach/fn-throws-then-closing-iterator-also-throws.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/forEach/fn-throws.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/forEach/get-next-method-only-once.js:
-  default: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
-  strict mode: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
-test/built-ins/Iterator/prototype/forEach/get-next-method-throws.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/forEach/is-function.js:
-  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
-test/built-ins/Iterator/prototype/forEach/iterator-already-exhausted.js:
-  default: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {"
-  strict mode: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {"
-test/built-ins/Iterator/prototype/forEach/length.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-test/built-ins/Iterator/prototype/forEach/name.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-test/built-ins/Iterator/prototype/forEach/next-method-returns-throwing-done.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/forEach/next-method-returns-throwing-value-done.js:
-  default: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
-  strict mode: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
-test/built-ins/Iterator/prototype/forEach/next-method-returns-throwing-value.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/forEach/next-method-throws.js:
-  default: 'Test262Error: Expected a Test262Error but got a TypeError'
-  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
-test/built-ins/Iterator/prototype/forEach/prop-desc.js:
-  default: 'Test262Error: obj should have an own property forEach'
-  strict mode: 'Test262Error: obj should have an own property forEach'
-test/built-ins/Iterator/prototype/forEach/proto.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.forEach)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.forEach)')"
-test/built-ins/Iterator/prototype/forEach/result-is-undefined.js:
-  default: "TypeError: iter.forEach is not a function. (In 'iter.forEach(() => {})', 'iter.forEach' is undefined)"
-  strict mode: "TypeError: iter.forEach is not a function. (In 'iter.forEach(() => {})', 'iter.forEach' is undefined)"
-test/built-ins/Iterator/prototype/forEach/this-plain-iterator.js:
-  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
 test/built-ins/Iterator/prototype/map/callable.js:
   default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
   strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"


### PR DESCRIPTION
#### 0de8b68389b2ac948056557a94146997abbac0a0
<pre>
[JSC] Implement `Iterator.prototype.forEach` from Iterator Helpers Proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=279501">https://bugs.webkit.org/show_bug.cgi?id=279501</a>

Reviewed by Yusuke Suzuki.

This patch implements `Iterator.prototype.forEach`[1] from Iterator Helpers Proposal[2].

[1]: <a href="https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach">https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach</a>
[2]: <a href="https://github.com/tc39/proposal-iterator-helpers">https://github.com/tc39/proposal-iterator-helpers</a>

* JSTests/stress/iterator-prototype-forEach.js: Added.
(assert):
(sameArray):
(shouldThrow):
(throw.new.Error.Iter.prototype.next):
(throw.new.Error.Iter):
(throw.new.Error):
(sameArray.Iter.prototype.get next):
(sameArray.Iter):
(sameArray.gen):
(const.validIter):
(const.invalidCallback.of.invalidCallbacks.shouldThrow):
(Iterator.prototype.forEach.call):
(const.iter.next):
(MyError):
(shouldThrow.const.validIter):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSIteratorPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/283673@main">https://commits.webkit.org/283673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05d7d7ed574ad197bfe9a2235899a8966c53a671

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18134 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17917 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12200 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16488 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60115 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72737 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66246 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61205 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61280 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14803 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2604 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42183 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15490 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->