### PR TITLE
Deploy more smart pointers in AudioSessionRoutingArbitratorProxy.cpp

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -44,20 +44,20 @@ public:
 #define LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(logClassName(), __func__, logIdentifier())
 
 #if VERBOSE_RELEASE_LOG
-#define ALWAYS_LOG(...)     logger().logAlwaysVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERROR_LOG(...)      logger().errorVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define WARNING_LOG(...)    logger().warningVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define INFO_LOG(...)       logger().infoVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define DEBUG_LOG(...)      logger().debugVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ALWAYS_LOG(...)     Ref { logger() }->logAlwaysVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERROR_LOG(...)      Ref { logger() }->errorVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define WARNING_LOG(...)    Ref { logger() }->warningVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define INFO_LOG(...)       Ref { logger() }->infoVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define DEBUG_LOG(...)      Ref { logger() }->debugVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #else
-#define ALWAYS_LOG(...)     logger().logAlways(logChannel(), __VA_ARGS__)
-#define ERROR_LOG(...)      logger().error(logChannel(), __VA_ARGS__)
-#define WARNING_LOG(...)    logger().warning(logChannel(), __VA_ARGS__)
-#define INFO_LOG(...)       logger().info(logChannel(), __VA_ARGS__)
-#define DEBUG_LOG(...)      logger().debug(logChannel(), __VA_ARGS__)
+#define ALWAYS_LOG(...)     Ref { logger() }->logAlways(logChannel(), __VA_ARGS__)
+#define ERROR_LOG(...)      Ref { logger() }->error(logChannel(), __VA_ARGS__)
+#define WARNING_LOG(...)    Ref { logger() }->warning(logChannel(), __VA_ARGS__)
+#define INFO_LOG(...)       Ref { logger() }->info(logChannel(), __VA_ARGS__)
+#define DEBUG_LOG(...)      Ref { logger() }->debug(logChannel(), __VA_ARGS__)
 #endif
 
-#define WILL_LOG(_level_)   logger().willLog(logChannel(), _level_)
+#define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_)
 
 #define ALWAYS_LOG_IF(condition, ...)     if (condition) ALWAYS_LOG(__VA_ARGS__)
 #define ERROR_LOG_IF(condition, ...)      if (condition) ERROR_LOG(__VA_ARGS__)
@@ -65,12 +65,12 @@ public:
 #define INFO_LOG_IF(condition, ...)       if (condition) INFO_LOG(__VA_ARGS__)
 #define DEBUG_LOG_IF(condition, ...)      if (condition) DEBUG_LOG(__VA_ARGS__)
 
-#define ALWAYS_LOG_IF_POSSIBLE(...)     if (loggerPtr()) loggerPtr()->logAlways(logChannel(), __VA_ARGS__)
-#define ERROR_LOG_IF_POSSIBLE(...)      if (loggerPtr()) loggerPtr()->error(logChannel(), __VA_ARGS__)
-#define WARNING_LOG_IF_POSSIBLE(...)    if (loggerPtr()) loggerPtr()->warning(logChannel(), __VA_ARGS__)
-#define INFO_LOG_IF_POSSIBLE(...)       if (loggerPtr()) loggerPtr()->info(logChannel(), __VA_ARGS__)
-#define DEBUG_LOG_IF_POSSIBLE(...)      if (loggerPtr()) loggerPtr()->debug(logChannel(), __VA_ARGS__)
-#define WILL_LOG_IF_POSSIBLE(_level_)   if (loggerPtr()) loggerPtr()->willLog(logChannel(), _level_)
+#define ALWAYS_LOG_IF_POSSIBLE(...)     if (RefPtr logger = loggerPtr()) logger->logAlways(logChannel(), __VA_ARGS__)
+#define ERROR_LOG_IF_POSSIBLE(...)      if (RefPtr logger = loggerPtr()) logger->error(logChannel(), __VA_ARGS__)
+#define WARNING_LOG_IF_POSSIBLE(...)    if (RefPtr logger = loggerPtr()) logger->warning(logChannel(), __VA_ARGS__)
+#define INFO_LOG_IF_POSSIBLE(...)       if (RefPtr logger = loggerPtr()) logger->info(logChannel(), __VA_ARGS__)
+#define DEBUG_LOG_IF_POSSIBLE(...)      if (RefPtr logger = loggerPtr()) logger->debug(logChannel(), __VA_ARGS__)
+#define WILL_LOG_IF_POSSIBLE(_level_)   if (RefPtr logger = loggerPtr()) logger->willLog(logChannel(), _level_)
 
 #if defined(__OBJC__)
 #define OBJC_LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(__PRETTY_FUNCTION__, self.logIdentifier)

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
@@ -77,7 +77,7 @@ Ref<WebProcessProxy> AudioSessionRoutingArbitratorProxy::protectedProcess()
 
 Logger& AudioSessionRoutingArbitratorProxy::logger()
 {
-    return m_process->logger();
+    return protectedProcess()->logger();
 }
 
 WTFLogChannel& AudioSessionRoutingArbitratorProxy::logChannel() const

--- a/Source/WebKit/UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm
@@ -43,7 +43,7 @@ AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy(WebProces
     , m_token(SharedRoutingArbitratorToken::create())
 {
     m_logIdentifier = m_token->logIdentifier();
-    SharedRoutingArbitrator::sharedInstance().setLogger(logger());
+    SharedRoutingArbitrator::sharedInstance().setLogger(Ref { logger() });
     proxy.addMessageReceiver(Messages::AudioSessionRoutingArbitratorProxy::messageReceiverName(), destinationId(), *this);
 }
 


### PR DESCRIPTION
#### 4b0473bc6664658ba6c51f198b3f0c50bdaea752
<pre>
Deploy more smart pointers in AudioSessionRoutingArbitratorProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279625">https://bugs.webkit.org/show_bug.cgi?id=279625</a>

Reviewed by Chris Dumez.

Deploy more smart pointers in AudioSessionRoutingArbitratorProxy.cpp as warned by the clang static analyzer.

* Source/WTF/wtf/LoggerHelper.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp:
(WebKit::AudioSessionRoutingArbitratorProxy::logger):
* Source/WebKit/UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm:
(WebKit::AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy):

Canonical link: <a href="https://commits.webkit.org/283593@main">https://commits.webkit.org/283593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b338deb2b0658481e6015c47bc97736185847d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53492 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12053 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57759 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16241 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59868 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72490 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/65999 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61139 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2422 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87766 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15435 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->