### PR TITLE
Remove LegacyReceiver from all Process message receivers

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -104,19 +104,6 @@ GPUProcess& GPUProcess::singleton()
     return gpuProcess.get();
 }
 
-void GPUProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
-{
-    if (messageReceiverMap().dispatchMessage(connection, decoder))
-        return;
-
-    if (decoder.messageReceiverName() == Messages::AuxiliaryProcess::messageReceiverName()) {
-        AuxiliaryProcess::didReceiveMessage(connection, decoder);
-        return;
-    }
-
-    didReceiveGPUProcessMessage(connection, decoder);
-}
-
 void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier identifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, GPUProcessConnectionParameters&& parameters, CompletionHandler<void()>&& completionHandler)
 {
     RELEASE_LOG(Process, "%p - GPUProcess::createGPUConnectionToWebProcess: processIdentifier=%" PRIu64, this, identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -71,7 +71,7 @@ struct GPUProcessCreationParameters;
 struct GPUProcessSessionParameters;
 struct SharedPreferencesForWebProcess;
 
-class GPUProcess : public AuxiliaryProcess, public ThreadSafeRefCounted<GPUProcess> {
+class GPUProcess final : public AuxiliaryProcess, public ThreadSafeRefCounted<GPUProcess> {
     WTF_MAKE_NONCOPYABLE(GPUProcess);
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GPUProcess);
@@ -151,7 +151,6 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    void didReceiveGPUProcessMessage(IPC::Connection&, IPC::Decoder&);
 
     // Message Handlers
     void initializeGPUProcess(GPUProcessCreationParameters&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> GPUProcess LegacyReceiver {
+messages -> GPUProcess : AuxiliaryProcess {
     InitializeGPUProcess(struct WebKit::GPUProcessCreationParameters processCreationParameters) -> ()
 
     CreateGPUConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::ConnectionHandle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -71,19 +71,6 @@ ModelProcess::ModelProcess(AuxiliaryProcessInitializationParameters&& parameters
 
 ModelProcess::~ModelProcess() = default;
 
-void ModelProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
-{
-    if (messageReceiverMap().dispatchMessage(connection, decoder))
-        return;
-
-    if (decoder.messageReceiverName() == Messages::AuxiliaryProcess::messageReceiverName()) {
-        AuxiliaryProcess::didReceiveMessage(connection, decoder);
-        return;
-    }
-
-    didReceiveModelProcessMessage(connection, decoder);
-}
-
 void ModelProcess::createModelConnectionToWebProcess(WebCore::ProcessIdentifier identifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, ModelProcessConnectionParameters&& parameters, CompletionHandler<void()>&& completionHandler)
 {
     RELEASE_LOG(Process, "%p - ModelProcess::createModelConnectionToWebProcess: processIdentifier=%" PRIu64, this, identifier.toUInt64());

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -44,7 +44,7 @@ class ModelConnectionToWebProcess;
 struct ModelProcessConnectionParameters;
 struct ModelProcessCreationParameters;
 
-class ModelProcess : public AuxiliaryProcess, public ThreadSafeRefCounted<ModelProcess> {
+class ModelProcess final : public AuxiliaryProcess, public ThreadSafeRefCounted<ModelProcess> {
     WTF_MAKE_NONCOPYABLE(ModelProcess);
     WTF_MAKE_TZONE_ALLOCATED(ModelProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ModelProcess);
@@ -83,7 +83,6 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    void didReceiveModelProcessMessage(IPC::Connection&, IPC::Decoder&);
 
     // Message Handlers
     void initializeModelProcess(ModelProcessCreationParameters&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/ModelProcess/ModelProcess.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcess.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(MODEL_PROCESS)
 
-messages -> ModelProcess LegacyReceiver {
+messages -> ModelProcess : AuxiliaryProcess {
     InitializeModelProcess(struct WebKit::ModelProcessCreationParameters processCreationParameters) -> ()
 
     CreateModelConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::ConnectionHandle connectionHandle, struct WebKit::ModelProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -462,6 +462,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) override;
+    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
 
     // DownloadManager::Client
     void didCreateDownload() override;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> NetworkProcess LegacyReceiver {
+messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     InitializeNetworkProcess(struct WebKit::NetworkProcessCreationParameters processCreationParameters) -> ()
 
     CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, struct WebKit::NetworkProcessConnectionParameters parameters) -> (std::optional<IPC::ConnectionHandle> connectionHandle, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1443,17 +1443,21 @@ def generate_message_handler(receiver):
         if receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE):
             result.append('    if (dispatchSyncMessage(connection, decoder, replyEncoder))\n')
             result.append('        return true;\n')
-        result.append('    UNUSED_PARAM(connection);\n')
-        result.append('    UNUSED_PARAM(decoder);\n')
-        result.append('    UNUSED_PARAM(replyEncoder);\n')
+        if (receiver.superclass):
+            result.append('    return %s::didReceiveSync%sMessage(connection, decoder, replyEncoder);\n' % (receiver.superclass, receive_variant))
+        else:
+            if not receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE):
+                result.append('    UNUSED_PARAM(connection);\n')
+            result.append('    UNUSED_PARAM(decoder);\n')
+            result.append('    UNUSED_PARAM(replyEncoder);\n')
 
-        if not receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE):
-            result.append('#if ENABLE(IPC_TESTING_API)\n')
-            result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
-            result.append('        return false;\n')
-            result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());\n')
-        result.append('    return false;\n')
+            if not receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE):
+                result.append('#if ENABLE(IPC_TESTING_API)\n')
+                result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
+                result.append('        return false;\n')
+                result.append('#endif // ENABLE(IPC_TESTING_API)\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());\n')
+            result.append('    return false;\n')
         result.append('}\n')
 
     result.append('\n')

--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -41,22 +41,27 @@ tests_directory = os.path.join(module_directory, 'tests')
 reset_results = False
 
 _test_receiver_names = [
-    'TestWithSuperclass',
+    'TestWithCVPixelBuffer',
+    'TestWithWantsDispatch',
+    'TestWithWantsDispatchNoSyncMessages',
+    'TestWithWantsAsyncDispatch',
+    'TestWithEnabledBy',
+    'TestWithEnabledByAndConjunction',
+    'TestWithEnabledByOrConjunction',
+    'TestWithEnabledIf',
+    'TestWithIfMessage',
+    'TestWithImageData',
     'TestWithLegacyReceiver',
     'TestWithoutAttributes',
     'TestWithoutUsingIPCConnection',
-    'TestWithIfMessage',
     'TestWithSemaphore',
-    'TestWithImageData',
     'TestWithStream',
     'TestWithStreamBatched',
     'TestWithStreamBuffer',
-    'TestWithCVPixelBuffer',
     'TestWithStreamServerConnectionHandle',
-    'TestWithEnabledBy',
-    'TestWithEnabledIf',
-    'TestWithEnabledByAndConjunction',
-    'TestWithEnabledByOrConjunction',
+    'TestWithSuperclass',
+    'TestWithSuperclassAndWantsAsyncDispatch',
+    'TestWithSuperclassAndWantsDispatch',
 ]
 
 

--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -1,21 +1,26 @@
 
 TESTS = \
-    TestWithSuperclass \
+    TestWithCVPixelBuffer \
+    TestWithWantsDispatch \
+    TestWithWantsDispatchNoSyncMessages \
+    TestWithWantsAsyncDispatch \
+    TestWithEnabledBy \
+    TestWithEnabledByAndConjunction \
+    TestWithEnabledByOrConjunction \
+    TestWithEnabledIf \
+    TestWithIfMessage \
+    TestWithImageData \
     TestWithLegacyReceiver \
     TestWithoutAttributes \
     TestWithoutUsingIPCConnection \
-    TestWithIfMessage \
     TestWithSemaphore \
-    TestWithImageData \
     TestWithStream \
     TestWithStreamBatched \
     TestWithStreamBuffer \
-    TestWithCVPixelBuffer \
     TestWithStreamServerConnectionHandle \
-    TestWithEnabledBy \
-    TestWithEnabledIf \
-    TestWithEnabledByAndConjunction \
-    TestWithEnabledByOrConjunction \
+    TestWithSuperclass \
+    TestWithSuperclassAndWantsAsyncDispatch \
+    TestWithSuperclassAndWantsDispatch \
 #
 
 all:

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -154,7 +154,16 @@
 #include <WebCore/TextManipulationToken.h>
 #include <WebCore/UserMediaRequestIdentifier.h>
 #include <WebCore/WebSocketIdentifier.h>
-#include "TestWithSuperclassMessages.h" // NOLINT
+#include "TestWithCVPixelBufferMessages.h" // NOLINT
+#include "TestWithWantsDispatchMessages.h" // NOLINT
+#include "TestWithWantsDispatchNoSyncMessagesMessages.h" // NOLINT
+#include "TestWithWantsAsyncDispatchMessages.h" // NOLINT
+#include "TestWithEnabledByMessages.h" // NOLINT
+#include "TestWithEnabledByAndConjunctionMessages.h" // NOLINT
+#include "TestWithEnabledByOrConjunctionMessages.h" // NOLINT
+#include "TestWithEnabledIfMessages.h" // NOLINT
+#include "TestWithIfMessageMessages.h" // NOLINT
+#include "TestWithImageDataMessages.h" // NOLINT
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
 #include "TestWithLegacyReceiverMessages.h" // NOLINT
 #endif
@@ -162,18 +171,14 @@
 #include "TestWithoutAttributesMessages.h" // NOLINT
 #endif
 #include "TestWithoutUsingIPCConnectionMessages.h" // NOLINT
-#include "TestWithIfMessageMessages.h" // NOLINT
 #include "TestWithSemaphoreMessages.h" // NOLINT
-#include "TestWithImageDataMessages.h" // NOLINT
 #include "TestWithStreamMessages.h" // NOLINT
 #include "TestWithStreamBatchedMessages.h" // NOLINT
 #include "TestWithStreamBufferMessages.h" // NOLINT
-#include "TestWithCVPixelBufferMessages.h" // NOLINT
 #include "TestWithStreamServerConnectionHandleMessages.h" // NOLINT
-#include "TestWithEnabledByMessages.h" // NOLINT
-#include "TestWithEnabledIfMessages.h" // NOLINT
-#include "TestWithEnabledByAndConjunctionMessages.h" // NOLINT
-#include "TestWithEnabledByOrConjunctionMessages.h" // NOLINT
+#include "TestWithSuperclassMessages.h" // NOLINT
+#include "TestWithSuperclassAndWantsAsyncDispatchMessages.h" // NOLINT
+#include "TestWithSuperclassAndWantsDispatchMessages.h" // NOLINT
 
 namespace IPC {
 
@@ -182,22 +187,50 @@ namespace IPC {
 std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObject, MessageName name, Decoder& decoder)
 {
     switch (name) {
-    case MessageName::TestWithSuperclass_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(globalObject, decoder);
-#if ENABLE(TEST_FEATURE)
-    case MessageName::TestWithSuperclass_TestAsyncMessage:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, decoder);
+#if USE(AVFOUNDATION)
+    case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
+        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer>(globalObject, decoder);
+    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
+        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
 #endif
-    case MessageName::TestWithSuperclass_TestSyncMessage:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsDispatch_TestMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithWantsDispatch_TestMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsDispatch_TestSyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithWantsDispatch_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsDispatchNoSyncMessages_TestMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithWantsDispatchNoSyncMessages_TestMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsAsyncDispatch_TestMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithWantsAsyncDispatch_TestMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsAsyncDispatch_TestSyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithWantsAsyncDispatch_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithEnabledBy_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledBy_ConditionallyEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_ConditionallyEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledBy_ConditionallyEnabledAnd:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_ConditionallyEnabledAnd>(globalObject, decoder);
+    case MessageName::TestWithEnabledBy_ConditionallyEnabledOr:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_ConditionallyEnabledOr>(globalObject, decoder);
+    case MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledIf_AlwaysEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(globalObject, decoder);
+#if PLATFORM(COCOA)
+    case MessageName::TestWithIfMessage_LoadURL:
+        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
+#endif
+#if PLATFORM(GTK)
+    case MessageName::TestWithIfMessage_LoadURL:
+        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
+#endif
+    case MessageName::TestWithImageData_SendImageData:
+        return jsValueForDecodedMessage<MessageName::TestWithImageData_SendImageData>(globalObject, decoder);
+    case MessageName::TestWithImageData_ReceiveImageData:
+        return jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_LoadURL:
         return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadURL>(globalObject, decoder);
@@ -330,22 +363,10 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, decoder);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
         return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, decoder);
-#if PLATFORM(COCOA)
-    case MessageName::TestWithIfMessage_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
-#endif
-#if PLATFORM(GTK)
-    case MessageName::TestWithIfMessage_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
-#endif
     case MessageName::TestWithSemaphore_SendSemaphore:
         return jsValueForDecodedMessage<MessageName::TestWithSemaphore_SendSemaphore>(globalObject, decoder);
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
         return jsValueForDecodedMessage<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, decoder);
-    case MessageName::TestWithImageData_SendImageData:
-        return jsValueForDecodedMessage<MessageName::TestWithImageData_SendImageData>(globalObject, decoder);
-    case MessageName::TestWithImageData_ReceiveImageData:
-        return jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
     case MessageName::TestWithStream_SendString:
         return jsValueForDecodedMessage<MessageName::TestWithStream_SendString>(globalObject, decoder);
     case MessageName::TestWithStream_SendStringAsync:
@@ -366,30 +387,32 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(globalObject, decoder);
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(globalObject, decoder);
-#if USE(AVFOUNDATION)
-    case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
-        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer>(globalObject, decoder);
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
-#endif
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
         return jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(globalObject, decoder);
-    case MessageName::TestWithEnabledBy_AlwaysEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_AlwaysEnabled>(globalObject, decoder);
-    case MessageName::TestWithEnabledBy_ConditionallyEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_ConditionallyEnabled>(globalObject, decoder);
-    case MessageName::TestWithEnabledBy_ConditionallyEnabledAnd:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_ConditionallyEnabledAnd>(globalObject, decoder);
-    case MessageName::TestWithEnabledBy_ConditionallyEnabledOr:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledBy_ConditionallyEnabledOr>(globalObject, decoder);
-    case MessageName::TestWithEnabledIf_AlwaysEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(globalObject, decoder);
-    case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(globalObject, decoder);
-    case MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled>(globalObject, decoder);
-    case MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_LoadURL:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(globalObject, decoder);
+#if ENABLE(TEST_FEATURE)
+    case MessageName::TestWithSuperclass_TestAsyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, decoder);
+#endif
+    case MessageName::TestWithSuperclass_TestSyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestSynchronousMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclassAndWantsAsyncDispatch_LoadURL:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsAsyncDispatch_LoadURL>(globalObject, decoder);
+    case MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclassAndWantsDispatch_LoadURL:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsDispatch_LoadURL>(globalObject, decoder);
+    case MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage>(globalObject, decoder);
     default:
         break;
     }
@@ -399,20 +422,16 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
 std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* globalObject, MessageName name, Decoder& decoder)
 {
     switch (name) {
-#if ENABLE(TEST_FEATURE)
-    case MessageName::TestWithSuperclass_TestAsyncMessage:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, decoder);
+#if USE(AVFOUNDATION)
+    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
+        return jsValueForDecodedMessageReply<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
 #endif
-    case MessageName::TestWithSuperclass_TestSyncMessage:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsDispatch_TestSyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithWantsDispatch_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithWantsAsyncDispatch_TestSyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithWantsAsyncDispatch_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithImageData_ReceiveImageData:
+        return jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_CreatePlugin:
         return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_CreatePlugin>(globalObject, decoder);
@@ -455,8 +474,6 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
         return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, decoder);
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
         return jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, decoder);
-    case MessageName::TestWithImageData_ReceiveImageData:
-        return jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
     case MessageName::TestWithStream_SendStringAsync:
         return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(globalObject, decoder);
     case MessageName::TestWithStream_SendStringSync:
@@ -469,10 +486,24 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
         return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, decoder);
 #endif
-#if USE(AVFOUNDATION)
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-        return jsValueForDecodedMessageReply<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
+#if ENABLE(TEST_FEATURE)
+    case MessageName::TestWithSuperclass_TestAsyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, decoder);
 #endif
+    case MessageName::TestWithSuperclass_TestSyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclass_TestSynchronousMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage>(globalObject, decoder);
     default:
         break;
     }
