### PR TITLE
[css-transitions] `transition-behavior: allow-discrete` may not start a transition for a custom property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete-expected.txt
@@ -1,3 +1,4 @@
 
 PASS It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete"
+PASS It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete" when setting "transition-property" in the style change that yields the transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete.html
@@ -36,6 +36,26 @@ promise_test(async t => {
 
   assert_equals(transitionCount, 1, 'A single "transitionstart" event was dispatched');
 }, 'It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete"');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.setProperty('--foo', 'bar');
+
+  let transitionCount = 0;
+  div.addEventListener("transitionstart", () => transitionCount++);
+
+  // Wait one frame and set the custom property to trigger a transition.
+  await waitForFrame();
+  div.style.transition = "--foo 10s allow-discrete";
+  div.style.setProperty('--foo', 'baz');
+
+  // Wait two more frames to allow that transition to start and to ensure
+  // only a single transition was started.
+  await waitForFrame();
+  await waitForFrame();
+
+  assert_equals(transitionCount, 1, 'A single "transitionstart" event was dispatched');
+}, 'It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete" when setting "transition-property" in the style change that yields the transition');
 </script>
 </body>
 </html>

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -825,7 +825,6 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
                 addProperty(property);
         }
 
-        transitionCustomProperties.clear();
         auto gatherAnimatableCustomProperties = [&](const StyleCustomPropertyData& customPropertyData) {
             if (!customPropertyData.mayHaveAnimatableProperties())
                 return;


### PR DESCRIPTION
#### ca687c87a08016d042679fecc6536d3ec8f7175c
<pre>
[css-transitions] `transition-behavior: allow-discrete` may not start a transition for a custom property
<a href="https://bugs.webkit.org/show_bug.cgi?id=279516">https://bugs.webkit.org/show_bug.cgi?id=279516</a>
<a href="https://rdar.apple.com/135805387">rdar://135805387</a>

Reviewed by Antti Koivisto.

When updating CSS Transitions for a target, we look at the previous style and the new style and compile
properties based on the `transition-property` value in both styles. If we encounter `all` we enter a specific
branch in `Styleable::updateCSSTransitions()` where we compile all properties that may have changed between
the two styles.

When we initially gather properties, any custom properties that is explicitly set via `transition-property` is
stored in a `transitionCustomProperties` hash.

In the case of custom properties, we have check in place to see if a given `StyleCustomPropertyData` object
has any animatable property to return early. This means that non-registered custom properties will be ignored.

But what goes wrong is that we previously would clear `transitionCustomProperties` if we&apos;re dealing with an `all`
case. This means that if `transition-property` was set to `all` for any of the styles being processed, any
non-registered custom property was ignored, even if it was explicitly set via `transition-property`.

We can simply remove the code that clears this hash.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/custom-property-and-allow-discrete.html:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/283498@main">https://commits.webkit.org/283498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba940c31b1bb3e6f6dc66539ec6aeb8b4e267332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53286 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15925 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72175 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60612 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60927 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2187 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10069 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41621 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->