### PR TITLE
[Writing Tools] Rename partialIntelligenceTextPonderingAnimation to partialIntelligenceTextAnimation since it isn't actually associated with pondering at all.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2215,7 +2215,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     }
 
     _writingToolsTextReplacementsFinished = finished;
-    _partialIntelligenceTextPonderingAnimationCount += 1;
+    _partialIntelligenceTextAnimationCount += 1;
 
     _page->compositionSessionDidReceiveTextWithReplacementRange(*webSession, WebCore::AttributedString::fromNSAttributedString(attributedText), { range }, *webContext, finished);
 }
@@ -2232,7 +2232,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
     if (webAction == WebCore::WritingTools::Action::Restart) {
         _writingToolsTextReplacementsFinished = false;
-        _partialIntelligenceTextPonderingAnimationCount = 0;
+        _partialIntelligenceTextAnimationCount = 0;
     }
 
     _page->writingToolsSessionDidReceiveAction(*webSession, webAction);
@@ -2272,16 +2272,16 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     [textViewDelegate proofreadingSessionWithUUID:[_activeWritingToolsSession uuid] updateState:WebKit::convertToPlatformTextSuggestionState(state) forSuggestionWithUUID:replacementUUID];
 }
 
-- (void)_didEndPartialIntelligenceTextPonderingAnimation
+- (void)_didEndPartialIntelligenceTextAnimation
 {
-    if (!_partialIntelligenceTextPonderingAnimationCount) {
+    if (!_partialIntelligenceTextAnimationCount) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    _partialIntelligenceTextPonderingAnimationCount -= 1;
+    _partialIntelligenceTextAnimationCount -= 1;
 
-    if (!_partialIntelligenceTextPonderingAnimationCount && _writingToolsTextReplacementsFinished) {
+    if (!_partialIntelligenceTextAnimationCount && _writingToolsTextReplacementsFinished) {
         // If the entire replacement has already been completed, and this is the end of the last animation,
         // then reveal the selection and end the session if needed.
         _page->intelligenceTextAnimationsDidComplete();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -251,7 +251,7 @@ struct PerWebProcessState {
     RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _writingToolsTextSuggestions;
     RetainPtr<WTSession> _activeWritingToolsSession;
 
-    NSUInteger _partialIntelligenceTextPonderingAnimationCount;
+    NSUInteger _partialIntelligenceTextAnimationCount;
     BOOL _writingToolsTextReplacementsFinished;
 #endif
 
@@ -424,7 +424,7 @@ struct PerWebProcessState {
 - (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
 #endif
 
-- (void)_didEndPartialIntelligenceTextPonderingAnimation;
+- (void)_didEndPartialIntelligenceTextAnimation;
 - (BOOL)_writingToolsTextReplacementsFinished;
 
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -121,7 +121,7 @@ public:
     void writingToolsActiveWillChange() final;
     void writingToolsActiveDidChange() final;
 
-    void didEndPartialIntelligenceTextPonderingAnimation() final;
+    void didEndPartialIntelligenceTextAnimation() final;
     bool writingToolsTextReplacementsFinished() final;
 
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -299,9 +299,9 @@ void PageClientImplCocoa::writingToolsActiveDidChange()
     [m_webView didChangeValueForKey:writingToolsActiveKey];
 }
 
-void PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation()
+void PageClientImplCocoa::didEndPartialIntelligenceTextAnimation()
 {
-    [m_webView _didEndPartialIntelligenceTextPonderingAnimation];
+    [m_webView _didEndPartialIntelligenceTextAnimation];
 }
 
 bool PageClientImplCocoa::writingToolsTextReplacementsFinished()

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1336,14 +1336,14 @@ void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::U
     legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::UpdateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::didEndPartialIntelligenceTextPonderingAnimationImpl()
+void WebPageProxy::didEndPartialIntelligenceTextAnimationImpl()
 {
-    protectedPageClient()->didEndPartialIntelligenceTextPonderingAnimation();
+    protectedPageClient()->didEndPartialIntelligenceTextAnimation();
 }
 
-void WebPageProxy::didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&)
+void WebPageProxy::didEndPartialIntelligenceTextAnimation(IPC::Connection&)
 {
-    didEndPartialIntelligenceTextPonderingAnimationImpl();
+    didEndPartialIntelligenceTextAnimationImpl();
 }
 
 bool WebPageProxy::writingToolsTextReplacementsFinished()

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -758,7 +758,7 @@ public:
     virtual void writingToolsActiveWillChange() = 0;
     virtual void writingToolsActiveDidChange() = 0;
 
-    virtual void didEndPartialIntelligenceTextPonderingAnimation() = 0;
+    virtual void didEndPartialIntelligenceTextAnimation() = 0;
     virtual bool writingToolsTextReplacementsFinished() = 0;
 
     virtual void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2458,8 +2458,8 @@ public:
     bool writingToolsTextReplacementsFinished();
     void intelligenceTextAnimationsDidComplete();
 
-    void didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&);
-    void didEndPartialIntelligenceTextPonderingAnimationImpl();
+    void didEndPartialIntelligenceTextAnimation(IPC::Connection&);
+    void didEndPartialIntelligenceTextAnimationImpl();
 #endif
 
     void resetVisibilityAdjustmentsForTargetedElements(const Vector<Ref<API::TargetedElementInfo>>&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -244,7 +244,7 @@ messages -> WebPageProxy {
     AddTextAnimationForAnimationID(WTF::UUID uuid, struct WebCore::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData)
     AddTextAnimationForAnimationIDWithCompletionHandler(WTF::UUID uuid, struct WebCore::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData) -> (enum:uint8_t WebCore::TextAnimationRunMode runMode)
     RemoveTextAnimationForAnimationID(WTF::UUID uuid)
-    DidEndPartialIntelligenceTextPonderingAnimation()
+    DidEndPartialIntelligenceTextAnimation()
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13383,7 +13383,7 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
 
 - (void)replacementEffectDidComplete
 {
-    _page->didEndPartialIntelligenceTextPonderingAnimationImpl();
+    _page->didEndPartialIntelligenceTextAnimationImpl();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -139,7 +139,7 @@
             if (!strongWebView || !animationID)
                 return;
 
-            strongWebView->page().didEndPartialIntelligenceTextPonderingAnimationImpl();
+            strongWebView->page().didEndPartialIntelligenceTextAnimationImpl();
 
             strongWebView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, true);
             strongWebView->page().callCompletionHandlerForAnimationID(*animationID, runMode);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -249,19 +249,19 @@ void TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession
 void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
 {
     if (!characterRangeAfterReplace) {
-        m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
+        m_webPage->didEndPartialIntelligenceTextAnimation();
         return;
     }
 
     auto sessionRange = contextRangeForActiveWritingToolsSession();
     if (!sessionRange) {
-        m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
+        m_webPage->didEndPartialIntelligenceTextAnimation();
         return;
     }
 
     RefPtr document = this->document();
     if (!document) {
-        m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
+        m_webPage->didEndPartialIntelligenceTextAnimation();
         ASSERT_NOT_REACHED();
         return;
     }
@@ -290,7 +290,7 @@ void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSe
     auto textIndicatorData = createTextIndicatorForRange(replacedRangeAfterReplace);
 
     if (!textIndicatorData) {
-        m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
+        m_webPage->didEndPartialIntelligenceTextAnimation();
         return;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1036,9 +1036,9 @@ void WebPage::intelligenceTextAnimationsDidComplete()
     corePage()->intelligenceTextAnimationsDidComplete();
 }
 
-void WebPage::didEndPartialIntelligenceTextPonderingAnimation()
+void WebPage::didEndPartialIntelligenceTextAnimation()
 {
-    send(Messages::WebPageProxy::DidEndPartialIntelligenceTextPonderingAnimation());
+    send(Messages::WebPageProxy::DidEndPartialIntelligenceTextAnimation());
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1796,7 +1796,7 @@ public:
     std::optional<WebCore::TextIndicatorData> createTextIndicatorForRange(const WebCore::SimpleRange&);
     void createTextIndicatorForTextAnimationID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
 
-    void didEndPartialIntelligenceTextPonderingAnimation();
+    void didEndPartialIntelligenceTextAnimation();
 #endif
 
     void startObservingNowPlayingMetadata();


### PR DESCRIPTION
#### 10fc68dfe56ce90956d121a41113492a7f57794a
<pre>
[Writing Tools] Rename partialIntelligenceTextPonderingAnimation to partialIntelligenceTextAnimation since it isn&apos;t actually associated with pondering at all.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279622">https://bugs.webkit.org/show_bug.cgi?id=279622</a>
<a href="https://rdar.apple.com/135912178">rdar://135912178</a>

Reviewed by Aditya Keerthi.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
(-[WKWebView writingToolsSession:didReceiveAction:]):
(-[WKWebView _didEndPartialIntelligenceTextAnimation]):
(-[WKWebView _didEndPartialIntelligenceTextPonderingAnimation]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didEndPartialIntelligenceTextAnimation):
(WebKit::PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didEndPartialIntelligenceTextAnimationImpl):
(WebKit::WebPageProxy::didEndPartialIntelligenceTextAnimation):
(WebKit::WebPageProxy::didEndPartialIntelligenceTextPonderingAnimationImpl): Deleted.
(WebKit::WebPageProxy::didEndPartialIntelligenceTextPonderingAnimation): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView replacementEffectDidComplete]):
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::didEndPartialIntelligenceTextAnimation):
(WebKit::WebPage::didEndPartialIntelligenceTextPonderingAnimation): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/283583@main">https://commits.webkit.org/283583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/515c6b9d14436daf1214212d73e8807533dbdc27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70756 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/17855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17622 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/17855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69789 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57738 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39108 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16209 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72458 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10679 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57795 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8785 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->