### PR TITLE
Infrastructure changes necessary for fractional touch events

### DIFF
--- a/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll-expected.txt
+++ b/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll-expected.txt
@@ -5,10 +5,10 @@ PASS event.touches[0].pageX is 100
 PASS event.touches[0].pageY is 100
 
 Just zoomed
-PASS event.touches[0].clientX is 83
-PASS event.touches[0].clientY is 83
-PASS event.touches[0].pageX is 83
-PASS event.touches[0].pageY is 83
+PASS event.touches[0].clientX is within 0.00001 of 83.33333
+PASS event.touches[0].clientY is within 0.00001 of 83.33333
+PASS event.touches[0].pageX is within 0.00001 of 83.33333
+PASS event.touches[0].pageY is within 0.00001 of 83.33333
 
 Just scrolled
 PASS event.touches[0].clientX is 100
@@ -17,10 +17,10 @@ PASS event.touches[0].pageX is 150
 PASS event.touches[0].pageY is 150
 
 Zoomed and scrolled
-PASS event.touches[0].clientX is 84
-PASS event.touches[0].clientY is 84
-PASS event.touches[0].pageX is 133
-PASS event.touches[0].pageY is 133
+PASS event.touches[0].clientX is within 0.00001 of 83.33333
+PASS event.touches[0].clientY is within 0.00001 of 83.33333
+PASS event.touches[0].pageX is within 0.00001 of 133.33333
+PASS event.touches[0].pageY is within 0.00001 of 133.33333
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html
+++ b/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html
@@ -67,10 +67,10 @@
     {
         event = e;
         debug("\nJust zoomed");
-        shouldBe("event.touches[0].clientX", "83");
-        shouldBe("event.touches[0].clientY", "83");
-        shouldBe("event.touches[0].pageX", "83");
-        shouldBe("event.touches[0].pageY", "83");
+        shouldBeCloseTo("event.touches[0].clientX", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].clientY", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageX", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageY", 83.33333, floatPrecision);
     }
     window.addEventListener("touchstart", justZoomed, false);
     zoomPageIn();
@@ -99,10 +99,10 @@
     {
         event = e;
         debug("\nZoomed and scrolled");
-        shouldBe("event.touches[0].clientX", "84");
-        shouldBe("event.touches[0].clientY", "84");
-        shouldBe("event.touches[0].pageX", "133");
-        shouldBe("event.touches[0].pageY", "133");
+        shouldBeCloseTo("event.touches[0].clientX", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].clientY", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageX", 133.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageY", 133.33333, floatPrecision);
     }
     window.addEventListener("touchstart", zoomedAndScrolled, false);
     zoomPageIn();

--- a/LayoutTests/fast/events/touch/touch-fractional-coordinates.html
+++ b/LayoutTests/fast/events/touch/touch-fractional-coordinates.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<script src='../../../resources/js-test.js'></script>
+<style>
+#spacer {
+  height: 1000px;
+  width: 1000px;
+}
+iframe {
+  width: 100px;
+  height: 100px;
+  border: 0;
+}
+#rotatedFrame {
+  transform: rotate(180deg);
+}
+#scaledFrame {
+  transform: scale(2);
+  width: 50px;
+  height: 50px;
+  margin-left: 50px;
+  margin-bottom: 20px;
+}
+#container {
+  /* Want this at a stable place across platforms so the output co-ords are stable */
+  position: absolute;
+  top: 100px;
+  left: 10px;
+}
+#console {
+  margin-top: 200px;
+}
+</style>
+<p id='description'></p>
+<div id='container'>
+  <iframe id=simpleFrame src='resources/frame-touchevent-forwarder.html'></iframe>
+  <iframe id=rotatedFrame src='resources/frame-touchevent-forwarder.html'></iframe>
+  <iframe id=scaledFrame src='resources/frame-touchevent-forwarder.html'></iframe>
+</div>
+<div id='console'></div>
+<div id='spacer'></div>
+<script>
+    description('Tests non-integer TouchEvent co-ordinates and radii');
+
+    var scrollX = 3;
+    var scrollY = 10;
+    scrollTo(scrollX, scrollY);
+
+    eventCount = 0;
+    function onTouchStart(e) {
+        eventCount++;
+        lastEvent = e;
+    }
+    function expectEvent(eventName) {
+        shouldBeEqualToNumber('eventCount', 1);
+        var origEventCount = eventCount;
+        eventCount = 0;
+        if (origEventCount > 0) {
+            shouldBeEqualToString('lastEvent.type', eventName);
+            return true;
+        }
+        return false;
+    }
+
+    document.addEventListener('touchstart', onTouchStart);
+    var floatPrecision = 0.00001;
+
+    function runTest() {
+        if (!eventSender) {
+            debug('This test requires eventSender.');
+            return;
+        }
+
+        debug('Testing simple fractional touch');
+        eventSender.addTouchPoint(30.33, 4.5, 5.2, 6.3);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', 30.33, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 30.33, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 30.33 + scrollX, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 4.5 + scrollY, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].radiusX', 5.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].radiusY', 6.3, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+
+        debug('Testing fractional touch inside simple iframe');
+        frameRect = document.getElementById('simpleFrame').getBoundingClientRect();
+        eventSender.addTouchPoint(frameRect.left + 4.5, frameRect.top + 2.2);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', frameRect.left + 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', frameRect.top + 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 2.2, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+
+        debug('Testing fractional touch inside rotated iframe');
+        frameRect = document.getElementById('rotatedFrame').getBoundingClientRect();
+        eventSender.addTouchPoint(frameRect.left + 4.5, frameRect.top + 2.2);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', frameRect.left + 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', frameRect.top + 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 100 - 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 100 - 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 100 - 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 100 - 2.2, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+
+        debug('Testing fractional touch inside scaled iframe');
+        frameRect = document.getElementById('scaledFrame').getBoundingClientRect();
+        eventSender.addTouchPoint(frameRect.left + 4.5, frameRect.top + 2.2);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', frameRect.left + 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', frameRect.top + 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 4.5 / 2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 2.2 / 2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 4.5 / 2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 2.2 / 2, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+    }
+
+    addEventListener('load', runTest);
+</script>

