### PR TITLE
Use CGDataConsumerRelease and CGPDFContextRelease to release CGDataConsumerRef and CGContextRef respectively

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -127,8 +127,9 @@ static bool encode(CGImageRef image, const String& mimeType, std::optional<doubl
         nullptr
     };
 
-    auto consumer = adoptCF(CGDataConsumerCreate(const_cast<ScopedLambda<PutBytesCallback>*>(&function), &callbacks));
-    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer.get(), destinationUTI.get(), 1, nullptr));
+    CGDataConsumerRef consumer = CGDataConsumerCreate(const_cast<ScopedLambda<PutBytesCallback>*>(&function), &callbacks);
+    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer, destinationUTI.get(), 1, nullptr));
+    CGDataConsumerRelease(consumer);
     
     auto imageProperties = imagePropertiesForDestinationUTIAndQuality(destinationUTI.get(), quality);
     CGImageDestinationAddImage(destination.get(), image, imageProperties.get());
@@ -212,8 +213,9 @@ static bool encode(std::span<const uint8_t> data, const String& mimeType, std::o
         nullptr
     };
 
-    auto consumer = adoptCF(CGDataConsumerCreate(const_cast<ScopedLambda<PutBytesCallback>*>(&function), &callbacks));
-    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer.get(), destinationUTI.get(), 1, nullptr));
+    CGDataConsumerRef consumer = CGDataConsumerCreate(const_cast<ScopedLambda<PutBytesCallback>*>(&function), &callbacks);
+    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer, destinationUTI.get(), 1, nullptr));
+    CGDataConsumerRelease(consumer);
 
     auto imageProperties = imagePropertiesForDestinationUTIAndQuality(destinationUTI.get(), quality);
     CGImageDestinationAddImageFromSource(destination.get(), source.get(), 0, nullptr);

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -82,8 +82,9 @@ static String transcodeImage(const String& path, const String& destinationUTI, c
         nullptr
     };
 
-    auto consumer = adoptCF(CGDataConsumerCreate(&destinationFileHandle, &callbacks));
-    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer.get(), destinationUTI.createCFString().get(), 1, nullptr));
+    CGDataConsumerRef consumer = CGDataConsumerCreate(&destinationFileHandle, &callbacks);
+    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer, destinationUTI.createCFString().get(), 1, nullptr));
+    CGDataConsumerRelease(consumer);
 
     CGImageDestinationAddImageFromSource(destination.get(), source.get(), 0, nullptr);
 

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -442,14 +442,15 @@ static size_t putBytesNowhere(void*, const void*, size_t count)
 static RetainPtr<CGContextRef> createScratchContext()
 {
     CGDataConsumerCallbacks callbacks = { putBytesNowhere, 0 };
-    auto consumer = adoptCF(CGDataConsumerCreate(0, &callbacks));
-    auto context = adoptCF(CGPDFContextCreate(consumer.get(), 0, 0));
+    CGDataConsumerRef consumer = CGDataConsumerCreate(0, &callbacks);
+    CGContextRef context = CGPDFContextCreate(consumer.get(), 0, 0);
+    CGDataConsumerRelease(consumer);
 
     CGFloat black[4] = { 0, 0, 0, 1 };
-    CGContextSetFillColor(context.get(), black);
-    CGContextSetStrokeColor(context.get(), black);
+    CGContextSetFillColor(context, black);
+    CGContextSetStrokeColor(context, black);
 
-    return context;
+    return adoptCF(context);
 }
 
 static inline CGContextRef scratchContext()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
@@ -51,10 +51,11 @@ static RetainPtr<NSData> createPDFWithLinkToURL(NSURL *url)
     CGDataConsumerCallbacks callbacks;
     callbacks.putBytes = (CGDataConsumerPutBytesCallback)putPDFBytesCallback;
     callbacks.releaseConsumer = (CGDataConsumerReleaseInfoCallback)emptyReleaseInfoCallback;
-    auto consumer = adoptCF(CGDataConsumerCreate(pdfData.get(), &callbacks));
+    CGDataConsumerRef consumer = CGDataConsumerCreate(pdfData.get(), &callbacks);
     auto contextDictionary = adoptCF(CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CGRect rectangle = CGRectMake(0, 0, 1000, 1000);
-    auto pdfContext = adoptCF(CGPDFContextCreate(consumer.get(), &rectangle, contextDictionary.get()));
+    auto pdfContext = adoptCF(CGPDFContextCreate(consumer, &rectangle, contextDictionary.get()));
+    CGDataConsumerRelease(pdfDataConsumer);
 
     auto pageDictionary = adoptCF(CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto boxData = adoptCF(CFDataCreate(NULL, (const UInt8 *)&rectangle, sizeof(CGRect)));


### PR DESCRIPTION
<pre>Use CGDataConsumerRelease and CGPDFContextRelease to release CGDataConsumerRef and CGContextRef respectively
https://bugs.webkit.org/show_bug.cgi?id=279533

Reviewed by NOBODY (OOPS!).

These types do not use CFRelease. They use unique functions to release
their memory, and we should use them as that is proper.

* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode): Use CGDataConsumerRelease and CGPDFContextRelease.
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::transcodeImage): Ditto.
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::createScratchContext): Ditto.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::pdfSnapshotAtSize): Ditto.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawPagesToPDFImpl): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm:
(createPDFWithLinkToURL): Ditto.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/530273f202be4be995050e4a376c7fdccdabe1a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66497 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45872 "Hash 530273f2 for PR 33482 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/19118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70530 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/17630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68615 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/53671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/17390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/17630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69564 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/53671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/19118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33966 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/53671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/19118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/15983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/53671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/19118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72233 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/10454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/17390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/10486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/19118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/19118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/43939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/42499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->