### PR TITLE
[GStreamer][WebRTC] Rewrite stats timestamps

### DIFF
--- a/LayoutTests/webrtc/stats-timestamp-increases-expected.txt
+++ b/LayoutTests/webrtc/stats-timestamp-increases-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RTCStats.timestamp increases with time passing
+

--- a/LayoutTests/webrtc/stats-timestamp-increases.html
+++ b/LayoutTests/webrtc/stats-timestamp-increases.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing monotonically increasing WebRTC stats timestamps</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script src ="routines.js"></script>
+        <script>
+         // Get stats object of type that is expected to be
+         // found in the statsReport
+         function getRequiredStats(statsReport, type) {
+             for(const stats of statsReport.values()) {
+                 if(stats.type === type) {
+                     return stats;
+                 }
+             }
+
+             assert_unreached(`required stats of type ${type} is not found in stats report`);
+         }
+
+         promise_test(async t => {
+             const kMinimumTimeElapsedBetweenGetStatsCallsMs = 500;
+             const pc = new RTCPeerConnection();
+             t.add_cleanup(() => pc.close());
+             const t0 = Math.floor(performance.now());
+             const t0Stats = getRequiredStats(await pc.getStats(), 'peer-connection');
+             assert_greater_than(t0Stats.timestamp, window.performance.timeOrigin + window.performance.now() - 100);
+             await new Promise(
+                 r => t.step_timeout(r, kMinimumTimeElapsedBetweenGetStatsCallsMs));
+             const t1Stats = getRequiredStats(await pc.getStats(), 'peer-connection');
+             const t1 = Math.ceil(performance.now());
+             const maximumTimeElapsedBetweenGetStatsCallsMs = t1 - t0;
+             const deltaTimestampMs = t1Stats.timestamp - t0Stats.timestamp;
+             // The delta must be at least the time we waited between calls.
+             assert_greater_than_equal(deltaTimestampMs,
+                                       kMinimumTimeElapsedBetweenGetStatsCallsMs);
+             // The delta must be at most the time elapsed before the first getStats()
+             // call and after the second getStats() call.
+             assert_less_than_equal(deltaTimestampMs,
+                                    maximumTimeElapsedBetweenGetStatsCallsMs);
+         }, `RTCStats.timestamp increases with time passing`);
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -44,7 +44,7 @@ RTCStatsReport::Stats::Stats(Type type, const GstStructure* structure)
     , id(gstStructureGetString(structure, "id"_s).toString())
 {
     if (auto value = gstStructureGet<double>(structure, "timestamp"_s))
-        timestamp = *value;
+        timestamp = Seconds::fromMicroseconds(*value).milliseconds();
 }
 
 RTCStatsReport::RtpStreamStats::RtpStreamStats(Type type, const GstStructure* structure)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -652,6 +652,19 @@ void setSsrcAudioLevelVadOn(GstStructure* structure)
     }
 }
 
+StatsTimestampConverter& StatsTimestampConverter::singleton()
+{
+    static NeverDestroyed<StatsTimestampConverter> sharedInstance;
+    return sharedInstance;
+}
+
+Seconds StatsTimestampConverter::convertFromMonotonicTime(Seconds value) const
+{
+    auto monotonicOffset = value - m_initialMonotonicTime;
+    auto newTimestamp = m_epoch.secondsSinceEpoch() + monotonicOffset;
+    return Performance::reduceTimeResolution(newTimestamp.secondsSinceEpoch());
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -25,6 +25,7 @@
 #include "GUniquePtrGStreamer.h"
 #include "MediaEndpointConfiguration.h"
 #include "PeerConnectionBackend.h"
+#include "Performance.h"
 #include "RTCBundlePolicy.h"
 #include "RTCCertificate.h"
 #include "RTCDtlsTransport.h"
@@ -303,6 +304,23 @@ inline void unmapRtpBuffer(GstBuffer*, GstRTPBuffer* rtpBuffer)
 }
 
 using GstMappedRtpBuffer = GstBufferMapper<GstRTPBuffer, mapRtpBuffer, unmapRtpBuffer>;
+
+class StatsTimestampConverter {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(StatsTimestampConverter);
+    friend NeverDestroyed<StatsTimestampConverter>;
+
+public:
+    static StatsTimestampConverter& singleton();
+
+    Seconds convertFromMonotonicTime(Seconds value) const;
+
+private:
+    explicit StatsTimestampConverter() = default;
+
+    WallTime m_epoch { WallTime::now() };
+    MonotonicTime m_initialMonotonicTime { MonotonicTime::now() };
+};
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### fa7d13583e7fecaeef8209f47ca396e7e026e71d
<pre>
[GStreamer][WebRTC] Rewrite stats timestamps
<a href="https://bugs.webkit.org/show_bug.cgi?id=279508">https://bugs.webkit.org/show_bug.cgi?id=279508</a>

Reviewed by Xabier Rodriguez-Calvar.

The stats provided by webrtcbin are timestamped using the system monotonic time, which is not
exactly following the spec which stipulates that we should use Performance.timeOrigin +
Performance.now(). By applying the monotonic offset to the epoch we can use
Performance::reduceTimeResolution() and get a bit closer to spec compliance.

Covered by a new test, inspired from
imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html that checks the
timestamp remain close to window.performance.timeOrigin + window.performance.now().

* LayoutTests/webrtc/stats-timestamp-increases-expected.txt: Added.
* LayoutTests/webrtc/stats-timestamp-increases.html: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::preprocessStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::Stats::Stats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::StatsTimestampConverter::singleton):
(WebCore::StatsTimestampConverter::convertFromMonotonicTime const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:

Canonical link: <a href="https://commits.webkit.org/283693@main">https://commits.webkit.org/283693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff43da22ef77d8e6c5a79bdec88a3c4a5bed9d0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53386 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11977 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72357 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10610 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57723 "Exiting early after 10 failures. 100 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2326 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41803 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->