### PR TITLE
[WGSL] validate that alignment is a multiple of RequiredAlignOf(T,C)

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -395,7 +395,8 @@ void AttributeValidator::visit(AST::StructureMember& member)
             else if (!isPowerOf2)
                 error(attribute.span(), "@align value must be a power of two"_s);
             // FIXME: validate that alignment is a multiple of RequiredAlignOf(T,C)
-            update(attribute.span(), member.m_alignment, static_cast<unsigned>(alignmentValue));
+            auto* type = member.type().inferredType();
+            update(attribute.span(), member.m_alignment, std::max<unsigned>(alignmentValue, type ? type->alignment() : 1u));
             continue;
         }
 


### PR DESCRIPTION
#### 7fcae8c7c3b8298f8e65bc899817d6d182ad4e31
<pre>
[WGSL] validate that alignment is a multiple of RequiredAlignOf(T,C)
<a href="https://bugs.webkit.org/show_bug.cgi?id=279604">https://bugs.webkit.org/show_bug.cgi?id=279604</a>
<a href="https://rdar.apple.com/135132177">rdar://135132177</a>

Reviewed by Dan Glastonbury.

Validate that alignment is a multiple of RequiredAlignOf(T,C) as
required per <a href="https://www.w3.org/TR/WGSL/#align-attr">https://www.w3.org/TR/WGSL/#align-attr</a>

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::requiredAlignOf):
(WGSL::AttributeValidator::visit):

Canonical link: <a href="https://commits.webkit.org/283657@main">https://commits.webkit.org/283657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd5e522d4785bc76d0d75496c7dd91b21846d48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18036 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53662 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12137 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39245 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61069 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61225 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14790 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2539 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->