### PR TITLE
Port WebExtension Display Strings to C++

### DIFF
--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -57,6 +57,7 @@ public:
     static constexpr int maxDepth = 1000;
 
     void operator delete(Value*, std::destroying_delete_t);
+    bool operator!() const;
 
     ~Value()
     {
@@ -467,6 +468,11 @@ public:
     using ArrayBase::end;
 };
 
+
+inline bool Value::operator!() const
+{
+    return isNull();
+}
 
 inline RefPtr<Value> Value::asValue()
 {

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -556,6 +556,7 @@ UIProcess/Downloads/DownloadProxyMap.cpp
 
 UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.cpp
 
+UIProcess/Extensions/WebExtension.cpp
 UIProcess/Extensions/WebExtensionAlarm.cpp
 UIProcess/Extensions/WebExtensionContext.cpp
 UIProcess/Extensions/WebExtensionController.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -196,22 +196,22 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (NSString *)displayName
 {
-    return self._protectedWebExtension->displayName();
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayName());
 }
 
 - (NSString *)displayShortName
 {
-    return self._protectedWebExtension->displayShortName();
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayShortName());
 }
 
 - (NSString *)displayVersion
 {
-    return self._protectedWebExtension->displayVersion();
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayVersion());
 }
 
 - (NSString *)displayDescription
 {
-    return self._protectedWebExtension->displayDescription();
+    return nsStringNilIfEmpty(self._protectedWebExtension->displayDescription());
 }
 
 - (NSString *)displayActionLabel
@@ -221,7 +221,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (NSString *)version
 {
-    return self._protectedWebExtension->version();
+    return nsStringNilIfEmpty(self._protectedWebExtension->version());
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -798,7 +798,7 @@ void WebExtensionAction::setPopupPath(String path)
 NSString *WebExtensionAction::popupWebViewInspectionName()
 {
     if (m_popupWebViewInspectionName.isEmpty())
-        m_popupWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Popup Page", "Label for an inspectable Web Extension popup page", (__bridge CFStringRef)extensionContext()->extension().displayShortName());
+        m_popupWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Popup Page", "Label for an inspectable Web Extension popup page", extensionContext()->extension().displayShortName().createCFString().get());
 
     return m_popupWebViewInspectionName;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3270,7 +3270,7 @@ WKWebView *WebExtensionContext::relatedWebView()
 NSString *WebExtensionContext::processDisplayName()
 {
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    return [NSString localizedStringWithFormat:WEB_UI_STRING("%@ Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension"), extension().displayShortName()];
+    return [NSString localizedStringWithFormat:WEB_UI_STRING("%@ Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension"), static_cast<NSString *>(extension().displayShortName())];
 ALLOW_NONLITERAL_FORMAT_END
 }
 
@@ -3477,9 +3477,9 @@ NSString *WebExtensionContext::backgroundWebViewInspectionName()
         return m_backgroundWebViewInspectionName;
 
     if (extension().backgroundContentIsServiceWorker())
-        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Service Worker", "Label for an inspectable Web Extension service worker", (__bridge CFStringRef)extension().displayShortName());
+        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Service Worker", "Label for an inspectable Web Extension service worker", extension().displayShortName().createCFString().get());
     else
-        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Background Page", "Label for an inspectable Web Extension background page", (__bridge CFStringRef)extension().displayShortName());
+        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Background Page", "Label for an inspectable Web Extension background page", extension().displayShortName().createCFString().get());
 
     return m_backgroundWebViewInspectionName;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtension.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+static constexpr auto manifestVersionManifestKey = "manifest_version"_s;
+
+static constexpr auto nameManifestKey = "name"_s;
+static constexpr auto shortNameManifestKey = "short_name"_s;
+static constexpr auto versionManifestKey = "version"_s;
+static constexpr auto versionNameManifestKey = "version_name"_s;
+static constexpr auto descriptionManifestKey = "description"_s;
+
+bool WebExtension::manifestParsedSuccessfully()
+{
+    if (m_parsedManifest)
+        return !!m_manifestJSON->asObject();
+
+    // If we haven't parsed yet, trigger a parse by calling the getter.
+    return !!manifest() && !!manifestObject();
+}
+
+double WebExtension::manifestVersion()
+{
+    RefPtr manifestObject = this->manifestObject();
+    if (!manifestObject)
+        return 0;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version
+    if (auto value = manifestObject->getDouble(manifestVersionManifestKey))
+        return *value;
+
+    return 0;
+}
+
+const String& WebExtension::displayName()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayName;
+}
+
+const String& WebExtension::displayShortName()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayShortName;
+}
+
+const String& WebExtension::displayVersion()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayVersion;
+}
+
+const String& WebExtension::displayDescription()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayDescription;
+}
+
+const String& WebExtension::version()
+{
+    populateDisplayStringsIfNeeded();
+    return m_version;
+}
+
+void WebExtension::populateDisplayStringsIfNeeded()
+{
+    if (m_parsedManifestDisplayStrings)
+        return;
+
+    m_parsedManifestDisplayStrings = true;
+
+    RefPtr manifestObject = this->manifestObject();
+    if (!manifestObject)
+        return;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name
+
+    m_displayName = manifestObject->getString(nameManifestKey);
+    m_displayShortName = manifestObject->getString(shortNameManifestKey);
+
+    if (m_displayShortName.isEmpty())
+        m_displayShortName = m_displayName;
+
+    if (m_displayName.isEmpty())
+        recordError(createError(Error::InvalidName));
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version
+
+    m_version = manifestObject->getString(versionManifestKey);
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name
+
+    m_displayVersion = manifestObject->getString(versionNameManifestKey);
+
+    if (m_displayVersion.isEmpty())
+        m_displayVersion = m_version;
+
+    if (m_version.isEmpty())
+        recordError(createError(Error::InvalidVersion));
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description
+
+    m_displayDescription = manifestObject->getString(descriptionManifestKey);
+    if (m_displayDescription.isEmpty())
+        recordError(createError(Error::InvalidDescription));
+}
+
+} // namespace WebKit
+
+#endif // WK_WEB_EXTENSIONS

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -34,6 +34,7 @@
 #include <WebCore/UserStyleSheetTypes.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/JSONValues.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -197,6 +198,7 @@ public:
 
     bool manifestParsedSuccessfully();
     NSDictionary *manifest();
