### PR TITLE
[GTK][WPE][Skia] Introduce hybrid threaded CPU+GPU rendering mode

### DIFF
--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -125,4 +125,10 @@ void WorkerPool::postTask(Function<void()>&& task)
     m_condition->notifyOne(locker);
 }
 
+unsigned WorkerPool::numberOfTasks() const
+{
+    Locker locker { *m_lock };
+    return m_tasks.size();
+}
+
 }

--- a/Source/WTF/wtf/WorkerPool.h
+++ b/Source/WTF/wtf/WorkerPool.h
@@ -49,6 +49,8 @@ public:
 
     ASCIILiteral name() const { return m_name; }
 
+    WTF_EXPORT_PRIVATE unsigned numberOfTasks() const;
+
 private:
     class Worker;
     friend class Worker;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -452,10 +452,11 @@ RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 #endif
 
 #if USE(SKIA)
-void ImageBuffer::finishAcceleratedRenderingAndCreateFence()
+bool ImageBuffer::finishAcceleratedRenderingAndCreateFence()
 {
     if (auto* backend = ensureBackend())
-        backend->finishAcceleratedRenderingAndCreateFence();
+        return backend->finishAcceleratedRenderingAndCreateFence();
+    return false;
 }
 
 void ImageBuffer::waitForAcceleratedRenderingFenceCompletion()

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -187,7 +187,7 @@ public:
 #if USE(SKIA)
     // During DisplayList recording a fence is created, so that we can wait until the SkSurface finished rendering
     // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
-    void finishAcceleratedRenderingAndCreateFence();
+    bool finishAcceleratedRenderingAndCreateFence();
     void waitForAcceleratedRenderingFenceCompletion();
 
     const GrDirectContext* skiaGrContext() const;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -142,7 +142,7 @@ public:
 #endif
 
 #if USE(SKIA)
-    virtual void finishAcceleratedRenderingAndCreateFence() { }
+    virtual bool finishAcceleratedRenderingAndCreateFence() { return false; }
     virtual void waitForAcceleratedRenderingFenceCompletion() { }
 
     virtual const GrDirectContext* skiaGrContext() const { return nullptr; }

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -94,7 +94,7 @@ public:
 #if USE(SKIA)
     // During DisplayList recording a fence is created, so that we can wait until the SkImage finished rendering
     // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
-    virtual void finishAcceleratedRenderingAndCreateFence() { }
+    virtual bool finishAcceleratedRenderingAndCreateFence() { return false; }
     virtual void waitForAcceleratedRenderingFenceCompletion() { }
 
     virtual const GrDirectContext* skiaGrContext() const { return nullptr; }
@@ -119,7 +119,7 @@ public:
     WEBCORE_EXPORT Headroom headroom() const final;
 
 #if USE(SKIA)
-    void finishAcceleratedRenderingAndCreateFence() final;
+    bool finishAcceleratedRenderingAndCreateFence() final;
     void waitForAcceleratedRenderingFenceCompletion() final;
 
     const GrDirectContext* skiaGrContext() const final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -503,8 +503,10 @@ void RecorderImpl::setURLForRect(const URL& link, const FloatRect& destRect)
 bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 {
 #if USE(SKIA)
-    if (m_displayList.replayOptions().contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion))
-        nativeImage.backend().finishAcceleratedRenderingAndCreateFence();
+    if (m_displayList.replayOptions().contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion)) {
+        if (nativeImage.backend().finishAcceleratedRenderingAndCreateFence())
+            m_usedAcceleratedRendering = true;
+    }
 #endif
 
     m_displayList.cacheNativeImage(nativeImage);
@@ -514,8 +516,10 @@ bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 bool RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
 {
 #if USE(SKIA)
-    if (m_displayList.replayOptions().contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion))
-        imageBuffer.finishAcceleratedRenderingAndCreateFence();
+    if (m_displayList.replayOptions().contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion)) {
+        if (imageBuffer.finishAcceleratedRenderingAndCreateFence())
+            m_usedAcceleratedRendering = true;
+    }
 #endif
 
     m_displayList.cacheImageBuffer(imageBuffer);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -40,6 +40,9 @@ public:
     WEBCORE_EXPORT virtual ~RecorderImpl();
 
     bool isEmpty() const { return m_displayList.isEmpty(); }
+#if USE(SKIA)
+    bool usedAcceleratedRendering() const { return m_usedAcceleratedRendering; }
+#endif
 
     void save(GraphicsContextState::Purpose) final;
     void restore(GraphicsContextState::Purpose) final;
@@ -143,6 +146,9 @@ private:
     }
 
     DisplayList& m_displayList;
+#if USE(SKIA)
+    bool m_usedAcceleratedRendering : 1 { false };
+#endif
 };
 
 }

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -121,15 +121,15 @@ void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
 #endif
 }
 
-void ImageBufferSkiaAcceleratedBackend::finishAcceleratedRenderingAndCreateFence()
+bool ImageBufferSkiaAcceleratedBackend::finishAcceleratedRenderingAndCreateFence()
 {
     Locker locker { m_fenceLock };
     if (m_fence)
-        return;
+        return true;
 
     auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
     if (!glContext || !glContext->makeContextCurrent())
-        return;
+        return false;
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     RELEASE_ASSERT(grContext);
@@ -141,6 +141,8 @@ void ImageBufferSkiaAcceleratedBackend::finishAcceleratedRenderingAndCreateFence
             grContext->submit(GrSyncCpu::kYes);
     } else
         grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kYes);
