### PR TITLE
Re-import WPT html/dom/elements/global-attributes/

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1093,6 +1093,8 @@ webkit.org/b/222750 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/217617 [ Release ] imported/w3c/web-platform-tests/service-workers/service-worker/clients-matchall-order.https.html [ Pass Failure ]
 webkit.org/b/217617 imported/w3c/web-platform-tests/service-workers/service-worker/navigate-window.https.html [ Pass Failure ]
 
+webkit.org/b/279748 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html [ Pass Failure ]
+
 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/getregistrations.https.html [ Slow ]
 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/multiple-update.https.html [ Slow ]
 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/windowclient-navigate.https.html [ Slow ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/cdata-dir_auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/cdata-dir_auto.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <div id="test1" dir="auto">
-        اختبر
+        <![CDATA[foo]]>اختبر
     </div>
 
     <iframe src="cdata-iframe.xhtml"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
@@ -12,11 +12,12 @@ PASS Slotted content affects multiple dir=auto slots
 PASS Removing slotted content resets direction on dir=auto slot
 FAIL Removing child of slotted content changes direction on dir=auto slot assert_equals: slot is reset to ltr expected "ltr" but got "rtl"
 PASS Child directionality gets updated when dir=auto is set on parent
-FAIL dir=auto slot is updated by text in value of input element children assert_equals: expected "ltr" but got "rtl"
-FAIL dir=auto slot is updated if input stops being auto-directionality form-associated assert_equals: expected "ltr" but got "rtl"
+FAIL dir=auto slot is not affected by text in value of input element children assert_equals: expected "ltr" but got "rtl"
+PASS input direction changes if it stops being auto-directionality form-associated
 PASS slot provides updated directionality from host to a dir=auto container
+PASS text input and textarea value changes should only be reflected in :dir() when dir=auto (value changes)
 א
 א א
 א
 
- abc
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js
@@ -371,31 +371,22 @@ test(() => {
     <slot dir=auto></slot>
   `);
   let slot = shadow.querySelector("slot");
-  assert_equals(html_direction(slot), "rtl");
-  let inp = tree.querySelector("input");
-  inp.value = "abc";
   assert_equals(html_direction(slot), "ltr");
   tree.remove();
-}, 'dir=auto slot is updated by text in value of input element children');
+}, 'dir=auto slot is not affected by text in value of input element children');
 
 test(() => {
-  let [tree, shadow] = setup_tree(`
+  let tree = setup_tree(`
     <div>
-      <div id=root>
-        <input value="اختبر">
-        abc
-      </div>
+      <input dir="auto" value="اختبر">
     </div>
-  `,`
-    <slot dir=auto></slot>
   `);
-  let slot = shadow.querySelector("slot");
-  assert_equals(html_direction(slot), "rtl");
   let inp = tree.querySelector("input");
+  assert_equals(html_direction(inp), "rtl");
   inp.type = "month";
-  assert_equals(html_direction(slot), "ltr");
+  assert_equals(html_direction(inp), "ltr");
   tree.remove();
-}, 'dir=auto slot is updated if input stops being auto-directionality form-associated');
+}, 'input direction changes if it stops being auto-directionality form-associated');
 
 test(() => {
   let [tree, shadow] = setup_tree(`
@@ -424,3 +415,31 @@ test(() => {
   assert_equals(html_direction(div), 'rtl', 'host dir change propagated via slot');
   tree.remove();
 }, 'slot provides updated directionality from host to a dir=auto container');
+
+test(() => {
+  let input = setup_tree(`<input type="text">`);
+  assert_equals(html_direction(input), "ltr", "initial direction of input");
+  input.value = "\u05D0";
+  assert_equals(html_direction(input), "ltr", "direction of input with RTL contents");
+  input.dir = "auto";
+  assert_equals(html_direction(input), "rtl", "direction of input dir=auto with RTL contents");
+  input.value = "a";
+  assert_equals(html_direction(input), "ltr", "direction of input dir=auto with LTR contents");
+  input.dir = "rtl";
+  assert_equals(html_direction(input), "rtl", "direction of input dir=rtl with LTR contents");
+  input.value = "ab";
+  assert_equals(html_direction(input), "rtl", "direction of input dir=rtl with LTR contents (2)");
+  input.value = "\u05D0";
+  assert_equals(html_direction(input), "rtl", "direction of input dir=rtl with RTL contents");
+
+  let textarea = setup_tree(`<textarea dir="auto"></textarea>`);
+  assert_equals(html_direction(textarea), "ltr", "direction of textarea dir=auto with empty contents");
+  textarea.value = "a";
+  assert_equals(html_direction(textarea), "ltr", "direction of textarea dir=auto with LTR contents");
+  textarea.value = "\u05D0";
+  assert_equals(html_direction(textarea), "rtl", "direction of textarea dir=auto with RTL contents");
+  textarea.dir = "rtl";
+  assert_equals(html_direction(textarea), "rtl", "direction of textarea dir=rtl with RTL contents");
+  textarea.value = "a";
+  assert_equals(html_direction(textarea), "rtl", "direction of textarea dir=rtl with LTR contents");
+}, 'text input and textarea value changes should only be reflected in :dir() when dir=auto (value changes)');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-not-changed-text-input-typing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-not-changed-text-input-typing-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS entering LTR text doesn't change directionality of a text input without dir=auto
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-not-changed-text-input-typing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-not-changed-text-input-typing.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<title>:dir() not changed by typing in a text input</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<div dir="rtl">
+  <input type="text">
+  <textarea></textarea>
+</div>
+
+<script>
+
+promise_test(async () => {
+  const input = document.querySelector("div[dir=rtl] > input");
+  const textarea = document.querySelector("div[dir=rtl] > textarea");
+
+  assert_true(input.matches(":dir(rtl)"), "input is RTL before text entered");
+  assert_true(textarea.matches(":dir(rtl)"), "input is RTL before text entered");
+
+  await test_driver.send_keys(input, "a");
+  await test_driver.send_keys(textarea, "a");
+
+  assert_true(input.matches(":dir(rtl)"), "input is RTL after text entered");
+  assert_true(textarea.matches(":dir(rtl)"), "input is RTL after text entered");
+}, "entering LTR text doesn't change directionality of a text input without dir=auto");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39-ref.html
@@ -18,7 +18,7 @@ span {border: 1px solid silver;}
 
 <p>text in the light tree, slotted node</p>
 <div id="host">slotted text.</div>
-<p id="result">The HTML direction / computed CSS `direction` value for the defaultContent when there is a slotted node: ltr / ltr (on the div).</p>
+<p id="result">The HTML direction / computed CSS `direction` value for the defaultContent when there is a slotted node: ltr / (on the div).</p>
 
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt
@@ -1,3 +1,8 @@
+اختبر
+Text
+اختبر
+
+     abc
 
 PASS Slots: Directionality: dir=rtl on slot
 PASS Slots: Directionality: dir=rtl on host
@@ -8,7 +13,11 @@ PASS Slots: Directionality: dir=auto on slot with Arabic light tree content
 PASS slot provides its directionality (from host) to a dir=auto container
 PASS children with dir attribute are skipped by dir=auto
 PASS slot with dir attribute is skipped by dir=auto
-PASS dir=auto slot ignores dir attribute of assigned nodes
-PASS dir=auto slot considers text in bdi assigned nodes
-PASS dir=auto slot considers text in value of input element children
+FAIL dir=auto slot ignores assigned nodes with dir attribute assert_equals: expected "ltr" but got "rtl"
+FAIL dir=auto slot ignores text in bdi assigned nodes assert_equals: expected "ltr" but got "rtl"
+FAIL dir=auto slot ignores text in value of input element children assert_equals: expected "ltr" but got "rtl"
+FAIL dir=auto slot is not affected by value of auto-directionality form associated elements assert_equals: expected "ltr" but got "rtl"
+PASS inner slot is given directionality from slotted content
+PASS dir=auto slot is not affected by content inside inner slot (version 1)
+PASS dir=auto slot is not affected by content inside inner slot (version 2)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality.html
@@ -173,9 +173,9 @@ test(() => {
   let div = tree.querySelector("#root");
   assert_equals(html_direction(div), "ltr");
   let slot = shadow.querySelector("slot");
-  assert_equals(html_direction(slot), "rtl");
+  assert_equals(html_direction(slot), "ltr");
   tree.remove();
-}, 'dir=auto slot ignores dir attribute of assigned nodes');
+}, 'dir=auto slot ignores assigned nodes with dir attribute');
 
 test(() => {
   let [tree, shadow] = setup_tree(`
@@ -188,9 +188,9 @@ test(() => {
     <slot dir="auto"></slot>
   `);
   let slot = shadow.querySelector("slot");
-  assert_equals(html_direction(slot), "rtl");
+  assert_equals(html_direction(slot), "ltr");
   tree.remove();
-}, 'dir=auto slot considers text in bdi assigned nodes');
+}, 'dir=auto slot ignores text in bdi assigned nodes');
 
 test(() => {
   let [tree, shadow] = setup_tree(`
@@ -205,13 +205,13 @@ test(() => {
   let inp = tree.querySelector("input");
   assert_equals(html_direction(inp), "ltr");
   let slot = shadow.querySelector("slot");
-  assert_equals(html_direction(slot), "rtl");
+  assert_equals(html_direction(slot), "ltr");
   tree.remove();
 
   [tree, shadow] = setup_tree(`
     <div>
       <div id=root>
-        <input value=" ">
+        <input value="a">
         اختبر
       </div>
     </div>
@@ -221,8 +221,75 @@ test(() => {
   inp = tree.querySelector("input");
   assert_equals(html_direction(inp), "ltr");
   slot = shadow.querySelector("slot");
-  assert_equals(html_direction(slot), "ltr", "no strong character in value counts as ltr");
+  assert_equals(html_direction(slot), "rtl");
   tree.remove();
-}, 'dir=auto slot considers text in value of input element children');
+}, 'dir=auto slot ignores text in value of input element children');
+
+test(() => {
+  let [tree, shadow] = setup_tree(`
+    <div>
+      <div id=root>
+        <input value="اختبر">
+        <input type=text value="اختبر">
+        <input type=submit value="اختبر">
+        abc
+      </div>
+    </div>
+  `,`
+    <slot dir=auto></slot>
+  `);
+  let slot = shadow.querySelector("slot");
+  assert_equals(html_direction(slot), "ltr");
+  tree.remove();
+}, 'dir=auto slot is not affected by value of auto-directionality form associated elements');
+
+test(() => {
+  let [tree, shadow] = setup_tree(`
+    <div>
+      <div id=root><div slot="inner">اختبر</div></div>
+    </div>
+  `,`
+    <slot name="outer">
+      <slot name="inner" dir="auto"></slot>
+    </slot>
+  `);
+  let slot = shadow.querySelector("slot[name='inner']");
+  assert_equals(html_direction(slot), "rtl");
+  tree.remove();
+}, 'inner slot is given directionality from slotted content');
+
+test(() => {
+  let [tree, shadow] = setup_tree(`
+    <div>
+      <div id=root><div slot="inner">اختبر</div></div>
+    </div>
+  `,`
+    <slot name="outer" dir=auto>
+    </slot>
+  `);
+  let slot = shadow.querySelector("slot[name='outer']");
+  slot.innerHTML = "<slot name='inner'></slot>";
+  assert_equals(html_direction(slot), "ltr");
+  tree.remove();
+}, 'dir=auto slot is not affected by content inside inner slot (version 1)');
+
+// version 2 of the test is simpler, but initially exposed assertion failures
+// (maybe crashes?) in Chromium, so was added later.
+test(() => {
+  let [tree, shadow] = setup_tree(`
+    <div>
+      <div id=root><div slot="inner">اختبر</div></div>
+    </div>
+  `,`
+    <slot name="outer" dir=auto>
+      <slot name="inner"></slot>
+    </slot>
+  `);
+  let slot = shadow.querySelector("slot[name='outer']");
+  assert_equals(html_direction(slot), "ltr");
+  // do an extra intermediate removal to make sure it doesn't crash/assert:
+  tree.querySelector("div[slot='inner']").remove();
+  tree.remove();
+}, 'dir=auto slot is not affected by content inside inner slot (version 2)');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-004.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-004.tentative-expected.txt
@@ -1,0 +1,5 @@
+Anchor 1
+Anchor 2
+
+FAIL the-anchor-attribute-004 assert_equals: Non-HTML elements can use the anchor attribute expected (object) Element node <div id="anchor1">Anchor 1</div> but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-004.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-004.tentative.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:masonf@chromium.org">
+<link rel="help" href="https://github.com/whatwg/html/pull/9144">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id=anchor1>Anchor 1</div>
+<div id=anchor2>Anchor 2</div>
+<svg id=foo anchor=anchor1></svg>
+
+<script>
+test(() => {
+  assert_equals(foo.anchorElement,anchor1,'Non-HTML elements can use the anchor attribute');
+  foo.anchorElement = anchor2;
+  assert_equals(foo.anchorElement,anchor2,'The anchorElement IDL also works for non-HTML elements');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-xml.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-xml.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL the-anchor-attribute-xml assert_equals: Setting the anchor attribute in XML should not set the anchorElement IDL. expected (object) null but got (undefined) undefined
+FAIL the-anchor-attribute-xml assert_equals: Setting the anchor attribute in XML should work. expected (object) Element node <div id="target">target</div> but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-xml.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-xml.tentative.html
@@ -9,17 +9,16 @@
 test(() => {
   const xmlDoc = document.implementation.createDocument(null, 'root', null);
   assert_equals(xmlDoc.contentType, 'application/xml');
-  xmlDoc.documentElement.innerHTML = '<div id="target">target</div><div anchor="target">anchored</div>';
-  assert_equals(xmlDoc.documentElement.innerHTML,
-    '<div id="target">target</div><div anchor="target">anchored</div>');
-  const target = xmlDoc.documentElement.children[0];
-  const anchored = xmlDoc.documentElement.children[1];
+  const innerDoc = xmlDoc.documentElement;
+  const html = '<div id="target">target</div><div anchor="target">anchored</div>';
+  innerDoc.innerHTML = html;
+  assert_equals(innerDoc.innerHTML, html);
+  const target = innerDoc.children[0];
+  const anchored = innerDoc.children[1];
 
-  assert_equals(xmlDoc.documentElement.children[1].anchorElement, null,
-    'Setting the anchor attribute in XML should not set the anchorElement IDL.');
+  assert_equals(anchored.anchorElement, target, 'Setting the anchor attribute in XML should work.');
 
   anchored.anchorElement = target;
-  assert_equals(xmlDoc.documentElement.children[1].anchorElement, null,
-    'Setting element.anchorElement in an XML document should not set the anchorElement IDL.');
+  assert_equals(anchored.anchorElement, target, 'Setting element.anchorElement in an XML document should work.');
 });
 </script>


### PR DESCRIPTION
#### fdec7447bb523fc07c06ffaff66806509a0e3050
<pre>
Re-import WPT html/dom/elements/global-attributes/
<a href="https://bugs.webkit.org/show_bug.cgi?id=279599">https://bugs.webkit.org/show_bug.cgi?id=279599</a>
<a href="https://rdar.apple.com/135885737">rdar://135885737</a>

Reviewed by Tim Nguyen and Sam Weinig.

Get the latest commit of this directory and update the expected results.

* LayoutTests/TestExpectations:
dir-auto-dynamic-changes.window.html fails because changing the input element
type from `text` to &apos;month&apos; should remove its text. See webkit.org/b/279748.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/cdata-dir_auto.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-not-changed-text-input-typing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-not-changed-text-input-typing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-004.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-004.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-xml.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-xml.tentative.html:

Canonical link: <a href="https://commits.webkit.org/283690@main">https://commits.webkit.org/283690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8135b1c2541db3cd6787ad0e44bc8ff3068c165

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53793 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12256 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15430 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16560 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15123 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61261 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/japanese-tag.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61338 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2672 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42257 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->