--- a/Source/WebCore/dom/Document+Touch.idl
+++ b/Source/WebCore/dom/Document+Touch.idl
@@ -25,8 +25,8 @@
     // FIXME: This has been dropped from the standard now that Touch has a constructor.
     [NewObject] Touch createTouch(optional WindowProxy? window = null, optional EventTarget? target = null,
         optional long identifier = 0,
-        optional long pageX = 0, optional long pageY = 0, optional long screenX = 0, optional long screenY = 0,
-        optional long webkitRadiusX = 0, optional long webkitRadiusY = 0,
+        optional double pageX = 0, optional double pageY = 0, optional double screenX = 0, optional double screenY = 0,
+        optional double webkitRadiusX = 0, optional double webkitRadiusY = 0,
         optional unrestricted float webkitRotationAngle = NaN, optional unrestricted float webkitForce = NaN);
     [NewObject] TouchList createTouchList(Touch... touches);
 };

--- a/Source/WebCore/dom/DocumentTouch.h
+++ b/Source/WebCore/dom/DocumentTouch.h
@@ -43,7 +43,7 @@ class WindowProxy;
 
 class DocumentTouch {
 public:
-    static Ref<Touch> createTouch(Document&, RefPtr<WindowProxy>&&, EventTarget*, int identifier, int pageX, int pageY, int screenX, int screenY, int radiusX, int radiusY, float rotationAngle, float force);
+    static Ref<Touch> createTouch(Document&, RefPtr<WindowProxy>&&, EventTarget*, int identifier, double pageX, double pageY, double screenX, double screenY, double radiusX, double radiusY, float rotationAngle, float force);
     static Ref<TouchList> createTouchList(Document&, FixedVector<std::reference_wrapper<Touch>>&&);
 };
 

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -95,9 +95,9 @@ public:
     static Ref<PointerEvent> create(const AtomString& type, PointerID, const String& pointerType, IsPrimary = IsPrimary::No);
 
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
-    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble, IsCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta = { });
-    static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const FloatPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble, IsCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const FloatPoint& touchDelta = { });
 #endif
 
     virtual ~PointerEvent();
@@ -174,7 +174,7 @@ private:
     PointerEvent(const AtomString&, Init&&, IsTrusted);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    PointerEvent(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    PointerEvent(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const FloatPoint& touchDelta = { });
 #endif
 
     PointerID m_pointerId { mousePointerID };

--- a/Source/WebCore/dom/Touch.cpp
+++ b/Source/WebCore/dom/Touch.cpp
@@ -29,68 +29,52 @@
 
 #include "Touch.h"
 
+#include "FloatPoint.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 
 namespace WebCore {
 
-static int contentsX(LocalFrame* frame)
+static FloatPoint contentsOffset(LocalFrame* frame)
 {
     if (!frame)
-        return 0;
+        return { };
     auto* frameView = frame->view();
     if (!frameView)
-        return 0;
-    return frameView->scrollX() / frame->pageZoomFactor() / frame->frameScaleFactor();
+        return { };
+    float scale = 1.0f / frame->pageZoomFactor();
+    return { frameView->scrollPosition() }.scaled(scale);
 }
 
-static int contentsY(LocalFrame* frame)
+static LayoutPoint scaledLocation(LocalFrame* frame, const FloatPoint& pagePosition)
 {
     if (!frame)
-        return 0;
-    auto* frameView = frame->view();
-    if (!frameView)
-        return 0;
-    return frameView->scrollY() / frame->pageZoomFactor() / frame->frameScaleFactor();
-}
-
-static LayoutPoint scaledLocation(LocalFrame* frame, int pageX, int pageY)
-{
-    if (!frame)
-        return { pageX, pageY };
+        return { pagePosition };
     float scaleFactor = frame->pageZoomFactor() * frame->frameScaleFactor();
-    return { pageX * scaleFactor, pageY * scaleFactor };
+    return pagePosition.scaled(scaleFactor);
 }
 
-Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force)
+Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, const FloatPoint& screenPosition, const FloatPoint& pagePosition, const FloatSize& radius, float rotationAngle, float force)
     : m_target(target)
     , m_identifier(identifier)
