### PR TITLE
[UIProcess] Use UITextCell's configuation variable to manage data

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -1155,20 +1155,25 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     [tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:NO];
 
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    UIListContentConfiguration *config = [cell defaultContentConfiguration];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // FIXME: <rdar://131638865> UITableViewCell.textLabel is deprecated.
     if (!cell.textLabel.enabled)
         return;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     auto option = [self optionItemAtIndexPath:indexPath];
     if (!option)
         return;
 
     if (!option->isSelected)
-        cell.imageView.image = [UIImage systemImageNamed:@"checkmark.circle.fill"];
-    else
-        cell.imageView.image = [[UIImage systemImageNamed:@"circle"] imageWithTintColor:UIColor.tertiaryLabelColor renderingMode:UIImageRenderingModeAlwaysOriginal];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        content.image = [UIImage systemImageNamed:@"checkmark.circle.fill"];
+    else {
+        content.image = [UIImage systemImageNamed:@"circle"];
+        content.imageProperties.tintColor = UIColor.tertiaryLabelColor;
+    }
+
+    cell.contentConfiguration = config;
 
     [_contentView updateFocusedElementSelectedIndex:[self findItemIndexAt:indexPath] allowsMultipleSelection:true];
     option->isSelected = !option->isSelected;


### PR DESCRIPTION
<pre>[UIProcess] Use UITextCell's configuation variable to manage data
https://bugs.webkit.org/show_bug.cgi?id=279536

Reviewed by NOBODY (OOPS!).

Do not manage the data directly.

* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm: (-[WKSelectPickerTableViewController tableView:didSelectRowAtIndexPath:]): Use configuration to manage data.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec0f3d2660e176ac75eb85f7585a30821252f68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66499 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45874 "Hash bec0f3d2 for PR 33485 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70532 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17632 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53673 "Hash bec0f3d2 for PR 33485 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53309 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11904 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69566 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/53673 "Hash bec0f3d2 for PR 33485 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33967 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/53673 "Hash bec0f3d2 for PR 33485 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15985 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/53673 "Hash bec0f3d2 for PR 33485 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72235 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10456 "Hash bec0f3d2 for PR 33485 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60637 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10488 "Hash bec0f3d2 for PR 33485 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60974 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2236 "Passed tests") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41681 "Hash bec0f3d2 for PR 33485 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42758 "Hash bec0f3d2 for PR 33485 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43941 "Hash bec0f3d2 for PR 33485 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42501 "Hash bec0f3d2 for PR 33485 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->