### PR TITLE
Prefer CFDataCreateMutable over [[NSMutableData alloc] init] followed by a cast

### DIFF
--- a/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
+++ b/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
@@ -42,9 +42,9 @@ using namespace WebCore;
 
 static std::optional<String> getBase64EncodedPNGData(const RetainPtr<CGImageRef>&& cgImage)
 {
-    RetainPtr<NSMutableData> imageData = adoptNS([[NSMutableData alloc] init]);
+    auto imageData = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, 0));
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr<CGImageDestinationRef> destination = adoptCF(CGImageDestinationCreateWithData((CFMutableDataRef)imageData.get(), kUTTypePNG, 1, 0));
+    RetainPtr<CGImageDestinationRef> destination = adoptCF(CGImageDestinationCreateWithData(imageData.get(), kUTTypePNG, 1, 0));
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (!destination)
         return std::nullopt;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
@@ -46,8 +46,8 @@ static void emptyReleaseInfoCallback(void*)
 
 static RetainPtr<NSData> createPDFWithLinkToURL(NSURL *url)
 {
-    auto pdfData = adoptNS([[NSMutableData alloc] init]);
-    
+    auto pdfData = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, 0));
+
     CGDataConsumerCallbacks callbacks;
     callbacks.putBytes = (CGDataConsumerPutBytesCallback)putPDFBytesCallback;
     callbacks.releaseConsumer = (CGDataConsumerReleaseInfoCallback)emptyReleaseInfoCallback;


### PR DESCRIPTION
<pre>Prefer CFDataCreateMutable over [[NSMutableData alloc] init] followed by a cast
https://bugs.webkit.org/show_bug.cgi?id=279528

Reviewed by NOBODY (OOPS!).

Creating an NSMutableArray and only to use it as casted to
CFMutableArrayRef is uglier than just making a CFMutableData object and
releasing that when done.

* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
  (WebKit::getBase64EncodedPNGData): Switch to CFDataCreateMutable.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm:
  (createPDFWithLinkToURL): Ditto.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/180fefd2a0d5f84552a6b1051947117e411c906a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66535 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45910 "Hash 180fefd2 for PR 33478 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19156 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70568 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68653 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53709 "Hash 180fefd2 for PR 33478 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17428 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53323 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/11917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69602 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/53709 "Hash 180fefd2 for PR 33478 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/19156 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33983 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/53709 "Hash 180fefd2 for PR 33478 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/19156 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16022 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/53709 "Hash 180fefd2 for PR 33478 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/19156 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72271 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/10492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/17428 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60653 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/10524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/19156 "Hash 180fefd2 for PR 33478 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60975 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/19156 "Hash 180fefd2 for PR 33478 does not build (failure)") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42537 "Hash 180fefd2 for PR 33478 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->