### PR TITLE
Use the terms "Percentage" and "LengthPercentage" more consistently

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1034,7 +1034,7 @@ css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
 css/parser/CSSPropertyParserConsumer+Lists.cpp
 css/parser/CSSPropertyParserConsumer+None.cpp
 css/parser/CSSPropertyParserConsumer+Number.cpp
-css/parser/CSSPropertyParserConsumer+Percent.cpp
+css/parser/CSSPropertyParserConsumer+Percentage.cpp
 css/parser/CSSPropertyParserConsumer+Position.cpp
 css/parser/CSSPropertyParserConsumer+Primitives.cpp
 css/parser/CSSPropertyParserConsumer+RawTypes.cpp

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -355,10 +355,10 @@ static FontSelectionRequest computeFontSelectionRequest(CSSPropertyParserHelpers
         [&](CSSValueID ident) -> FontSelectionValue {
             return *fontStretchValue(ident);
         },
-        [&](PercentRaw percent) -> FontSelectionValue  {
+        [&](PercentageRaw percent) -> FontSelectionValue  {
             return FontSelectionValue::clampFloat(percent.value);
         },
-        [&](const UnevaluatedCalc<PercentRaw>& calc) -> FontSelectionValue  {
+        [&](const UnevaluatedCalc<PercentageRaw>& calc) -> FontSelectionValue  {
             // FIXME: Figure out correct behavior when conversion data is required.
             if (requiresConversionData(calc))
                 return normalStretchValue();

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -101,13 +101,13 @@ template<StopPositionResolution resolution> static inline std::optional<Length> 
         return Style::BuilderConverter::convertLength(state, *position);
 }
 
-static inline std::variant<std::monostate, AngleRaw, PercentRaw> computeAngularStopPosition(const RefPtr<CSSPrimitiveValue>& position, Style::BuilderState& state)
+static inline std::variant<std::monostate, AngleRaw, PercentageRaw> computeAngularStopPosition(const RefPtr<CSSPrimitiveValue>& position, Style::BuilderState& state)
 {
     if (!position)
         return std::monostate { };
 
     if (position->isPercentage())
-        return { PercentRaw { position->resolveAsPercentage(state.cssToLengthConversionData()) } };
+        return { PercentageRaw { position->resolveAsPercentage(state.cssToLengthConversionData()) } };
 
     if (position->isAngle())
         return { AngleRaw { CSSUnitType::CSS_DEG, position->resolveAsAngle<double, CSSPrimitiveValue::AngleUnit::Degrees>(state.cssToLengthConversionData()) } };
@@ -135,7 +135,7 @@ static decltype(auto) computeAngularStops(const CSSGradientColorStopList& stops,
 static StyleGradientDeprecatedPoint::Coordinate resolvePointCoordinate(const Ref<CSSPrimitiveValue>& coordinate, Style::BuilderState& state)
 {
     if (coordinate->isPercentage())
-        return { PercentRaw { coordinate->resolveAsPercentage(state.cssToLengthConversionData()) } };
+        return { PercentageRaw { coordinate->resolveAsPercentage(state.cssToLengthConversionData()) } };
     return { NumberRaw { coordinate->resolveAsNumber(state.cssToLengthConversionData()) } };
 }
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -498,7 +498,7 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(double value, CSSUnitType type)
             return *result;
         break;
     case CSSUnitType::CSS_PERCENTAGE:
-        if (auto* result = valueFromPool(staticCSSValuePool->m_percentValues, value))
+        if (auto* result = valueFromPool(staticCSSValuePool->m_percentageValues, value))
             return *result;
         break;
     case CSSUnitType::CSS_PX:

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -49,7 +49,7 @@ StaticCSSValuePool::StaticCSSValuePool()
 
     for (unsigned i = 0; i <= maximumCacheableIntegerValue; ++i) {
         m_pixelValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PX);
-        m_percentValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PERCENTAGE);
+        m_percentageValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PERCENTAGE);
         m_numberValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_NUMBER);
     }
 }

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -56,7 +56,7 @@ private:
     static constexpr int maximumCacheableIntegerValue = 255;
 
     LazyNeverDestroyed<CSSPrimitiveValue> m_pixelValues[maximumCacheableIntegerValue + 1];
-    LazyNeverDestroyed<CSSPrimitiveValue> m_percentValues[maximumCacheableIntegerValue + 1];
+    LazyNeverDestroyed<CSSPrimitiveValue> m_percentageValues[maximumCacheableIntegerValue + 1];
     LazyNeverDestroyed<CSSPrimitiveValue> m_numberValues[maximumCacheableIntegerValue + 1];
     LazyNeverDestroyed<CSSPrimitiveValue> m_identifierValues[numCSSValueKeywords];
 };

