### PR TITLE
MediaPlayerPrivate are not consistent in how much they reuse the MediaPlayer resource loader

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1588,9 +1588,12 @@ CachedResourceLoader* MediaPlayer::cachedResourceLoader()
     return client().mediaPlayerCachedResourceLoader();
 }
 
-Ref<PlatformMediaResourceLoader> MediaPlayer::createResourceLoader()
+Ref<PlatformMediaResourceLoader> MediaPlayer::mediaResourceLoader()
 {
-    return client().mediaPlayerCreateResourceLoader();
+    if (!m_mediaResourceLoader)
+        m_mediaResourceLoader = client().mediaPlayerCreateResourceLoader();
+
+    return *m_mediaResourceLoader;
 }
 
 void MediaPlayer::addAudioTrack(AudioTrackPrivate& track)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -618,7 +618,7 @@ public:
     String elementId() const;
 
     CachedResourceLoader* cachedResourceLoader();
-    Ref<PlatformMediaResourceLoader> createResourceLoader();
+    Ref<PlatformMediaResourceLoader> mediaResourceLoader();
 
     void addAudioTrack(AudioTrackPrivate&);
     void addTextTrack(InbandTextTrackPrivate&);
@@ -809,6 +809,7 @@ private:
     bool m_initializingMediaEngine { false };
     DynamicRangeMode m_preferredDynamicRangeMode;
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
+    RefPtr<PlatformMediaResourceLoader> m_mediaResourceLoader;
 
 #if ENABLE(MEDIA_SOURCE)
     ThreadSafeWeakPtr<MediaSourcePrivateClient> m_mediaSource;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1020,7 +1020,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     AVAssetResourceLoader *resourceLoader = [m_avAsset resourceLoader];
     [resourceLoader setDelegate:m_loaderDelegate.get() queue:globalLoaderDelegateQueue()];
 
-    Ref mediaResourceLoader = player->createResourceLoader();
+    Ref mediaResourceLoader = player->mediaResourceLoader();
     m_targetDispatcher = mediaResourceLoader->targetDispatcher();
     resourceLoader.URLSession = (NSURLSession *)adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:mediaResourceLoader delegate:resourceLoader.URLSessionDataDelegate delegateQueue:resourceLoader.URLSessionDataDelegateQueue]).get();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -332,7 +332,7 @@ void WebCoreAVFResourceLoader::startLoading()
             return;
     }
 
-    m_platformMediaLoader = PlatformResourceMediaLoader::create(*this, parent->player()->createResourceLoader(), WTFMove(request));
+    m_platformMediaLoader = PlatformResourceMediaLoader::create(*this, parent->player()->mediaResourceLoader(), WTFMove(request));
     if (m_platformMediaLoader)
         return;
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -268,7 +268,7 @@ bool MediaPlayerPrivateWebM::createResourceClient()
         request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes="_s, m_contentReceived, '-', m_contentLength));
     }
 
-    m_resourceClient = WebMResourceClient::create(*this, player->createResourceLoader(), WTFMove(request));
+    m_resourceClient = WebMResourceClient::create(*this, player->mediaResourceLoader(), WTFMove(request));
 
     return !!m_resourceClient;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -178,7 +178,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
 #if USE(TEXTURE_MAPPER_DMABUF)
     , m_swapchain(adoptRef(new GBMBufferSwapchain(GBMBufferSwapchain::BufferSwapchainSize::Eight)))
 #endif
-    , m_loader(player->createResourceLoader())
+    , m_loader(player->mediaResourceLoader())
 {
 
 #if !RELEASE_LOG_DISABLED && !defined(GST_DISABLE_GST_DEBUG)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -478,7 +478,6 @@ private:
     RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return m_manager.gpuProcessConnection().videoFrameObjectHeapProxy(); }
 
     ThreadSafeWeakPtr<WebCore::MediaPlayer> m_player;
-    Ref<WebCore::PlatformMediaResourceLoader> m_mediaResourceLoader;
 #if PLATFORM(COCOA)
     mutable UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager;
 #endif


### PR DESCRIPTION
#### 0a1d85c0a0c45262b15eefecf04efbf86a7a8f5c
<pre>
MediaPlayerPrivate are not consistent in how much they reuse the MediaPlayer resource loader
<a href="https://rdar.apple.com/135853071">rdar://135853071</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279579">https://bugs.webkit.org/show_bug.cgi?id=279579</a>

Reviewed by Jean-Yves Avenard.

MediaPlayerPrivateRemote is keeping the same MediaResourceLoader throughout the loads, while other player private may create several MediaResourceLoaders.
To keep things consistent between all of them, we align with MediaPlayerPrivateRemote and move the actualy creation of the MediaResourceLoader to MediaPlayer.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::mediaResourceLoader):
(WebCore::MediaPlayer::createResourceLoader): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::startLoading):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::createResourceClient):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::MediaPlayerPrivateRemote):
(WebKit::MediaPlayerPrivateRemote::requestResource):
(WebKit::MediaPlayerPrivateRemote::sendH2Ping):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/283611@main">https://commits.webkit.org/283611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f0890fa0648b6056e92aa70ddd145f57be964e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53396 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61070 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14760 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2338 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41816 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->