-    , m_clientX(pageX - contentsX(frame))
-    , m_clientY(pageY - contentsY(frame))
-    , m_screenX(screenX)
-    , m_screenY(screenY)
-    , m_pageX(pageX)
-    , m_pageY(pageY)
-    , m_radiusX(radiusX)
-    , m_radiusY(radiusY)
+    , m_clientPosition(pagePosition - contentsOffset(frame))
+    , m_screenPosition(screenPosition)
+    , m_pagePosition(pagePosition)
+    , m_radius(radius)
     , m_rotationAngle(rotationAngle)
     , m_force(force)
-    , m_absoluteLocation(scaledLocation(frame, pageX, pageY))
+    , m_absoluteLocation(scaledLocation(frame, pagePosition))
 {
 }
 
-Touch::Touch(EventTarget* target, int identifier, int clientX, int clientY, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation)
+Touch::Touch(EventTarget* target, int identifier, const FloatPoint& clientPosition, const FloatPoint& screenPosition, const FloatPoint& pagePosition, const FloatSize& radius, float rotationAngle, float force, LayoutPoint absoluteLocation)
     : m_target(target)
     , m_identifier(identifier)
-    , m_clientX(clientX)
-    , m_clientY(clientY)
-    , m_screenX(screenX)
-    , m_screenY(screenY)
-    , m_pageX(pageX)
-    , m_pageY(pageY)
-    , m_radiusX(radiusX)
-    , m_radiusY(radiusY)
+    , m_clientPosition(clientPosition)
+    , m_screenPosition(screenPosition)
+    , m_pagePosition(pagePosition)
+    , m_radius(radius)
     , m_rotationAngle(rotationAngle)
     , m_force(force)
     , m_absoluteLocation(absoluteLocation)