--- a/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
@@ -59,7 +59,7 @@ static auto fromCalculationValue(const Vector<Calculation::Child>&, const FromCo
 static auto fromCalculationValue(const std::optional<Calculation::Child>&, const FromConversionOptions&) -> std::optional<Child>;
 static auto fromCalculationValue(const Calculation::Child&, const FromConversionOptions&) -> Child;
 static auto fromCalculationValue(const Calculation::Number&, const FromConversionOptions&) -> Child;
-static auto fromCalculationValue(const Calculation::Percent&, const FromConversionOptions&) -> Child;
+static auto fromCalculationValue(const Calculation::Percentage&, const FromConversionOptions&) -> Child;
 static auto fromCalculationValue(const Calculation::Dimension&, const FromConversionOptions&) -> Child;
 static auto fromCalculationValue(const Calculation::IndirectNode<Calculation::Blend>&, const FromConversionOptions&) -> Child;
 template<typename CalculationOp> auto fromCalculationValue(const Calculation::IndirectNode<CalculationOp>&, const FromConversionOptions&) -> Child;
@@ -70,7 +70,7 @@ static auto toCalculationValue(const ChildOrNone&, const ToConversionOptions&) -
 static auto toCalculationValue(const Children&, const ToConversionOptions&) -> Calculation::Children;
 static auto toCalculationValue(const Child&, const ToConversionOptions&) -> Calculation::Child;
 static auto toCalculationValue(const Number&, const ToConversionOptions&) -> Calculation::Child;
-static auto toCalculationValue(const Percent&, const ToConversionOptions&) -> Calculation::Child;
+static auto toCalculationValue(const Percentage&, const ToConversionOptions&) -> Calculation::Child;
 static auto toCalculationValue(const CanonicalDimension&, const ToConversionOptions&) -> Calculation::Child;
 static auto toCalculationValue(const NonCanonicalDimension&, const ToConversionOptions&) -> Calculation::Child;
 static auto toCalculationValue(const Symbol&, const ToConversionOptions&) -> Calculation::Child;
@@ -81,12 +81,12 @@ static CanonicalDimension::Dimension determineCanonicalDimension(Calculation::Ca
     // FIXME: For now, Calculation::Dimension always means <length>, but could be used for any of percent-hint capable categories as they are added to `Calculation::Category`.
 
     switch (category) {
-    case Calculation::Category::PercentLength:
+    case Calculation::Category::LengthPercentage:
         return CanonicalDimension::Dimension::Length;
 
     case Calculation::Category::Integer:
     case Calculation::Category::Number:
-    case Calculation::Category::Percent:
+    case Calculation::Category::Percentage:
     case Calculation::Category::Length:
     case Calculation::Category::Angle:
     case Calculation::Category::Time:
@@ -134,9 +134,9 @@ Child fromCalculationValue(const Calculation::Number& number, const FromConversi
     return makeChild(Number { .value = number.value });
 }
 
-Child fromCalculationValue(const Calculation::Percent& percent, const FromConversionOptions& options)
+Child fromCalculationValue(const Calculation::Percentage& percentage, const FromConversionOptions& options)
 {
-    return makeChild(Percent { .value = percent.value, .hint = Type::determinePercentHint(options.simplification.category) });
+    return makeChild(Percentage { .value = percentage.value, .hint = Type::determinePercentHint(options.simplification.category) });
 }
 
 Child fromCalculationValue(const Calculation::Dimension& root, const FromConversionOptions& options)
@@ -220,9 +220,9 @@ Calculation::Child toCalculationValue(const Number& root, const ToConversionOpti
     return Calculation::number(root.value);
 }
 
-Calculation::Child toCalculationValue(const Percent& root, const ToConversionOptions&)
+Calculation::Child toCalculationValue(const Percentage& root, const ToConversionOptions&)
 {
-    return Calculation::percent(root.value);
+    return Calculation::percentage(root.value);
 }
 
 Calculation::Child toCalculationValue(const CanonicalDimension& root, const ToConversionOptions& options)
@@ -297,8 +297,8 @@ Tree fromCalculationValue(const CalculationValue& calculationValue, const Render
 
 Ref<CalculationValue> toCalculationValue(const Tree& tree, const EvaluationOptions& options)
 {
-    // We currently only ever need to create CalculationValues from calc() to implement late resolution of percentages to Length values, so we assert that we only call this with `PercentLength` trees. That said, the code is agnostic to this, and could work for any tree if needed.
-    ASSERT(tree.category == Calculation::Category::PercentLength);
+    // We currently only ever need to create CalculationValues from calc() to implement late resolution of percentages to Length values, so we assert that we only call this with `LengthPercentage` trees. That said, the code is agnostic to this, and could work for any tree if needed.
+    ASSERT(tree.category == Calculation::Category::LengthPercentage);
 
     auto category = tree.category;
     auto range = tree.range;

--- a/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
@@ -142,7 +142,7 @@ static void collectComputedStyleDependencies(const Child& root, ComputedStyleDep
         [&](const Number&) {
             // No potential dependencies.
         },
-        [&](const Percent&) {
+        [&](const Percentage&) {
             // No potential dependencies.
         },
         [&](const CanonicalDimension&) {

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -38,7 +38,7 @@ static auto evaluate(const ChildOrNone&, const EvaluationOptions&) -> std::optio
 static auto evaluate(const std::optional<Child>&, const EvaluationOptions&) -> std::optional<std::optional<double>>;
 static auto evaluate(const Child&, const EvaluationOptions&) -> std::optional<double>;
 static auto evaluate(const Number&, const EvaluationOptions&) -> std::optional<double>;
-static auto evaluate(const Percent&, const EvaluationOptions&) -> std::optional<double>;
+static auto evaluate(const Percentage&, const EvaluationOptions&) -> std::optional<double>;
 static auto evaluate(const CanonicalDimension&, const EvaluationOptions&) -> std::optional<double>;
 static auto evaluate(const NonCanonicalDimension&, const EvaluationOptions&) -> std::optional<double>;
 static auto evaluate(const Symbol&, const EvaluationOptions&) -> std::optional<double>;
@@ -109,9 +109,9 @@ std::optional<double> evaluate(const Number& number, const EvaluationOptions&)
     return number.value;
 }
 
-std::optional<double> evaluate(const Percent& percent, const EvaluationOptions&)
+std::optional<double> evaluate(const Percentage& percentage, const EvaluationOptions&)
 {
-    return percent.value;
+    return percentage.value;
 }
 
 std::optional<double> evaluate(const CanonicalDimension& root, const EvaluationOptions&)

--- a/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
@@ -34,7 +34,7 @@ namespace CSSCalc {
 
 enum class NumericIdentity : uint8_t {
     Number,
-    Percent,
+    Percentage,
 
     // Canonical dimension units
     PX,
@@ -110,9 +110,9 @@ constexpr NumericIdentity toNumericIdentity(const Number&)
     return NumericIdentity::Number;
 }
 
-constexpr NumericIdentity toNumericIdentity(const Percent&)
+constexpr NumericIdentity toNumericIdentity(const Percentage&)
 {
-    return NumericIdentity::Percent;
+    return NumericIdentity::Percentage;
 }
 
 constexpr NumericIdentity toNumericIdentity(const CanonicalDimension& dimension)
@@ -279,7 +279,7 @@ constexpr bool isLength(NumericIdentity id)
         return true;
 
     case NumericIdentity::Number:
-    case NumericIdentity::Percent:
+    case NumericIdentity::Percentage:
     case NumericIdentity::DEG:
     case NumericIdentity::S:
     case NumericIdentity::HZ:

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -969,7 +969,7 @@ std::optional<TypedChild> parseCalcNumber(const CSSParserToken& token, ParserSta
 
 std::optional<TypedChild> parseCalcPercentage(const CSSParserToken& token, ParserState& state)
 {
-    auto child = Percent { .value = token.numericValue(), .hint = Type::determinePercentHint(state.parserOptions.category) };
+    auto child = Percentage { .value = token.numericValue(), .hint = Type::determinePercentHint(state.parserOptions.category) };
     auto type = getType(child);
 
     return TypedChild { makeChild(WTFMove(child)), type };

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -66,7 +66,7 @@ Child copyAndSimplify(const Child&, const SimplificationOptions&);
 // MARK: In-place Simplify
 
 std::optional<Child> simplify(Number&, const SimplificationOptions&);
-std::optional<Child> simplify(Percent&, const SimplificationOptions&);
+std::optional<Child> simplify(Percentage&, const SimplificationOptions&);
 std::optional<Child> simplify(NonCanonicalDimension&, const SimplificationOptions&);
 std::optional<Child> simplify(CanonicalDimension&, const SimplificationOptions&);
 std::optional<Child> simplify(Symbol&, const SimplificationOptions&);

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -40,9 +40,9 @@ Child makeNumeric(double value, CSSUnitType unit)
     case CSSUnitType::CSS_INTEGER:
         return makeChild(Number { .value = value });
 
-    // Percent
+    // Percentage
     case CSSUnitType::CSS_PERCENTAGE:
-        return makeChild(Percent { .value = value, .hint = { } });
+        return makeChild(Percentage { .value = value, .hint = { } });
 
     // Canonical Dimension
     case CSSUnitType::CSS_PX:
@@ -166,7 +166,7 @@ Type getType(const Number&)
     return Type { };
 }
 
-Type getType(const Percent& root)
+Type getType(const Percentage& root)
 {
     auto type = Type { .percent = 1 };
     if (root.hint)

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -91,14 +91,14 @@ struct Number {
     bool operator==(const Number&) const = default;
 };
 
-struct Percent {
+struct Percentage {
     static constexpr bool isLeaf = true;
     static constexpr bool isNumeric = true;
 
     double value;
     Type::PercentHintValue hint;
 
-    bool operator==(const Percent&) const = default;
+    bool operator==(const Percentage&) const = default;
 };
 
 struct CanonicalDimension {
@@ -156,7 +156,7 @@ template<typename Op> struct IndirectNode {
 
 using Node = std::variant<
     Number,
-    Percent,
+    Percentage,
     CanonicalDimension,
     NonCanonicalDimension,
     Symbol,
@@ -756,10 +756,10 @@ template<> struct ChildConstruction<Number> {
     static Child make(Number&& op) { return Child { WTFMove(op) }; }
 };
 
-// Specialized implementation of ChildConstruction for Percent, needed to avoid `makeUniqueRef`.
-template<> struct ChildConstruction<Percent> {
-    static Child make(Percent&& op, Type) { return Child { WTFMove(op) }; }
-    static Child make(Percent&& op) { return Child { WTFMove(op) }; }
+// Specialized implementation of ChildConstruction for Percentage, needed to avoid `makeUniqueRef`.
+template<> struct ChildConstruction<Percentage> {
+    static Child make(Percentage&& op, Type) { return Child { WTFMove(op) }; }
+    static Child make(Percentage&& op) { return Child { WTFMove(op) }; }
 };
 
 // Specialized implementation of ChildConstruction for CanonicalDimension, needed to avoid `makeUniqueRef`.
@@ -803,7 +803,7 @@ Type getType(CanonicalDimension::Dimension);
 
 // Gets the Type of the leaf node.
 Type getType(const Number&);
-Type getType(const Percent&);
+Type getType(const Percentage&);
 Type getType(const NonCanonicalDimension&);
 Type getType(const CanonicalDimension&);
 Type getType(const Symbol&);
@@ -860,7 +860,7 @@ constexpr CSSUnitType toCSSUnit(const CanonicalDimension::Dimension& dimension)
 
 // Maps Numeric type to its CSSUnitType counterpart.
 constexpr CSSUnitType toCSSUnit(const Number&) { return CSSUnitType::CSS_NUMBER; }
-constexpr CSSUnitType toCSSUnit(const Percent&) { return CSSUnitType::CSS_PERCENTAGE; }
+constexpr CSSUnitType toCSSUnit(const Percentage&) { return CSSUnitType::CSS_PERCENTAGE; }
 constexpr CSSUnitType toCSSUnit(const CanonicalDimension& dimension) { return toCSSUnit(dimension.dimension); }
 constexpr CSSUnitType toCSSUnit(const NonCanonicalDimension& dimension) { return dimension.unit; }
 
@@ -876,7 +876,7 @@ inline bool isNumeric(const Child& root)
 
 // Convenience constructors
 
-// Makes the appropriate child type (number, percent, canonical-dimensions, non-canonical-dimension) based on the CSSUnitType.
+// Makes the appropriate child type (number, percentage, canonical-dimensions, non-canonical-dimension) based on the CSSUnitType.
 Child makeNumeric(double, CSSUnitType);
 
 inline Sum add(Child&& a, Child&& b)
@@ -905,9 +905,9 @@ inline Child makeChildWithValueBasedOn(double value, const Number&)
     return makeChild(Number { .value = value });
 }
 
-inline Child makeChildWithValueBasedOn(double value, const Percent& a)
+inline Child makeChildWithValueBasedOn(double value, const Percentage& a)
 {
-    return makeChild(Percent { .value = value, .hint = a.hint });
+    return makeChild(Percentage { .value = value, .hint = a.hint });
 }
 
 inline Child makeChildWithValueBasedOn(double value, const CanonicalDimension& a)

--- a/Source/WebCore/css/calc/CSSCalcType.cpp
+++ b/Source/WebCore/css/calc/CSSCalcType.cpp
@@ -322,7 +322,7 @@ Type::PercentHintValue Type::determinePercentHint(Calculation::Category category
     switch (category) {
     case Calculation::Category::Integer:
     case Calculation::Category::Number:
-    case Calculation::Category::Percent:
+    case Calculation::Category::Percentage:
     case Calculation::Category::Length:
     case Calculation::Category::Angle:
     case Calculation::Category::Time:
@@ -331,7 +331,7 @@ Type::PercentHintValue Type::determinePercentHint(Calculation::Category category
     case Calculation::Category::Flex:
         return { };
 
-    case Calculation::Category::PercentLength:
+    case Calculation::Category::LengthPercentage:
         return PercentHint::Length;
     }
 
@@ -345,7 +345,7 @@ bool Type::matches(Calculation::Category category) const
     case Calculation::Category::Integer:
     case Calculation::Category::Number:
         return matchesAny<Match::Number>();
-    case Calculation::Category::Percent:
+    case Calculation::Category::Percentage:
         return matchesAny<Match::Percent>();
     case Calculation::Category::Length:
         return matchesAny<Match::Length>();
@@ -359,7 +359,7 @@ bool Type::matches(Calculation::Category category) const
         return matchesAny<Match::Resolution>();
     case Calculation::Category::Flex:
         return matchesAny<Match::Flex>();
-    case Calculation::Category::PercentLength:
+    case Calculation::Category::LengthPercentage:
         return matchesAny<Match::Length, Match::Percent>({ .allowsPercentHint = true });
     }
 
@@ -392,7 +392,7 @@ std::optional<Calculation::Category> Type::calculationCategory() const
     switch (*matchingUnit) {
     case BaseType::Length:
         if (percentHint)
-            return Calculation::Category::PercentLength;
+            return Calculation::Category::LengthPercentage;
         return Calculation::Category::Length;
     case BaseType::Angle:
         ASSERT(!percentHint);
@@ -411,7 +411,7 @@ std::optional<Calculation::Category> Type::calculationCategory() const
         return Calculation::Category::Flex;
     case BaseType::Percent:
         ASSERT(!percentHint);
-        return Calculation::Category::Percent;
+        return Calculation::Category::Percentage;
     }
 
     ASSERT_NOT_REACHED();
@@ -440,7 +440,7 @@ static ASCIILiteral literal(PercentHint percentHint)
     case PercentHint::Length: return "length"_s;
     case PercentHint::Angle: return "angle"_s;
     case PercentHint::Time: return "time"_s;
-    case PercentHint::Frequency: return "trequency"_s;
+    case PercentHint::Frequency: return "frequency"_s;
     case PercentHint::Resolution: return "resolution"_s;
     case PercentHint::Flex: return "flex"_s;
     }

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -131,7 +131,7 @@ CSSUnitType CSSCalcValue::primitiveType() const
         return CSSUnitType::CSS_INTEGER;
     case Calculation::Category::Number:
         return CSSUnitType::CSS_NUMBER;
-    case Calculation::Category::Percent:
+    case Calculation::Category::Percentage:
         return CSSUnitType::CSS_PERCENTAGE;
     case Calculation::Category::Length:
         return CSSUnitType::CSS_PX;
@@ -145,10 +145,10 @@ CSSUnitType CSSCalcValue::primitiveType() const
         return CSSUnitType::CSS_DPPX;
     case Calculation::Category::Flex:
         return CSSUnitType::CSS_FR;
-    case Calculation::Category::PercentLength:
+    case Calculation::Category::LengthPercentage:
         if (!m_tree.type.percentHint)
             return CSSUnitType::CSS_PX;
-        if (std::holds_alternative<CSSCalc::Percent>(m_tree.root))
+        if (std::holds_alternative<CSSCalc::Percentage>(m_tree.root))
             return CSSUnitType::CSS_PERCENTAGE;
         return CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH;
     }
@@ -263,15 +263,15 @@ NumberRaw CSSCalcValue::numberValue(const CSSToLengthConversionData& conversionD
     return { doubleValue(conversionData, symbolTable) };
 }
 
-PercentRaw CSSCalcValue::percentValueNoConversionDataRequired(const CSSCalcSymbolTable& symbolTable) const
+PercentageRaw CSSCalcValue::percentageValueNoConversionDataRequired(const CSSCalcSymbolTable& symbolTable) const
 {
-    ASSERT(m_tree.category == Calculation::Category::Percent);
+    ASSERT(m_tree.category == Calculation::Category::Percentage);
     return { doubleValueNoConversionDataRequired(symbolTable) };
 }
 
-PercentRaw CSSCalcValue::percentValue(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
+PercentageRaw CSSCalcValue::percentageValue(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
-    ASSERT(m_tree.category == Calculation::Category::Percent);
+    ASSERT(m_tree.category == Calculation::Category::Percentage);
     return { doubleValue(conversionData, symbolTable) };
 }
 
@@ -325,22 +325,22 @@ TimeRaw CSSCalcValue::timeValue(const CSSToLengthConversionData& conversionData,
 
 Length CSSCalcValue::lengthPercentageValueNoConversionDataRequired(const CSSCalcSymbolTable& symbolTable) const
 {
-    ASSERT(m_tree.category == Calculation::Category::PercentLength);
+    ASSERT(m_tree.category == Calculation::Category::LengthPercentage);
 
     if (!m_tree.type.percentHint)
         return Length { doubleValueNoConversionDataRequired(symbolTable), LengthType::Fixed };
-    if (std::holds_alternative<CSSCalc::Percent>(m_tree.root))
+    if (std::holds_alternative<CSSCalc::Percentage>(m_tree.root))
         return Length { doubleValueNoConversionDataRequired(symbolTable), LengthType::Percent };
     return Length { createCalculationValueNoConversionDataRequired(symbolTable) };
 }
 
 Length CSSCalcValue::lengthPercentageValue(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
-    ASSERT(m_tree.category == Calculation::Category::PercentLength);
+    ASSERT(m_tree.category == Calculation::Category::LengthPercentage);
 
     if (!m_tree.type.percentHint)
         return Length { doubleValue(conversionData, symbolTable), LengthType::Fixed };
-    if (std::holds_alternative<CSSCalc::Percent>(m_tree.root))
+    if (std::holds_alternative<CSSCalc::Percentage>(m_tree.root))
         return Length { doubleValue(conversionData, symbolTable), LengthType::Percent };
     return Length { createCalculationValue(conversionData, symbolTable) };
 }

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -87,8 +87,8 @@ public:
 
     NumberRaw numberValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;
     NumberRaw numberValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
-    PercentRaw percentValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;
-    PercentRaw percentValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
+    PercentageRaw percentageValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;
+    PercentageRaw percentageValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
     AngleRaw angleValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;
     AngleRaw angleValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
     LengthRaw lengthValueNoConversionDataRequired(const CSSCalcSymbolTable&) const;

--- a/Source/WebCore/css/color/CSSColorConversion+Normalize.h
+++ b/Source/WebCore/css/color/CSSColorConversion+Normalize.h
@@ -54,7 +54,7 @@ NumberRaw normalizeAndClampNumericComponents(NumberRaw number)
 }
 
 template<typename Descriptor, unsigned Index>
-NumberRaw normalizeAndClampNumericComponents(PercentRaw percent)
+NumberRaw normalizeAndClampNumericComponents(PercentageRaw percent)
 {
     constexpr auto info = std::get<Index>(Descriptor::components);
 
@@ -125,7 +125,7 @@ NumberRaw normalizeNumericComponents(NumberRaw number)
 }
 
 template<typename Descriptor, unsigned Index>
-NumberRaw normalizeNumericComponents(PercentRaw percent)
+NumberRaw normalizeNumericComponents(PercentageRaw percent)
 {
     constexpr auto info = std::get<Index>(Descriptor::components);
 

--- a/Source/WebCore/css/color/CSSColorConversion+ToTypedColor.h
+++ b/Source/WebCore/css/color/CSSColorConversion+ToTypedColor.h
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 // This file implements support for converting "raw" parsed values
-// (e.g. tuple of `std::variant<NumberRaw, PercentRaw>`) into typed
+// (e.g. tuple of `std::variant<NumberRaw, PercentageRaw>`) into typed
 // colors (e.g. `SRGBA<float>`).
 
 template<typename Descriptor> GetColorType<Descriptor> normalizeRawComponents(CSSColorParseType<Descriptor>);
@@ -55,7 +55,7 @@ template<typename Descriptor, unsigned Index> float normalizeComponent(NumberRaw
         return std::clamp(number.value * multiplier, min, max);
 }
 
-template<typename Descriptor, unsigned Index> float normalizeComponent(PercentRaw percent)
+template<typename Descriptor, unsigned Index> float normalizeComponent(PercentageRaw percent)
 {
     constexpr auto info = std::get<Index>(Descriptor::components);
     constexpr auto multiplier = info.percentMultiplier * info.numberMultiplier;

--- a/Source/WebCore/css/color/CSSColorDescriptors.h
+++ b/Source/WebCore/css/color/CSSColorDescriptors.h
@@ -178,8 +178,8 @@ template<typename Descriptor> bool requiresConversionData(const CSSColorParseTyp
 
 // MARK: - Shared Component Descriptors
 
-constexpr auto AlphaComponent = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw> { .symbol = CSSValueAlpha, .min = 0.0, .max = 1.0 };
-constexpr auto AlphaLegacyComponent = CSSColorComponent<PercentRaw, NumberRaw> { .symbol = CSSValueAlpha, .min = 0.0, .max = 1.0 };
+constexpr auto AlphaComponent = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw> { .symbol = CSSValueAlpha, .min = 0.0, .max = 1.0 };
+constexpr auto AlphaLegacyComponent = CSSColorComponent<PercentageRaw, NumberRaw> { .symbol = CSSValueAlpha, .min = 0.0, .max = 1.0 };
 
 // MARK: - Color Function Descriptors
 
@@ -195,9 +195,9 @@ struct RGBFunctionModernAbsolute {
     static constexpr bool usesColorFunctionForSerialization = false;
     static constexpr ASCIILiteral serializationFunctionName = "rgb"_s;
 
-    using R = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using G = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using B = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using R = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using G = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using B = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         R { .symbol = CSSValueR, .min = 0.0, .max = 255.0, .numberMultiplier = 1.0 / 255.0, .percentMultiplier = 255.0 / 100.0, .symbolMultiplier = 255.0 },
@@ -243,9 +243,9 @@ struct RGBFunctionModernRelative {
     static constexpr bool usesColorFunctionForSerialization = false;
     static constexpr ASCIILiteral serializationFunctionName = "rgb"_s;
 
-    using R = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using G = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using B = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using R = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using G = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using B = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         R { .symbol = CSSValueR, .numberMultiplier = 1.0 / 255.0, .percentMultiplier = 255.0 / 100.0, .symbolMultiplier = 255.0 },
@@ -269,8 +269,8 @@ struct HSLFunctionModern {
     static constexpr ASCIILiteral serializationFunctionName = "hsl"_s;
 
     using H = CSSColorComponent<AngleRaw, NumberRaw, NoneRaw>;
-    using S = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using L = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using S = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using L = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         H { .symbol = CSSValueH, .type = ColorComponentType::Angle    },
@@ -293,8 +293,8 @@ struct HSLFunctionLegacy {
     static constexpr ASCIILiteral serializationFunctionName = "hsl"_s;
 
     using H = CSSColorComponent<AngleRaw, NumberRaw>;
-    using S = CSSColorComponent<PercentRaw>;
-    using L = CSSColorComponent<PercentRaw>;
+    using S = CSSColorComponent<PercentageRaw>;
+    using L = CSSColorComponent<PercentageRaw>;
 
     static constexpr auto components = std::make_tuple(
         H { .symbol = CSSValueH, .type = ColorComponentType::Angle    },
@@ -317,8 +317,8 @@ struct HWBFunction {
     static constexpr ASCIILiteral serializationFunctionName = "hwb"_s;
 
     using H = CSSColorComponent<AngleRaw, NumberRaw, NoneRaw>;
-    using W = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using B = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using W = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using B = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         H { .symbol = CSSValueH, .type = ColorComponentType::Angle },
@@ -340,9 +340,9 @@ struct LabFunction {
     static constexpr bool usesColorFunctionForSerialization = false;
     static constexpr ASCIILiteral serializationFunctionName = "lab"_s;
 
-    using L = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using A = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using B = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using L = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using A = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using B = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         L { .symbol = CSSValueL, .min = 0.0, .max = 100.0, .percentMultiplier = 1.0           },
@@ -364,8 +364,8 @@ struct LCHFunction {
     static constexpr bool usesColorFunctionForSerialization = false;
     static constexpr ASCIILiteral serializationFunctionName = "lch"_s;
 
-    using L = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using C = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using L = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using C = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
     using H = CSSColorComponent<AngleRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
@@ -388,9 +388,9 @@ struct OKLabFunction {
     static constexpr bool usesColorFunctionForSerialization = false;
     static constexpr ASCIILiteral serializationFunctionName = "oklab"_s;
 
-    using L = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using A = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using B = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using L = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using A = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using B = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         L { .symbol = CSSValueL, .min = 0.0, .max = 1.0                                   },
@@ -412,8 +412,8 @@ struct OKLCHFunction {
     static constexpr bool usesColorFunctionForSerialization = false;
     static constexpr ASCIILiteral serializationFunctionName = "oklch"_s;
 
-    using L = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using C = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using L = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using C = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
     using H = CSSColorComponent<AngleRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
@@ -438,9 +438,9 @@ template<typename T> struct ColorRGBFunction {
     static constexpr bool usesColorFunctionForSerialization = true;
     static constexpr ASCIILiteral serializationFunctionName = "color"_s;
 
-    using R = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using G = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using B = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using R = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using G = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using B = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         R { .symbol = CSSValueR },
@@ -464,9 +464,9 @@ template<typename T> struct ColorXYZFunction {
     static constexpr bool usesColorFunctionForSerialization = true;
     static constexpr ASCIILiteral serializationFunctionName = "color"_s;
 
-    using X = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using Y = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
-    using Z = CSSColorComponent<PercentRaw, NumberRaw, NoneRaw>;
+    using X = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using Y = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
+    using Z = CSSColorComponent<PercentageRaw, NumberRaw, NoneRaw>;
 
     static constexpr auto components = std::make_tuple(
         X { .symbol = CSSValueX },

--- a/Source/WebCore/css/color/CSSColorMixResolver.cpp
+++ b/Source/WebCore/css/color/CSSColorMixResolver.cpp
@@ -40,7 +40,7 @@ struct ColorMixPercentages {
 
 }
 
-static std::optional<ColorMixPercentages> normalizedMixPercentages(std::optional<PercentRaw> mixComponents1Percentage, std::optional<PercentRaw> mixComponents2Percentage)
+static std::optional<ColorMixPercentages> normalizedMixPercentages(std::optional<PercentageRaw> mixComponents1Percentage, std::optional<PercentageRaw> mixComponents2Percentage)
 {
     // The percentages are normalized as follows:
 

--- a/Source/WebCore/css/color/CSSColorMixResolver.h
+++ b/Source/WebCore/css/color/CSSColorMixResolver.h
@@ -35,7 +35,7 @@ namespace WebCore {
 struct CSSColorMixResolver {
     struct Component {
         Color color;
-        std::optional<PercentRaw> percentage;
+        std::optional<PercentageRaw> percentage;
     };
 
     ColorInterpolationMethod colorInterpolationMethod;

--- a/Source/WebCore/css/color/CSSColorMixSerialization.cpp
+++ b/Source/WebCore/css/color/CSSColorMixSerialization.cpp
@@ -37,14 +37,14 @@ namespace WebCore {
 
 bool isCalc(const CSSUnresolvedColorMix::Component::Percentage& percentage)
 {
-    return std::holds_alternative<UnevaluatedCalc<PercentRaw>>(percentage);
+    return std::holds_alternative<UnevaluatedCalc<PercentageRaw>>(percentage);
 }
 
 bool is50Percent(const CSSUnresolvedColorMix::Component::Percentage& percentage)
 {
     return WTF::switchOn(percentage,
-        [](const PercentRaw& raw) { return raw.value == 50.0; },
-        [](const UnevaluatedCalc<PercentRaw>&) { return false; }
+        [](const PercentageRaw& raw) { return raw.value == 50.0; },
+        [](const UnevaluatedCalc<PercentageRaw>&) { return false; }
     );
 }
 
@@ -56,16 +56,16 @@ bool is50Percent(const StyleColorMix::Component::Percentage& percentage)
 bool sumTo100Percent(const CSSUnresolvedColorMix::Component::Percentage& a, const CSSUnresolvedColorMix::Component::Percentage& b)
 {
     auto visitor = WTF::makeVisitor(
-        [](const PercentRaw& a, const PercentRaw& b) {
+        [](const PercentageRaw& a, const PercentageRaw& b) {
             return a.value + b.value == 100.0;
         },
-        [](const PercentRaw&, const UnevaluatedCalc<PercentRaw>&) {
+        [](const PercentageRaw&, const UnevaluatedCalc<PercentageRaw>&) {
             return false;
         },
-        [](const UnevaluatedCalc<PercentRaw>&, const PercentRaw&) {
+        [](const UnevaluatedCalc<PercentageRaw>&, const PercentageRaw&) {
             return false;
         },
-        [](const UnevaluatedCalc<PercentRaw>&, const UnevaluatedCalc<PercentRaw>&) {
+        [](const UnevaluatedCalc<PercentageRaw>&, const UnevaluatedCalc<PercentageRaw>&) {
             return false;
         }
     );
@@ -78,21 +78,21 @@ bool sumTo100Percent(const StyleColorMix::Component::Percentage& a, const StyleC
     return a.value + b.value == 100.0;
 }
 
-std::optional<PercentRaw> subtractFrom100Percent(const CSSUnresolvedColorMix::Component::Percentage& percentage)
+std::optional<PercentageRaw> subtractFrom100Percent(const CSSUnresolvedColorMix::Component::Percentage& percentage)
 {
     return WTF::switchOn(percentage,
-        [&](const PercentRaw& raw) -> std::optional<PercentRaw> {
-            return PercentRaw { 100.0 - raw.value };
+        [&](const PercentageRaw& raw) -> std::optional<PercentageRaw> {
+            return PercentageRaw { 100.0 - raw.value };
         },
-        [&](const UnevaluatedCalc<PercentRaw>&) -> std::optional<PercentRaw> {
+        [&](const UnevaluatedCalc<PercentageRaw>&) -> std::optional<PercentageRaw> {
             return std::nullopt;
         }
     );
 }
 
-std::optional<PercentRaw> subtractFrom100Percent(const StyleColorMix::Component::Percentage& percentage)
+std::optional<PercentageRaw> subtractFrom100Percent(const StyleColorMix::Component::Percentage& percentage)
 {
-    return PercentRaw { 100.0 - percentage.value };
+    return PercentageRaw { 100.0 - percentage.value };
 }
 
 void serializeColorMixColor(StringBuilder& builder, const CSSUnresolvedColorMix::Component& component)

--- a/Source/WebCore/css/color/CSSColorMixSerialization.h
+++ b/Source/WebCore/css/color/CSSColorMixSerialization.h
@@ -40,8 +40,8 @@ bool is50Percent(const StyleColorMix::Component::Percentage&);
 bool sumTo100Percent(const CSSUnresolvedColorMix::Component::Percentage&, const CSSUnresolvedColorMix::Component::Percentage&);
 bool sumTo100Percent(const StyleColorMix::Component::Percentage&, const StyleColorMix::Component::Percentage&);
 
-std::optional<PercentRaw> subtractFrom100Percent(const CSSUnresolvedColorMix::Component::Percentage&);
-std::optional<PercentRaw> subtractFrom100Percent(const StyleColorMix::Component::Percentage&);
+std::optional<PercentageRaw> subtractFrom100Percent(const CSSUnresolvedColorMix::Component::Percentage&);
+std::optional<PercentageRaw> subtractFrom100Percent(const StyleColorMix::Component::Percentage&);
 
 void serializeColorMixColor(StringBuilder&, const CSSUnresolvedColorMix::Component&);
 void serializeColorMixColor(StringBuilder&, const StyleColorMix::Component&);

--- a/Source/WebCore/css/color/CSSUnresolvedColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.h
@@ -79,7 +79,7 @@ private:
         CSSUnresolvedColorMix,
         CSSUnresolvedLightDark,
         CSSUnresolvedAbsoluteColor<RGBFunctionLegacy<NumberRaw>>,
-        CSSUnresolvedAbsoluteColor<RGBFunctionLegacy<PercentRaw>>,
+        CSSUnresolvedAbsoluteColor<RGBFunctionLegacy<PercentageRaw>>,
         CSSUnresolvedAbsoluteColor<RGBFunctionModernAbsolute>,
         CSSUnresolvedAbsoluteColor<HSLFunctionLegacy>,
         CSSUnresolvedAbsoluteColor<HSLFunctionModern>,

--- a/Source/WebCore/css/color/CSSUnresolvedColorMix.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColorMix.cpp
@@ -36,26 +36,26 @@
 
 namespace WebCore {
 
-PercentRaw resolveComponentPercentage(const CSSUnresolvedColorMix::Component::Percentage& percentage, const CSSToLengthConversionData& conversionData)
+PercentageRaw resolveComponentPercentage(const CSSUnresolvedColorMix::Component::Percentage& percentage, const CSSToLengthConversionData& conversionData)
 {
     return evaluateCalc(percentage, conversionData, CSSCalcSymbolTable { });
 }
 
-PercentRaw resolveComponentPercentageNoConversionDataRequired(const CSSUnresolvedColorMix::Component::Percentage& percentage)
+PercentageRaw resolveComponentPercentageNoConversionDataRequired(const CSSUnresolvedColorMix::Component::Percentage& percentage)
 {
     ASSERT(!requiresConversionData(percentage));
 
     return evaluateCalcNoConversionDataRequired(percentage, CSSCalcSymbolTable { });
 }
 
-static std::optional<PercentRaw> resolveComponentPercentage(const std::optional<CSSUnresolvedColorMix::Component::Percentage>& percentage, const CSSToLengthConversionData& conversionData)
+static std::optional<PercentageRaw> resolveComponentPercentage(const std::optional<CSSUnresolvedColorMix::Component::Percentage>& percentage, const CSSToLengthConversionData& conversionData)
 {
     if (!percentage)
         return std::nullopt;
     return resolveComponentPercentage(*percentage, conversionData);
 }
 
-static std::optional<PercentRaw> resolveComponentPercentageNoConversionDataRequired(const std::optional<CSSUnresolvedColorMix::Component::Percentage>& percentage)
+static std::optional<PercentageRaw> resolveComponentPercentageNoConversionDataRequired(const std::optional<CSSUnresolvedColorMix::Component::Percentage>& percentage)
 {
     if (!percentage)
         return std::nullopt;
@@ -131,8 +131,8 @@ Color createColor(const CSSUnresolvedColorMix& unresolved, CSSUnresolvedColorRes
     if (!component2Color.isValid())
         return { };
 
-    std::optional<PercentRaw> percentage1;
-    std::optional<PercentRaw> percentage2;
+    std::optional<PercentageRaw> percentage1;
+    std::optional<PercentageRaw> percentage2;
     if (requiresConversionData(unresolved.mixComponents1.percentage) || requiresConversionData(unresolved.mixComponents2.percentage)) {
         if (!state.conversionData)
             return { };

--- a/Source/WebCore/css/color/CSSUnresolvedColorMix.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColorMix.h
@@ -42,7 +42,7 @@ struct CSSUnresolvedColorMix {
     struct Component {
         bool operator==(const Component&) const;
 
-        using Percentage = std::variant<PercentRaw, UnevaluatedCalc<PercentRaw>>;
+        using Percentage = std::variant<PercentageRaw, UnevaluatedCalc<PercentageRaw>>;
 
         UniqueRef<CSSUnresolvedColor> color;
         std::optional<Percentage> percentage;
@@ -55,8 +55,8 @@ struct CSSUnresolvedColorMix {
     Component mixComponents2;
 };
 
-PercentRaw resolveComponentPercentage(const CSSUnresolvedColorMix::Component::Percentage&, const CSSToLengthConversionData&);
-PercentRaw resolveComponentPercentageNoConversionDataRequired(const CSSUnresolvedColorMix::Component::Percentage&);
+PercentageRaw resolveComponentPercentage(const CSSUnresolvedColorMix::Component::Percentage&, const CSSToLengthConversionData&);
+PercentageRaw resolveComponentPercentageNoConversionDataRequired(const CSSUnresolvedColorMix::Component::Percentage&);
 
 void serializationForCSS(StringBuilder&, const CSSUnresolvedColorMix&);
 String serializationForCSS(const CSSUnresolvedColorMix&);

--- a/Source/WebCore/css/color/StyleColorMix.h
+++ b/Source/WebCore/css/color/StyleColorMix.h
@@ -39,7 +39,7 @@ struct StyleColorMix {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     struct Component {
-        using Percentage = PercentRaw;
+        using Percentage = PercentageRaw;
 
         StyleColor color;
         std::optional<Percentage> percentage;

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -603,7 +603,7 @@ template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseLegac
     if (characters.empty() || characters.front() != ')')
         return std::nullopt;
 
-    auto parsedColor = CSSColorParseType<HSLFunctionLegacy>(AngleRaw { angleUnit, hue }, PercentRaw { *saturation }, PercentRaw { *lightness }, NumberRaw { alpha });
+    auto parsedColor = CSSColorParseType<HSLFunctionLegacy>(AngleRaw { angleUnit, hue }, PercentageRaw { *saturation }, PercentageRaw { *lightness }, NumberRaw { alpha });
     auto typedColor = convertToTypedColor<HSLFunctionLegacy>(parsedColor, 1.0);
     auto resultColor = convertToColor<HSLFunctionLegacy, CSSColorFunctionForm::Absolute>(typedColor, 0);
     return resultColor.tryGetAsSRGBABytes();

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -59,7 +59,7 @@
 #include "CSSPropertyParserConsumer+LengthPercentage.h"
 #include "CSSPropertyParserConsumer+List.h"
 #include "CSSPropertyParserConsumer+Number.h"
-#include "CSSPropertyParserConsumer+Percent.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
 #include "CSSPropertyParserConsumer+Position.h"
 #include "CSSPropertyParserConsumer+Resolution.h"
 #include "CSSPropertyParserConsumer+String.h"
@@ -393,7 +393,7 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
             }
             return nullptr;
         case CSSCustomPropertySyntax::Type::Percentage:
-            return consumePercent(range);
+            return consumePercentage(range);
         case CSSCustomPropertySyntax::Type::Integer:
             return consumeInteger(range);
         case CSSCustomPropertySyntax::Type::Number:

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
@@ -31,7 +31,7 @@
 #include "CSSCalcValue.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CalculationCategory.h"
 
 namespace WebCore {
@@ -113,7 +113,7 @@ RefPtr<CSSPrimitiveValue> consumeAngleOrPercent(CSSParserTokenRange& range, CSSP
         .parserMode = parserMode,
         .unitlessZero = UnitlessZeroQuirk::Allow
     };
-    return CSSPrimitiveValueResolver<AngleRaw, PercentRaw>::consumeAndResolve(range, { }, { }, options);
+    return CSSPrimitiveValueResolver<AngleRaw, PercentageRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp
@@ -32,7 +32,7 @@
 #include "CSSPropertyParserConsumer+LengthDefinitions.h"
 #include "CSSPropertyParserConsumer+NoneDefinitions.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+ResolutionDefinitions.h"
 #include "CSSPropertyParserConsumer+SymbolDefinitions.h"
 #include "CSSPropertyParserConsumer+TimeDefinitions.h"
@@ -55,7 +55,7 @@ RefPtr<CSSPrimitiveValue> CSSPrimitiveValueResolverBase::resolve(NumberRaw value
     return CSSPrimitiveValue::create(value.value, CSSUnitType::CSS_NUMBER);
 }
 
-RefPtr<CSSPrimitiveValue> CSSPrimitiveValueResolverBase::resolve(PercentRaw value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+RefPtr<CSSPrimitiveValue> CSSPrimitiveValueResolverBase::resolve(PercentageRaw value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
 {
     return CSSPrimitiveValue::create(value.value, CSSUnitType::CSS_PERCENTAGE);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -41,7 +41,7 @@ struct CSSPrimitiveValueResolverBase {
     static RefPtr<CSSPrimitiveValue> resolve(AngleRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
     static RefPtr<CSSPrimitiveValue> resolve(LengthRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
     static RefPtr<CSSPrimitiveValue> resolve(NumberRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
-    static RefPtr<CSSPrimitiveValue> resolve(PercentRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static RefPtr<CSSPrimitiveValue> resolve(PercentageRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
     static RefPtr<CSSPrimitiveValue> resolve(ResolutionRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
     static RefPtr<CSSPrimitiveValue> resolve(TimeRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
     static RefPtr<CSSPrimitiveValue> resolve(LengthPercentageRaw, const CSSCalcSymbolTable&, CSSPropertyParserOptions);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -42,7 +42,7 @@
 #include "CSSPropertyParserConsumer+NoneDefinitions.h"
 #include "CSSPropertyParserConsumer+Number.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserConsumer+SymbolDefinitions.h"
 #include "CSSPropertyParsing.h"
@@ -567,8 +567,8 @@ static std::optional<CSSUnresolvedColorMix::Component> consumeColorMixComponent(
 
     std::optional<CSSUnresolvedColorMix::Component::Percentage> percentage;
 
-    if (auto percent = MetaConsumer<PercentRaw>::consume(args, { }, { })) {
-        if (PercentRaw* rawValue = std::get_if<PercentRaw>(&(*percent))) {
+    if (auto percent = MetaConsumer<PercentageRaw>::consume(args, { }, { })) {
+        if (PercentageRaw* rawValue = std::get_if<PercentageRaw>(&(*percent))) {
             auto value = rawValue->value;
             if (value < 0.0 || value > 100.0)
                 return std::nullopt;
@@ -581,8 +581,8 @@ static std::optional<CSSUnresolvedColorMix::Component> consumeColorMixComponent(
         return std::nullopt;
 
     if (!percentage) {
-        if (auto percent = MetaConsumer<PercentRaw>::consume(args, { }, { })) {
-            if (PercentRaw* rawValue = std::get_if<PercentRaw>(&(*percent))) {
+        if (auto percent = MetaConsumer<PercentageRaw>::consume(args, { }, { })) {
+            if (PercentageRaw* rawValue = std::get_if<PercentageRaw>(&(*percent))) {
                 auto value = rawValue->value;
                 if (value < 0.0 || value > 100.0)
                     return std::nullopt;
@@ -600,7 +600,7 @@ static std::optional<CSSUnresolvedColorMix::Component> consumeColorMixComponent(
 static bool hasNonCalculatedZeroPercentage(const CSSUnresolvedColorMix::Component& mixComponent)
 {
     if (auto percentage = mixComponent.percentage) {
-        if (PercentRaw* rawValue = std::get_if<PercentRaw>(&(*percentage)))
+        if (PercentageRaw* rawValue = std::get_if<PercentageRaw>(&(*percentage)))
             return rawValue->value == 0.0;
     }
     return false;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
@@ -35,7 +35,7 @@
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Length.h"
 #include "CSSPropertyParserConsumer+Number.h"
-#include "CSSPropertyParserConsumer+Percent.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
 #include "CSSPropertyParserConsumer+URL.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSToLengthConversionData.h"
@@ -63,7 +63,7 @@ template<CSSValueID filterFunction> static constexpr bool isAllowed(AllowedFilte
 
 template<CSSValueID filterFunction> static RefPtr<CSSValue> consumeNumberOrPercentFilterParameter(CSSParserTokenRange& args, const CSSParserContext&)
 {
-    if (RefPtr percentage = consumePercent(args, ValueRange::NonNegative)) {
+    if (RefPtr percentage = consumePercentage(args, ValueRange::NonNegative)) {
         if (!filterFunctionAllowsValuesGreaterThanOne<filterFunction>() && percentage->resolveAsPercentageIfNotCalculated() > 100.0)
             percentage = CSSPrimitiveValue::create(100.0, CSSUnitType::CSS_PERCENTAGE);
         return percentage;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -56,8 +56,8 @@
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+Number.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
-#include "CSSPropertyParserConsumer+Percent.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+URL.h"
 #include "CSSPropertyParsing.h"
 #include "CSSUnicodeRangeValue.h"
@@ -958,7 +958,7 @@ RefPtr<CSSValue> parseFontFaceSizeAdjust(const String& string, ScriptExecutionCo
     if (range.atEnd())
         return nullptr;
 
-    RefPtr parsedValue = consumePercent(range, ValueRange::NonNegative);
+    RefPtr parsedValue = consumePercentage(range, ValueRange::NonNegative);
     if (!parsedValue || !range.atEnd())
         return nullptr;
 
@@ -1356,14 +1356,14 @@ RefPtr<CSSValue> consumeFontFaceFontStretch(CSSParserTokenRange& range)
     if (RefPtr result = CSSPropertyParsing::consumeFontStretchAbsolute(range))
         return result;
 
-    RefPtr firstPercent = consumePercent(range, ValueRange::NonNegative);
+    RefPtr firstPercent = consumePercentage(range, ValueRange::NonNegative);
     if (!firstPercent)
         return nullptr;
 
     if (range.atEnd())
         return firstPercent;
 
-    RefPtr secondPercent = consumePercent(range, ValueRange::NonNegative);
+    RefPtr secondPercent = consumePercentage(range, ValueRange::NonNegative);
     if (!secondPercent)
         return nullptr;
 
@@ -1382,7 +1382,7 @@ RefPtr<CSSValue> consumeFontFaceFontStretch(CSSParserTokenRange& range)
 
     if (RefPtr result = CSSPropertyParsing::consumeFontStretchAbsolute(range))
         return result;
-    if (RefPtr percent = consumePercent(range, ValueRange::NonNegative))
+    if (RefPtr percent = consumePercentage(range, ValueRange::NonNegative))
         return percent;
     return nullptr;
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -71,8 +71,8 @@ using UnresolvedFontWeightNumber = std::variant<NumberRaw, UnevaluatedCalc<Numbe
 using UnresolvedFontWeight = std::variant<CSSValueID, NumberRaw, UnevaluatedCalc<NumberRaw>>;
 
 // normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded
-using UnresolvedFontStretchPercentage = std::variant<PercentRaw, UnevaluatedCalc<PercentRaw>>;
-using UnresolvedFontStretch = std::variant<CSSValueID, PercentRaw, UnevaluatedCalc<PercentRaw>>;
+using UnresolvedFontStretchPercentage = std::variant<PercentageRaw, UnevaluatedCalc<PercentageRaw>>;
+using UnresolvedFontStretch = std::variant<CSSValueID, PercentageRaw, UnevaluatedCalc<PercentageRaw>>;
 
 // <absolute-size> | <relative-size> | <length-percentage [0,∞]>
 using UnresolvedFontSize = std::variant<CSSValueID, LengthPercentageRaw, UnevaluatedCalc<LengthPercentageRaw>>;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -51,8 +51,8 @@
 #include "CSSPropertyParserConsumer+MetaResolver.h"
 #include "CSSPropertyParserConsumer+Number.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
-#include "CSSPropertyParserConsumer+Percent.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+Position.h"
 #include "CSSPropertyParserConsumer+RawTypes.h"
 #include "CSSPropertyParserConsumer+Resolution.h"
@@ -84,7 +84,7 @@ static RefPtr<CSSPrimitiveValue> consumeDeprecatedGradientPointValue(CSSParserTo
             return CSSPrimitiveValue::create(50, CSSUnitType::CSS_PERCENTAGE);
         return nullptr;
     }
-    RefPtr<CSSPrimitiveValue> result = consumePercent(range);
+    RefPtr<CSSPrimitiveValue> result = consumePercentage(range);
     if (!result)
         result = consumeNumber(range);
     return result;
@@ -134,7 +134,7 @@ static bool consumeDeprecatedGradientColorStop(CSSParserTokenRange& range, CSSGr
         position = CSSPrimitiveValue::create(1);
         break;
     case CSSValueColorStop:
-        position = consumePercentOrNumber(args);
+        position = consumePercentageOrNumber(args);
         if (!position)
             return false;
         if (!consumeCommaIncludingWhitespace(args))
@@ -896,7 +896,7 @@ static RefPtr<CSSValue> consumeCrossFade(CSSParserTokenRange& args, const CSSPar
     if (!toImageValueOrNone || !consumeCommaIncludingWhitespace(args))
         return nullptr;
 
-    auto value = consumePercentDividedBy100OrNumber(args);
+    auto value = consumePercentageDividedBy100OrNumber(args);
     if (!value)
         return nullptr;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp
@@ -33,7 +33,7 @@
 #include "CSSCalcValue.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CalculationCategory.h"
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
@@ -34,7 +34,7 @@
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+LengthDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CalculationCategory.h"
 
@@ -55,7 +55,7 @@ std::optional<UnevaluatedCalc<LengthPercentageRaw>> LengthPercentageKnownTokenTy
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, Calculation::Category::PercentLength, WTFMove(symbolsAllowed), options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, Calculation::Category::LengthPercentage, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
@@ -49,8 +49,8 @@ template<typename... Ts>
 using MetaConsumerVariantWrapper = typename std::variant<Ts...>;
 
 /// The result of a meta consume.
-/// To be used with a list of `raw` types. e.g. `ConsumeResult<AngleRaw, PercentRaw, NoneRaw>`, which will yield a
-/// result type of `std::variant<AngleRaw, UnevaluatedCalc<AngleRaw>, PercentRaw, UnevaluatedCalc<PercentRaw>, NoneRaw>`.
+/// To be used with a list of `raw` types. e.g. `ConsumeResult<AngleRaw, PercentageRaw, NoneRaw>`, which will yield a
+/// result type of `std::variant<AngleRaw, UnevaluatedCalc<AngleRaw>, PercentageRaw, UnevaluatedCalc<PercentageRaw>, NoneRaw>`.
 template<typename... Ts>
 struct MetaConsumeResult {
     using TypeList = brigand::flatten<
@@ -152,7 +152,7 @@ struct MetaConsumerUnroller<tokenType, ResultType, T, Ts...> {
 // An example use that attempts to consumer either a <number> or <percentage>
 // looks like:
 //
-//    auto result = MetaConsumer<PercentRaw, NumberRaw>::consume(range, ...);
+//    auto result = MetaConsumer<PercentageRaw, NumberRaw>::consume(range, ...);
 //
 // (Argument list elided for brevity)
 template<typename... Ts>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp
@@ -23,8 +23,8 @@
  */
 
 #include "config.h"
-#include "CSSPropertyParserConsumer+Percent.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 
 #include "CSSCalcParser.h"
 #include "CSSCalcSymbolTable.h"
@@ -38,8 +38,7 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-
-std::optional<PercentRaw> validatedRange(PercentRaw value, CSSPropertyParserOptions options)
+std::optional<PercentageRaw> validatedRange(PercentageRaw value, CSSPropertyParserOptions options)
 {
     if (options.valueRange == ValueRange::NonNegative && value.value < 0)
         return std::nullopt;
@@ -48,12 +47,12 @@ std::optional<PercentRaw> validatedRange(PercentRaw value, CSSPropertyParserOpti
     return value;
 }
 
-std::optional<UnevaluatedCalc<PercentRaw>> PercentKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<PercentageRaw>> PercentageKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, Calculation::Category::Percent, WTFMove(symbolsAllowed), options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, Calculation::Category::Percentage, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
@@ -61,11 +60,11 @@ std::optional<UnevaluatedCalc<PercentRaw>> PercentKnownTokenTypeFunctionConsumer
     return std::nullopt;
 }
 
-std::optional<PercentRaw> PercentKnownTokenTypePercentConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
+std::optional<PercentageRaw> PercentageKnownTokenTypePercentConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == PercentageToken);
 
-    if (auto validatedValue = validatedRange(PercentRaw { range.peek().numericValue() }, options)) {
+    if (auto validatedValue = validatedRange(PercentageRaw { range.peek().numericValue() }, options)) {
         range.consumeIncludingWhitespace();
         return validatedValue;
     }
@@ -74,23 +73,23 @@ std::optional<PercentRaw> PercentKnownTokenTypePercentConsumer::consume(CSSParse
 
 // MARK: - Consumer functions
 
-RefPtr<CSSPrimitiveValue> consumePercent(CSSParserTokenRange& range, ValueRange valueRange)
+RefPtr<CSSPrimitiveValue> consumePercentage(CSSParserTokenRange& range, ValueRange valueRange)
 {
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return CSSPrimitiveValueResolver<PercentRaw>::consumeAndResolve(range, { }, { }, options);
+    return CSSPrimitiveValueResolver<PercentageRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
-RefPtr<CSSPrimitiveValue> consumePercentOrNumber(CSSParserTokenRange& range, ValueRange valueRange)
+RefPtr<CSSPrimitiveValue> consumePercentageOrNumber(CSSParserTokenRange& range, ValueRange valueRange)
 {
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return CSSPrimitiveValueResolver<PercentRaw, NumberRaw>::consumeAndResolve(range, { }, { }, options);
+    return CSSPrimitiveValueResolver<PercentageRaw, NumberRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
-RefPtr<CSSPrimitiveValue> consumePercentDividedBy100OrNumber(CSSParserTokenRange& range, ValueRange valueRange)
+RefPtr<CSSPrimitiveValue> consumePercentageDividedBy100OrNumber(CSSParserTokenRange& range, ValueRange valueRange)
 {
     auto& token = range.peek();
 
@@ -102,8 +101,8 @@ RefPtr<CSSPrimitiveValue> consumePercentDividedBy100OrNumber(CSSParserTokenRange
     case FunctionToken:
         if (auto value = NumberKnownTokenTypeFunctionConsumer::consume(range, { }, options))
             return CSSPrimitiveValueResolver<NumberRaw>::resolve(*value, { }, options);
-        if (auto value = PercentKnownTokenTypeFunctionConsumer::consume(range, { }, options))
-            return CSSPrimitiveValueResolver<PercentRaw>::resolve(*value, { }, options);
+        if (auto value = PercentageKnownTokenTypeFunctionConsumer::consume(range, { }, options))
+            return CSSPrimitiveValueResolver<PercentageRaw>::resolve(*value, { }, options);
         break;
 
     case NumberToken:
@@ -112,7 +111,7 @@ RefPtr<CSSPrimitiveValue> consumePercentDividedBy100OrNumber(CSSParserTokenRange
         break;
 
     case PercentageToken:
-        if (auto value = PercentKnownTokenTypePercentConsumer::consume(range, { }, options))
+        if (auto value = PercentageKnownTokenTypePercentConsumer::consume(range, { }, options))
             return CSSPrimitiveValue::create(value->value / 100.0);
         break;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.h
@@ -24,38 +24,28 @@
 
 #pragma once
 
-#include "CSSParserToken.h"
-#include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
-#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
-#include <wtf/Brigand.h>
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolsAllowed;
+class CSSCalcSymbolTable;
+class CSSPrimitiveValue;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
 
-std::optional<PercentRaw> validatedRange(PercentRaw, CSSPropertyParserOptions);
+// MARK: - Consumer functions
 
-struct PercentKnownTokenTypeFunctionConsumer {
-    static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<PercentRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
-};
+// MARK: - Percent
+RefPtr<CSSPrimitiveValue> consumePercentage(CSSParserTokenRange&, ValueRange = ValueRange::All);
 
-struct PercentKnownTokenTypePercentConsumer {
-    static constexpr CSSParserTokenType tokenType = PercentageToken;
-    static std::optional<PercentRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
-};
+// MARK: - Percent or Number
+RefPtr<CSSPrimitiveValue> consumePercentageOrNumber(CSSParserTokenRange&, ValueRange = ValueRange::All);
 
-template<> struct ConsumerDefinition<PercentRaw> {
-    using type = brigand::list<PercentRaw, UnevaluatedCalc<PercentRaw>>;
-
-    using FunctionToken = PercentKnownTokenTypeFunctionConsumer;
-    using PercentageToken = PercentKnownTokenTypePercentConsumer;
-};
+// FIXME: Users of this function are likely getting incorrect results when used with calc() producing a percent, as it is not getting divided by 100.
+RefPtr<CSSPrimitiveValue> consumePercentageDividedBy100OrNumber(CSSParserTokenRange&, ValueRange = ValueRange::All);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.cpp
@@ -42,7 +42,7 @@ void serializationForCSS(StringBuilder& builder, const NumberRaw& value)
     formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(CSSUnitType::CSS_NUMBER));
 }
 
-void serializationForCSS(StringBuilder& builder, const PercentRaw& value)
+void serializationForCSS(StringBuilder& builder, const PercentageRaw& value)
 {
     formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(CSSUnitType::CSS_PERCENTAGE));
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h
@@ -64,12 +64,12 @@ struct NumberRaw {
 };
 void serializationForCSS(StringBuilder&, const NumberRaw&);
 
-struct PercentRaw {
+struct PercentageRaw {
     double value;
 
-    bool operator==(const PercentRaw&) const = default;
+    bool operator==(const PercentageRaw&) const = default;
 };
-void serializationForCSS(StringBuilder&, const PercentRaw&);
+void serializationForCSS(StringBuilder&, const PercentageRaw&);
 
 struct AngleRaw {
     CSSUnitType type;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimingFunction.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimingFunction.cpp
@@ -31,7 +31,7 @@
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Integer.h"
 #include "CSSPropertyParserConsumer+Number.h"
-#include "CSSPropertyParserConsumer+Percent.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
 #include "CSSTimingFunctionValue.h"
 #include "CSSValueKeywords.h"
 #include "TimingFunction.h"
@@ -109,11 +109,11 @@ static std::optional<CSSLinearTimingFunctionValue::LinearStop::Length> consumeLi
 {
     // <linear-stop-length> = <percentage>{1,2}
 
-    auto input = consumePercent(args);
+    auto input = consumePercentage(args);
     if (!input)
         return std::nullopt;
 
-    auto extra = consumePercent(args);
+    auto extra = consumePercentage(args);
 
     return CSSLinearTimingFunctionValue::LinearStop::Length {
         .input = input.releaseNonNull(),

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
@@ -35,7 +35,7 @@
 #include "CSSPropertyParserConsumer+Length.h"
 #include "CSSPropertyParserConsumer+LengthPercentage.h"
 #include "CSSPropertyParserConsumer+Number.h"
-#include "CSSPropertyParserConsumer+Percent.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParsing.h"
 #include "CSSToLengthConversionData.h"
@@ -64,7 +64,7 @@ static bool consumeNumbers(CSSParserTokenRange& args, CSSValueListBuilder& argum
 static bool consumeNumbersOrPercents(CSSParserTokenRange& args, CSSValueListBuilder& arguments, unsigned numberOfArguments)
 {
     auto parseNumberAndAppend = [&] {
-        auto parsedValue = consumePercentDividedBy100OrNumber(args);
+        auto parsedValue = consumePercentageDividedBy100OrNumber(args);
         if (!parsedValue)
             return false;
         arguments.append(parsedValue.releaseNonNull());
@@ -228,13 +228,13 @@ static std::optional<CSSValueListBuilder> consumeScaleFunctionArguments(CSSParse
 
     CSSValueListBuilder arguments;
 
-    auto value = consumePercentDividedBy100OrNumber(args);
+    auto value = consumePercentageDividedBy100OrNumber(args);
     if (!value)
         return { };
     arguments.append(value.releaseNonNull());
 
     if (consumeCommaIncludingWhitespace(args)) {
-        value = consumePercentDividedBy100OrNumber(args);
+        value = consumePercentageDividedBy100OrNumber(args);
         if (!value)
             return { };
         arguments.append(value.releaseNonNull());
@@ -260,7 +260,7 @@ static std::optional<CSSValueListBuilder> consumeScaleXFunctionArguments(CSSPars
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scalex
     // scaleX() = scaleX( [ <number> | <percentage> ] )
 
-    auto value = consumePercentDividedBy100OrNumber(args);
+    auto value = consumePercentageDividedBy100OrNumber(args);
     if (!value)
         return { };
     return { { value.releaseNonNull() } };
@@ -271,7 +271,7 @@ static std::optional<CSSValueListBuilder> consumeScaleYFunctionArguments(CSSPars
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scaley
     // scaleY() = scaleY( [ <number> | <percentage> ] )
 
-    auto value = consumePercentDividedBy100OrNumber(args);
+    auto value = consumePercentageDividedBy100OrNumber(args);
     if (!value)
         return { };
     return { { value.releaseNonNull() } };
@@ -282,7 +282,7 @@ static std::optional<CSSValueListBuilder> consumeScaleZFunctionArguments(CSSPars
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scalez
     // scaleZ() = scaleZ( [ <number> | <percentage> ] )
 
-    auto value = consumePercentDividedBy100OrNumber(args);
+    auto value = consumePercentageDividedBy100OrNumber(args);
     if (!value)
         return { };
     return { { value.releaseNonNull() } };
@@ -688,7 +688,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange& range, const CSSParserContext
     // If one or two values are given, this specifies a 2d scaling, equivalent to the scale() function.
     // If three values are given, this specifies a 3d scaling, equivalent to the scale3d() function.
 
-    auto x = consumePercentDividedBy100OrNumber(range);
+    auto x = consumePercentageDividedBy100OrNumber(range);
     if (!x)
         return nullptr;
 
@@ -697,7 +697,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange& range, const CSSParserContext
     if (range.atEnd())
         return CSSValueList::createSpaceSeparated(x.releaseNonNull());
 
-    auto y = consumePercentDividedBy100OrNumber(range);
+    auto y = consumePercentageDividedBy100OrNumber(range);
     if (!y)
         return nullptr;
 
@@ -713,7 +713,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange& range, const CSSParserContext
         return CSSValueList::createSpaceSeparated(x.releaseNonNull());
     }
 
-    auto z = consumePercentDividedBy100OrNumber(range);
+    auto z = consumePercentageDividedBy100OrNumber(range);
     if (!z)
         return nullptr;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
@@ -71,14 +71,14 @@ NumberRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<NumberRaw>&
     return calc.calc->numberValueNoConversionDataRequired(symbolTable);
 }
 
-PercentRaw evaluateCalc(const UnevaluatedCalc<PercentRaw>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+PercentageRaw evaluateCalc(const UnevaluatedCalc<PercentageRaw>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
 {
-    return calc.calc->percentValue(conversionData, symbolTable);
+    return calc.calc->percentageValue(conversionData, symbolTable);
 }
 
-PercentRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<PercentRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+PercentageRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<PercentageRaw>& calc, const CSSCalcSymbolTable& symbolTable)
 {
-    return calc.calc->percentValueNoConversionDataRequired(symbolTable);
+    return calc.calc->percentageValueNoConversionDataRequired(symbolTable);
 }
 
 LengthRaw evaluateCalc(const UnevaluatedCalc<LengthRaw>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
@@ -71,8 +71,8 @@ template<typename> struct TypePlusUnevaluatedCalc;
 template<> struct TypePlusUnevaluatedCalc<AngleRaw> {
     using type = brigand::list<AngleRaw, UnevaluatedCalc<AngleRaw>>;
 };
-template<> struct TypePlusUnevaluatedCalc<PercentRaw> {
-    using type = brigand::list<PercentRaw, UnevaluatedCalc<PercentRaw>>;
+template<> struct TypePlusUnevaluatedCalc<PercentageRaw> {
+    using type = brigand::list<PercentageRaw, UnevaluatedCalc<PercentageRaw>>;
 };
 template<> struct TypePlusUnevaluatedCalc<NumberRaw> {
     using type = brigand::list<NumberRaw, UnevaluatedCalc<NumberRaw>>;
@@ -162,8 +162,8 @@ AngleRaw evaluateCalc(const UnevaluatedCalc<AngleRaw>&, const CSSToLengthConvers
 AngleRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<AngleRaw>&, const CSSCalcSymbolTable&);
 NumberRaw evaluateCalc(const UnevaluatedCalc<NumberRaw>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
 NumberRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<NumberRaw>&, const CSSCalcSymbolTable&);
-PercentRaw evaluateCalc(const UnevaluatedCalc<PercentRaw>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
-PercentRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<PercentRaw>&, const CSSCalcSymbolTable&);
+PercentageRaw evaluateCalc(const UnevaluatedCalc<PercentageRaw>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
+PercentageRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<PercentageRaw>&, const CSSCalcSymbolTable&);
 LengthRaw evaluateCalc(const UnevaluatedCalc<LengthRaw>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
 LengthRaw evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<LengthRaw>&, const CSSCalcSymbolTable&);
 ResolutionRaw evaluateCalc(const UnevaluatedCalc<ResolutionRaw>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -45,8 +45,8 @@
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+Number.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
-#include "CSSPropertyParserConsumer+Percent.h"
-#include "CSSPropertyParserConsumer+PercentDefinitions.h"
+#include "CSSPropertyParserConsumer+Percentage.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+Position.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserConsumer+String.h"
@@ -1764,7 +1764,7 @@ RefPtr<CSSValue> consumeBorderImageSlice(CSSPropertyID property, CSSParserTokenR
     std::array<RefPtr<CSSPrimitiveValue>, 4> slices;
 
     for (auto& value : slices) {
-        value = consumePercent(range, ValueRange::NonNegative);
+        value = consumePercentage(range, ValueRange::NonNegative);
         if (!value)
             value = consumeNumber(range, ValueRange::NonNegative);
         if (!value)

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -1515,7 +1515,7 @@ class ReferenceTerm:
         BuiltinSchema.Entry("number", "consumeNumber",
             # FIXME: "FontWeight" is not real. Add support for arbitrary ranges.
             BuiltinSchema.OptionalParameter("value_range", values={"[0,inf]": "ValueRange::NonNegative", "[1,1000]": "ValueRange::FontWeight"}, default="ValueRange::All")),
-        BuiltinSchema.Entry("percentage", "consumePercent",
+        BuiltinSchema.Entry("percentage", "consumePercentage",
             BuiltinSchema.OptionalParameter("value_range", values={"[0,inf]": "ValueRange::NonNegative"}, default="ValueRange::All")),
         BuiltinSchema.Entry("position", "consumePosition",
             BuiltinSchema.OptionalParameter("unitless", values={"unitless-allowed": "UnitlessQuirk::Allow"}, default="UnitlessQuirk::Forbid")),
@@ -3950,7 +3950,7 @@ class GenerateCSSPropertyParsing:
                     "CSSPropertyParserConsumer+List.h",
                     "CSSPropertyParserConsumer+Lists.h",
                     "CSSPropertyParserConsumer+Number.h",
-                    "CSSPropertyParserConsumer+Percent.h",
+                    "CSSPropertyParserConsumer+Percentage.h",
                     "CSSPropertyParserConsumer+Position.h",
                     "CSSPropertyParserConsumer+Primitives.h",
                     "CSSPropertyParserConsumer+Resolution.h",

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -456,16 +456,16 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::parse(String&& cssText)
     case CSSParserTokenType::FunctionToken: {
         auto functionID = componentValueRange.peek().functionId();
         if (functionID == CSSValueCalc || functionID == CSSValueMin || functionID == CSSValueMax || functionID == CSSValueClamp) {
-            // FIXME: The spec is unclear on what context to use when parsing in CSSNumericValue so for the time-being, we use `Category::PercentLength`, as it is the most permissive.
+            // FIXME: The spec is unclear on what context to use when parsing in CSSNumericValue so for the time-being, we use `Category::LengthPercentage`, as it is the most permissive.
             // See https://github.com/w3c/csswg-drafts/issues/10753
 
             auto parserOptions = CSSCalc::ParserOptions {
-                .category = Calculation::Category::PercentLength,
+                .category = Calculation::Category::LengthPercentage,
                 .allowedSymbols = { },
                 .range = ValueRange::All
             };
             auto simplificationOptions = CSSCalc::SimplificationOptions {
-                .category = Calculation::Category::PercentLength,
+                .category = Calculation::Category::LengthPercentage,
                 .conversionData = std::nullopt,
                 .symbolTable = { },
                 .allowZeroValueLengthRemovalFromSum = false,

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -356,7 +356,7 @@ static Calculation::Category calculationCategoryForProperty(CSSPropertyID, CSSUn
     case CSSUnitType::CSS_CQMAX:
         return Calculation::Category::Length;
     case CSSUnitType::CSS_PERCENTAGE:
-        return Calculation::Category::Percent;
+        return Calculation::Category::Percentage;
     case CSSUnitType::CSS_DEG:
     case CSSUnitType::CSS_RAD:
     case CSSUnitType::CSS_GRAD:

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -352,7 +352,7 @@ bool Length::isCalculatedEqual(const Length& other) const
 static Calculation::Child lengthCalculation(const Length& length)
 {
     if (length.isPercent())
-        return Calculation::percent(length.value());
+        return Calculation::percentage(length.value());
 
     if (length.isCalculated()) {
         auto tree = length.calculationValue().copyTree();
@@ -368,7 +368,7 @@ static Length makeLength(Calculation::Child&& root)
     // FIXME: Value range should be passed in.
 
     // NOTE: category is always `PercentLength` as late resolved `Length` values defined by percentages is the only reason calculation value is needed by `Length`.
-    return Length(CalculationValue::create(Calculation::Tree { .root = WTFMove(root), .category = Calculation::Category::PercentLength, .range = ValueRange::All }));
+    return Length(CalculationValue::create(Calculation::Tree { .root = WTFMove(root), .category = Calculation::Category::LengthPercentage, .range = ValueRange::All }));
 }
 
 Length convertTo100PercentMinusLength(const Length& length)
@@ -378,7 +378,7 @@ Length convertTo100PercentMinusLength(const Length& length)
         return Length(100 - length.value(), LengthType::Percent);
 
     // Otherwise, turn this into a calc expression: calc(100% - length)
-    return makeLength(Calculation::subtract(Calculation::percent(100), lengthCalculation(length)));
+    return makeLength(Calculation::subtract(Calculation::percentage(100), lengthCalculation(length)));
 }
 
 Length convertTo100PercentMinusLengthSum(const Length& a, const Length& b)
@@ -392,7 +392,7 @@ Length convertTo100PercentMinusLengthSum(const Length& a, const Length& b)
         // And if `b` is a percent, we can avoid the `calc` altogether.
         if (b.isPercent())
             return Length(100 - b.value(), LengthType::Percent);
-        return makeLength(Calculation::subtract(Calculation::percent(100), lengthCalculation(b)));
+        return makeLength(Calculation::subtract(Calculation::percentage(100), lengthCalculation(b)));
     }
 
     // If just `b` is 0, we can just consider the case of `calc(100% - a)`.
@@ -400,7 +400,7 @@ Length convertTo100PercentMinusLengthSum(const Length& a, const Length& b)
         // And if `a` is a percent, we can avoid the `calc` altogether.
         if (a.isPercent())
             return Length(100 - a.value(), LengthType::Percent);
-        return makeLength(Calculation::subtract(Calculation::percent(100), lengthCalculation(a)));
+        return makeLength(Calculation::subtract(Calculation::percentage(100), lengthCalculation(a)));
     }
 
     // If both and `a` and `b` are percentages, we can avoid the `calc` altogether.
@@ -408,7 +408,7 @@ Length convertTo100PercentMinusLengthSum(const Length& a, const Length& b)
         return Length(100 - (a.value() + b.value()), LengthType::Percent);
 
     // Otherwise, turn this into a calc expression: calc(100% - (a + b))
-    return makeLength(Calculation::subtract(Calculation::percent(100), Calculation::add(lengthCalculation(a), lengthCalculation(b))));
+    return makeLength(Calculation::subtract(Calculation::percentage(100), Calculation::add(lengthCalculation(a), lengthCalculation(b))));
 }
 
 static Length blendMixedTypes(const Length& from, const Length& to, const BlendingContext& context)

--- a/Source/WebCore/platform/calc/CalculationCategory.cpp
+++ b/Source/WebCore/platform/calc/CalculationCategory.cpp
@@ -36,14 +36,14 @@ TextStream& operator<<(TextStream& ts, Category category)
     switch (category) {
     case Category::Integer: ts << "integer"; break;
     case Category::Number: ts << "number"; break;
-    case Category::Percent: ts << "percent"; break;
+    case Category::Percentage: ts << "percentage"; break;
     case Category::Length: ts << "length"; break;
     case Category::Angle: ts << "angle"; break;
     case Category::Time: ts << "time"; break;
     case Category::Frequency: ts << "frequency"; break;
     case Category::Resolution: ts << "resolution"; break;
     case Category::Flex: ts << "flex"; break;
-    case Category::PercentLength: ts << "percent-length"; break;
+    case Category::LengthPercentage: ts << "length-percentage"; break;
     }
 
     return ts;

--- a/Source/WebCore/platform/calc/CalculationCategory.h
+++ b/Source/WebCore/platform/calc/CalculationCategory.h
@@ -33,14 +33,14 @@ namespace Calculation {
 enum class Category : uint8_t {
     Integer,
     Number,
-    Percent,
+    Percentage,
     Length,
     Angle,
     Time,
     Frequency,
     Resolution,
     Flex,
-    PercentLength
+    LengthPercentage
 };
 
 TextStream& operator<<(TextStream&, Category);

--- a/Source/WebCore/platform/calc/CalculationTree+Evaluation.cpp
+++ b/Source/WebCore/platform/calc/CalculationTree+Evaluation.cpp
@@ -37,7 +37,7 @@ static auto evaluate(const ChildOrNone&, NumericValue percentResolutionLength) -
 static auto evaluate(const std::optional<Child>&, NumericValue percentResolutionLength) -> std::optional<double>;
 static auto evaluate(const Child&, NumericValue percentResolutionLength) -> NumericValue;
 static auto evaluate(const Number&, NumericValue percentResolutionLength) -> NumericValue;
-static auto evaluate(const Percent&, NumericValue percentResolutionLength) -> NumericValue;
+static auto evaluate(const Percentage&, NumericValue percentResolutionLength) -> NumericValue;
 static auto evaluate(const Dimension&, NumericValue percentResolutionLength) -> NumericValue;
 static auto evaluate(const IndirectNode<Sum>&, NumericValue percentResolutionLength) -> NumericValue;
 static auto evaluate(const IndirectNode<Product>&, NumericValue percentResolutionLength) -> NumericValue;
@@ -77,9 +77,9 @@ NumericValue evaluate(const Number& number, NumericValue)
     return number.value;
 }
 
-NumericValue evaluate(const Percent& percent, NumericValue percentResolutionLength)
+NumericValue evaluate(const Percentage& percentage, NumericValue percentResolutionLength)
 {
-    return percentResolutionLength * percent.value / 100.0f;
+    return percentResolutionLength * percentage.value / 100.0f;
 }
 
 NumericValue evaluate(const Dimension& root, NumericValue)

--- a/Source/WebCore/platform/calc/CalculationTree.cpp
+++ b/Source/WebCore/platform/calc/CalculationTree.cpp
@@ -41,7 +41,7 @@ static auto operator<<(TextStream&, const None&) -> TextStream&;
 static auto operator<<(TextStream&, const ChildOrNone&) -> TextStream&;
 static auto operator<<(TextStream&, const Child&) -> TextStream&;
 static auto operator<<(TextStream&, const Number&) -> TextStream&;
-static auto operator<<(TextStream&, const Percent&) -> TextStream&;
+static auto operator<<(TextStream&, const Percentage&) -> TextStream&;
 static auto operator<<(TextStream&, const Dimension&) -> TextStream&;
 static auto operator<<(TextStream&, const IndirectNode<Sum>&) -> TextStream&;
 static auto operator<<(TextStream&, const IndirectNode<Product>&) -> TextStream&;
@@ -102,7 +102,7 @@ TextStream& operator<<(TextStream& ts, const Number& root)
     return ts << TextStream::FormatNumberRespectingIntegers(root.value);
 }
 
-TextStream& operator<<(TextStream& ts, const Percent& root)
+TextStream& operator<<(TextStream& ts, const Percentage& root)
 {
     return ts << TextStream::FormatNumberRespectingIntegers(root.value) << "%";
 }

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -100,13 +100,13 @@ struct Number {
     bool operator==(const Number&) const = default;
 };
 
-struct Percent {
+struct Percentage {
     static constexpr bool isLeaf = true;
     static constexpr bool isNumeric = true;
 
     NumericValue value;
 
-    bool operator==(const Percent&) const = default;
+    bool operator==(const Percentage&) const = default;
 };
 
 struct Dimension {
@@ -135,7 +135,7 @@ template<typename Op> struct IndirectNode {
 
 using Child = std::variant<
     Number,
-    Percent,
+    Percentage,
     Dimension,
     IndirectNode<Sum>,
     IndirectNode<Product>,
@@ -499,9 +499,9 @@ template<> struct ChildConstruction<Number> {
     static Child make(Number&& op) { return Child { WTFMove(op) }; }
 };
 
-// Specialized implementation of ChildConstruction for Percent, needed to avoid `makeUniqueRef`.
-template<> struct ChildConstruction<Percent> {
-    static Child make(Percent&& op) { return Child { WTFMove(op) }; }
+// Specialized implementation of ChildConstruction for Percentage, needed to avoid `makeUniqueRef`.
+template<> struct ChildConstruction<Percentage> {
+    static Child make(Percentage&& op) { return Child { WTFMove(op) }; }
 };
 
 // Specialized implementation of ChildConstruction for Dimension, needed to avoid `makeUniqueRef`.
@@ -521,9 +521,9 @@ inline Child number(NumericValue value)
     return makeChild(Number { .value = value });
 }
 
-inline Child percent(NumericValue value)
+inline Child percentage(NumericValue value)
 {
-    return makeChild(Percent { .value = value });
+    return makeChild(Percentage { .value = value });
 }
 
 inline Child dimension(NumericValue value)

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -94,7 +94,7 @@ static std::optional<float> resolveColorStopPosition(const StyleGradientImageAng
         [](AngleRaw angle) -> std::optional<float> {
             return CSSPrimitiveValue::computeDegrees(angle.type, angle.value) / 360.0;
         },
-        [](PercentRaw percent) -> std::optional<float> {
+        [](PercentageRaw percent) -> std::optional<float> {
             return percent.value / 100.0;
         }
     );
@@ -154,7 +154,7 @@ static inline RefPtr<CSSPrimitiveValue> computedStyleValueForColorStopPosition(c
         [](AngleRaw angle) -> RefPtr<CSSPrimitiveValue> {
             return CSSPrimitiveValue::create(angle.value, angle.type);
         },
-        [](PercentRaw percent) -> RefPtr<CSSPrimitiveValue> {
+        [](PercentageRaw percent) -> RefPtr<CSSPrimitiveValue> {
             return CSSPrimitiveValue::create(percent.value, CSSUnitType::CSS_PERCENTAGE);
         }
     );
@@ -186,7 +186,7 @@ static Ref<CSSPrimitiveValue> computedStyleValue(const StyleGradientDeprecatedPo
         [](NumberRaw number) -> Ref<CSSPrimitiveValue> {
             return CSSPrimitiveValue::create(number.value, CSSUnitType::CSS_NUMBER);
         },
-        [](PercentRaw percent) -> Ref<CSSPrimitiveValue> {
+        [](PercentageRaw percent) -> Ref<CSSPrimitiveValue> {
             return CSSPrimitiveValue::create(percent.value, CSSUnitType::CSS_PERCENTAGE);
         }
     );
@@ -986,7 +986,7 @@ static float positionFromValue(const StyleGradientDeprecatedPoint::Coordinate& c
         [&](NumberRaw number) -> float {
             return number.value;
         },
-        [&](PercentRaw percent) -> float {
+        [&](PercentageRaw percent) -> float {
             return percent.value / 100.0f * edgeDistance;
         }
     );

--- a/Source/WebCore/rendering/style/StyleGradientImage.h
+++ b/Source/WebCore/rendering/style/StyleGradientImage.h
@@ -42,7 +42,7 @@ template<typename Position> struct StyleGradientImageStop {
 };
 
 using StyleGradientImageLengthStop = StyleGradientImageStop<std::optional<Length>>;
-using StyleGradientImageAngularStop = StyleGradientImageStop<std::variant<std::monostate, AngleRaw, PercentRaw>>;
+using StyleGradientImageAngularStop = StyleGradientImageStop<std::variant<std::monostate, AngleRaw, PercentageRaw>>;
 
 
 // MARK: StyleGradientPosition
@@ -64,7 +64,7 @@ struct StyleGradientPosition {
 
 struct StyleGradientDeprecatedPoint {
     struct Coordinate {
-        std::variant<NumberRaw, PercentRaw> value;
+        std::variant<NumberRaw, PercentageRaw> value;
 
         bool operator==(const Coordinate&) const = default;
     };


### PR DESCRIPTION
#### fe300c2ab99831fae74e9aea409b016c06d8f452
<pre>
Use the terms &quot;Percentage&quot; and &quot;LengthPercentage&quot; more consistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=279629">https://bugs.webkit.org/show_bug.cgi?id=279629</a>

Reviewed by Tim Nguyen.

Replaces haphazard use of &quot;Percent&quot; with &quot;Percentage&quot; when referring to the CSS
primitive value &lt;percentage&gt; and the of use &quot;PercentLength&quot;/&quot;LengthPercent&quot; with
&quot;LengthPercentage&quot; when referring to the CSS primitive value &lt;length-percentage&gt;.

In places where specifications use &quot;Percent&quot; explicitly, like CSS Typed OM&apos;s
&quot;percent hint&quot; content, the spec&apos;s term is retained.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSFontFaceSet.cpp:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSValuePool.cpp:
* Source/WebCore/css/CSSValuePool.h:
* Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp:
* Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
* Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcTree.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/calc/CSSCalcType.cpp:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/color/CSSColorConversion+Normalize.h:
* Source/WebCore/css/color/CSSColorConversion+ToTypedColor.h:
* Source/WebCore/css/color/CSSColorDescriptors.h:
* Source/WebCore/css/color/CSSColorMixResolver.cpp:
* Source/WebCore/css/color/CSSColorMixResolver.h:
* Source/WebCore/css/color/CSSColorMixSerialization.cpp:
* Source/WebCore/css/color/CSSColorMixSerialization.h:
* Source/WebCore/css/color/CSSUnresolvedColor.h:
* Source/WebCore/css/color/CSSUnresolvedColorMix.cpp:
* Source/WebCore/css/color/CSSUnresolvedColorMix.h:
* Source/WebCore/css/color/StyleColorMix.h:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp: Renamed from Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.h: Renamed from Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h: Renamed from Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentDefinitions.h.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimingFunction.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/css/process-css-properties.py:
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
* Source/WebCore/platform/Length.cpp:
* Source/WebCore/platform/calc/CalculationCategory.cpp:
* Source/WebCore/platform/calc/CalculationCategory.h:
* Source/WebCore/platform/calc/CalculationTree+Evaluation.cpp:
* Source/WebCore/platform/calc/CalculationTree.cpp:
* Source/WebCore/platform/calc/CalculationTree.h:
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
* Source/WebCore/rendering/style/StyleGradientImage.h:

Canonical link: <a href="https://commits.webkit.org/283630@main">https://commits.webkit.org/283630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26d5dd75474b0357f6e87ee916e6be24c202a835

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66891 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19513 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/70926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/57880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/15272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/15613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10848 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/72627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10880 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/57937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14770 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8911 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->