+    RefPtr<const JSON::Object> manifestObject() { return manifestParsedSuccessfully() ? m_manifestJSON->asObject() : nullptr; }
     Ref<API::Data> serializeManifest();
 
     double manifestVersion();
@@ -222,11 +224,11 @@ public:
     _WKWebExtensionLocalization *localization();
     NSLocale *defaultLocale();
 
-    NSString *displayName();
-    NSString *displayShortName();
-    NSString *displayVersion();
-    NSString *displayDescription();
-    NSString *version();
+    const String& displayName();
+    const String& displayShortName();
+    const String& displayVersion();
+    const String& displayDescription();
+    const String& version();
 
     NSString *contentSecurityPolicy();
 
@@ -360,6 +362,7 @@ private:
     mutable RetainPtr<SecStaticCodeRef> m_bundleStaticCode;
     RetainPtr<NSURL> m_resourceBaseURL;
     RetainPtr<NSDictionary> m_manifest;
+    Ref<const JSON::Value> m_manifestJSON;
     RetainPtr<NSMutableDictionary> m_resources;
 
     RetainPtr<NSLocale> m_defaultLocale;
@@ -367,11 +370,11 @@ private:
 
     RetainPtr<NSMutableArray> m_errors;
 
-    RetainPtr<NSString> m_displayName;
-    RetainPtr<NSString> m_displayShortName;
-    RetainPtr<NSString> m_displayVersion;
-    RetainPtr<NSString> m_displayDescription;
-    RetainPtr<NSString> m_version;
+    String m_displayName;
+    String m_displayShortName;
+    String m_displayVersion;
+    String m_displayDescription;
+    String m_version;
 
     RetainPtr<NSMutableDictionary> m_iconsCache;
 


### PR DESCRIPTION
#### fdd79f3b8daaecb342721c8103d55f129b80ee38
<pre>
Port WebExtension Display Strings to C++
<a href="https://webkit.org/b/279610">https://webkit.org/b/279610</a>

Reviewed by Timothy Hatcher.

Create a JSON manifest to use in parallel with the Cocoa NSDictionary, and port the Display Strings to C++ (version, name, description).

* Source/WTF/wtf/JSONValues.h:
(WTF::JSONImpl::Value::operator! const):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::parseManifest):
(WebKit::WebExtension::manifestParsedSuccessfully): Deleted
(WebKit::WebExtension::manifestVersion): Deleted.
(WebKit::WebExtension::displayName): Deleted.
(WebKit::WebExtension::displayShortName): Deleted.
(WebKit::WebExtension::displayVersion): Deleted.
(WebKit::WebExtension::displayDescription): Deleted.
(WebKit::WebExtension::version): Deleted.
(WebKit::WebExtension::populateDisplayStringsIfNeeded): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp: Added.
(WebKit::WebExtension::manifestParsedSuccessfuly):
(WebKit::WebExtension::manifestObject):
(WebKit::WebExtension::manifestVersion):
(WebKit::WebExtension::displayName):
(WebKit::WebExtension::displayShortName):
(WebKit::WebExtension::displayVersion):
(WebKit::WebExtension::displayDescription):
(WebKit::WebExtension::version):
(WebKit::WebExtension::populateDisplayStringsIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:

Canonical link: <a href="https://commits.webkit.org/283662@main">https://commits.webkit.org/283662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c499e2f6c478f5d7470cc0316eae77e0c4281c0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18080 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17861 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53707 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12162 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57922 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16434 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60061 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72683 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66192 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15000 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57981 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61256 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2569 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87960 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10164 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15480 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43206 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->