### PR TITLE
Deploy smart pointers in NetworkConnectionToWebProcess.cpp

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3001,6 +3001,11 @@ RTCDataChannelRemoteManagerProxy& NetworkProcess::rtcDataChannelProxy()
         m_rtcDataChannelProxy = RTCDataChannelRemoteManagerProxy::create();
     return *m_rtcDataChannelProxy;
 }
+
+Ref<RTCDataChannelRemoteManagerProxy> NetworkProcess::protectedRTCDataChannelProxy()
+{
+    return rtcDataChannelProxy();
+}
 #endif
 
 void NetworkProcess::addWebPageNetworkParameters(PAL::SessionID sessionID, WebPageProxyIdentifier pageID, WebPageNetworkParameters&& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -389,6 +389,7 @@ public:
 
 #if ENABLE(WEB_RTC)
     RTCDataChannelRemoteManagerProxy& rtcDataChannelProxy();
+    Ref<RTCDataChannelRemoteManagerProxy> protectedRTCDataChannelProxy();
 #endif
 
     bool ftpEnabled() const { return m_ftpEnabled; }

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -551,14 +551,6 @@ void Connection::invalidate()
     });
 }
 
-void Connection::markCurrentlyDispatchedMessageAsInvalid()
-{
-    // This should only be called while processing a message.
-    ASSERT(m_inDispatchMessageCount > 0);
-
-    m_didReceiveInvalidMessage = true;
-}
-
 UniqueRef<Encoder> Connection::createSyncMessageEncoder(MessageName messageName, uint64_t destinationID, SyncRequestID& syncRequestID)
 {
     auto encoder = makeUniqueRef<Encoder>(messageName, destinationID);


### PR DESCRIPTION
#### 1ab309d8b028328351c5176e12e0e80eafabc730
<pre>
Deploy smart pointers in NetworkConnectionToWebProcess.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279549">https://bugs.webkit.org/show_bug.cgi?id=279549</a>

Reviewed by Chris Dumez.

Deployed more smart pointers in NetworkConnectionToWebProcess.cpp as warned by the clang static analyzer.

Also move Connection::markCurrentlyDispatchedMessageAsInvalid to Connection.h so that it would be inlined
and treated as a trivial function by the static analyzer.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::NetworkConnectionToWebProcess::~NetworkConnectionToWebProcess):
(WebKit::NetworkConnectionToWebProcess::hasUploadStateChanged):
(WebKit::NetworkConnectionToWebProcess::didCleanupResourceLoader):
(WebKit::NetworkConnectionToWebProcess::transferKeptAliveLoad):
(WebKit::NetworkConnectionToWebProcess::didReceiveMessage):
(WebKit::NetworkConnectionToWebProcess::connectToRTCDataChannelRemoteSource):
(WebKit::NetworkConnectionToWebProcess::registerToRTCDataChannelProxy):
(WebKit::NetworkConnectionToWebProcess::unregisterToRTCDataChannelProxy):
(WebKit::NetworkConnectionToWebProcess::didClose):
(WebKit::NetworkConnectionToWebProcess::didReceiveInvalidMessage):
(WebKit::NetworkConnectionToWebProcess::networkSession):
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
(WebKit::NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
(WebKit::NetworkConnectionToWebProcess::setOnLineState):
(WebKit::NetworkConnectionToWebProcess::cookieAcceptPolicyChanged):
(WebKit::NetworkConnectionToWebProcess::browsingContextRemoved):
(WebKit::NetworkConnectionToWebProcess::prefetchDNS):
(WebKit::NetworkConnectionToWebProcess::preconnectTo):
(WebKit::NetworkConnectionToWebProcess::didFinishPreconnection):
(WebKit::NetworkConnectionToWebProcess::storageSession):
(WebKit::NetworkConnectionToWebProcess::startDownload):
(WebKit::NetworkConnectionToWebProcess::convertMainResourceLoadToDownload):
(WebKit::NetworkConnectionToWebProcess::registerURLSchemesAsCORSEnabled):
(WebKit::NetworkConnectionToWebProcess::clearPageSpecificData):
(WebKit::NetworkConnectionToWebProcess::sharedWorkerServerToContextConnectionIsNoLongerNeeded):
(WebKit::NetworkConnectionToWebProcess::establishSWServerConnection):
(WebKit::NetworkConnectionToWebProcess::establishSWContextConnection):
(WebKit::NetworkConnectionToWebProcess::serviceWorkerServerToContextConnectionNoLongerNeeded):
(WebKit::NetworkConnectionToWebProcess::postMessageToRemote):
(WebKit::NetworkConnectionToWebProcess::setCORSDisablingPatterns):
(WebKit::NetworkConnectionToWebProcess::useRedirectionForCurrentNavigation):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::protectedRTCDataChannelProxy):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::markCurrentlyDispatchedMessageAsInvalid): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::markCurrentlyDispatchedMessageAsInvalid):

Canonical link: <a href="https://commits.webkit.org/283532@main">https://commits.webkit.org/283532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cafd20eb174a5a434c6bcd0337080ecb35f22d44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53327 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11919 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38950 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72275 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60655 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60977 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2255 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10091 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42798 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->