### PR TITLE
Fix potential crash with InteractionRegion layers management

### DIFF
--- a/LayoutTests/interaction-region/guard-crash-expected.txt
+++ b/LayoutTests/interaction-region/guard-crash-expected.txt
@@ -1,0 +1,172 @@
+
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer anchorPoint [x: 0 y: 0])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer anchorPoint [x: 0 y: 0])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer position [x: 400 y: 400])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer anchorPoint [x: 0 y: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer anchorPoint [x: 0 y: 0])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer anchorPoint [x: 0 y: 0]))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 382 y: 382]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 498 y: 498]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 614 y: 614]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 730 y: 730]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 58 y: 58]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 174 y: 174]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 290 y: 290]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 406 y: 406]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 522 y: 522]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 638 y: 638]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 58 y: 58]))
+                            (
+                              (type 2)
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 27 y: 27]))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 38 height: 38]))
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 27 y: 27]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 18 height: 18])
+                              (layer position [x: 27 y: 27]))
+                            (
+                              (type 2)
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 81 y: 81]))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 38 height: 38]))
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 81 y: 81]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 18 height: 18])
+                              (layer position [x: 81 y: 81]))
+                            (
+                              (type 2)
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 135 y: 135]))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 38 height: 38]))
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 135 y: 135]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 18 height: 18])
+                              (layer position [x: 135 y: 135]))
+                            (
+                              (type 2)
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 189 y: 189]))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 38 height: 38]))
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 189 y: 189]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 18 height: 18])
+                              (layer position [x: 189 y: 189]))
+                            (
+                              (type 2)
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 243 y: 243]))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 38 height: 38]))
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 243 y: 243]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 18 height: 18])
+                              (layer position [x: 243 y: 243]))
+                            (
+                              (type 2)
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 297 y: 297]))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 38 height: 38]))
+                              (layer bounds [x: 0 y: 0 width: 38 height: 38])
+                              (layer position [x: 297 y: 297]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 18 height: 18])
+                              (layer position [x: 297 y: 297]))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+      (layer position [x: 400 y: 400]))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+

--- a/LayoutTests/interaction-region/guard-crash.html
+++ b/LayoutTests/interaction-region/guard-crash.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    .guard-dupe {
+        position: relative;
+    }
+
+    .guard-dupe a {
+        font-size: 20px;
+        line-height: 20px;
+        background: white;
+    }
+
+    .guard-dupe img {
+        display: block;
+        width: 38px;
+        height:38px;
+    }
+
+    .red {
+        cursor: pointer;
+        background: red;
+        opacity: 0.5;
+
+        width: 18px;
+        height: 18px;
+        position: absolute;
+        top: 10px;
+        left: 10px;
+    }
+
+    .interaction {
+        width: 100px;
+        height: 100px;
+
+        cursor: pointer;
+        background: yellow;
+    }
+
+    .guard-dupe, .interaction {
+        float: left;
+        margin: 8px;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+
+<div class="guard-dupe">
+    <!-- This would get a guard because it's too small. -->
+    <div class="red" style="" onclick="click()"></div>
+    <!-- This guard container will have the exact same rect -->
+    <a href="#" onclick="click()" class="duck">
+        <img src="../css3/blending/resources/ducky.png" style="" alt="ducky" />
+    </a>
+</div>
+
+<div class="interaction" onclick="click()"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    const repeat = 10;
+    let guard = document.querySelector(".guard-dupe");
+    let interaction = document.querySelector(".interaction");
+
+    let guards = [];
+    let interactions = [];
+    for (let i = 0; i < repeat; i++) {
+        guards.push(guard.cloneNode(true));
+        interactions.push(interaction.cloneNode(true));
+    }
+
+    for (let i = 0; i < repeat; i++) {
+        document.body.appendChild(interactions[i]);
+        document.body.appendChild(guards[i]);
+    }
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    // Remove and re-order elements to cause InteractionRegion layers churn.
+    await Array.from(document.querySelectorAll(".guard-dupe")).reduce( async (acc, el, idx) => {
+        await acc;
+        el.remove();
+        if (idx % 2 == 0)
+            document.body.insertBefore(el, document.body.firstElementChild);
+        return UIHelper.ensureStablePresentationUpdate();
+    }, Promise.resolve());
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    if (window.internals)
+        results.textContent = await UIHelper.getCALayerTree();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -76,7 +76,8 @@ private:
     Vector<InteractionRegion> m_interactionRegions;
     HashMap<IntRect, InteractionRegion::ContentHint> m_interactionRectsAndContentHints;
     HashSet<IntRect> m_occlusionRects;
-    HashSet<IntRect> m_elementGuardRects;
+    enum class Inflated : bool { No, Yes };
+    HashMap<IntRect, Inflated> m_guardRects;
     HashSet<ElementIdentifier> m_containerRemovalCandidates;
     HashSet<ElementIdentifier> m_containersToRemove;
     HashMap<ElementIdentifier, Vector<InteractionRegion>> m_discoveredRegionsByElement;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -266,6 +266,7 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
 
         if (didReuseLayer) {
             auto layerKey = std::make_pair(enclosingIntRect([regionLayer frame]), region.type);
+            auto reuseKey = std::make_pair(interactionRegionGroupNameForLayer(regionLayer.get()), region.type);
             existingLayers.remove(layerKey);
             reusableLayers.remove(reuseKey);
 


### PR DESCRIPTION
#### 42916e1617b60d50109fbaf402b3993c169e8068
<pre>
Fix potential crash with InteractionRegion layers management
<a href="https://bugs.webkit.org/show_bug.cgi?id=279584">https://bugs.webkit.org/show_bug.cgi?id=279584</a>
&lt;<a href="https://rdar.apple.com/134409589">rdar://134409589</a>&gt;

Reviewed by Mike Wyrzykowski.

This patches addresses 2 sources of assertion failures which could lead
to a crash:
- duplicate Guard layers covering the same IntRect, breaking the
  assertion on the uniqueness of the `&lt;IntRect, InteractionRegion::Type&gt;`
  pairs.
- layers reused twice, breaking the assertion on the `insertionPoint`
  always being &lt;=the sublayers count.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
(WebCore::EventRegionContext::removeSuperfluousInteractionRegions):
Keep track of all guard rects, _including_ the inflated ones we add for
small elements or complex shapes, to avoid duplicates.
We still need to differentiate the two since only the inflated ones can
get collided out in `removeSuperfluousInteractionRegions`.

(WebCore::EventRegionContext::convertGuardContainersToInterationIfNeeded):
Finish migrating the InteractionRegion rect tracking code to use
`HashMap#add()` / `isNewEntry` to avoid extra hash lookups.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
Fix a bug where a layer was sometimes not removed from the reusable map
after use.

* LayoutTests/interaction-region/guard-crash-expected.txt: Added.
* LayoutTests/interaction-region/guard-crash.html: Added.
Introduce a test covering those assertion failures.
(The expected layer tree would reveal the bug even in release mode.)

Canonical link: <a href="https://commits.webkit.org/283602@main">https://commits.webkit.org/283602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f09d2874e063b6188139154e5ae26e692b2dac2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53400 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72379 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61061 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2346 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->