### PR TITLE
Deploy more smart pointers in GPUProcess and NetworkProcess code

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModuleCompilationHint.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModuleCompilationHint.h
@@ -25,12 +25,16 @@
 
 #pragma once
 
+#include "WebGPUPipelineLayout.h"
+#include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
+
 namespace WebCore::WebGPU {
 
-class WebGPUPipelineLayout;
-
 struct ShaderModuleCompilationHint {
-    PipelineLayout& pipelineLayout;
+    WeakRef<PipelineLayout> pipelineLayout;
+
+    Ref<PipelineLayout> protectedPipelineLayout() const { return pipelineLayout.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
@@ -56,6 +56,11 @@ RemoteXRProjectionLayer::RemoteXRProjectionLayer(WebCore::WebGPU::XRProjectionLa
 
 RemoteXRProjectionLayer::~RemoteXRProjectionLayer() = default;
 
+Ref<WebCore::WebGPU::XRProjectionLayer> RemoteXRProjectionLayer::protectedBacking()
+{
+    return m_backing;
+}
+
 Ref<IPC::StreamServerConnection> RemoteXRProjectionLayer::protectedStreamConnection()
 {
     return m_streamConnection;
@@ -82,7 +87,7 @@ void RemoteXRProjectionLayer::destruct()
 #if PLATFORM(COCOA)
 void RemoteXRProjectionLayer::startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex)
 {
-    m_backing->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex);
+    protectedBacking()->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -93,6 +93,7 @@ private:
     RemoteXRProjectionLayer& operator=(const RemoteXRProjectionLayer&) = delete;
     RemoteXRProjectionLayer& operator=(RemoteXRProjectionLayer&&) = delete;
 
+    Ref<WebCore::WebGPU::XRProjectionLayer> protectedBacking();
     Ref<IPC::StreamServerConnection> protectedStreamConnection();
     Ref<RemoteGPU> protectedGPU() const;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
@@ -88,9 +88,11 @@ private:
     RemoteXRSubImage& operator=(const RemoteXRSubImage&) = delete;
     RemoteXRSubImage& operator=(RemoteXRSubImage&&) = delete;
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection();
-
     WebCore::WebGPU::XRSubImage& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::XRSubImage> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+    Ref<RemoteGPU> protectedGPU() const;
 
     RefPtr<IPC::Connection> connection() const;
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -339,4 +339,9 @@ String NetworkLoad::attributedBundleIdentifier(WebPageProxyIdentifier pageID)
     return { };
 }
 
+RefPtr<NetworkDataTask> NetworkLoad::protectedTask()
+{
+    return m_task;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -75,7 +75,7 @@ public:
     void setPendingDownloadID(DownloadID);
     void setSuggestedFilename(const String&);
     void setPendingDownload(PendingDownload&);
-    std::optional<DownloadID> pendingDownloadID() { return m_task->pendingDownloadID(); }
+    std::optional<DownloadID> pendingDownloadID() { return protectedTask()->pendingDownloadID(); }
 
     bool shouldCaptureExtraNetworkLoadMetrics() const final;
 
@@ -98,6 +98,8 @@ private:
     void wasBlockedByRestrictions() final;
     void wasBlockedByDisabledFTP() final;
     void didNegotiateModernTLS(const URL&) final;
+
+    RefPtr<NetworkDataTask> protectedTask();
 
     void notifyDidReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -375,6 +375,11 @@ void NetworkRTCProvider::signalSocketIsClosed(LibWebRTCSocketIdentifier identifi
     m_connection->connection().send(Messages::LibWebRTCNetwork::SignalClose(identifier, 1), 0);
 }
 
+Ref<NetworkRTCMonitor> NetworkRTCProvider::protectedRTCMonitor()
+{
+    return m_rtcMonitor;
+}
+
 #undef RTC_RELEASE_LOG
 #undef RTC_RELEASE_LOG_ERROR
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -93,7 +93,7 @@ public:
     }
     ~NetworkRTCProvider();
 
-    void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { m_rtcMonitor.didReceiveMessage(connection, decoder); }
+    void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { protectedRTCMonitor()->didReceiveMessage(connection, decoder); }
 
     class Socket {
     public:
@@ -156,6 +156,8 @@ private:
     void signalSocketIsClosed(WebCore::LibWebRTCSocketIdentifier);
 
     void assertIsRTCNetworkThread();
+
+    Ref<NetworkRTCMonitor> protectedRTCMonitor();
 
     static constexpr size_t maxSockets { 256 };
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<ShaderModuleCompilationHint> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ShaderModuleCompilationHint& shaderModuleCompilationHint)
 {
-    WebGPUIdentifier pipelineLayout = convertToBacking(shaderModuleCompilationHint.pipelineLayout);
+    WebGPUIdentifier pipelineLayout = convertToBacking(shaderModuleCompilationHint.protectedPipelineLayout());
     if (!pipelineLayout)
         return std::nullopt;
 


### PR DESCRIPTION
#### 2c1777e4f7835d4a802b33ccf99521a837bf6d41
<pre>
Deploy more smart pointers in GPUProcess and NetworkProcess code
<a href="https://bugs.webkit.org/show_bug.cgi?id=279530">https://bugs.webkit.org/show_bug.cgi?id=279530</a>

Reviewed by Chris Dumez and Mike Wyrzykowski.

Deployed more smart pointers in the code as warned by the clang static analyzer.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModuleCompilationHint.h:
(WebCore::WebGPU::ShaderModuleCompilationHint::protectedPipelineLayout const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp:
(WebKit::RemoteXRProjectionLayer::protectedBacking):
(WebKit::RemoteXRProjectionLayer::startFrame):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp:
(WebKit::RemoteXRSubImage::protectedBacking):
(WebKit::RemoteXRSubImage::protectedGPU const):
(WebKit::RemoteXRSubImage::connection const):
(WebKit::RemoteXRSubImage::getColorTexture):
(WebKit::RemoteXRSubImage::getDepthTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h:
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::protectedTask):
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::protectedRTCMonitor):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
(WebKit::NetworkRTCProvider::didReceiveNetworkRTCMonitorMessage):
* Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):

Canonical link: <a href="https://commits.webkit.org/283508@main">https://commits.webkit.org/283508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0993dc11253a2313231891cafe22ea7539476e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53305 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11899 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14651 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57617 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2228 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10078 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->