### PR TITLE
Use a non-empty, non-'about:' cookie url when getting/setting cookies in CookieStore

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'frameCookie.value')"
-FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: The domain must be a part of the current host"
+PASS cookieStore.get() sees cookieStore.set() in frame
+PASS cookieStore.get() in frame sees cookieStore.set()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL cookieStore in non-sandboxed iframe should not throw assert_equals: cookieStore ${apiCall} should not throw expected "no exception" but got "TypeError"
+PASS cookieStore in non-sandboxed iframe should not throw
 PASS cookieStore in sandboxed iframe should throw SecurityError
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -259,7 +259,7 @@ void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& pr
         return;
     }
 
-    auto url = context->creationURL();
+    auto url = context->cookieURL();
     if (!options.url.isNull()) {
         auto parsed = context->completeURL(options.url);
         if (context->isDocument() && parsed != url) {
@@ -322,7 +322,7 @@ void CookieStore::getAll(CookieStoreGetOptions&& options, Ref<DeferredPromise>&&
         return;
     }
 
-    auto url = context->creationURL();
+    auto url = context->cookieURL();
     if (!options.url.isNull()) {
         auto parsed = context->completeURL(options.url);
         if (context->isDocument() && parsed != url) {
@@ -385,7 +385,7 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
     // The maximum attribute value size is specified at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
     static constexpr auto maximumAttributeValueSize = 1024;
 
-    auto url = context->creationURL();
+    auto url = context->cookieURL();
     auto host = url.host();
     auto domain = origin->domain();
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -839,7 +839,7 @@ public:
 
     URL adjustedURL() const;
 
-    const URL& creationURL() const final { return m_creationURL; }
+    const URL& creationURL() const { return m_creationURL; }
 
     // To understand how these concepts relate to one another, please see the
     // comments surrounding their declaration.
@@ -1157,7 +1157,7 @@ public:
     //    document inherits the security context of another document, it
     //    inherits its cookieURL but not its URL.
     //
-    const URL& cookieURL() const { return m_cookieURL; }
+    const URL& cookieURL() const final { return m_cookieURL; }
     void setCookieURL(const URL&);
 
     // The firstPartyForCookies is used to compute whether this document

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -55,7 +55,7 @@ public:
         return *m_eventLoopTaskGroup;
     }
     const URL& url() const final { return m_url; }
-    const URL& creationURL() const final { return url(); }
+    const URL& cookieURL() const final { return url(); }
     URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final { return { }; };
     String userAgent(const URL&) const final { return emptyString(); }
     ReferrerPolicy referrerPolicy() const final { return ReferrerPolicy::EmptyString; }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -130,7 +130,7 @@ public:
     enum class ForceUTF8 : bool { No, Yes };
     virtual URL completeURL(const String& url, ForceUTF8 = ForceUTF8::No) const = 0;
 
-    virtual const URL& creationURL() const = 0;
+    virtual const URL& cookieURL() const = 0;
 
     virtual String userAgent(const URL&) const = 0;
 

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -89,7 +89,7 @@ public:
     virtual Type type() const = 0;
 
     const URL& url() const final { return m_url; }
-    const URL& creationURL() const final { return url(); }
+    const URL& cookieURL() const final { return url(); }
     const URL& ownerURL() const { return m_ownerURL; }
     String origin() const;
     const String& inspectorIdentifier() const { return m_inspectorIdentifier; }

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -66,7 +66,7 @@ public:
     MessagePortChannelProvider& messagePortChannelProvider();
 
     const URL& url() const final { return m_url; }
-    const URL& creationURL() const final { return url(); }
+    const URL& cookieURL() const final { return url(); }
 
     void evaluate();
 


### PR DESCRIPTION
#### 4973ae3a5e854e1e056dedcbced9c1db450bc6f0
<pre>
Use a non-empty, non-&apos;about:&apos; cookie url when getting/setting cookies in CookieStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=279578">https://bugs.webkit.org/show_bug.cgi?id=279578</a>
<a href="https://rdar.apple.com/135853069">rdar://135853069</a>

Reviewed by Chris Dumez and Sihui Liu.

As per the CookieStore API spec, the CookieStore uses the ScriptExecutionContext&apos;s
creation URL when getting/setting cookies. Two of the layout tests attempt to get/set
cookies from iFrames. The creation URL&apos;s for these iFrames are &apos;about:blank&apos; and
&apos;about:srcdoc&apos;. These url&apos;s don&apos;t have hosts and so the get/set requests fail.

We fix this by using Document::cookieURL() in the Document case. The document&apos;s cookie
URL is set when the Document is created and never changed after that (so it matches the
creation URL). This works in the iFrame case because Document::initSecurityContext()
sets the cookieURL to the parent document&apos;s cookies URL for a Document if it
shouldInheritSecurityOriginFromOwner (which is true for iFrames).

We added ScriptExecutionContext::creationURL() in 283530@main specifically for getting/
setting cookies. Since Document had a creationURL() function, we wanted one in
ServiceWorkerGlobalScope so that the usage in CookieStore was consistent. Since we are
now using cookieURL() in Document instead of creationURL(), we want to do the same in
ServiceWorkerGlobalScope. So we rename ScriptExecutionContext::creationURL() to
ScriptExecutionContext::cookieURL(). So now, we use cookieURL() in both the Document
and Service Worker case. This works in all cases, not just for iFrames.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::set):
* Source/WebCore/dom/Document.h:
(WebCore::Document::creationURL const):
(WebCore::Document::cookieURL const): Deleted.
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/283622@main">https://commits.webkit.org/283622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b0dc39419bf5119304ae9f050b619c22589795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53504 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16269 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14898 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60912 "Found 1 new test failure: fast/css/focus-ring-exists-for-search-field.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61147 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2436 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->