### PR TITLE
[css-transitions] `getKeyframes()` returns the same values for "from" and "to" with a custom property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes.tentative-expected.txt
@@ -3,4 +3,5 @@ PASS KeyframeEffect.getKeyframes() returns expected frames for a simple transiti
 PASS KeyframeEffect.getKeyframes() returns frames unaffected by a non-default easing function
 PASS KeyframeEffect.getKeyframes() returns expected frames for a transition with a CSS variable endpoint
 PASS KeyframeEffect.getKeyframes() returns expected frames for a transition after resetting the effect target
+PASS KeyframeEffect.getKeyframes() returns expected frames for a custom property transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes.tentative.html
@@ -166,4 +166,38 @@ test(t => {
 }, 'KeyframeEffect.getKeyframes() returns expected frames for a'
    + ' transition after resetting the effect target');
 
+test(t => {
+  const div = addDiv(t);
+
+  div.style.transition = '--foo 100s allow-discrete';
+  div.style.setProperty("--foo", "10");
+  getComputedStyle(div).getPropertyValue("--foo");
+  div.style.setProperty("--foo", "20");
+
+  const frames = getKeyframes(div);
+
+  assert_equals(frames.length, 2, 'number of frames');
+
+  const expected = [
+    { offset: 0,
+      computedOffset: 0,
+      easing: 'linear',
+      composite: 'auto',
+      "--foo": '10',
+    },
+    {
+      offset: 1,
+      computedOffset: 1,
+      easing: 'linear',
+      composite: 'auto',
+      "--foo": '20',
+    },
+  ];
+
+  for (let i = 0; i < frames.length; i++) {
+    assert_frames_equal(frames[i], expected[i], `ComputedKeyframe #${i}`);
+  }
+}, 'KeyframeEffect.getKeyframes() returns expected frames for a custom'
+      + ' property transition');
+
 </script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -802,7 +802,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
                 }
             }
             if (styleString.isEmpty()) {
-                if (auto cssValue = computedStyleExtractor.customPropertyValue(customProperty))
+                if (auto* cssValue = style.customPropertyValue(customProperty))
                     styleString = cssValue->cssText();
             }
             computedKeyframe.customStyleStrings.set(customProperty, styleString);


### PR DESCRIPTION
#### cd5cb94159722ad679077c4d11b48f9234ba65ad
<pre>
[css-transitions] `getKeyframes()` returns the same values for &quot;from&quot; and &quot;to&quot; with a custom property
<a href="https://bugs.webkit.org/show_bug.cgi?id=279514">https://bugs.webkit.org/show_bug.cgi?id=279514</a>
<a href="https://rdar.apple.com/135802510">rdar://135802510</a>

Reviewed by Antti Koivisto.

We need to read the custom property from the keyframe&apos;s style, not the current computed style of the target element.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes.tentative.html:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):

Canonical link: <a href="https://commits.webkit.org/283485@main">https://commits.webkit.org/283485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88823adbe21819ba528549f913b5140eecd8b298

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70460 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/17560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53278 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/17560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14886 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15913 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14605 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60918 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2179 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10063 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->