### PR TITLE
Deploy more smart pointers in RemoteMediaSessionCoordinatorProxy.cpp

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -496,12 +496,12 @@ const String& WebPageProxy::Internals::paymentCoordinatorSourceApplicationSecond
 
 void WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName receiverName, IPC::MessageReceiver& messageReceiver)
 {
-    protectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(receiverName, webPageID, messageReceiver);
+    protectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(receiverName, page->webPageIDInMainFrameProcess(), messageReceiver);
 }
 
 void WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName receiverName)
 {
-    protectedPage()->protectedLegacyMainFrameProcess()->removeMessageReceiver(receiverName, webPageID);
+    protectedPage()->protectedLegacyMainFrameProcess()->removeMessageReceiver(receiverName, page->webPageIDInMainFrameProcess());
 }
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -59,17 +59,17 @@ RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy(WebPagePr
     : m_webPageProxy(webPageProxy)
     , m_privateCoordinator(WTFMove(privateCoordinator))
 #if !RELEASE_LOG_DISABLED
-    , m_logger(m_webPageProxy->logger())
+    , m_logger(Ref { m_webPageProxy->logger() })
     , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 #endif
 {
     m_privateCoordinator->setClient(*this);
-    m_webPageProxy->legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
+    m_webPageProxy->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
 }
 
 RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 {
-    m_webPageProxy->legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 const SharedPreferencesForWebProcess& RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess() const
@@ -165,27 +165,27 @@ void RemoteMediaSessionCoordinatorProxy::trackIdentifierChanged(const String& id
 
 void RemoteMediaSessionCoordinatorProxy::seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::playSession(std::optional<double> atTime, std::optional<MonotonicTime> hostTime, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTFMove(atTime), WTFMove(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTFMove(atTime), WTFMove(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::pauseSession(CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::setSessionTrack(const String& trackId, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy->legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged(WebCore::MediaSessionCoordinatorState state)
 {
-    m_webPageProxy->legacyMainFrameProcess().send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
+    m_webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -608,7 +608,7 @@ public:
     using Identifier = WebPageProxyIdentifier;
 
     Identifier identifier() const;
-    WebCore::PageIdentifier webPageIDInMainFrameProcess() const;
+    WebCore::PageIdentifier webPageIDInMainFrameProcess() const { return m_webPageID; }
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return webPageIDInMainFrameProcess(); }
     WebCore::PageIdentifier webPageIDInProcess(const WebProcessProxy&) const;
 
@@ -3162,6 +3162,7 @@ private:
 #endif
 
     UniqueRef<Internals> m_internals;
+    WebCore::PageIdentifier m_webPageID;
 
     WeakPtr<PageClient> m_pageClient;
     Ref<API::PageConfiguration> m_configuration;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -269,7 +269,6 @@ public:
     std::optional<WebCore::FloatSize> viewportSizeForCSSViewportUnits;
     VisibleWebPageToken visiblePageToken;
     WebCore::IntRect visibleScrollerThumbRect;
-    WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
     std::unique_ptr<ProcessThrottlerActivity> pageAllowedToRunInTheBackgroundActivityDueToTitleChanges;
     std::unique_ptr<ProcessThrottlerActivity> pageAllowedToRunInTheBackgroundActivityDueToNotifications;


### PR DESCRIPTION
#### 1b90616d249e1a17c14155cfb72d55fa7fed4d3f
<pre>
Deploy more smart pointers in RemoteMediaSessionCoordinatorProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279628">https://bugs.webkit.org/show_bug.cgi?id=279628</a>

Reviewed by Geoffrey Garen.

Deploy more smart pointers in RemoteMediaSessionCoordinatorProxy.cpp as warned by the clang static analyzer.
To inline webPageIDInMainFrameProcess(), move m_webPageID from WebPageProxy::Internals to WebPageProxy.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver):
(WebKit::WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy):
(WebKit::m_logIdentifier):
(WebKit::RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::seekSessionToTime):
(WebKit::RemoteMediaSessionCoordinatorProxy::playSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::pauseSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::setSessionTrack):
(WebKit::RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::Internals::Internals):
(WebKit::WebPageProxy::WebPageProxy):
(WebKit::WebPageProxy::addAllMessageReceivers):
(WebKit::WebPageProxy::removeAllMessageReceivers):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::activateMediaStreamCaptureInPage):
(WebKit::WebPageProxy::sendGestureEvent):
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::windowScreenDidChange):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::viewIsBecomingInvisible):
(WebKit::WebPageProxy::decidePolicyForResponse):
(WebKit::WebPageProxy::setMuted):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::setOverlayScrollbarStyle):
(WebKit::WebPageProxy::startURLSchemeTask):
(WebKit::WebPageProxy::loadSynchronousURLSchemeTask):
(WebKit::WebPageProxy::createRealtimeMediaSourceForSpeechRecognition):
(WebKit::WebPageProxy::webPageIDInProcess const):
(WebKit::WebPageProxy::webPageIDInMainFrameProcess const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/283650@main">https://commits.webkit.org/283650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5619fd2717a17dc6de93ff7d24f957b6a22f3895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53654 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12125 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39228 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2526 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43144 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->