@@ -99,7 +83,7 @@ Touch::Touch(EventTarget* target, int identifier, int clientX, int clientY, int 
 
 Ref<Touch> Touch::cloneWithNewTarget(EventTarget* eventTarget) const
 {
-    return adoptRef(*new Touch(eventTarget, m_identifier, m_clientX, m_clientY, m_screenX, m_screenY, m_pageX, m_pageY, m_radiusX, m_radiusY, m_rotationAngle, m_force, m_absoluteLocation));
+    return adoptRef(*new Touch(eventTarget, m_identifier, m_clientPosition, m_screenPosition, m_pagePosition, m_radius, m_rotationAngle, m_force, m_absoluteLocation));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Touch.h
+++ b/Source/WebCore/dom/Touch.h
@@ -30,6 +30,8 @@
 #elif ENABLE(TOUCH_EVENTS)
 
 #include "EventTarget.h"
+#include "FloatPoint.h"
+#include "FloatSize.h"
 #include "LayoutPoint.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -41,23 +43,23 @@ class LocalFrame;
 class Touch : public RefCounted<Touch> {
 public:
     static Ref<Touch> create(LocalFrame* frame, EventTarget* target,
-            int identifier, int screenX, int screenY, int pageX, int pageY,
-            int radiusX, int radiusY, float rotationAngle, float force)
+        int identifier, const FloatPoint& screenPosition, const FloatPoint& pagePosition,
+        const FloatSize& radius, float rotationAngle, float force)
     {
-        return adoptRef(*new Touch(frame, target, identifier, screenX, 
-                screenY, pageX, pageY, radiusX, radiusY, rotationAngle, force));
+        return adoptRef(
+            *new Touch(frame, target, identifier, screenPosition, pagePosition, radius, rotationAngle, force));
     }
 
     EventTarget* target() const { return m_target.get(); }
     int identifier() const { return m_identifier; }
-    int clientX() const { return m_clientX; }
-    int clientY() const { return m_clientY; }
-    int screenX() const { return m_screenX; }
-    int screenY() const { return m_screenY; }
-    int pageX() const { return m_pageX; }
-    int pageY() const { return m_pageY; }
-    int webkitRadiusX() const { return m_radiusX; }
-    int webkitRadiusY() const { return m_radiusY; }
+    double clientX() const { return m_clientPosition.x(); }
+    double clientY() const { return m_clientPosition.y(); }
+    double screenX() const { return m_screenPosition.x(); }
+    double screenY() const { return m_screenPosition.y(); }
+    double pageX() const { return m_pagePosition.x(); }
+    double pageY() const { return m_pagePosition.y(); }
+    double webkitRadiusX() const { return m_radius.width(); }
+    double webkitRadiusY() const { return m_radius.height(); }
     float webkitRotationAngle() const { return m_rotationAngle; }
     float webkitForce() const { return m_force; }
     const LayoutPoint& absoluteLocation() const { return m_absoluteLocation; }
@@ -65,23 +67,23 @@ public:
 
 private:
     Touch(LocalFrame*, EventTarget*, int identifier,
-            int screenX, int screenY, int pageX, int pageY,
-            int radiusX, int radiusY, float rotationAngle, float force);
+        const FloatPoint& screenPosition, const FloatPoint& pagePosition,
+            const FloatSize& radius, float rotationAngle, float force);
 
-    Touch(EventTarget*, int identifier, int clientX, int clientY,
-        int screenX, int screenY, int pageX, int pageY,
-        int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation);
+    Touch(EventTarget*, int identifier, const FloatPoint& clientPosition,
+        const FloatPoint& screenPosition, const FloatPoint& pagePosition,
+        const FloatSize& radius, float rotationAngle, float force, LayoutPoint absoluteLocation);
 
     RefPtr<EventTarget> m_target;
     int m_identifier;
-    int m_clientX;
-    int m_clientY;
-    int m_screenX;
-    int m_screenY;
-    int m_pageX;
-    int m_pageY;
-    int m_radiusX;
-    int m_radiusY;
+    // Position relative to the viewport in CSS px.
+    FloatPoint m_clientPosition;
+    // Position relative to the screen in DIPs.
+    FloatPoint m_screenPosition;
+    // Position relative to the page in CSS px.
+    FloatPoint m_pagePosition;
+    // Radius in CSS px.
+    FloatSize m_radius;
     float m_rotationAngle;
     float m_force;
     LayoutPoint m_absoluteLocation;

--- a/Source/WebCore/dom/Touch.idl
+++ b/Source/WebCore/dom/Touch.idl
@@ -29,16 +29,16 @@
     Conditional=TOUCH_EVENTS,
     Exposed=Window
 ] interface Touch {
-    readonly attribute long                clientX;
-    readonly attribute long                clientY;
-    readonly attribute long                screenX;
-    readonly attribute long                screenY;
-    readonly attribute long                pageX;
-    readonly attribute long                pageY;
+    readonly attribute double              clientX;
+    readonly attribute double              clientY;
+    readonly attribute double              screenX;
+    readonly attribute double              screenY;
+    readonly attribute double              pageX;
+    readonly attribute double              pageY;
     readonly attribute EventTarget         target;
     readonly attribute long                identifier;
-    readonly attribute long                webkitRadiusX;
-    readonly attribute long               webkitRadiusY;
+    readonly attribute double              webkitRadiusX;
+    readonly attribute double              webkitRadiusY;
     readonly attribute unrestricted float webkitRotationAngle;
     readonly attribute unrestricted float webkitForce;
 };

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -52,7 +52,7 @@ static AtomString mouseEventType(PlatformTouchPoint::TouchPhaseType phase)
 Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned index, Ref<WindowProxy>&& view, IsCancelable cancelable)
 {
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
-        event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0,
+        event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, flooredIntPoint(event.touchLocationAtIndex(index)), flooredIntPoint(event.touchLocationAtIndex(index)), 0, 0,
         event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes));
 }
 

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -51,28 +51,28 @@ static const AtomString& pointerEventType(PlatformTouchPoint::TouchPhaseType pha
     return nullAtom();
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPhaseAtIndex(index));
 
     return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPhaseAtIndex(index));
 
     return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
 {
     return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
     : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
-        event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
+        flooredIntPoint(event.touchLocationAtIndex(index)), flooredIntPoint(event.touchLocationAtIndex(index)), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchIdentifierAtIndex(index))
     , m_width(2 * event.radiusXAtIndex(index))
     , m_height(2 * event.radiusYAtIndex(index))

--- a/Source/WebCore/dom/wpe/PointerEventWPE.cpp
+++ b/Source/WebCore/dom/wpe/PointerEventWPE.cpp
@@ -54,28 +54,28 @@ static const AtomString& pointerEventType(PlatformTouchPoint::State state)
     return nullAtom();
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPoints().at(index).state());
     return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPoints().at(index).state());
     return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
 {
     return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
+PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const FloatPoint& touchDelta)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, roundedIntPoint(event.touchPoints().at(index).pos()), roundedIntPoint(event.touchPoints().at(index).pos()), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchPoints().at(index).id())
-    , m_width(2 * event.touchPoints().at(index).radiusX())
-    , m_height(2 * event.touchPoints().at(index).radiusY())
+    , m_width(2 * event.touchPoints().at(index).radius().width())
+    , m_height(2 * event.touchPoints().at(index).radius().height())
     , m_pressure(event.touchPoints().at(index).force())
     , m_pointerType(touchPointerEventType())
     , m_isPrimary(isPrimary)

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -236,7 +236,7 @@ public:
 #if ENABLE(IOS_TOUCH_EVENTS)
     enum class InTouchEventHandling : bool { No, Yes };
     enum class InMotion : bool { No, Yes };