@@ -778,32 +809,81 @@ Vector<ASCIILiteral> serializedIdentifiers()
 std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageName name)
 {
     switch (name) {
-    case MessageName::TestWithSuperclass_LoadURL:
+#if USE(AVFOUNDATION)
+    case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
+        return Vector<ArgumentDescription> {
+            { "s0"_s, "RetainPtr<CVPixelBufferRef>"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
+        return Vector<ArgumentDescription> { };
+#endif
+    case MessageName::TestWithWantsDispatch_TestMessage:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s, ASCIILiteral(), false },
         };
-#if ENABLE(TEST_FEATURE)
-    case MessageName::TestWithSuperclass_TestAsyncMessage:
-        return Vector<ArgumentDescription> {
-            { "twoStateEnum"_s, "bool"_s, "WebKit::TestTwoStateEnum"_s, false },
-        };
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return Vector<ArgumentDescription> { };
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return Vector<ArgumentDescription> { };
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return Vector<ArgumentDescription> {
-            { "value"_s, "int"_s, ASCIILiteral(), false },
-        };
-#endif
-    case MessageName::TestWithSuperclass_TestSyncMessage:
+    case MessageName::TestWithWantsDispatch_TestSyncMessage:
         return Vector<ArgumentDescription> {
             { "param"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
+    case MessageName::TestWithWantsDispatchNoSyncMessages_TestMessage:
         return Vector<ArgumentDescription> {
-            { "value"_s, "bool"_s, ASCIILiteral(), false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
+    case MessageName::TestWithWantsAsyncDispatch_TestMessage:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithWantsAsyncDispatch_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "param"_s, "uint32_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledBy_AlwaysEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledBy_ConditionallyEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledBy_ConditionallyEnabledAnd:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithEnabledBy_ConditionallyEnabledOr:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledIf_AlwaysEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+#if PLATFORM(COCOA)
+    case MessageName::TestWithIfMessage_LoadURL:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+        };
+#endif
+#if PLATFORM(GTK)
+    case MessageName::TestWithIfMessage_LoadURL:
+        return Vector<ArgumentDescription> {
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+            { "value"_s, "int64_t"_s, ASCIILiteral(), false },
+        };
+#endif
+    case MessageName::TestWithImageData_SendImageData:
+        return Vector<ArgumentDescription> {
+            { "s0"_s, "RefPtr<WebCore::ImageData>"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithImageData_ReceiveImageData:
+        return Vector<ArgumentDescription> { };
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_LoadURL:
         return Vector<ArgumentDescription> {
@@ -1040,30 +1120,11 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "argument"_s, "String"_s, ASCIILiteral(), false },
         };
-#if PLATFORM(COCOA)
-    case MessageName::TestWithIfMessage_LoadURL:
-        return Vector<ArgumentDescription> {
-            { "url"_s, "String"_s, ASCIILiteral(), false },
-        };
-#endif
-#if PLATFORM(GTK)
-    case MessageName::TestWithIfMessage_LoadURL:
-        return Vector<ArgumentDescription> {
-            { "url"_s, "String"_s, ASCIILiteral(), false },
-            { "value"_s, "int64_t"_s, ASCIILiteral(), false },
-        };
-#endif
     case MessageName::TestWithSemaphore_SendSemaphore:
         return Vector<ArgumentDescription> {
             { "s0"_s, "IPC::Semaphore"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
-        return Vector<ArgumentDescription> { };
-    case MessageName::TestWithImageData_SendImageData:
-        return Vector<ArgumentDescription> {
-            { "s0"_s, "RefPtr<WebCore::ImageData>"_s, ASCIILiteral(), false },
-        };
-    case MessageName::TestWithImageData_ReceiveImageData:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithStream_SendString:
         return Vector<ArgumentDescription> {
@@ -1099,45 +1160,51 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "stream"_s, "IPC::StreamConnectionBuffer"_s, ASCIILiteral(), false },
         };
-#if USE(AVFOUNDATION)
-    case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
-        return Vector<ArgumentDescription> {
-            { "s0"_s, "RetainPtr<CVPixelBufferRef>"_s, ASCIILiteral(), false },
-        };
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-        return Vector<ArgumentDescription> { };
-#endif
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
         return Vector<ArgumentDescription> {
             { "handle"_s, "IPC::StreamServerConnectionHandle"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithEnabledBy_AlwaysEnabled:
+    case MessageName::TestWithSuperclass_LoadURL:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithEnabledBy_ConditionallyEnabled:
+#if ENABLE(TEST_FEATURE)
+    case MessageName::TestWithSuperclass_TestAsyncMessage:
         return Vector<ArgumentDescription> {
-            { "url"_s, "String"_s, ASCIILiteral(), false },
+            { "twoStateEnum"_s, "bool"_s, "WebKit::TestTwoStateEnum"_s, false },
         };
-    case MessageName::TestWithEnabledBy_ConditionallyEnabledAnd:
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
         return Vector<ArgumentDescription> { };
-    case MessageName::TestWithEnabledBy_ConditionallyEnabledOr:
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
         return Vector<ArgumentDescription> { };
-    case MessageName::TestWithEnabledIf_AlwaysEnabled:
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
+        return Vector<ArgumentDescription> {
+            { "value"_s, "int"_s, ASCIILiteral(), false },
+        };
+#endif
+    case MessageName::TestWithSuperclass_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "param"_s, "uint32_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclass_TestSynchronousMessage:
+        return Vector<ArgumentDescription> {
+            { "value"_s, "bool"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclassAndWantsAsyncDispatch_LoadURL:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
+    case MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "param"_s, "uint32_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclassAndWantsDispatch_LoadURL:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithEnabledByAndConjunction_AlwaysEnabled:
+    case MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage:
         return Vector<ArgumentDescription> {
-            { "url"_s, "String"_s, ASCIILiteral(), false },
-        };
-    case MessageName::TestWithEnabledByOrConjunction_AlwaysEnabled:
-        return Vector<ArgumentDescription> {
-            { "url"_s, "String"_s, ASCIILiteral(), false },
+            { "param"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
     default:
         break;
@@ -1148,30 +1215,23 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
 std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(MessageName name)
 {
     switch (name) {
-#if ENABLE(TEST_FEATURE)
-    case MessageName::TestWithSuperclass_TestAsyncMessage:
+#if USE(AVFOUNDATION)
+    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
         return Vector<ArgumentDescription> {
-            { "result"_s, "uint64_t"_s, ASCIILiteral(), false },
-        };
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return Vector<ArgumentDescription> { };
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return Vector<ArgumentDescription> {
-            { "flag"_s, "bool"_s, ASCIILiteral(), false },
-            { "value"_s, "uint64_t"_s, ASCIILiteral(), false },
-        };
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return Vector<ArgumentDescription> {
-            { "flag"_s, "bool"_s, ASCIILiteral(), false },
+            { "r0"_s, "RetainPtr<CVPixelBufferRef>"_s, ASCIILiteral(), false },
         };
 #endif
-    case MessageName::TestWithSuperclass_TestSyncMessage:
+    case MessageName::TestWithWantsDispatch_TestSyncMessage:
         return Vector<ArgumentDescription> {
             { "reply"_s, "uint8_t"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
+    case MessageName::TestWithWantsAsyncDispatch_TestSyncMessage:
         return Vector<ArgumentDescription> {
-            { "optionalReply"_s, "WebKit::TestClassName"_s, ASCIILiteral(), true },
+            { "reply"_s, "uint8_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithImageData_ReceiveImageData:
+        return Vector<ArgumentDescription> {
+            { "r0"_s, "RefPtr<WebCore::ImageData>"_s, ASCIILiteral(), false },
         };
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_CreatePlugin:
@@ -1237,10 +1297,6 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
         return Vector<ArgumentDescription> {
             { "r0"_s, "IPC::Semaphore"_s, ASCIILiteral(), false },
         };
-    case MessageName::TestWithImageData_ReceiveImageData:
-        return Vector<ArgumentDescription> {
-            { "r0"_s, "RefPtr<WebCore::ImageData>"_s, ASCIILiteral(), false },
-        };
     case MessageName::TestWithStream_SendStringAsync:
         return Vector<ArgumentDescription> {
             { "returnValue"_s, "int64_t"_s, ASCIILiteral(), false },
@@ -1261,12 +1317,39 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
             { "r1"_s, "MachSendRight"_s, ASCIILiteral(), false },
         };
 #endif
-#if USE(AVFOUNDATION)
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
+#if ENABLE(TEST_FEATURE)
+    case MessageName::TestWithSuperclass_TestAsyncMessage:
         return Vector<ArgumentDescription> {
-            { "r0"_s, "RetainPtr<CVPixelBufferRef>"_s, ASCIILiteral(), false },
+            { "result"_s, "uint64_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
+        return Vector<ArgumentDescription> {
+            { "flag"_s, "bool"_s, ASCIILiteral(), false },
+            { "value"_s, "uint64_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
+        return Vector<ArgumentDescription> {
+            { "flag"_s, "bool"_s, ASCIILiteral(), false },
         };
 #endif
+    case MessageName::TestWithSuperclass_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "reply"_s, "uint8_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclass_TestSynchronousMessage:
+        return Vector<ArgumentDescription> {
+            { "optionalReply"_s, "WebKit::TestClassName"_s, ASCIILiteral(), true },
+        };
+    case MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "reply"_s, "uint8_t"_s, ASCIILiteral(), false },
+        };
+    case MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "reply"_s, "uint8_t"_s, ASCIILiteral(), false },
+        };
     default:
         break;
     }

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -90,6 +90,8 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
 #endif
     { "TestWithStream_SendString"_s, ReceiverName::TestWithStream, true, false },
     { "TestWithStream_SendStringAsync"_s, ReceiverName::TestWithStream, true, false },
+    { "TestWithSuperclassAndWantsAsyncDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, false, false },
+    { "TestWithSuperclassAndWantsDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, false, false },
     { "TestWithSuperclass_LoadURL"_s, ReceiverName::TestWithSuperclass, false, false },
 #if ENABLE(TEST_FEATURE)
     { "TestWithSuperclass_TestAsyncMessage"_s, ReceiverName::TestWithSuperclass, false, false },
@@ -97,6 +99,9 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments"_s, ReceiverName::TestWithSuperclass, false, false },
     { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false },
 #endif
+    { "TestWithWantsAsyncDispatch_TestMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, false, false },
+    { "TestWithWantsDispatchNoSyncMessages_TestMessage"_s, ReceiverName::TestWithWantsDispatchNoSyncMessages, false, false },
+    { "TestWithWantsDispatch_TestMessage"_s, ReceiverName::TestWithWantsDispatch, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     { "TestWithoutAttributes_AddEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
@@ -180,8 +185,12 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithStream_SendAndReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
 #endif
     { "TestWithStream_SendStringSync"_s, ReceiverName::TestWithStream, true, false },
+    { "TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, true, false },
+    { "TestWithSuperclassAndWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, true, false },
     { "TestWithSuperclass_TestSyncMessage"_s, ReceiverName::TestWithSuperclass, true, false },
     { "TestWithSuperclass_TestSynchronousMessage"_s, ReceiverName::TestWithSuperclass, true, false },
+    { "TestWithWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, true, false },
+    { "TestWithWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsDispatch, true, false },
     { "TestWithoutAttributes_GetPluginProcessConnection"_s, ReceiverName::TestWithoutAttributes, true, false },
     { "TestWithoutAttributes_TestMultipleAttributes"_s, ReceiverName::TestWithoutAttributes, true, false },
     { "WrappedAsyncMessageForTesting"_s, ReceiverName::IPC, true, false },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -45,11 +45,16 @@ enum class ReceiverName : uint8_t {
     , TestWithStreamBuffer = 12
     , TestWithStreamServerConnectionHandle = 13
     , TestWithSuperclass = 14
-    , TestWithoutAttributes = 15
-    , TestWithoutUsingIPCConnection = 16
-    , IPC = 17
-    , AsyncReply = 18
-    , Invalid = 19
+    , TestWithSuperclassAndWantsAsyncDispatch = 15
+    , TestWithSuperclassAndWantsDispatch = 16
+    , TestWithWantsAsyncDispatch = 17
+    , TestWithWantsDispatch = 18
+    , TestWithWantsDispatchNoSyncMessages = 19
+    , TestWithoutAttributes = 20
+    , TestWithoutUsingIPCConnection = 21
+    , IPC = 22
+    , AsyncReply = 23
+    , Invalid = 24
 };
 
 enum class MessageName : uint16_t {
@@ -115,6 +120,8 @@ enum class MessageName : uint16_t {
 #endif
     TestWithStream_SendString,
     TestWithStream_SendStringAsync,
+    TestWithSuperclassAndWantsAsyncDispatch_LoadURL,
+    TestWithSuperclassAndWantsDispatch_LoadURL,
     TestWithSuperclass_LoadURL,
 #if ENABLE(TEST_FEATURE)
     TestWithSuperclass_TestAsyncMessage,
@@ -122,6 +129,9 @@ enum class MessageName : uint16_t {
     TestWithSuperclass_TestAsyncMessageWithMultipleArguments,
     TestWithSuperclass_TestAsyncMessageWithNoArguments,
 #endif
+    TestWithWantsAsyncDispatch_TestMessage,
+    TestWithWantsDispatchNoSyncMessages_TestMessage,
+    TestWithWantsDispatch_TestMessage,
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     TestWithoutAttributes_AddEvent,
 #endif
@@ -207,8 +217,12 @@ enum class MessageName : uint16_t {
     TestWithStream_SendAndReceiveMachSendRight,
 #endif
     TestWithStream_SendStringSync,
+    TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage,
+    TestWithSuperclassAndWantsDispatch_TestSyncMessage,
     TestWithSuperclass_TestSyncMessage,
     TestWithSuperclass_TestSynchronousMessage,
+    TestWithWantsAsyncDispatch_TestSyncMessage,
+    TestWithWantsDispatch_TestSyncMessage,
     TestWithoutAttributes_GetPluginProcessConnection,
     TestWithoutAttributes_TestMultipleAttributes,
     WrappedAsyncMessageForTesting,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatch.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,18 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AuxiliaryProcess NotRefCounted WantsDispatchMessage {
-    ShutDown()
-    SetProcessSuppressionEnabled(bool flag)
-
-    MainThreadPing() -> ()
-
-#if ENABLE(CFPREFS_DIRECT_MODE)
-    PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
-    PreferencesDidUpdate(HashMap<String, std::optional<String>> domainlessPreferences, HashMap<std::pair<String, String>, std::optional<String>> preferences)
-#endif
-
-#if OS(LINUX)
-    void DidReceiveMemoryPressureEvent(bool isCritical)
-#endif
+messages -> TestWithSuperclassAndWantsAsyncDispatch : WebPageBase WantsAsyncDispatchMessage {
+    LoadURL(String url)
+    TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessageReceiver.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithSuperclassAndWantsAsyncDispatch.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithSuperclassAndWantsAsyncDispatchMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithSuperclassAndWantsAsyncDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL>(connection, decoder, this, &TestWithSuperclassAndWantsAsyncDispatch::loadURL);
+    if (dispatchMessage(connection, decoder))
+        return;
+    WebPageBase::didReceiveMessage(connection, decoder);
+}
+
+bool TestWithSuperclassAndWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclassAndWantsAsyncDispatch::testSyncMessage);
+    return WebPageBase::didReceiveSyncMessage(connection, decoder, replyEncoder);
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsAsyncDispatch_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::ReplyArguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessages.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithSuperclassAndWantsAsyncDispatch {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithSuperclassAndWantsAsyncDispatch;
+}
+
+class LoadURL {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclassAndWantsAsyncDispatch_LoadURL; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    explicit LoadURL(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+class TestSyncMessage {
+public:
+    using Arguments = std::tuple<uint32_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage; }
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<uint8_t>;
+    using Reply = CompletionHandler<void(uint8_t)>;
+    explicit TestSyncMessage(uint32_t param)
+        : m_arguments(param)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<uint32_t> m_arguments;
+};
+
+} // namespace TestWithSuperclassAndWantsAsyncDispatch
+} // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatch.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,18 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AuxiliaryProcess NotRefCounted WantsDispatchMessage {
-    ShutDown()
-    SetProcessSuppressionEnabled(bool flag)
-
-    MainThreadPing() -> ()
-
-#if ENABLE(CFPREFS_DIRECT_MODE)
-    PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
-    PreferencesDidUpdate(HashMap<String, std::optional<String>> domainlessPreferences, HashMap<std::pair<String, String>, std::optional<String>> preferences)
-#endif
-
-#if OS(LINUX)
-    void DidReceiveMemoryPressureEvent(bool isCritical)
-#endif
+messages -> TestWithSuperclassAndWantsDispatch : WebPageBase WantsDispatchMessage {
+    LoadURL(String url)
+    TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessageReceiver.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithSuperclassAndWantsDispatch.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithSuperclassAndWantsDispatchMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithSuperclassAndWantsDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsDispatch::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithSuperclassAndWantsDispatch::LoadURL>(connection, decoder, this, &TestWithSuperclassAndWantsDispatch::loadURL);
+    if (dispatchMessage(connection, decoder))
+        return;
+    WebPageBase::didReceiveMessage(connection, decoder);
+}
+
+bool TestWithSuperclassAndWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclassAndWantsDispatch::testSyncMessage);
+    if (dispatchSyncMessage(connection, decoder, replyEncoder))
+        return true;
+    return WebPageBase::didReceiveSyncMessage(connection, decoder, replyEncoder);
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsDispatch_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclassAndWantsDispatch::LoadURL::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::ReplyArguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessages.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithSuperclassAndWantsDispatch {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithSuperclassAndWantsDispatch;
+}
+
+class LoadURL {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclassAndWantsDispatch_LoadURL; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    explicit LoadURL(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+class TestSyncMessage {
+public:
+    using Arguments = std::tuple<uint32_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage; }
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<uint8_t>;
+    using Reply = CompletionHandler<void(uint8_t)>;
+    explicit TestSyncMessage(uint32_t param)
+        : m_arguments(param)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<uint32_t> m_arguments;
+};
+
+} // namespace TestWithSuperclassAndWantsDispatch
+} // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -67,15 +67,7 @@ bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC:
         return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSyncMessage);
     if (decoder.messageName() == Messages::TestWithSuperclass::TestSynchronousMessage::name())
         return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSynchronousMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSynchronousMessage);
-    UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-    UNUSED_PARAM(replyEncoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return false;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
-    return false;
+    return WebPageBase::didReceiveSyncMessage(connection, decoder, replyEncoder);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatch.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,18 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AuxiliaryProcess NotRefCounted WantsDispatchMessage {
-    ShutDown()
-    SetProcessSuppressionEnabled(bool flag)
-
-    MainThreadPing() -> ()
-
-#if ENABLE(CFPREFS_DIRECT_MODE)
-    PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
-    PreferencesDidUpdate(HashMap<String, std::optional<String>> domainlessPreferences, HashMap<std::pair<String, String>, std::optional<String>> preferences)
-#endif
-
-#if OS(LINUX)
-    void DidReceiveMemoryPressureEvent(bool isCritical)
-#endif
+messages -> TestWithWantsAsyncDispatch WantsAsyncDispatchMessage {
+    TestMessage(String url)
+    TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithWantsAsyncDispatch.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithWantsAsyncDispatchMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithWantsAsyncDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestMessage::name())
+        return IPC::handleMessage<Messages::TestWithWantsAsyncDispatch::TestMessage>(connection, decoder, this, &TestWithWantsAsyncDispatch::testMessage);
+    if (dispatchMessage(connection, decoder))
+        return;
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+}
+
+bool TestWithWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestSyncMessage::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithWantsAsyncDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithWantsAsyncDispatch::testSyncMessage);
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(replyEncoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return false;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    return false;
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithWantsAsyncDispatch_TestMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsAsyncDispatch::TestMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithWantsAsyncDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsAsyncDispatch::TestSyncMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithWantsAsyncDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsAsyncDispatch::TestSyncMessage::ReplyArguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessages.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithWantsAsyncDispatch {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithWantsAsyncDispatch;
+}
+
+class TestMessage {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithWantsAsyncDispatch_TestMessage; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    explicit TestMessage(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+class TestSyncMessage {
+public:
+    using Arguments = std::tuple<uint32_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithWantsAsyncDispatch_TestSyncMessage; }
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<uint8_t>;
+    using Reply = CompletionHandler<void(uint8_t)>;
+    explicit TestSyncMessage(uint32_t param)
+        : m_arguments(param)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<uint32_t> m_arguments;
+};
+
+} // namespace TestWithWantsAsyncDispatch
+} // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatch.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatch.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,18 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AuxiliaryProcess NotRefCounted WantsDispatchMessage {
-    ShutDown()
-    SetProcessSuppressionEnabled(bool flag)
-
-    MainThreadPing() -> ()
-
-#if ENABLE(CFPREFS_DIRECT_MODE)
-    PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
-    PreferencesDidUpdate(HashMap<String, std::optional<String>> domainlessPreferences, HashMap<std::pair<String, String>, std::optional<String>> preferences)
-#endif
-
-#if OS(LINUX)
-    void DidReceiveMemoryPressureEvent(bool isCritical)
-#endif
+messages -> TestWithWantsDispatch WantsDispatchMessage {
+    TestMessage(String url)
+    TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithWantsDispatch.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithWantsDispatchMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithWantsDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithWantsDispatch::TestMessage::name())
+        return IPC::handleMessage<Messages::TestWithWantsDispatch::TestMessage>(connection, decoder, this, &TestWithWantsDispatch::testMessage);
+    if (dispatchMessage(connection, decoder))
+        return;
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+}
+
+bool TestWithWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithWantsDispatch::TestSyncMessage::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithWantsDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithWantsDispatch::testSyncMessage);
+    if (dispatchSyncMessage(connection, decoder, replyEncoder))
+        return true;
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(replyEncoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return false;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    return false;
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithWantsDispatch_TestMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsDispatch::TestMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithWantsDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsDispatch::TestSyncMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithWantsDispatch_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsDispatch::TestSyncMessage::ReplyArguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessages.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithWantsDispatch {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithWantsDispatch;
+}
+
+class TestMessage {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithWantsDispatch_TestMessage; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    explicit TestMessage(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+class TestSyncMessage {
+public:
+    using Arguments = std::tuple<uint32_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithWantsDispatch_TestSyncMessage; }
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<uint8_t>;
+    using Reply = CompletionHandler<void(uint8_t)>;
+    explicit TestSyncMessage(uint32_t param)
+        : m_arguments(param)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<uint32_t> m_arguments;
+};
+
+} // namespace TestWithWantsDispatch
+} // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessages.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessages.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,18 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AuxiliaryProcess NotRefCounted WantsDispatchMessage {
-    ShutDown()
-    SetProcessSuppressionEnabled(bool flag)
-
-    MainThreadPing() -> ()
-
-#if ENABLE(CFPREFS_DIRECT_MODE)
-    PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
-    PreferencesDidUpdate(HashMap<String, std::optional<String>> domainlessPreferences, HashMap<std::pair<String, String>, std::optional<String>> preferences)
-#endif
-
-#if OS(LINUX)
-    void DidReceiveMemoryPressureEvent(bool isCritical)
-#endif
+// Tests that WantsDispatchMessage generates sync message handing even though 
+// the message list does not have sync messages.
+messages -> TestWithWantsDispatchNoSyncMessages WantsDispatchMessage {
+    TestMessage(String url)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithWantsDispatchNoSyncMessages.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithWantsDispatchNoSyncMessagesMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithWantsDispatchNoSyncMessages::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::name())
+        return IPC::handleMessage<Messages::TestWithWantsDispatchNoSyncMessages::TestMessage>(connection, decoder, this, &TestWithWantsDispatchNoSyncMessages::testMessage);
+    if (dispatchMessage(connection, decoder))
+        return;
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+}
+
+bool TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    Ref protectedThis { *this };
+    if (dispatchSyncMessage(connection, decoder, replyEncoder))
+        return true;
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(replyEncoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return false;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    return false;
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithWantsDispatchNoSyncMessages_TestMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::Arguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessages.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithWantsDispatchNoSyncMessages {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithWantsDispatchNoSyncMessages;
+}
+
+class TestMessage {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithWantsDispatchNoSyncMessages_TestMessage; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    explicit TestMessage(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+} // namespace TestWithWantsDispatchNoSyncMessages
+} // namespace Messages

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -130,6 +130,16 @@ void AuxiliaryProcess::initializeConnection(IPC::Connection*)
 {
 }
 
+bool AuxiliaryProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    return m_messageReceiverMap.dispatchMessage(connection, decoder);
+}
+
+bool AuxiliaryProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
+}
+
 void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -142,6 +142,9 @@ protected:
 #endif
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
 #if OS(LINUX)
     void didReceiveMemoryPressureEvent(bool isCritical);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -167,7 +167,7 @@ class LayerHostingContext;
 class SpeechRecognitionRealtimeMediaSourceManager;
 #endif
 
-class WebProcess : public AuxiliaryProcess
+class WebProcess final : public AuxiliaryProcess
 {
     WTF_MAKE_TZONE_ALLOCATED(WebProcess);
 public:
@@ -599,11 +599,8 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) final;
-
-    // Implemented in generated WebProcessMessageReceiver.cpp
-    void didReceiveWebProcessMessage(IPC::Connection&, IPC::Decoder&);
+    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
 
 #if PLATFORM(MAC)
     void scrollerStylePreferenceChanged(bool useOverlayScrollbars);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebProcess LegacyReceiver NotRefCounted {
+messages -> WebProcess : AuxiliaryProcess NotRefCounted WantsAsyncDispatchMessage {
     InitializeWebProcess(struct WebKit::WebProcessCreationParameters processCreationParameters) -> (WebCore::ProcessIdentity processIdentity)
     SetWebsiteDataStoreParameters(struct WebKit::WebProcessDataStoreParameters parameters)
 


### PR DESCRIPTION
#### 64e0879489042142d935d6b615999b111bc1a5e1
<pre>
Remove LegacyReceiver from all Process message receivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=279582">https://bugs.webkit.org/show_bug.cgi?id=279582</a>
<a href="https://rdar.apple.com/135859566">rdar://135859566</a>

Reviewed by Chris Dumez.

Avoid forwarding the messages manually, rather mark the message
receivers as having AuxiliaryProcess as the superclass.

Fix superclass implementation to generate call to superclass sync
message handling code.

This is work towads simplifying delivery of messages by being able to
remove LegacyReceiver implementation.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::didReceiveMessage): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
(WebKit::GPUProcess::sharedSceneContext): Deleted.
(WebKit::GPUProcess::applicationVisibleName const): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::didReceiveMessage): Deleted.
* Source/WebKit/ModelProcess/ModelProcess.h:
(WebKit::ModelProcess::applicationVisibleName const): Deleted.
* Source/WebKit/ModelProcess/ModelProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::dispatchMessage):
(WebKit::NetworkProcess::didReceiveMessage): Deleted.
(WebKit::NetworkProcess::didReceiveSyncMessage): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::jsValueForReplyArguments):
(IPC::messageArgumentDescriptions):
(IPC::messageReplyArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatch.messages.in: Copied from Source/WebKit/Shared/AuxiliaryProcess.messages.in.
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessageReceiver.cpp: Added.
(WebKit::TestWithSuperclassAndWantsAsyncDispatch::didReceiveMessage):
(WebKit::TestWithSuperclassAndWantsAsyncDispatch::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclassAndWantsAsyncDispatch_LoadURL&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclassAndWantsAsyncDispatch_TestSyncMessage&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessages.h: Added.
(Messages::TestWithSuperclassAndWantsAsyncDispatch::messageReceiverName):
(Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::name):
(Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::LoadURL):
(Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::arguments):
(Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::name):
(Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::TestSyncMessage):
(Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::arguments):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatch.messages.in: Copied from Source/WebKit/Shared/AuxiliaryProcess.messages.in.
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessageReceiver.cpp: Added.
(WebKit::TestWithSuperclassAndWantsDispatch::didReceiveMessage):
(WebKit::TestWithSuperclassAndWantsDispatch::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclassAndWantsDispatch_LoadURL&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclassAndWantsDispatch_TestSyncMessage&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessages.h: Added.
(Messages::TestWithSuperclassAndWantsDispatch::messageReceiverName):
(Messages::TestWithSuperclassAndWantsDispatch::LoadURL::name):
(Messages::TestWithSuperclassAndWantsDispatch::LoadURL::LoadURL):
(Messages::TestWithSuperclassAndWantsDispatch::LoadURL::arguments):
(Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::name):
(Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::TestSyncMessage):
(Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::arguments):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatch.messages.in: Copied from Source/WebKit/Shared/AuxiliaryProcess.messages.in.
* Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp: Added.
(WebKit::TestWithWantsAsyncDispatch::didReceiveMessage):
(WebKit::TestWithWantsAsyncDispatch::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithWantsAsyncDispatch_TestMessage&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithWantsAsyncDispatch_TestSyncMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithWantsAsyncDispatch_TestSyncMessage&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessages.h: Added.
(Messages::TestWithWantsAsyncDispatch::messageReceiverName):
(Messages::TestWithWantsAsyncDispatch::TestMessage::name):
(Messages::TestWithWantsAsyncDispatch::TestMessage::TestMessage):
(Messages::TestWithWantsAsyncDispatch::TestMessage::arguments):
(Messages::TestWithWantsAsyncDispatch::TestSyncMessage::name):
(Messages::TestWithWantsAsyncDispatch::TestSyncMessage::TestSyncMessage):
(Messages::TestWithWantsAsyncDispatch::TestSyncMessage::arguments):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatch.messages.in: Copied from Source/WebKit/Shared/AuxiliaryProcess.messages.in.
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp: Added.
(WebKit::TestWithWantsDispatch::didReceiveMessage):
(WebKit::TestWithWantsDispatch::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithWantsDispatch_TestMessage&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithWantsDispatch_TestSyncMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithWantsDispatch_TestSyncMessage&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessages.h: Added.
(Messages::TestWithWantsDispatch::messageReceiverName):
(Messages::TestWithWantsDispatch::TestMessage::name):
(Messages::TestWithWantsDispatch::TestMessage::TestMessage):
(Messages::TestWithWantsDispatch::TestMessage::arguments):
(Messages::TestWithWantsDispatch::TestSyncMessage::name):
(Messages::TestWithWantsDispatch::TestSyncMessage::TestSyncMessage):
(Messages::TestWithWantsDispatch::TestSyncMessage::arguments):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessages.messages.in: Copied from Source/WebKit/Shared/AuxiliaryProcess.messages.in.
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp: Added.
(WebKit::TestWithWantsDispatchNoSyncMessages::didReceiveMessage):
(WebKit::TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithWantsDispatchNoSyncMessages_TestMessage&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessages.h: Added.
(Messages::TestWithWantsDispatchNoSyncMessages::messageReceiverName):
(Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::name):
(Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::TestMessage):
(Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::arguments):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::dispatchMessage):
(WebKit::AuxiliaryProcess::dispatchSyncMessage):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/AuxiliaryProcess.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::dispatchMessage):
(WebKit::WebProcess::didReceiveSyncMessage): Deleted.
(WebKit::WebProcess::didReceiveMessage): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::supplement): Deleted.
(WebKit::WebProcess::addSupplement): Deleted.
(WebKit::WebProcess::hasEverHadAnyWebPages const): Deleted.
(WebKit::WebProcess::isWebTransportEnabled const): Deleted.
(WebKit::WebProcess::injectedBundle const): Deleted.
(WebKit::WebProcess::sessionID const): Deleted.
(WebKit::WebProcess::thirdPartyCookieBlockingMode const): Deleted.
(WebKit::WebProcess::compositingRenderServerPort const): Deleted.
(WebKit::WebProcess::setCompositingRenderServerPort): Deleted.
(WebKit::WebProcess::fullKeyboardAccessEnabled const): Deleted.
(WebKit::WebProcess::hasMouseDevice const): Deleted.
(WebKit::WebProcess::hasStylusDevice const): Deleted.
(WebKit::WebProcess::textCheckerState const): Deleted.
(WebKit::WebProcess::eventDispatcher): Deleted.
(WebKit::WebProcess::existingNetworkProcessConnection): Deleted.
(WebKit::WebProcess::existingGPUProcessConnection): Deleted.
(WebKit::WebProcess::existingModelProcessConnection): Deleted.
(WebKit::WebProcess::uiProcessBundleIdentifier const): Deleted.
(WebKit::WebProcess::hasImageServices const): Deleted.
(WebKit::WebProcess::hasSelectionServices const): Deleted.
(WebKit::WebProcess::hasRichContentServices const): Deleted.
(WebKit::WebProcess::automationSessionProxy): Deleted.
(WebKit::WebProcess::modelProcessModelPlayerManager): Deleted.
(WebKit::WebProcess::cacheStorageProvider): Deleted.
(WebKit::WebProcess::badgeClient): Deleted.
(WebKit::WebProcess::remoteMediaPlayerManager): Deleted.
(WebKit::WebProcess::remoteImageDecoderAVFManager): Deleted.
(WebKit::WebProcess::broadcastChannelRegistry): Deleted.
(WebKit::WebProcess::cookieJar): Deleted.
(WebKit::WebProcess::webSocketChannelManager): Deleted.
(WebKit::WebProcess::backlightLevel const): Deleted.
(WebKit::WebProcess::isLockdownModeEnabled const): Deleted.
(WebKit::WebProcess::imageAnimationEnabled const): Deleted.
(WebKit::WebProcess::prefersNonBlinkingCursor const): Deleted.
(WebKit::WebProcess::setHadMainFrameMainResourcePrivateRelayed): Deleted.
(WebKit::WebProcess::hadMainFrameMainResourcePrivateRelayed const): Deleted.
(WebKit::WebProcess::dmaBufRendererBufferMode const): Deleted.
(WebKit::WebProcess::mediaKeysStorageDirectory const): Deleted.
(WebKit::WebProcess::mediaKeysStorageSalt const): Deleted.
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/283632@main">https://commits.webkit.org/283632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e414a91e85556da0afe905377c75e48cb7792ac1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17824 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53442 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34110 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/66203 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39081 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16178 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59805 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72427 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65936 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60767 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61102 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2386 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41873 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15423 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->