### PR TITLE
Continue running the audio unit even if microphone tracks are all muted

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt
@@ -1,6 +1,5 @@
 CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 
-PASS Detection of missing capturing device should not trigger capture to fail if device disappears when track is muted
-PASS Detection of missing capturing device should trigger capture to fail even if device disappears when track is muted and track gets later on unmuted
+PASS Detection of missing capturing device triggers capture to fail even if capture was muted
 

--- a/LayoutTests/fast/mediastream/microphone-change-while-muted.html
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted.html
@@ -44,53 +44,17 @@
             internals.setPageMuted("capturedevices");
 
         await new Promise(resolve => video.srcObject.getAudioTracks()[0].onmute = resolve);
-
-        await new Promise(resolve => setTimeout(resolve, 500));
-        testRunner.removeMockMediaDevice("usbmic");
-
-        await new Promise(resolve => setTimeout(resolve, 500));
         assert_true(video.srcObject.getAudioTracks()[0].muted);
-        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
 
-        testRunner.addMockMicrophoneDevice("usbmic", "my USB microphone");
-
-        if (window.internals)
-            internals.setPageMuted("");
-
-        await new Promise(resolve => video.srcObject.getAudioTracks()[0].onunmute = resolve);
-        await new Promise(resolve => setTimeout(resolve, 500));
-        assert_false(video.srcObject.getAudioTracks()[0].muted);
-        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
-    }, "Detection of missing capturing device should not trigger capture to fail if device disappears when track is muted");
-
-    promise_test(async (test) => {
-        await setup(test);
-
-        testRunner.addMockMicrophoneDevice("usbmic", "my USB microphone");
-
-        const deviceId = await getDeviceId("my USB microphone");
-        video.srcObject = await navigator.mediaDevices.getUserMedia({ audio: { deviceId } });
-        await video.play();
-
-        if (window.internals)
-            internals.setPageMuted("capturedevices");
-
-        await new Promise(resolve => video.srcObject.getAudioTracks()[0].onmute = resolve);
-
-        testRunner.removeMockMediaDevice("usbmic");
-
-        await new Promise(resolve => setTimeout(resolve, 500));
-        assert_true(video.srcObject.getAudioTracks()[0].muted);
-        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
-
-        if (window.internals)
-            internals.setPageMuted("");
-
-        return new Promise((resolve, reject) => {
-            video.srcObject.getAudioTracks()[0].onended = resolve;
-            setTimeout(() => reject("track did not end"), 2000);
+        const promise = new Promise((resolve, reject) => {
+             setTimeout(() => reject("no ended event"), 2000);
+             video.srcObject.getAudioTracks()[0].onended = resolve;
         });
-    }, "Detection of missing capturing device should trigger capture to fail even if device disappears when track is muted and track gets later on unmuted");
+        testRunner.removeMockMediaDevice("usbmic");
+
+        await promise;
+        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "ended");
+    }, "Detection of missing capturing device triggers capture to fail even if capture was muted");
     </script>
 </body>
 </html>

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -129,12 +129,13 @@ protected:
 
     void setVoiceActivityListenerCallback(Function<void()>&& callback) { m_voiceActivityCallback = WTFMove(callback); }
     void voiceActivityDetected();
-    bool isListeningToVoiceActivity() const { return !!m_voiceActivityCallback; }
 
     void disableVoiceActivityThrottleTimerForTesting() { m_voiceActivityThrottleTimer.stop(); }
+    void stopRunning();
 
 private:
     OSStatus startUnit();
+    bool shouldContinueRunning() const { return m_producingCount || m_isRenderingAudio || hasClients(); }
 
     // RealtimeMediaSourceCenterObserver
     void devicesChanged() final;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -580,6 +580,12 @@ OSStatus CoreAudioSharedUnit::reconfigureAudioUnit()
     if (!hasAudioUnit())
         return 0;
 
+    if (!hasClients()) {
+        RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit::reconfigureAudioUnit(%p) stopping since there are no clients", this);
+        stopRunning();
+        return 0;
+    }
+
     m_isReconfiguring = true;
     auto scope = makeScopeExit([this] { m_isReconfiguring = false; });
 


### PR DESCRIPTION
#### f078400396ccb6f110537517333f81594652e74e
<pre>
Continue running the audio unit even if microphone tracks are all muted
<a href="https://rdar.apple.com/135801398">rdar://135801398</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279515">https://bugs.webkit.org/show_bug.cgi?id=279515</a>

Reviewed by Eric Carlson.

For AirPods mute API, we need the audio unit to run so that we can react to unmuting through AirPods.
Similarly for voice detection, we need to continue running the audio unit to get voice detection.

For that reason, we are now always keeping the audio unit running when it has CoreAudioCaptureSource clients,
even though those clients are not requiring to get microphone samples.

We are now running the audio unit if:
- it has clients.
- it has no client but is being used to render audio.

In case of input device disappearing, since we are now continuing to run the audio unit to detect voice detection or get AirPods unmuting,
we can no longer pretend to have muted capture without a device.
For that reason, we are now failing when the device disappears, even if capture is muted.
We update BaseAudioSharedUnit::devicesChanged and LayoutTests/fast/mediastream/microphone-change-while-muted.html accordingly.

Given running the audio unit can consume some CPU, we might want to stop capture for pages that muted microphone tracks and have been idle for some time.
This will be done in a follow-up.

* LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt:
* LayoutTests/fast/mediastream/microphone-change-while-muted.html:
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::removeClient):
(WebCore::BaseAudioSharedUnit::devicesChanged):
(WebCore::BaseAudioSharedUnit::captureFailed):
(WebCore::BaseAudioSharedUnit::stopProducingData):
(WebCore::BaseAudioSharedUnit::setIsRenderingAudio):
(WebCore::BaseAudioSharedUnit::stopRunning):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::shouldContinueRunning const):
(WebCore::BaseAudioSharedUnit::isListeningToVoiceActivity const): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::reconfigureAudioUnit):

Canonical link: <a href="https://commits.webkit.org/283755@main">https://commits.webkit.org/283755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98b3882238cd9ca660dd941b98fe74e3d16c819f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53403 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11996 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15072 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14790 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60735 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-fill.html imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child-abspos.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2354 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41832 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->