-    void updateTouchLastGlobalPositionAndDelta(PointerID, const IntPoint&, InTouchEventHandling, InMotion);
+    void updateTouchLastGlobalPositionAndDelta(PointerID, const FloatPoint&, InTouchEventHandling, InMotion);
     bool dispatchTouchEvent(const PlatformTouchEvent&, const AtomString&, const EventTargetTouchArrayMap&, float, float);
     bool dispatchSimulatedTouchEvent(IntPoint location);
     Frame* touchEventTargetSubframe() const { return m_touchEventTargetSubframe.get(); }
@@ -715,7 +715,7 @@ private:
 
     TouchArray m_touches;
     RefPtr<Frame> m_touchEventTargetSubframe;
-    UncheckedKeyHashMap<PointerID, std::pair<IntPoint, IntPoint>, WTF::IntHash<PointerID>, WTF::UnsignedWithZeroKeyHashTraits<PointerID>> m_touchLastGlobalPositionAndDeltaMap;
+    UncheckedKeyHashMap<PointerID, std::pair<FloatPoint, FloatPoint>, WTF::IntHash<PointerID>, WTF::UnsignedWithZeroKeyHashTraits<PointerID>> m_touchLastGlobalPositionAndDeltaMap;
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -208,7 +208,7 @@ static bool hierarchyHasCapturingEventListeners(Element* target, const AtomStrin
     return false;
 }
 
-void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target, const PlatformTouchEvent& platformTouchEvent, unsigned index, bool isPrimary, WindowProxy& view, const IntPoint& touchDelta)
+void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target, const PlatformTouchEvent& platformTouchEvent, unsigned index, bool isPrimary, WindowProxy& view, const FloatPoint& touchDelta)
 {
     RELEASE_ASSERT(is<Element>(target));
 
@@ -315,7 +315,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 
 #if PLATFORM(IOS_FAMILY)
     if (pointerEvent->type() == eventNames().pointercancelEvent) {
-        cancelPointer(pointerEvent->pointerId(), platformTouchEvent.touchLocationAtIndex(index), pointerEvent.ptr());
+        cancelPointer(pointerEvent->pointerId(), flooredIntPoint(platformTouchEvent.touchLocationAtIndex(index)), pointerEvent.ptr());
         return;
     }
 #endif
@@ -474,7 +474,7 @@ void PointerCaptureController::pointerEventWasDispatched(const PointerEvent& eve
         capturingData->preventsCompatibilityMouseEvents = event.defaultPrevented();
 }
 
-void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint& documentPoint, PointerEvent* existingCancelEvent)
+void PointerCaptureController::cancelPointer(PointerID pointerId, const FloatPoint& documentPoint, PointerEvent* existingCancelEvent)
 {
     // https://w3c.github.io/pointerevents/#the-pointercancel-event
 
@@ -514,7 +514,7 @@ void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint
         RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
         if (!localMainFrame)
             return nullptr;
-        return localMainFrame->checkedEventHandler()->hitTestResultAtPoint(documentPoint, hitType).innerNonSharedElement();
+        return localMainFrame->checkedEventHandler()->hitTestResultAtPoint(LayoutPoint(documentPoint), hitType).innerNonSharedElement();
     }();
 
     if (!target)

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -60,14 +60,14 @@ public:
     RefPtr<PointerEvent> pointerEventForMouseEvent(const MouseEvent&, PointerID, const String& pointerType);
 
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    void dispatchEventForTouchAtIndex(EventTarget&, const PlatformTouchEvent&, unsigned, bool isPrimary, WindowProxy&, const IntPoint&);
+    void dispatchEventForTouchAtIndex(EventTarget&, const PlatformTouchEvent&, unsigned, bool isPrimary, WindowProxy&, const FloatPoint&);
 #endif
 
     WEBCORE_EXPORT void touchWithIdentifierWasRemoved(PointerID);
     bool hasCancelledPointerEventForIdentifier(PointerID) const;
     bool preventsCompatibilityMouseEventsForIdentifier(PointerID) const;
     void dispatchEvent(PointerEvent&, EventTarget*);
-    WEBCORE_EXPORT void cancelPointer(PointerID, const IntPoint&, PointerEvent* existingCancelEvent = nullptr);
+    WEBCORE_EXPORT void cancelPointer(PointerID, const FloatPoint&, PointerEvent* existingCancelEvent = nullptr);
     void processPendingPointerCapture(PointerID);
 
 private:

--- a/Source/WebCore/platform/PlatformTouchPoint.h
+++ b/Source/WebCore/platform/PlatformTouchPoint.h
@@ -20,7 +20,7 @@
 #ifndef PlatformTouchPoint_h
 #define PlatformTouchPoint_h
 
-#include "IntPoint.h"
+#include "FloatPoint.h"
 
 #if ENABLE(TOUCH_EVENTS)
 
@@ -42,8 +42,6 @@ public:
     // This is necessary for us to be able to build synthetic events.
     PlatformTouchPoint()
         : m_id(0)