+
+    return true;
 }
 
 void ImageBufferSkiaAcceleratedBackend::waitForAcceleratedRenderingFenceCompletion()

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -57,7 +57,7 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
-    void finishAcceleratedRenderingAndCreateFence() final;
+    bool finishAcceleratedRenderingAndCreateFence() final;
     void waitForAcceleratedRenderingFenceCompletion() final;
 
     const GrDirectContext* skiaGrContext() const final { return m_skiaGrContext; }

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -42,15 +42,15 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-void PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence()
+bool PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence()
 {
     Locker locker { m_fenceLock };
     if (m_fence)
-        return;
+        return true;
 
     auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
     if (!glContext || !glContext->makeContextCurrent())
-        return;
+        return false;
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     RELEASE_ASSERT(grContext);
@@ -64,6 +64,8 @@ void PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence()
 
     if (!m_fence)
         grContext->submit(GrSyncCpu::kYes);
+
+    return true;
 }
 
 void PlatformImageNativeImageBackend::waitForAcceleratedRenderingFenceCompletion()

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -95,6 +95,9 @@ class GtkPort(GLibPort):
                 environment['LIBGL_DRIVERS_PATH'] = dri_libgl_path
             else:
                 _log.warning("Can't find Gallium llvmpipe driver. Try to run update-webkitgtk-libs or update-webkit-flatpak")
+
+        # Gtk uses hybrid painting mode by default (preferring GPU) -- for deterministic tests we always want to use the GPU for Gtk.
+        environment['WEBKIT_SKIA_CPU_PAINTING_THREADS'] = '0'
         return environment
 
     def _generate_all_test_configurations(self):


### PR DESCRIPTION
#### 5ce158e9149ee257aab657a3d022fc29fdf25f9b
<pre>
[GTK][WPE][Skia] Introduce hybrid threaded CPU+GPU rendering mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=279618">https://bugs.webkit.org/show_bug.cgi?id=279618</a>

Reviewed by Carlos Garcia Campos.

Introduce a hybrid threaded rendering mode, scheduling tasks to both the
CPU and GPU worker pools, according to several possible strategies, that
can be selected using an environment variable. By default we use
CPU-affine rendering on WPE, and GPU-affine rendering on Gtk.

CPU-affine rendering:
1) If there is a non-identity device scale factor applied, dispatch to GPU pool
2) Dispatch to CPU pool if free workers are available
3) Dispatch to GPU pool if free workers are available
4) Randomly use either CPU or GPU pool, 50% each by default

GPU-affine rendering has 2) and 3) swapped.

Take into account the presence of accelerated ImageBuffer/NativeImage
references in the DisplayList. If we encounter them in a display list,
we can be sure that GPU rendering was used during recording. Therefore
in hybrid mode, we have to use a GPU worker thread for replay, which has
a GL/EGL context associated, and is able to wait for those fences that
signal completion of accelerated ImageBuffer/NativeImage rendering
completion.

Existing tests do not use hybrid mode by default -- otherwise lots of
0.01% pixel tests differences will appear, and non-determinism,
depending on CPU/GPU queue utilization -- we agreed to avoid testing
this for now.

* Source/WTF/wtf/WorkerPool.cpp:
(WTF::WorkerPool::numberOfTasks const):
Add accessor for the number of enqueued tasks.
* Source/WTF/wtf/WorkerPool.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::finishAcceleratedRenderingAndCreateFence):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::finishAcceleratedRenderingAndCreateFence):
* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImageBackend::finishAcceleratedRenderingAndCreateFence):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
(WebCore::DisplayList::RecorderImpl::usedAcceleratedRendering const):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::finishAcceleratedRenderingAndCreateFence):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::canPerformAcceleratedRendering):
(WebCore::SkiaPaintingEngine::recordDisplayList const):
(WebCore::SkiaPaintingEngine::isHybridMode const):
(WebCore::SkiaPaintingEngine::decideHybridRenderingMode const):
(WebCore::SkiaPaintingEngine::paintLayer):
(WebCore::SkiaPaintingEngine::minimumAreaForGPUPainting):
(WebCore::SkiaPaintingEngine::minimumFractionOfTasksUsingGPUPainting):
(WebCore::SkiaPaintingEngine::hybridPaintingStrategy):
(WebCore::SkiaPaintingEngine::renderingMode const): Deleted.
(WebCore::SkiaPaintingEngine::threadedRenderingMode const): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.setup_environ_for_server):
Disable hybrid mode for Gtk, only use GPU (WPE does the opposite).

Canonical link: <a href="https://commits.webkit.org/291106@main">https://commits.webkit.org/291106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc456280f4b8dfa395999ccc6856f5387c35ed93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70462 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27957 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50789 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/91272 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/741 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41618 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84573 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98748 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90519 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79483 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78707 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23229 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11992 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24140 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113106 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18612 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32753 "Found 317 jsc stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager ...") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->