### PR TITLE
Ensure CookieStoreManager is exposed only to Window and ServiceWorker

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/idlharness.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/idlharness.https.any.sharedworker-expected.txt
@@ -20,5 +20,5 @@ PASS CookieStore interface: existence and properties of interface object
 PASS CookieStoreManager interface: existence and properties of interface object
 PASS CookieChangeEvent interface: existence and properties of interface object
 PASS ExtendableCookieChangeEvent interface: existence and properties of interface object
-FAIL ServiceWorkerRegistration interface: member cookies assert_false: The prototype object must not have a property "cookies" expected false got true
+PASS ServiceWorkerRegistration interface: member cookies
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/idlharness.https.any.worker-expected.txt
@@ -20,5 +20,5 @@ PASS CookieStore interface: existence and properties of interface object
 PASS CookieStoreManager interface: existence and properties of interface object
 PASS CookieChangeEvent interface: existence and properties of interface object
 PASS ExtendableCookieChangeEvent interface: existence and properties of interface object
-FAIL ServiceWorkerRegistration interface: member cookies assert_false: The prototype object must not have a property "cookies" expected false got true
+PASS ServiceWorkerRegistration interface: member cookies
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -4190,6 +4190,8 @@ sub GenerateRuntimeEnableConditionalStringForExposeScope
       $wrapperType = "JSDedicatedWorkerGlobalScope";
     } elsif ($exposed eq "SharedWorker") {
       $wrapperType = "JSSharedWorkerGlobalScope";
+    } elsif ($exposed eq "ServiceWorker") {
+      $wrapperType = "JSServiceWorkerGlobalScope";
     } elsif ($exposed eq "ShadowRealm") {
       $wrapperType = "JSShadowRealmGlobalScopeBase";
     } elsif ($exposed eq "Worklet") {

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
@@ -41,7 +41,7 @@
     readonly attribute USVString scope;
     readonly attribute ServiceWorkerUpdateViaCache updateViaCache;
 
-    [EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled] readonly attribute CookieStoreManager cookies;
+    [Exposed=(Window, ServiceWorker), EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled] readonly attribute CookieStoreManager cookies;
 
     [NewObject] Promise<undefined> update();
     [NewObject] Promise<boolean> unregister();


### PR DESCRIPTION
#### 402a2777996a7e7680023e5d3083801ab1de8d3e
<pre>
Ensure CookieStoreManager is exposed only to Window and ServiceWorker
<a href="https://bugs.webkit.org/show_bug.cgi?id=279573">https://bugs.webkit.org/show_bug.cgi?id=279573</a>
<a href="https://rdar.apple.com/135847353">rdar://135847353</a>

Reviewed by Chris Dumez and Sihui Liu.

As per the Cookie Store API spec (<a href="https://wicg.github.io/cookie-store/#ServiceWorkerRegistration)">https://wicg.github.io/cookie-store/#ServiceWorkerRegistration)</a>,
the ServiceWorkerRegistration interface gives access to a CookieStoreManager via cookies. This
cookies attribute should be exposed only to Window and ServiceWorker.

In order to support exposing this to ServiceWorker, we update CodeGeneratorJS.pm. Previously,
adding Exposed=ServiceWorker for a partial interface, or for a single attribute within an interface,
would result in an IDL parsing error.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/idlharness.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/idlharness.https.any.worker-expected.txt:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateRuntimeEnableConditionalStringForExposeScope):
* Source/WebCore/workers/service/ServiceWorkerRegistration.idl:

Canonical link: <a href="https://commits.webkit.org/283588@main">https://commits.webkit.org/283588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ec7474493588d2288b9b20b4d0ab10c92ea7590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53360 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11950 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34025 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16075 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14715 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61018 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2295 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41770 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->