-        , m_radiusY(0)
-        , m_radiusX(0)
         , m_rotationAngle(0)
         , m_force(0)
     {
@@ -52,7 +50,7 @@ public:
 #if PLATFORM(WPE)
     // FIXME: since WPE currently does not send touch stationary events, we need to be able to
     // create a PlatformTouchPoint of type TouchCancelled artificially
-    PlatformTouchPoint(unsigned id, State state, IntPoint screenPos, IntPoint pos)
+    PlatformTouchPoint(unsigned id, State state, FloatPoint screenPos, FloatPoint pos)
         : m_id(id)
         , m_state(state)
         , m_screenPos(screenPos)
@@ -63,20 +61,18 @@ public:
 
     unsigned id() const { return m_id; }
     State state() const { return m_state; }
-    IntPoint screenPos() const { return m_screenPos; }
-    IntPoint pos() const { return m_pos; }
-    int radiusX() const { return m_radiusX; }
-    int radiusY() const { return m_radiusY; }
+    FloatPoint screenPos() const { return m_screenPos; }
+    FloatPoint pos() const { return m_pos; }
+    FloatSize radius() const { return m_radius; }
     float rotationAngle() const { return m_rotationAngle; }
     float force() const { return m_force; }
 
 protected:
     unsigned m_id;
     State m_state;
-    IntPoint m_screenPos;
-    IntPoint m_pos;
-    int m_radiusY;
-    int m_radiusX;
+    FloatPoint m_screenPos;
+    FloatPoint m_pos;
+    FloatSize m_radius;
     float m_rotationAngle;
     float m_force;
 };

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -920,7 +920,7 @@ FloatPoint ScrollView::viewToContents(const FloatPoint& point) const
     if (delegatesScrollingToNativeView())
         return point;
 
-    return viewToContents(IntPoint(point));
+    return point + toFloatSize(documentScrollPositionRelativeToViewOrigin());
 }
 
 FloatPoint ScrollView::contentsToView(const FloatPoint& point) const
@@ -1062,6 +1062,14 @@ IntRect ScrollView::contentsToRootView(const IntRect& contentsRect) const
 
 IntPoint ScrollView::windowToContents(const IntPoint& windowPoint) const
 {
+    return viewToContents(convertFromContainingWindow(windowPoint));
+}
+
+FloatPoint ScrollView::windowToContents(const FloatPoint& windowPoint) const
+{
+    if (delegatesScrolling())
+        return convertFromContainingWindow(windowPoint);
+
     return viewToContents(convertFromContainingWindow(windowPoint));
 }
 

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -341,6 +341,7 @@ public:
     // the entire widget hierarchy. It is up to the platform to decide what the precise definition
     // of containing window is. (For example on Mac it is the containing NSWindow.)
     WEBCORE_EXPORT IntPoint windowToContents(const IntPoint&) const;
+    WEBCORE_EXPORT FloatPoint windowToContents(const FloatPoint&) const;
     WEBCORE_EXPORT IntPoint contentsToWindow(const IntPoint&) const;
     WEBCORE_EXPORT IntRect windowToContents(const IntRect&) const;
     WEBCORE_EXPORT IntRect contentsToWindow(const IntRect&) const;

--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -164,6 +164,20 @@ IntRect Widget::convertFromContainingWindow(const IntRect& windowRect) const
     return convertFromContainingWindowToRoot(this, windowRect);
 }
 
