### PR TITLE
[Writing Tools] Text underneath replaced range does not animate smoothly

### DIFF
--- a/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
@@ -63,9 +63,14 @@ void WritingToolsCompositionCommand::replaceContentsOfRangeWithFragment(RefPtr<D
 
     if (state == State::Complete) {
         // When the command is signaled to be "complete", this commits the entire command as a whole to the undo/redo stack.
-        this->apply();
-        m_endingContextRange = *newContextRange;
+        commit();
     }
+}
+
+void WritingToolsCompositionCommand::commit()
+{
+    this->apply();
+    m_endingContextRange = m_currentContextRange;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.h
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.h
@@ -59,6 +59,8 @@ public:
     // FIXME: Remove this when WritingToolsController no longer needs to support `contextRangeForSessionWithID`.
     SimpleRange currentContextRange() const { return m_currentContextRange; }
 
+    void commit();
+
 private:
     WritingToolsCompositionCommand(Ref<Document>&&, const SimpleRange&);
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -102,6 +102,10 @@ private:
         Vector<Ref<WritingToolsCompositionCommand>> reappliedCommands;
         WritingTools::Session session;
         OptionSet<ClearStateDeferralReason> clearStateDeferralReasons;
+
+        bool shouldCommitAfterReplacement { false };
+        std::optional<CharacterRange> replacedRange;
+        std::optional<CharacterRange> pendingReplacedRange;
     };
 
     struct ProofreadingState : CanMakeCheckedPtr<ProofreadingState> {
@@ -176,6 +180,8 @@ private:
 
     template<WritingTools::Session::Type Type>
     void didEndWritingToolsSession(bool accepted);
+
+    void commitComposition(CompositionState&, Document&);
 
     RefPtr<Document> document() const;
 


### PR DESCRIPTION
#### addeb52fffc6561775b2304d98b161c55bc2d3aa
<pre>
[Writing Tools] Text underneath replaced range does not animate smoothly
<a href="https://bugs.webkit.org/show_bug.cgi?id=279600">https://bugs.webkit.org/show_bug.cgi?id=279600</a>
<a href="https://rdar.apple.com/135741279">rdar://135741279</a>

Reviewed by Richard Robinson.

Writing Tools supplies text to its delegate using
`-[WTWritingToolsDelegate compositionSession:didReceiveText:replacementRange:inContext:finished:]`.
However, the last replacement can end up calling the method twice with the same
content, varying only the finished parameter.

This is problematic for the animations, as an animation is only initiated on
the first call with `finished=false`, but both calls perform the same
replacement. The second, redundant, replacement results in text being modified
before the animation is complete, resulting in a bad animation.

Fix by removing the redundant replacement.

* Source/WebCore/editing/WritingToolsCompositionCommand.cpp:
(WebCore::WritingToolsCompositionCommand::replaceContentsOfRangeWithFragment):
(WebCore::WritingToolsCompositionCommand::commit):
* Source/WebCore/editing/WritingToolsCompositionCommand.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync):

Commit the command immediately after performing replacement if the finished flag was
observed with the same range.

(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):

If `finished` is true and the same replaced range is observed, simply commit
the overall replacement to the undo stack, and skip animations and redundant
replacement.

This is correct as replaced ranges will always have the same prefix. Additionally,
comparing to the replaced range keeps the logic robust against clients that
only send `finished=true` for the last replacement without a `finished=false`,
such as smart replies.

If the `finished` flag comes in while the same range is still pending application,
the command will be committed in `compositionSessionDidReceiveTextWithReplacementRangeAsync`.

(WebCore::WritingToolsController::restartCompositionForSession):

Reset the replaced range when a composition is restarted.

(WebCore::WritingToolsController::commitComposition):

Helper method to apply the command to the undo stack.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:

Adjust tests to use the delegate in the same way that Writing Tools does.

(TEST(WritingTools, CompositionWithAttemptedEditing)):
(TEST(WritingTools, Composition)):
(TEST(WritingTools, CompositionRevert)):
(TEST(WritingTools, CompositionWithAttributedStringAttributes)):
(TEST(WritingTools, CompositionWithList)):
(TEST(WritingTools, CompositionWithTextAttachment)):
(TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)):
(TEST(WritingTools, CompositionWithMultipleChunks)):
(TEST(WritingTools, CompositionWithTrailingNewlines)):
(TEST(WritingTools, CompositionWithTrailingBreaks)):
(TEST(WritingTools, ContextRangeWithNoSelection)):
(TEST(WritingTools, ContextRangeFromCaretSelection)):
(TEST(WritingTools, ContextRangeFromRangeSelection)):

Canonical link: <a href="https://commits.webkit.org/283725@main">https://commits.webkit.org/283725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adad154f967097bae76bbc62439920e454aaf0a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53841 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12298 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61390 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2728 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42324 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->