### PR TITLE
Check for invalid characters in name and value when setting a cookie

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -1,8 +1,36 @@
 
 PASS cookieStore.set with positional name and value
 PASS cookieStore.set with name and value in options
+PASS cookieStore.set fails with empty name and empty value
 PASS cookieStore.set with empty name and an '=' in value
 PASS cookieStore.set with normal name and an '=' in value
+PASS cookieStore.set checks if name or value contain invalid character U+0000
+PASS cookieStore.set checks if name or value contain invalid character U+0001
+PASS cookieStore.set checks if name or value contain invalid character U+0002
+PASS cookieStore.set checks if name or value contain invalid character U+0003
+PASS cookieStore.set checks if name or value contain invalid character U+0004
+PASS cookieStore.set checks if name or value contain invalid character U+0005
+PASS cookieStore.set checks if name or value contain invalid character U+0006
+PASS cookieStore.set checks if name or value contain invalid character U+0007
+PASS cookieStore.set checks if name or value contain invalid character U+0008
+PASS cookieStore.set checks if name or value contain invalid character U+0010
+PASS cookieStore.set checks if name or value contain invalid character U+0011
+PASS cookieStore.set checks if name or value contain invalid character U+0012
+PASS cookieStore.set checks if name or value contain invalid character U+0013
+PASS cookieStore.set checks if name or value contain invalid character U+0014
+PASS cookieStore.set checks if name or value contain invalid character U+0015
+PASS cookieStore.set checks if name or value contain invalid character U+0016
+PASS cookieStore.set checks if name or value contain invalid character U+0017
+PASS cookieStore.set checks if name or value contain invalid character U+0018
+PASS cookieStore.set checks if name or value contain invalid character U+0019
+PASS cookieStore.set checks if name or value contain invalid character U+001A
+PASS cookieStore.set checks if name or value contain invalid character U+001B
+PASS cookieStore.set checks if name or value contain invalid character U+001C
+PASS cookieStore.set checks if name or value contain invalid character U+001D
+PASS cookieStore.set checks if name or value contain invalid character U+001E
+PASS cookieStore.set checks if name or value contain invalid character U+001F
+PASS cookieStore.set checks if name or value contain invalid character U+003B
+PASS cookieStore.set checks if name or value contain invalid character U+007F
 PASS cookieStore.set with expires set to a future Date
 PASS cookieStore.set with expires set to a past Date
 PASS cookieStore.set with expires set to a future timestamp

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
@@ -30,6 +30,11 @@ promise_test(async testCase => {
 
 promise_test(async testCase => {
   await promise_rejects_js(testCase, TypeError,
+      cookieStore.set('', ''));
+}, "cookieStore.set fails with empty name and empty value");
+
+promise_test(async testCase => {
+  await promise_rejects_js(testCase, TypeError,
       cookieStore.set('', 'suspicious-value=resembles-name-and-value'));
 }, "cookieStore.set with empty name and an '=' in value");
 
@@ -43,6 +48,28 @@ promise_test(async testCase => {
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'suspicious-value=resembles-name-and-value');
 }, "cookieStore.set with normal name and an '=' in value");
+
+let invalidCharacters = [ '\u0000', '\u0001', '\u0002'
+                        , '\u0003', '\u0004', '\u0005'
+                        , '\u0006', '\u0007', '\u0008'
+                                  , '\u0010', '\u0011'
+                        , '\u0012', '\u0013', '\u0014'
+                        , '\u0015', '\u0016', '\u0017'
+                        , '\u0018', '\u0019', '\u001A'
+                        , '\u001B', '\u001C', '\u001D'
+                        , '\u001E', '\u001F'
+                        , '\u003B', '\u007F'];
+
+invalidCharacters.forEach(invalidCharacter => {
+  let invalidCookieName = 'cookie' + invalidCharacter + 'name';
+  let invalidCookieValue = 'cookie' + invalidCharacter + 'value';
+  promise_test(async testCase => {
+    await promise_rejects_js(testCase, TypeError,
+        cookieStore.set(invalidCookieName, 'cookie-value'));
+    await promise_rejects_js(testCase, TypeError,
+      cookieStore.set('cookie-name', invalidCookieValue));
+  }, `cookieStore.set checks if name or value contain invalid character U+${invalidCharacter.charCodeAt(0).toString(16).padStart(4, "0").toUpperCase()}`);
+});
 
 promise_test(async testCase => {
   const tenYears = 10 * 365 * 24 * 60 * 60 * 1000;

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -1,8 +1,36 @@
 
 PASS cookieStore.set with positional name and value
 PASS cookieStore.set with name and value in options
+PASS cookieStore.set fails with empty name and empty value
 PASS cookieStore.set with empty name and an '=' in value
 PASS cookieStore.set with normal name and an '=' in value
+PASS cookieStore.set checks if name or value contain invalid character U+0000
+PASS cookieStore.set checks if name or value contain invalid character U+0001
+PASS cookieStore.set checks if name or value contain invalid character U+0002
+PASS cookieStore.set checks if name or value contain invalid character U+0003
+PASS cookieStore.set checks if name or value contain invalid character U+0004
+PASS cookieStore.set checks if name or value contain invalid character U+0005
+PASS cookieStore.set checks if name or value contain invalid character U+0006
+PASS cookieStore.set checks if name or value contain invalid character U+0007
+PASS cookieStore.set checks if name or value contain invalid character U+0008
+PASS cookieStore.set checks if name or value contain invalid character U+0010
+PASS cookieStore.set checks if name or value contain invalid character U+0011
+PASS cookieStore.set checks if name or value contain invalid character U+0012
+PASS cookieStore.set checks if name or value contain invalid character U+0013
+PASS cookieStore.set checks if name or value contain invalid character U+0014
+PASS cookieStore.set checks if name or value contain invalid character U+0015
+PASS cookieStore.set checks if name or value contain invalid character U+0016
+PASS cookieStore.set checks if name or value contain invalid character U+0017
+PASS cookieStore.set checks if name or value contain invalid character U+0018
+PASS cookieStore.set checks if name or value contain invalid character U+0019
+PASS cookieStore.set checks if name or value contain invalid character U+001A
+PASS cookieStore.set checks if name or value contain invalid character U+001B
+PASS cookieStore.set checks if name or value contain invalid character U+001C
+PASS cookieStore.set checks if name or value contain invalid character U+001D
+PASS cookieStore.set checks if name or value contain invalid character U+001E
+PASS cookieStore.set checks if name or value contain invalid character U+001F
+PASS cookieStore.set checks if name or value contain invalid character U+003B
+PASS cookieStore.set checks if name or value contain invalid character U+007F
 PASS cookieStore.set with expires set to a future Date
 PASS cookieStore.set with expires set to a past Date
 PASS cookieStore.set with expires set to a future timestamp

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -230,6 +230,14 @@ CookieStore::~CookieStore()
     m_mainThreadBridge->detach();
 }
 
+static bool containsInvalidCharacters(const String& string)
+{
+    // The invalid characters are specified at https://wicg.github.io/cookie-store/#set-a-cookie.
+    return string.contains([](UChar character) {
+        return character == 0x003B || character == 0x007F || (character <= 0x001F && character != 0x0009);
+    });
+}
+
 void CookieStore::get(String&& name, Ref<DeferredPromise>&& promise)
 {
     get(CookieStoreGetOptions { WTFMove(name), { } }, WTFMove(promise));
@@ -392,6 +400,29 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
     Cookie cookie;
     cookie.name = WTFMove(options.name);
     cookie.value = WTFMove(options.value);
+
+    if (containsInvalidCharacters(cookie.name)) {
+        promise->reject(Exception { ExceptionCode::TypeError, "The cookie name must not contain '\u003B', '\u007F', or any C0 control character except '\u0009'."_s });
+        return;
+    }
+
+    if (containsInvalidCharacters(cookie.value)) {
+        promise->reject(Exception { ExceptionCode::TypeError, "The cookie value must not contain '\u003B', '\u007F', or any C0 control character except '\u0009'."_s });
+        return;
+    }
+
+    if (cookie.name.isEmpty()) {
+        if (cookie.value.contains('=')) {
+            promise->reject(Exception { ExceptionCode::TypeError, "The cookie name and value must not both be set from the 'value' field."_s });
+            return;
+        }
+
+        if (cookie.value.isEmpty()) {
+            promise->reject(Exception { ExceptionCode::TypeError, "The cookie name and value must not both be empty."_s });
+            return;
+        }
+    }
+
     cookie.created = WallTime::now().secondsSinceEpoch().milliseconds();
 
     cookie.domain = options.domain.isNull() ? domain : WTFMove(options.domain);


### PR DESCRIPTION
#### ea42e80465ced88ed7a4d396eb4aacffcae500f0
<pre>
Check for invalid characters in name and value when setting a cookie
<a href="https://bugs.webkit.org/show_bug.cgi?id=279151">https://bugs.webkit.org/show_bug.cgi?id=279151</a>
<a href="https://rdar.apple.com/135304982">rdar://135304982</a>

Reviewed by Chris Dumez.

As per the CookieStore API spec (<a href="https://wicg.github.io/cookie-store/#set-a-cookie)">https://wicg.github.io/cookie-store/#set-a-cookie)</a>,
we must return a type error when setting a cookie if:
(1) Certain invalid characters are in the name or value
(2) Name is empty and Value contains a &apos;=&apos; (signifies that user is trying to set
    both the name and value in the value field with &quot;name=value&quot; syntax)
(3) Name and Value are both empty

Currently, the WPT tests only test (2). This test was passing before this change--but
for the wrong reason. It was not passing because the CookieStore returns a type error
on empty name and &apos;=&apos; in value, but rather because the CookieStore allows this call and
eventually reaches the CFNetwork function to set a cookie--which incorrectly rejects
the request to set a cookie with an empty name (a bug has been filed for this).

This test for (2) now passes for the right reason, and we also add tests for (1) and (3).
A future patch will add them to the WPT repo as well.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js:
(promise_test.async testCase):
(promise_test.async testCase.async const):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::containsInvalidCharacters):
(WebCore::CookieStore::set):

Canonical link: <a href="https://commits.webkit.org/283624@main">https://commits.webkit.org/283624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a3c5425908d5d9b24f25104f54aede7732025b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53505 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12065 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15177 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72529 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10750 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61150 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2447 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10142 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42795 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->