+FloatPoint Widget::convertFromContainingWindow(const FloatPoint& windowPoint) const
+{
+    IntPoint flooredPoint = flooredIntPoint(windowPoint);
+    FloatPoint parentPoint = this->convertFromContainingWindow(flooredPoint);
+    FloatSize windowFraction = windowPoint - flooredPoint;
+    if (!windowFraction.isEmpty()) {
+        const int kFactor = 1000;
+        IntPoint parentLineEnd = this->convertFromContainingWindow(flooredPoint + roundedIntSize(windowFraction.scaled(kFactor)));
+        FloatSize parentFraction = (parentLineEnd - parentPoint).scaled(1.0f / kFactor);
+        parentPoint.move(parentFraction);
+    }
+    return parentPoint;
+}
+
 IntRect Widget::convertToContainingWindow(const IntRect& localRect) const
 {
     if (const ScrollView* parentScrollView = parent()) {

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -163,6 +163,7 @@ public:
     // when converting window rects.
     WEBCORE_EXPORT IntRect convertToContainingWindow(const IntRect&) const;
     IntRect convertFromContainingWindow(const IntRect&) const;
+    FloatPoint convertFromContainingWindow(const FloatPoint&) const;
 
     WEBCORE_EXPORT IntPoint convertToContainingWindow(const IntPoint&) const;
     IntPoint convertFromContainingWindow(const IntPoint&) const;

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.h
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.h
@@ -48,7 +48,7 @@ public:
 
 private:
 #if ENABLE(TOUCH_EVENTS)
-    void determineScrollableAreaForTouchSequence(const IntSize& touchDelta);
+    void determineScrollableAreaForTouchSequence(const FloatSize& touchDelta);
 
     // State for handling sequences of touches in defaultTouchEventHandler.
     enum AxisLatch {
@@ -61,8 +61,8 @@ private:
     bool m_inTouchSequence { false };
     bool m_committedToScrollAxis { false };
     bool m_startedScroll { false };
-    IntPoint m_firstTouchPoint;
-    IntPoint m_lastTouchPoint;
+    FloatPoint m_firstTouchPoint;
+    FloatPoint m_lastTouchPoint;
 
     // When we're in a touch sequence, this will point to the scrollable area that
     // should actually be scrolled during the sequence.

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -91,9 +91,9 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
         return false;
     }
     
-    IntPoint currentPoint = touchEvent.touchLocationAtIndex(0);
+    FloatPoint currentPoint = touchEvent.touchLocationAtIndex(0);
 
-    IntSize touchDelta = m_lastTouchPoint - currentPoint;
+    FloatSize touchDelta = m_lastTouchPoint - currentPoint;
     m_lastTouchPoint = currentPoint;
 
     if (!m_scrollableAreaForTouchSequence)
@@ -107,7 +107,7 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
         if (!horizontallyScrollable && !verticallyScrollable)
             return false;
 
-        IntSize deltaFromStart = m_firstTouchPoint - currentPoint;
+        FloatSize deltaFromStart = m_firstTouchPoint - currentPoint;
     
         const int latchAxisMovementThreshold = 10;
         if (!horizontallyScrollable && verticallyScrollable) {
@@ -141,13 +141,13 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
     
     // Horizontal
     if (m_touchScrollAxisLatch != AxisLatchVertical) {
-        int delta = touchDelta.width();
+        float delta = touchDelta.width();
         handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollDirection::ScrollLeft : ScrollDirection::ScrollRight, ScrollGranularity::Pixel, std::abs(delta));
     }
     
     // Vertical
     if (m_touchScrollAxisLatch != AxisLatchHorizontal) {
-        int delta = touchDelta.height();
+        float delta = touchDelta.height();
         handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollDirection::ScrollUp : ScrollDirection::ScrollDown, ScrollGranularity::Pixel, std::abs(delta));
     }
     
@@ -163,7 +163,7 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
     return true;
 }
 
-void ScrollAnimatorIOS::determineScrollableAreaForTouchSequence(const IntSize& scrollDelta)
+void ScrollAnimatorIOS::determineScrollableAreaForTouchSequence(const FloatSize& scrollDelta)
 {
     ASSERT(!m_scrollableAreaForTouchSequence);
 

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -123,7 +123,7 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
 [CustomHeader] class WebKit::WebPlatformTouchPoint {
 #if PLATFORM(IOS_FAMILY)
     unsigned identifier()
-    WebCore::IntPoint location()
+    WebCore::FloatPoint location()
     WebKit::WebPlatformTouchPoint::State phase()
 #endif
 #if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -323,8 +323,7 @@ public:
 
         m_screenPos = webTouchPoint.screenPosition();
         m_pos = webTouchPoint.position();
-        m_radiusX = webTouchPoint.radius().width();
-        m_radiusY = webTouchPoint.radius().height();
+        m_radius = webTouchPoint.radius();
         m_force = webTouchPoint.force();
         m_rotationAngle = webTouchPoint.rotationAngle();
     }

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "WebEvent.h"
+#include <WebCore/FloatPoint.h>
 #include <WebCore/IntPoint.h>
 
 namespace WebKit {
@@ -52,14 +53,14 @@ public:
     };
 
     WebPlatformTouchPoint() = default;
-    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint location, State phase)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::FloatPoint location, State phase)
         : m_identifier(identifier)
         , m_location(location)
         , m_phase(phase)
     {
     }
 #if ENABLE(IOS_TOUCH_EVENTS)
-    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint location, State phase, double radiusX, double radiusY, double rotationAngle, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::FloatPoint location, State phase, double radiusX, double radiusY, double rotationAngle, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
         : m_identifier(identifier)
         , m_location(location)
         , m_phase(phase)
@@ -75,7 +76,7 @@ public:
 #endif
 
     unsigned identifier() const { return m_identifier; }
-    WebCore::IntPoint location() const { return m_location; }
+    WebCore::FloatPoint location() const { return m_location; }
     State phase() const { return m_phase; }
     State state() const { return phase(); }
 
@@ -99,7 +100,7 @@ public:
 
 private:
     unsigned m_identifier { 0 };
