### PR TITLE
Expose host app audit token on webpushd config object

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -131,7 +131,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(NetworkProcess& ne
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
 static WebPushD::WebPushDaemonConnectionConfiguration configurationWithHostAuditToken(NetworkProcess& networkProcess, WebPushD::WebPushDaemonConnectionConfiguration configuration)
 {
-#if PLATFORM(COCOA)
+#if !USE(EXTENSIONKIT)
     auto token = networkProcess.parentProcessConnection()->getAuditToken();
     if (token) {
         Vector<uint8_t> auditTokenData(sizeof(*token));

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -32,7 +32,7 @@
 namespace WebKit::WebPushD {
 
 struct WebPushDaemonConnectionConfiguration {
-    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    Vector<uint8_t> hostAppAuditTokenData;
     String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -23,7 +23,7 @@
 webkit_platform_headers: "ArgumentCoders.h" "WebPushDaemonConnectionConfiguration.h"
 
 [CustomHeader, WebKitPlatform] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
-    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    Vector<uint8_t> hostAppAuditTokenData;
     String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp
@@ -35,9 +35,9 @@
 
 namespace API {
 
-WebPushDaemonConnection::WebPushDaemonConnection(const WTF::String& machServiceName, const WTF::String& partition, const WTF::String& bundleIdentifier)
+WebPushDaemonConnection::WebPushDaemonConnection(const WTF::String& machServiceName, WebKit::WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    : m_connection(makeUniqueRef<WebKit::WebPushD::Connection>(machServiceName.utf8(), WebKit::WebPushD::WebPushDaemonConnectionConfiguration { { }, bundleIdentifier, partition, { } }))
+    : m_connection(makeUniqueRef<WebKit::WebPushD::Connection>(machServiceName.utf8(), WTFMove(configuration)))
 #endif
 {
 }

--- a/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.h
+++ b/Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.h
@@ -38,6 +38,7 @@ struct PushSubscriptionData;
 namespace WebKit {
 namespace WebPushD {
 class Connection;
+struct WebPushDaemonConnectionConfiguration;
 }
 struct WebPushMessage;
 }
@@ -46,7 +47,7 @@ namespace API {
 
 class WebPushDaemonConnection final : public ObjectImpl<Object::Type::WebPushDaemonConnection> {
 public:
-    WebPushDaemonConnection(const WTF::String& machServiceName, const WTF::String& partition, const WTF::String& bundleIdentifier);
+    WebPushDaemonConnection(const WTF::String& machServiceName, WebKit::WebPushD::WebPushDaemonConnectionConfiguration&&);
 
     void getPushPermissionState(const WTF::URL&, CompletionHandler<void(WebCore::PushPermissionState)>&&);
     void requestPushPermission(const WTF::URL&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
@@ -45,8 +45,8 @@ WK_EXTERN
 - (instancetype)init;
 @property (nonatomic, copy) NSString *machServiceName;
 @property (nonatomic, copy) NSString *partition;
-@property (nonatomic, copy) NSString *bundleIdentifier;
-
+@property (nonatomic, assign) audit_token_t hostApplicationAuditToken;
+@property (nonatomic, copy) NSString *bundleIdentifierOverrideForTesting;
 @end
 
 WK_EXTERN

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -164,15 +164,12 @@ RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t conne
     audit_token_t hostAppAuditToken = handle.hostProcess.auditToken;
 #else
     audit_token_t hostAppAuditToken { };
-    if (auto hostAppAuditTokenData = configuration.hostAppAuditTokenData) {
-        if (hostAppAuditTokenData->size() != sizeof(audit_token_t)) {
-            RELEASE_LOG_ERROR(Push, "PushClientConnection::create failed: client attempted to set audit token with incorrect size");
-            return nullptr;
-        }
+    if (configuration.hostAppAuditTokenData.size() != sizeof(audit_token_t)) {
+        RELEASE_LOG_ERROR(Push, "PushClientConnection::create failed: client attempted to set audit token with incorrect size");
+        return nullptr;
+    }
 
-        memcpy(&hostAppAuditToken, hostAppAuditTokenData->data(), sizeof(hostAppAuditToken));
-    } else
-        hostAppAuditToken = peerAuditToken;
+    memcpy(&hostAppAuditToken, configuration.hostAppAuditTokenData.data(), sizeof(hostAppAuditToken));
 #endif
 
     bool hostAppHasWebPushEntitlement = hostAppHasEntitlement(hostAppAuditToken, hostAppWebPushEntitlement);


### PR DESCRIPTION
#### 6349190ed64de1db4dca4098591dbbc37ac928a3
<pre>
Expose host app audit token on webpushd config object
<a href="https://bugs.webkit.org/show_bug.cgi?id=279552">https://bugs.webkit.org/show_bug.cgi?id=279552</a>
<a href="https://rdar.apple.com/135836107">rdar://135836107</a>

Reviewed by Per Arne Vollan.

On macOS, webpushd clients are expected to fill out the audit token of the host app in the initial
connection setup message. (This isn&apos;t required on iOS because we can read the audit token directly
from ExtensionKit as described in 282035@main.) Since this is a requirement for connecting to the
daemon, we should expose a host app audit token property on the connection configuration object.

I also renamed the bundleIdentifier property to bundleIdentifierOverrideForTesting since that
property is only used for certain testing tools (namely webpushtool and TestWebKitAPI) that have the
push injection entitlement.

This also reverts 283426@main which was fixing a test failure caused by not setting the audit token.

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::configurationWithHostAuditToken):
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.cpp:
(API::WebPushDaemonConnection::WebPushDaemonConnection):
* Source/WebKit/UIProcess/API/APIWebPushDaemonConnection.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnection initWithConfiguration:]):
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::create):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::getSelfAuditToken):
(TestWebKitAPI::defaultWebPushDaemonConfiguration):
(TestWebKitAPI::(WebPushD, WKWebPushDaemonConnectionRequestPushPermission)):
(TestWebKitAPI::(WebPushD, WKWebPushDaemonConnectionPushSubscription)):

Canonical link: <a href="https://commits.webkit.org/283668@main">https://commits.webkit.org/283668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e44617cb147a22637b9b128b96f8ef1d42cae36e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18034 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53659 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16388 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72637 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61224 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2537 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42083 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->