### PR TITLE
[GTK][WPE][Skia] Switch UnacceleratedBuffer buffer format to RGBA

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -51,6 +51,8 @@
 #endif
 #endif
 
+#include "PixelFormat.h"
+
 namespace Nicosia {
 using namespace WebCore;
 
@@ -78,7 +80,7 @@ Ref<Buffer> UnacceleratedBuffer::create(const WebCore::IntSize& size, Flags flag
     return adoptRef(*new UnacceleratedBuffer(size, flags));
 }
 
-UnacceleratedBuffer::UnacceleratedBuffer(const WebCore::IntSize& size, Flags flags)
+UnacceleratedBuffer::UnacceleratedBuffer(const IntSize& size, Flags flags)
     : Buffer(flags)
     , m_size(size)
 {
@@ -92,10 +94,19 @@ UnacceleratedBuffer::UnacceleratedBuffer(const WebCore::IntSize& size, Flags fla
     }
 
 #if USE(SKIA)
-    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height(), SkColorSpace::MakeSRGB());
+    auto imageInfo = SkImageInfo::Make(size.width(), size.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
-    SkSurfaceProps properties = { 0, WebCore::FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     m_surface = SkSurfaces::WrapPixels(imageInfo, m_data.get(), imageInfo.minRowBytes64(), &properties);
+#endif
+}
+
+PixelFormat UnacceleratedBuffer::pixelFormat() const
+{
+#if USE(SKIA)
+    return PixelFormat::RGBA8;
+#elif USE(CAIRO)
+    return PixelFormat::BGRA8;
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h
@@ -43,6 +43,7 @@ IGNORE_CLANG_WARNINGS_END
 
 namespace WebCore {
 class GLFence;
+enum class PixelFormat : uint8_t;
 }
 
 namespace Nicosia {
@@ -96,6 +97,8 @@ public:
 
     int stride() const { return m_size.width() * 4; }
     unsigned char* data() const { return m_data.get(); }
+
+    WebCore::PixelFormat pixelFormat() const;
 
 private:
     UnacceleratedBuffer(const WebCore::IntSize&, Flags);

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -31,6 +31,7 @@
 #include "IntPoint.h"
 #include "IntRect.h"
 #include "IntSize.h"
+#include "PixelFormat.h"
 #include "TextureMapperGLHeaders.h"
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
@@ -50,16 +51,15 @@ public:
         DepthBuffer = 1 << 1,
     };
 
-    static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { }, GLint internalFormat = GL_DONT_CARE)
+    static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
     {
-        return adoptRef(*new BitmapTexture(size, flags, internalFormat));
+        return adoptRef(*new BitmapTexture(size, flags));
     }
 
     WEBCORE_EXPORT ~BitmapTexture();
 
     const IntSize& size() const { return m_size; };
     OptionSet<Flags> flags() const { return m_flags; }
-    GLint internalFormat() const { return m_internalFormat; }
     bool isOpaque() const { return !m_flags.contains(Flags::SupportsAlpha); }
 
     void bindAsSurface();
@@ -69,7 +69,7 @@ public:
 
     void updateContents(NativeImage*, const IntRect&, const IntPoint& offset);
     void updateContents(GraphicsLayer*, const IntRect& target, const IntPoint& offset, float scale = 1);
-    void updateContents(const void*, const IntRect& target, const IntPoint& offset, int bytesPerLine);
+    void updateContents(const void* srcData, const IntRect& targetRect, const IntPoint& sourceOffset, int bytesPerLine, PixelFormat);
 
     void reset(const IntSize&, OptionSet<Flags> = { });
 
@@ -84,10 +84,10 @@ public:
     void copyFromExternalTexture(BitmapTexture& sourceTexture, const IntRect& sourceRect, const IntSize& destinationOffset);
     void copyFromExternalTexture(GLuint sourceTextureID, const IntRect& targetRect, const IntSize& sourceOffset);
 
-    OptionSet<TextureMapperFlags> colorConvertFlags() const { return m_colorConvertFlags; }
+    OptionSet<TextureMapperFlags> colorConvertFlags() const;
 
 private:
-    BitmapTexture(const IntSize&, OptionSet<Flags>, GLint internalFormat);
+    BitmapTexture(const IntSize&, OptionSet<Flags>);
 
     void clearIfNeeded();
     void createFboIfNeeded();
@@ -101,10 +101,9 @@ private:
     bool m_stencilBound { false };
     bool m_shouldClear { true };
     ClipStack m_clipStack;
-    OptionSet<TextureMapperFlags> m_colorConvertFlags;
     RefPtr<const FilterOperation> m_filterOperation;
-    GLint m_internalFormat { 0 };
-    GLenum m_format { 0 };
+    GLenum m_textureFormat { 0 };
+    PixelFormat m_pixelFormat { PixelFormat::RGBA8 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -291,7 +291,7 @@ void TextureMapper::drawNumber(int number, const Color& color, const FloatPoint&
     auto texture = m_texturePool.acquireTexture(size, { BitmapTexture::Flags::SupportsAlpha });
     const unsigned char* bits = cairo_image_surface_get_data(surface);
     int stride = cairo_image_surface_get_stride(surface);
-    texture->updateContents(bits, sourceRect, IntPoint::zero(), stride);
+    texture->updateContents(bits, sourceRect, IntPoint::zero(), stride, PixelFormat::BGRA8);
     drawTexture(texture.get(), targetRect, modelViewMatrix, 1.0f, AllEdgesExposed::Yes);
 
     cairo_surface_destroy(surface);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -69,7 +69,7 @@ void CoordinatedBackingStoreTile::swapBuffers(TextureMapper& textureMapper)
 
         ASSERT(!update.buffer->isBackedByOpenGL());
         auto& buffer = static_cast<Nicosia::UnacceleratedBuffer&>(*update.buffer);
-        m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride());
+        m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride(), buffer.pixelFormat());
         update.buffer = nullptr;
     }
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -106,12 +106,12 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(TextureMapper& t
 #if USE(CAIRO)
     auto* surface = m_image->platformImage().get();
     auto* imageData = cairo_image_surface_get_data(surface);
-    texture->updateContents(imageData, IntRect(IntPoint(), m_size), IntPoint(), cairo_image_surface_get_stride(surface));
+    texture->updateContents(imageData, IntRect(IntPoint(), m_size), IntPoint(), cairo_image_surface_get_stride(surface), PixelFormat::BGRA8);
 #elif USE(SKIA)
     const auto& image = m_image->platformImage();
     SkPixmap pixmap;
     if (image->peekPixels(&pixmap))
-        texture->updateContents(pixmap.addr(), IntRect(IntPoint(), m_size), IntPoint(), image->imageInfo().minRowBytes());
+        texture->updateContents(pixmap.addr(), IntRect(IntPoint(), m_size), IntPoint(), image->imageInfo().minRowBytes(), PixelFormat::BGRA8);
 #endif
 
     m_buffer = CoordinatedPlatformLayerBufferRGB::create(WTFMove(texture), m_flags, nullptr);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -180,7 +180,7 @@ void CoordinatedPlatformLayerBufferVideo::paintToTextureMapper(TextureMapper& te
         if (!m_buffer) {
             int stride = GST_VIDEO_FRAME_PLANE_STRIDE(&m_videoFrame, 0);
             const void* srcData = GST_VIDEO_FRAME_PLANE_DATA(&m_videoFrame, 0);
-            texture->updateContents(srcData, IntRect(0, 0, m_size.width(), m_size.height()), IntPoint(0, 0), stride);
+            texture->updateContents(srcData, IntRect(0, 0, m_size.width(), m_size.height()), IntPoint(0, 0), stride, PixelFormat::BGRA8);
             m_buffer = CoordinatedPlatformLayerBufferRGB::create(WTFMove(texture), m_flags, nullptr);
             gst_video_frame_unmap(&m_videoFrame);
             m_isMapped = false;


### PR DESCRIPTION
#### 8a692724af8345c25047dd8ff9620c3eec2673b9
<pre>
[GTK][WPE][Skia] Switch UnacceleratedBuffer buffer format to RGBA
<a href="https://bugs.webkit.org/show_bug.cgi?id=279614">https://bugs.webkit.org/show_bug.cgi?id=279614</a>

Reviewed by Miguel Gomez.

Cairo rendering was performed in BGRA/ARGB (little/big-endian) and
BitmapTexture had to take care of converting to RGBA, when mapping
CPU-rendered buffers to GL textures. Skia supports RGBA directly, saving
the color conversion in TextureMapperShaderProgram.

Testing on desktop/rpi4 shows this change is perf neutral. This is a
preparation to introduce a hybrid rendering mode, where both CPU/GPU
participate in the rendering pipeline, simultaneously.

* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::UnacceleratedBuffer::UnacceleratedBuffer):
(Nicosia::UnacceleratedBuffer::pixelFormat const):
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::updateContents):
(WebCore::BitmapTexture::copyFromExternalTexture):
(WebCore::BitmapTexture::colorConvertFlags const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawNumber):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStoreTile::swapBuffers):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::paintToTextureMapper):

Canonical link: <a href="https://commits.webkit.org/283783@main">https://commits.webkit.org/283783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e2cc0f6c01ff276d603bb299bb4a74a05d9282f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53932 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15650 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73087 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15323 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2854 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->