### PR TITLE
[WTF] Introduce validateKey to HashMap (2/3)

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -132,11 +132,12 @@ struct IdentityExtractor;
 template<typename T> struct KeyValuePairKeyExtractor;
 template<typename KeyTraits, typename MappedTraits> struct KeyValuePairTraits;
 template<typename KeyTypeArg, typename ValueTypeArg> struct KeyValuePair;
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits> class HashTable;
+enum class ShouldValidateKey : bool { No, Yes };
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey = ShouldValidateKey::No> class HashTable;
 template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Value>> class HashCountedSet;
-template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits> class HashMap;
+template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashMap;
 template<typename KeyArg, typename MappedArg, typename KeyHash = DefaultHash<KeyArg>, typename KeyTraits = HashTraits<KeyArg>, typename MappedTraits = HashTraits<MappedArg>, typename HashTraits = HashTableTraits>
-using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits>;
+using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits, ShouldValidateKey::No>;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits> class HashSet;
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
 using GenericPromise = NativePromise<void, void>;

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -37,7 +37,7 @@ template<typename T> struct KeyValuePairKeyExtractor {
     static const typename T::KeyType& extract(const T& p) { return p.key; }
 };
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 class HashMap final {
     WTF_MAKE_FAST_ALLOCATED;
 private:
@@ -286,95 +286,95 @@ struct HashMapEnsureTranslatorAdapter {
     }
 };
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline void HashMap<T, U, V, W, X, Y>::swap(HashMap& other)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::swap(HashMap& other)
 {
     m_impl.swap(other.m_impl);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline unsigned HashMap<T, U, V, W, X, Y>::size() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey>::size() const
 {
     return m_impl.size(); 
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline unsigned HashMap<T, U, V, W, X, Y>::capacity() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey>::capacity() const
 { 
     return m_impl.capacity(); 
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline size_t HashMap<T, U, V, W, X, Y>::byteSize() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline size_t HashMap<T, U, V, W, X, Y, shouldValidateKey>::byteSize() const
 {
     return m_impl.byteSize();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline bool HashMap<T, U, V, W, X, Y>::isEmpty() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::isEmpty() const
 {
     return m_impl.isEmpty();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::begin() -> iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::begin() -> iterator
 {
     return m_impl.begin();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::end() -> iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::end() -> iterator
 {
     return m_impl.end();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::begin() const -> const_iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::begin() const -> const_iterator
 {
     return m_impl.begin();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::end() const -> const_iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::end() const -> const_iterator
 {
     return m_impl.end();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::find(const KeyType& key) -> iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const KeyType& key) -> iterator
 {
     return m_impl.find(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::find(const KeyType& key) const -> const_iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const KeyType& key) const -> const_iterator
 {
     return m_impl.find(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline bool HashMap<T, U, V, W, X, Y>::contains(const KeyType& key) const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(const KeyType& key) const
 {
     return m_impl.contains(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename TYPE>
-inline auto HashMap<T, U, V, W, X, Y>::find(const TYPE& value) -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const TYPE& value) -> iterator
 {
     return m_impl.template find<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename TYPE>
-inline auto HashMap<T, U, V, W, X, Y>::find(const TYPE& value) const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const TYPE& value) const -> const_iterator
 {
     return m_impl.template find<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename TYPE>
-auto HashMap<T, U, V, W, X, Y>::get(const TYPE& value) const -> MappedPeekType
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(const TYPE& value) const -> MappedPeekType
 {
     auto* entry = const_cast<HashTableType&>(m_impl).template lookup<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
     if (!entry)
@@ -382,9 +382,9 @@ auto HashMap<T, U, V, W, X, Y>::get(const TYPE& value) const -> MappedPeekType
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename TYPE>
-auto HashMap<T, U, V, W, X, Y>::inlineGet(const TYPE& value) const -> MappedPeekType
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(const TYPE& value) const -> MappedPeekType
 {
     auto* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
     if (!entry)
@@ -392,16 +392,16 @@ auto HashMap<T, U, V, W, X, Y>::inlineGet(const TYPE& value) const -> MappedPeek
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename TYPE>
-inline bool HashMap<T, U, V, W, X, Y>::contains(const TYPE& value) const
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(const TYPE& value) const
 {
     return m_impl.template contains<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename TYPE>
-inline bool HashMap<T, U, V, W, X, Y>::remove(const TYPE& value)
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(const TYPE& value)
 {
     auto it = find<HashTranslator>(value);
     if (it == end())
@@ -410,9 +410,9 @@ inline bool HashMap<T, U, V, W, X, Y>::remove(const TYPE& value)
     return true;
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename K, typename V>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::inlineSet(K&& key, V&& value) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::inlineSet(K&& key, V&& value) -> AddResult
 {
     AddResult result = inlineAdd(std::forward<K>(key), std::forward<V>(value));
     if (!result.isNewEntry) {
@@ -422,96 +422,96 @@ auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTra
     return result;
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename K, typename V>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::inlineAdd(K&& key, V&& value) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::inlineAdd(K&& key, V&& value) -> AddResult
 {
     return m_impl.template add<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename K>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::inlineEnsure(K&& key, const Invocable<MappedType()> auto& functor) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::inlineEnsure(K&& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return m_impl.template add<HashMapEnsureTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), functor);
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::set(const KeyType& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::set(const KeyType& key, T&& mapped) -> AddResult
 {
     return inlineSet(key, std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::set(KeyType&& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::set(KeyType&& key, T&& mapped) -> AddResult
 {
     return inlineSet(WTFMove(key), std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename K>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(K&& key, const Invocable<MappedType()> auto& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::ensure(K&& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapEnsureTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), functor);
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename K, typename V>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::add(K&& key, V&& value) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::add(K&& key, V&& value) -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::add(const KeyType& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::add(const KeyType& key, T&& mapped) -> AddResult
 {
     return inlineAdd(key, std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::add(KeyType&& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::add(KeyType&& key, T&& mapped) -> AddResult
 {
     return inlineAdd(WTFMove(key), std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename T>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::fastAdd(const KeyType& key, T&& mapped) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::fastAdd(const KeyType& key, T&& mapped) -> AddResult
 {
     return inlineAdd(key, std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 template<typename T>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::fastAdd(KeyType&& key, T&& mapped) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::fastAdd(KeyType&& key, T&& mapped) -> AddResult
 {
     return inlineAdd(WTFMove(key), std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(const KeyType& key, const Invocable<MappedType()> auto& functor) -> AddResult
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::ensure(const KeyType& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return inlineEnsure(key, functor);
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(KeyType&& key, const Invocable<MappedType()> auto& functor) -> AddResult
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::ensure(KeyType&& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return inlineEnsure(std::forward<KeyType>(key), functor);
 }
     
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::get(const KeyType& key) const -> MappedPeekType
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(const KeyType& key) const -> MappedPeekType
 {
     return get<IdentityTranslatorType>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline auto HashMap<T, U, V, W, X, Y>::getOptional(const KeyType& key) const -> std::optional<MappedType>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::getOptional(const KeyType& key) const -> std::optional<MappedType>
 {
     auto* entry = const_cast<HashTableType&>(m_impl).template lookup<IdentityTranslatorType>(key);
     if (!entry)
@@ -519,8 +519,8 @@ inline auto HashMap<T, U, V, W, X, Y>::getOptional(const KeyType& key) const -> 
     return { entry->value };
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
-ALWAYS_INLINE auto HashMap<T, U, V, W, MappedTraits, Y>::inlineGet(const KeyType& key) const -> MappedPeekType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
+ALWAYS_INLINE auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::inlineGet(const KeyType& key) const -> MappedPeekType
 {
     KeyValuePairType* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<IdentityTranslatorType>(key);
     if (!entry)
@@ -528,8 +528,8 @@ ALWAYS_INLINE auto HashMap<T, U, V, W, MappedTraits, Y>::inlineGet(const KeyType
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline bool HashMap<T, U, V, W, X, Y>::remove(iterator it)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(iterator it)
 {
     if (it.m_impl == m_impl.end())
         return false;
@@ -538,32 +538,32 @@ inline bool HashMap<T, U, V, W, X, Y>::remove(iterator it)
     return true;
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline bool HashMap<T, U, V, W, X, Y>::removeIf(const Invocable<bool(KeyValuePairType&)> auto& functor)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::removeIf(const Invocable<bool(KeyValuePairType&)> auto& functor)
 {
     return m_impl.removeIf(functor);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline bool HashMap<T, U, V, W, X, Y>::remove(const KeyType& key)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(const KeyType& key)
 {
     return remove(find(key));
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline void HashMap<T, U, V, W, X, Y>::clear()
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::clear()
 {
     m_impl.clear();
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
-auto HashMap<T, U, V, W, MappedTraits, Y>::take(const KeyType& key) -> MappedTakeType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::take(const KeyType& key) -> MappedTakeType
 {
     return take(find(key));
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
-auto HashMap<T, U, V, W, MappedTraits, Y>::take(iterator it) -> MappedTakeType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::take(iterator it) -> MappedTakeType
 {
     if (it == end())
         return MappedTraits::take(MappedTraits::emptyValue());
@@ -572,8 +572,8 @@ auto HashMap<T, U, V, W, MappedTraits, Y>::take(iterator it) -> MappedTakeType
     return value;
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
-auto HashMap<T, U, V, W, MappedTraits, Y>::takeOptional(const KeyType& key) -> std::optional<MappedType>
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::takeOptional(const KeyType& key) -> std::optional<MappedType>
 {
     auto it = find(key);
     if (it == end())
@@ -581,36 +581,36 @@ auto HashMap<T, U, V, W, MappedTraits, Y>::takeOptional(const KeyType& key) -> s
     return take(it);
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
-auto HashMap<T, U, V, W, MappedTraits, Y>::takeFirst() -> MappedTakeType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::takeFirst() -> MappedTakeType
 {
     return take(begin());
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
 {
     return m_impl.template contains<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
 {
     KeyValuePairType* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
     if (!entry)
@@ -618,23 +618,23 @@ inline auto HashMap<T, U, V, W, X, Y>::inlineGet(std::add_const_t<typename GetPt
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-auto HashMap<T, U, V, W, X, Y>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
 {
     return inlineGet(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
 {
     return remove(find(key));
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type
 {
     iterator it = find(key);
     if (it == end())
@@ -644,63 +644,63 @@ inline auto HashMap<T, U, V, W, X, Y>::take(std::add_const_t<typename GetPtrHelp
     return value;
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, iterator>::type
 {
     return find(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, const_iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, const_iterator>::type
 {
     return find(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
 {
     return contains(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
 {
     return inlineGet(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-auto HashMap<T, U, V, W, X, Y>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
 {
     return inlineGet(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
 {
     return remove(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedTakeType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedTakeType>::type
 {
     return take(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline void HashMap<T, U, V, W, X, Y>::checkConsistency() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::checkConsistency() const
 {
     m_impl.checkTableConsistency();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-inline bool HashMap<T, U, V, W, X, Y>::isValidKey(const KeyType& key)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::isValidKey(const KeyType& key)
 {
     if (KeyTraits::isDeletedValue(key))
         return false;
@@ -716,13 +716,13 @@ inline bool HashMap<T, U, V, W, X, Y>::isValidKey(const KeyType& key)
     return true;
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y>
-bool operator==(const HashMap<T, U, V, W, X, Y>& a, const HashMap<T, U, V, W, X, Y>& b)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+bool operator==(const HashMap<T, U, V, W, X, Y, shouldValidateKey>& a, const HashMap<T, U, V, W, X, Y, shouldValidateKey>& b)
 {
     if (a.size() != b.size())
         return false;
 
-    typedef typename HashMap<T, U, V, W, X, Y>::const_iterator const_iterator;
+    typedef typename HashMap<T, U, V, W, X, Y, shouldValidateKey>::const_iterator const_iterator;
 
     const_iterator end = a.end();
     const_iterator notFound = b.end();

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -50,7 +50,7 @@ enum class AnchorPositionResolutionStage : uint8_t {
     Positioned,
 };
 
-using AnchorElements = HashMap<AtomString, WeakRef<Element, WeakPtrImplWithEventTargetData>>;
+using AnchorElements = UncheckedKeyHashMap<AtomString, WeakRef<Element, WeakPtrImplWithEventTargetData>>;
 
 struct AnchorPositionedState {
     WTF_MAKE_TZONE_ALLOCATED(AnchorPositionedState);


### PR DESCRIPTION
#### df2b100eb9bbe0ffb024788c7652aa045359ed7e
<pre>
[WTF] Introduce validateKey to HashMap (2/3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=279544">https://bugs.webkit.org/show_bug.cgi?id=279544</a>
<a href="https://rdar.apple.com/135826905">rdar://135826905</a>

Reviewed by Geoffrey Garen.

TLDR: `WTF::HashMap` is now safe by default. Use `UncheckedKeyHashMap`
to circumvent checks in performance sensitive code. The vast majority  of code should
use `HashMap`.

Elevate `ASSERT`s to `RELEASE_ASSERT`s in `WTF::HashTable::checkKey()` for `HashMap`, building on
a previous patch that a new type alias for an unsafe hashmap, aptly called `UncheckedKeyHashMap`.
Followup patches will expand on spreading this now safe HashMap across the codebase,
with the ultimate goal of having safe HashMap used in every non
performance sensitive portion of the code. [1]

[1] <a href="https://bugs.webkit.org/show_bug.cgi?id=278488">https://bugs.webkit.org/show_bug.cgi?id=278488</a>

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/HashMap.h:
(WTF::validateKey&gt;::swap):
(WTF::validateKey&gt;::size const):
(WTF::validateKey&gt;::capacity const):
(WTF::validateKey&gt;::byteSize const):
(WTF::validateKey&gt;::isEmpty const):
(WTF::validateKey&gt;::begin):
(WTF::validateKey&gt;::end):
(WTF::validateKey&gt;::begin const):
(WTF::validateKey&gt;::end const):
(WTF::validateKey&gt;::find):
(WTF::validateKey&gt;::find const):
(WTF::validateKey&gt;::contains const):
(WTF::validateKey&gt;::get const):
(WTF::validateKey&gt;::inlineGet const):
(WTF::validateKey&gt;::remove):
(WTF::validateKey&gt;::inlineSet):
(WTF::validateKey&gt;::inlineAdd):
(WTF::validateKey&gt;::inlineEnsure):
(WTF::validateKey&gt;::set):
(WTF::validateKey&gt;::ensure):
(WTF::validateKey&gt;::add):
(WTF::validateKey&gt;::fastAdd):
(WTF::validateKey&gt;::getOptional const):
(WTF::validateKey&gt;::removeIf):
(WTF::validateKey&gt;::clear):
(WTF::validateKey&gt;::take):
(WTF::validateKey&gt;::takeOptional):
(WTF::validateKey&gt;::takeFirst):
(WTF::validateKey&gt;::checkConsistency const):
(WTF::validateKey&gt;::isValidKey):
(WTF::operator==):
(WTF::Y&gt;::swap): Deleted.
(WTF::Y&gt;::size const): Deleted.
(WTF::Y&gt;::capacity const): Deleted.
(WTF::Y&gt;::byteSize const): Deleted.
(WTF::Y&gt;::isEmpty const): Deleted.
(WTF::Y&gt;::begin): Deleted.
(WTF::Y&gt;::end): Deleted.
(WTF::Y&gt;::begin const): Deleted.
(WTF::Y&gt;::end const): Deleted.
(WTF::Y&gt;::find): Deleted.
(WTF::Y&gt;::find const): Deleted.
(WTF::Y&gt;::contains const): Deleted.
(WTF::Y&gt;::get const): Deleted.
(WTF::Y&gt;::inlineGet const): Deleted.
(WTF::Y&gt;::remove): Deleted.
(WTF::TableTraitsArg&gt;::inlineSet): Deleted.
(WTF::TableTraitsArg&gt;::inlineAdd): Deleted.
(WTF::TableTraitsArg&gt;::inlineEnsure): Deleted.
(WTF::TableTraitsArg&gt;::set): Deleted.
(WTF::TableTraitsArg&gt;::ensure): Deleted.
(WTF::TableTraitsArg&gt;::add): Deleted.
(WTF::TableTraitsArg&gt;::fastAdd): Deleted.
(WTF::Y&gt;::getOptional const): Deleted.
(WTF::Y&gt;::removeIf): Deleted.
(WTF::Y&gt;::clear): Deleted.
(WTF::Y&gt;::take): Deleted.
(WTF::Y&gt;::takeOptional): Deleted.
(WTF::Y&gt;::takeFirst): Deleted.
(WTF::Y&gt;::checkConsistency const): Deleted.
(WTF::Y&gt;::isValidKey): Deleted.
* Source/WTF/wtf/HashTable.h:
(WTF::validateKey&gt;::HashTable):
(WTF::validateKey&gt;::checkKey):
(WTF::validateKey&gt;::lookup):
(WTF::validateKey&gt;::inlineLookup):
(WTF::validateKey&gt;::lookupForReinsert):
(WTF::validateKey&gt;::fullLookupForWriting):
(WTF::validateKey&gt;::addUniqueForInitialization):
(WTF::validateKey&gt;::initializeBucket):
(WTF::validateKey&gt;::add):
(WTF::validateKey&gt;::addPassingHashCode):
(WTF::validateKey&gt;::reinsert):
(WTF::validateKey&gt;::find):
(WTF::validateKey&gt;::find const):
(WTF::validateKey&gt;::contains const):
(WTF::validateKey&gt;::removeAndInvalidateWithoutEntryConsistencyCheck):
(WTF::validateKey&gt;::removeAndInvalidate):
(WTF::validateKey&gt;::remove):
(WTF::validateKey&gt;::removeWithoutEntryConsistencyCheck):
(WTF::validateKey&gt;::removeIf):
(WTF::validateKey&gt;::allocateTable):
(WTF::validateKey&gt;::deallocateTable):
(WTF::validateKey&gt;::expand):
(WTF::validateKey&gt;::computeBestTableSize):
(WTF::validateKey&gt;::shrinkToBestSize):
(WTF::validateKey&gt;::deleteReleasedWeakBuckets):
(WTF::validateKey&gt;::rehash):
(WTF::validateKey&gt;::clear):
(WTF::validateKey&gt;::swap):
(WTF::=):
(WTF::validateKey&gt;::checkTableConsistency const):
(WTF::validateKey&gt;::checkTableConsistencyExceptSize const):
(WTF::KeyTraits&gt;::HashTable): Deleted.
(WTF::KeyTraits&gt;::checkKey): Deleted.
(WTF::KeyTraits&gt;::lookup): Deleted.
(WTF::KeyTraits&gt;::inlineLookup): Deleted.
(WTF::KeyTraits&gt;::lookupForReinsert): Deleted.
(WTF::KeyTraits&gt;::fullLookupForWriting): Deleted.
(WTF::KeyTraits&gt;::addUniqueForInitialization): Deleted.
(WTF::KeyTraits&gt;::initializeBucket): Deleted.
(WTF::KeyTraits&gt;::add): Deleted.
(WTF::KeyTraits&gt;::addPassingHashCode): Deleted.
(WTF::KeyTraits&gt;::reinsert): Deleted.
(WTF::KeyTraits&gt;::find): Deleted.
(WTF::KeyTraits&gt;::find const): Deleted.
(WTF::KeyTraits&gt;::contains const): Deleted.
(WTF::KeyTraits&gt;::removeAndInvalidateWithoutEntryConsistencyCheck): Deleted.
(WTF::KeyTraits&gt;::removeAndInvalidate): Deleted.
(WTF::KeyTraits&gt;::remove): Deleted.
(WTF::KeyTraits&gt;::removeWithoutEntryConsistencyCheck): Deleted.
(WTF::KeyTraits&gt;::removeIf): Deleted.
(WTF::KeyTraits&gt;::allocateTable): Deleted.
(WTF::KeyTraits&gt;::deallocateTable): Deleted.
(WTF::KeyTraits&gt;::expand): Deleted.
(WTF::KeyTraits&gt;::computeBestTableSize): Deleted.
(WTF::KeyTraits&gt;::shrinkToBestSize): Deleted.
(WTF::KeyTraits&gt;::deleteReleasedWeakBuckets): Deleted.
(WTF::KeyTraits&gt;::rehash): Deleted.
(WTF::KeyTraits&gt;::clear): Deleted.
(WTF::KeyTraits&gt;::swap): Deleted.
(WTF::KeyTraits&gt;::checkTableConsistency const): Deleted.
(WTF::KeyTraits&gt;::checkTableConsistencyExceptSize const): Deleted.

Canonical link: <a href="https://commits.webkit.org/285319@main">https://commits.webkit.org/285319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a056f958c6f33490b55fe8be647ee1d93a6ceb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23260 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15448 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62202 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19677 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21788 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65358 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78074 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71483 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19192 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62226 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15955 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6531 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47448 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2232 "Found 1 new failure in dom/UserGestureIndicator.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20528 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->