-    WebCore::IntPoint m_location;
+    WebCore::FloatPoint m_location;
     State m_phase { State::Released };
 #if ENABLE(IOS_TOUCH_EVENTS)
     double m_radiusX { 0 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -33,6 +33,7 @@ OBJC_CLASS UIScrollView;
 
 namespace WebCore {
 class FloatRect;
+class FloatPoint;
 class IntPoint;
 
 enum class EventListenerRegionType : uint8_t;
@@ -74,7 +75,7 @@ class WebPageProxy;
 
 namespace WebKit {
 
-OptionSet<WebCore::TouchAction> touchActionsForPoint(UIView *rootView, const WebCore::IntPoint&);
+OptionSet<WebCore::TouchAction> touchActionsForPoint(UIView *rootView, const WebCore::FloatPoint&);
 UIScrollView *findActingScrollParent(UIScrollView *, const RemoteLayerTreeHost&);
 
 OptionSet<WebCore::EventListenerRegionType> eventListenerTypesAtPoint(UIView *rootView, const WebCore::IntPoint&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -192,7 +192,7 @@ static bool isScrolledBy(WKChildScrollView* scrollView, UIView *hitView)
     return false;
 }
 
-OptionSet<WebCore::TouchAction> touchActionsForPoint(UIView *rootView, const WebCore::IntPoint& point)
+OptionSet<WebCore::TouchAction> touchActionsForPoint(UIView *rootView, const WebCore::FloatPoint& point)
 {
     Vector<RetainPtr<UIView>, 16> viewsAtPoint;
     collectDescendantViewsAtPoint(viewsAtPoint, rootView, point, nil);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4188,7 +4188,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
         auto update = [this, location](TrackingType& trackingType, EventTrackingRegions::EventType eventType) {
             if (trackingType == TrackingType::Synchronous)
                 return;
-            auto trackingTypeForLocation = m_scrollingCoordinatorProxy->eventTrackingTypeForPoint(eventType, location);
+            auto trackingTypeForLocation = m_scrollingCoordinatorProxy->eventTrackingTypeForPoint(eventType, roundedIntPoint(location));
             trackingType = mergeTrackingTypes(trackingType, trackingTypeForLocation);
         };
         auto& tracking = internals().touchEventTracking;


### PR DESCRIPTION
#### ec7536055f49d33a9b01d499dc4a3c1c2e6ad4a8
<pre>
Infrastructure changes necessary for fractional touch events
<a href="https://bugs.webkit.org/show_bug.cgi?id=279540">https://bugs.webkit.org/show_bug.cgi?id=279540</a>
<a href="https://rdar.apple.com/135822830">rdar://135822830</a>

Reviewed by NOBODY (OOPS!).

Contains infrastructure changes necessary to eventually expose fractional coordinates for touch events and pointer events. These changes are based heavily on Sun Shin&apos;s (@xingri) earlier proposal.

* LayoutTests/fast/events/touch/resources/frame-touchevent-forwarder.html: Added.
* LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll-expected.txt:
* LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html:
* LayoutTests/fast/events/touch/touch-fractional-coordinates-expected.txt: Added.
* LayoutTests/fast/events/touch/touch-fractional-coordinates.html: Added.
* Source/WebCore/dom/Document+Touch.idl:
* Source/WebCore/dom/DocumentTouch.cpp:
(WebCore::DocumentTouch::createTouch):
* Source/WebCore/dom/DocumentTouch.h:
* Source/WebCore/dom/PointerEvent.h:
(WebCore::PointerEvent::create):
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/Touch.cpp:
(WebCore::contentsOffset):
(WebCore::scaledLocation):
(WebCore::Touch::Touch):
(WebCore::Touch::cloneWithNewTarget const):
(WebCore::contentsX): Deleted.
(WebCore::contentsY): Deleted.
* Source/WebCore/dom/Touch.h:
(WebCore::Touch::create):
(WebCore::Touch::clientX const):
(WebCore::Touch::clientY const):
(WebCore::Touch::screenX const):
(WebCore::Touch::screenY const):
(WebCore::Touch::pageX const):
(WebCore::Touch::pageY const):
(WebCore::Touch::webkitRadiusX const):
(WebCore::Touch::webkitRadiusY const):
* Source/WebCore/dom/Touch.idl:
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::MouseEvent::create):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::PointerEvent::create):
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/wpe/PointerEventWPE.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::SyntheticTouchPoint::SyntheticTouchPoint):
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchEventForTouchAtIndex):
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/platform/PlatformTouchPoint.h:
(WebCore::PlatformTouchPoint::PlatformTouchPoint):
(WebCore::PlatformTouchPoint::screenPos const):
(WebCore::PlatformTouchPoint::pos const):
(WebCore::PlatformTouchPoint::radius const):
(WebCore::PlatformTouchPoint::radiusX const): Deleted.
(WebCore::PlatformTouchPoint::radiusY const): Deleted.
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::viewToContents const):
(WebCore::ScrollView::windowToContents const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::convertFromContainingWindow const):
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:
(WebCore::ScrollAnimatorIOS::handleTouchEvent):
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchPoint::WebKit2PlatformTouchPoint):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebPlatformTouchPoint::WebPlatformTouchPoint):
(WebKit::WebPlatformTouchPoint::location const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::touchActionsForPoint):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateTouchEventTracking):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/165af4664a8076c29b1d0e985f6d54e8020b1de2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27418 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79022 "Hash 165af466 for PR 33490 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1821 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/79022 "Hash 165af466 for PR 33490 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64129 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/79022 "Hash 165af466 for PR 33490 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21625 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24178 "Hash 165af466 for PR 33490 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21971 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80518 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1129 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/80518 "Failed to compile WebKit") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64147 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/80518 "Failed to compile WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8263 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1889 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4676 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/2838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->