### PR TITLE
Use more smart pointers in PDF extension Part 2

### DIFF
--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -82,6 +82,7 @@ public:
     DDHighlightRef highlight() const { return m_highlight.get(); }
     const SimpleRange& range() const;
     GraphicsLayer& layer() const { return m_graphicsLayer.get(); }
+    Ref<GraphicsLayer> protectedLayer() const { return layer(); }
 
     enum class Type : uint8_t {
         None = 0,

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -108,7 +108,6 @@ WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/WebMDNSRegister.cpp
 WebProcess/Notifications/WebNotificationManager.cpp
 WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
-WebProcess/Plugins/PDF/PDFPlugin.mm
 WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -57,6 +57,8 @@ public:
     PDFAnnotation *annotation() const { return m_annotation.get(); }
     PDFPluginBase* plugin() const { return m_plugin.get(); }
 
+    RefPtr<WebCore::Element> protectedElement() const { return element(); }
+
     virtual void updateGeometry();
     virtual void commit();
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -215,6 +215,8 @@ public:
     WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
     WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
+    RefPtr<WebCore::Scrollbar> protectedHorizontalScrollbar() const { return horizontalScrollbar(); }
+    RefPtr<WebCore::Scrollbar> protectedVerticalScrollbar() const { return verticalScrollbar(); }
     void setScrollOffset(const WebCore::ScrollOffset&) final;
 
     virtual void willAttachScrollingNode() { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -78,7 +78,7 @@ PageOverlay& PDFDataDetectorOverlayController::installOverlayIfNeeded()
         return *m_overlay;
 
     m_overlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
-    protectedPlugin()->installDataDetectorOverlay(*m_overlay);
+    protectedPlugin()->installDataDetectorOverlay(Ref { *m_overlay });
 
     return *m_overlay;
 }
@@ -92,7 +92,7 @@ void PDFDataDetectorOverlayController::uninstallOverlay()
     if (!plugin)
         return;
 
-    plugin->uninstallDataDetectorOverlay(*std::exchange(m_overlay, nullptr));
+    plugin->uninstallDataDetectorOverlay(Ref { *std::exchange(m_overlay, nullptr) });
 }
 
 void PDFDataDetectorOverlayController::teardown()
@@ -176,7 +176,7 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
             previousActiveHighlight->fadeOut();
 
         if (activeHighlight) {
-            installOverlayIfNeeded().layer().addChild(activeHighlight->layer());
+            installOverlayIfNeeded().layer().addChild(activeHighlight->protectedLayer());
             activeHighlight->fadeIn();
         }
 
@@ -184,7 +184,7 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
     }
 
     if (event.type() == WebEventType::MouseDown && mouseIsOverActiveHighlightButton)
-        return handleDataDetectorAction(mousePositionInWindowSpace, *m_activeDataDetectorItemWithHighlight.first);
+        return handleDataDetectorAction(mousePositionInWindowSpace, Ref { *m_activeDataDetectorItemWithHighlight.first });
 
     return false;
 }
@@ -249,7 +249,7 @@ void PDFDataDetectorOverlayController::updatePlatformHighlightData(PDFDocumentLa
 {
     WTF::forEach(m_pdfDataDetectorItemsWithHighlightsMap.get(pageIndex), [&](auto& dataDetectorItemWithHighlight) {
         auto& [dataDetectorItem, coreHighlight] = dataDetectorItemWithHighlight;
-        coreHighlight->setHighlight(createPlatformDataDetectorHighlight(dataDetectorItem.get()).get());
+        coreHighlight->setHighlight(createPlatformDataDetectorHighlight(Ref { dataDetectorItem }).get());
     });
 }
 


### PR DESCRIPTION
#### 5f790ebbf8e34fa2d36ce21a0d5025198710058d
<pre>
Use more smart pointers in PDF extension Part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=279612">https://bugs.webkit.org/show_bug.cgi?id=279612</a>
<a href="https://rdar.apple.com/136315936">rdar://136315936</a>

Reviewed by Chris Dumez.

Protect object with smart pointer when calling a non-trivial member function on it.

* Source/WebCore/platform/mac/DataDetectorHighlight.h:
(WebCore::DataDetectorHighlight::protectedLayer const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject parent]):
(-[WKPDFPluginAccessibilityObject accessibilityFocusedUIElement]):
(-[WKPDFPluginAccessibilityObject accessibilityAssociatedControlForAnnotation:]):
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::updateScrollbars):
(WebKit::PDFPlugin::installPDFDocument):
(WebKit::PDFPlugin::updatePageAndDeviceScaleFactors):
(WebKit::PDFPlugin::teardown):
(WebKit::PDFPlugin::showContextMenuAtPoint):
(WebKit::PDFPlugin::handleContextMenuEvent):
(WebKit::PDFPlugin::notifyContentScaleFactorChanged):
(WebKit::PDFPlugin::showDefinitionForAttributedString):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
(WebKit::PDFPluginAnnotation::protectedElement const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::protectedHorizontalScrollbar const):
(WebKit::PDFPluginBase::protectedVerticalScrollbar const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::installOverlayIfNeeded):
(WebKit::PDFDataDetectorOverlayController::uninstallOverlay):
(WebKit::PDFDataDetectorOverlayController::handleMouseEvent):
(WebKit::PDFDataDetectorOverlayController::updatePlatformHighlightData):

Canonical link: <a href="https://commits.webkit.org/286287@main">https://commits.webkit.org/286287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c234ff6aaacfe1a14df6e40e8866afb1ebdb637e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75448 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77564 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39574 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25040 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1763 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8853 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5565 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->