### PR TITLE
[scroll-animations] Add parsing support for timeline-scope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -349,6 +349,7 @@ PASS text-underline-offset
 PASS text-underline-position
 PASS text-wrap-mode
 PASS text-wrap-style
+PASS timeline-scope
 PASS top
 PASS touch-action
 PASS transform

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -325,6 +325,7 @@ PASS text-underline-offset
 PASS text-underline-position
 PASS text-wrap-mode
 PASS text-wrap-style
+PASS timeline-scope
 PASS top
 PASS touch-action
 PASS transform

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-computed.tentative-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Property timeline-scope value 'initial' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'inherit' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'unset' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'revert' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'none' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'test' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'foo, bar' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'bar, foo' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-scope value 'a, b, c, D, e' assert_true: timeline-scope doesn't seem to be supported in the computed style expected true got false
-FAIL The timeline-scope property shows up in CSSStyleDeclaration enumeration assert_not_equals: got disallowed value -1
-FAIL The timeline-scope property shows up in CSSStyleDeclaration.cssText assert_not_equals: got disallowed value -1
+PASS Property timeline-scope value 'initial'
+FAIL Property timeline-scope value 'inherit' assert_equals: expected "foo" but got "none"
+PASS Property timeline-scope value 'unset'
+PASS Property timeline-scope value 'revert'
+PASS Property timeline-scope value 'none'
+FAIL Property timeline-scope value 'test' assert_true: 'test' is a supported value for timeline-scope. expected true got false
+FAIL Property timeline-scope value 'foo, bar' assert_true: 'foo, bar' is a supported value for timeline-scope. expected true got false
+FAIL Property timeline-scope value 'bar, foo' assert_true: 'bar, foo' is a supported value for timeline-scope. expected true got false
+FAIL Property timeline-scope value 'a, b, c, D, e' assert_true: 'a, b, c, D, e' is a supported value for timeline-scope. expected true got false
+PASS The timeline-scope property shows up in CSSStyleDeclaration enumeration
+PASS The timeline-scope property shows up in CSSStyleDeclaration.cssText
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-parsing.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-parsing.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL e.style['timeline-scope'] = "initial" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-scope'] = "inherit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-scope'] = "unset" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-scope'] = "revert" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-scope'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['timeline-scope'] = "initial" should set the property value
+PASS e.style['timeline-scope'] = "inherit" should set the property value
+PASS e.style['timeline-scope'] = "unset" should set the property value
+PASS e.style['timeline-scope'] = "revert" should set the property value
+PASS e.style['timeline-scope'] = "none" should set the property value
 FAIL e.style['timeline-scope'] = "abc" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-scope'] = "  abc" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-scope'] = "aBc" should set the property value assert_not_equals: property should be set got disallowed value ""

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -347,6 +347,7 @@ PASS text-underline-offset
 PASS text-underline-position
 PASS text-wrap-mode
 PASS text-wrap-style
+PASS timeline-scope
 PASS top
 PASS touch-action
 PASS transform

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -323,6 +323,7 @@ PASS text-underline-offset
 PASS text-underline-position
 PASS text-wrap-mode
 PASS text-wrap-style
+PASS timeline-scope
 PASS top
 PASS touch-action
 PASS transform

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -713,6 +713,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/ScrollAxis.h
     animation/ScrollTimeline.h
     animation/ScrollTimelineOptions.h
+    animation/TimelineScope.h
     animation/ViewTimeline.h
     animation/ViewTimelineOptions.h
     animation/WebAnimationTypes.h

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4289,6 +4289,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertySpeakAs:
         case CSSPropertyTextCombineUpright:
         case CSSPropertyTextOrientation:
+        case CSSPropertyTimelineScope:
         case CSSPropertyTransition:
         case CSSPropertyTransitionBehavior:
         case CSSPropertyTransitionDelay:

--- a/Source/WebCore/animation/TimelineScope.h
+++ b/Source/WebCore/animation/TimelineScope.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/AtomString.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+struct TimelineScope {
+    bool operator==(const TimelineScope& other) const
+    {
+        if (type == Type::Ident)
+            return other.type == Type::Ident && scopeNames != other.scopeNames;
+        return type == other.type;
+    }
+
+    enum class Type : uint8_t { None, All, Ident };
+
+    Type type { Type::None };
+    Vector<AtomString> scopeNames;
+};
+
+inline TextStream& operator<<(TextStream& ts, const TimelineScope& timelineScope)
+{
+    switch (timelineScope.type) {
+    case TimelineScope::Type::None:
+        ts << "none";
+        break;
+    case TimelineScope::Type::All:
+        ts << "all";
+        break;
+    case TimelineScope::Type::Ident:
+        ts << "ident: " << timelineScope.scopeNames;
+        break;
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9259,6 +9259,17 @@
                 "url": "https://www.w3.org/TR/css-shapes/#propdef-shape-image-threshold"
             }
         },
+        "timeline-scope": {
+           "codegen-properties": {
+               "converter": "TimelineScope",
+               "parser-grammar": "none | all | <dashed-ident>#",
+               "settings-flag": "scrollDrivenAnimationsEnabled"
+           },
+           "specification": {
+               "category": "scroll-animations",
+               "url": "https://drafts.csswg.org/scroll-animations-1/#timeline-scope"
+           }
+       },
         "view-timeline": {
             "codegen-properties": {
                 "longhands": [

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3194,6 +3194,19 @@ static Ref<CSSValue> valueForAnchorName(const Vector<AtomString>& names)
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
+static Ref<CSSValue> valueForTimelineScopeNames(const Vector<AtomString>& names)
+{
+    if (names.isEmpty())
+        return CSSPrimitiveValue::create(CSSValueNone);
+
+    CSSValueListBuilder list;
+    for (auto& name : names) {
+        ASSERT(!name.isNull());
+        list.append(CSSPrimitiveValue::createCustomIdent(name));
+    }
+    return CSSValueList::createCommaSeparated(WTFMove(list));
+}
+
 static Ref<CSSValue> scrollTimelineShorthandValue(const Vector<Ref<ScrollTimeline>>& timelines)
 {
     if (timelines.isEmpty())
@@ -4862,6 +4875,17 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         if (style.positionAnchor().isNull())
             return CSSPrimitiveValue::create(CSSValueAuto);
         return CSSPrimitiveValue::createCustomIdent(style.positionAnchor());
+    case CSSPropertyTimelineScope:
+        switch (style.timelineScope().type) {
+        case TimelineScope::Type::None:
+            return CSSPrimitiveValue::create(CSSValueNone);
+        case TimelineScope::Type::All:
+            return CSSPrimitiveValue::create(CSSValueAll);
+        case TimelineScope::Type::Ident:
+            return valueForTimelineScopeNames(style.timelineScope().scopeNames);
+        }
+        ASSERT_NOT_REACHED();
+        return CSSPrimitiveValue::create(CSSValueNone);
 
     // Unimplemented CSS 3 properties (including CSS3 shorthand properties).
     case CSSPropertyAll:

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -267,6 +267,7 @@ struct ScrollSnapAlign;
 struct ScrollSnapType;
 struct ScrollbarGutter;
 struct ScrollbarColor;
+struct TimelineScope;
 struct ViewTimelineInsets;
 
 struct TabSize;
@@ -990,6 +991,10 @@ public:
     inline void setViewTimelineAxes(const Vector<ScrollAxis>&);
     inline void setViewTimelineInsets(const Vector<ViewTimelineInsets>&);
     inline void setViewTimelineNames(const Vector<AtomString>&);
+
+    static inline const TimelineScope initialTimelineScope();
+    inline const TimelineScope& timelineScope() const;
+    inline void setTimelineScope(const TimelineScope&);
 
     inline const AnimationList* animations() const;
     inline const AnimationList* transitions() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -518,6 +518,7 @@ inline Vector<ViewTimelineInsets> RenderStyle::initialViewTimelineInsets() { ret
 inline Vector<Style::ScopedName> RenderStyle::initialViewTransitionClasses() { return { }; }
 inline std::optional<Style::ScopedName> RenderStyle::initialViewTransitionName() { return std::nullopt; }
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
+inline const TimelineScope RenderStyle::initialTimelineScope() { return { }; }
 constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
 constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
 inline Length RenderStyle::initialLetterSpacing() { return zeroLength(); }
@@ -683,6 +684,7 @@ inline const Vector<Ref<ViewTimeline>>& RenderStyle::viewTimelines() const { ret
 inline const Vector<ScrollAxis>& RenderStyle::viewTimelineAxes() const { return m_nonInheritedData->rareData->viewTimelineAxes; }
 inline const Vector<ViewTimelineInsets>& RenderStyle::viewTimelineInsets() const { return m_nonInheritedData->rareData->viewTimelineInsets; }
 inline const Vector<AtomString>& RenderStyle::viewTimelineNames() const { return m_nonInheritedData->rareData->viewTimelineNames; }
+inline const TimelineScope& RenderStyle::timelineScope() const { return m_nonInheritedData->rareData->timelineScope; }
 inline std::optional<ScrollbarColor> RenderStyle::scrollbarColor() const { return m_rareInheritedData->scrollbarColor.asOptional(); }
 inline const StyleColor& RenderStyle::scrollbarThumbColor() const { return m_rareInheritedData->scrollbarColor->thumbColor; }
 inline const StyleColor& RenderStyle::scrollbarTrackColor() const { return m_rareInheritedData->scrollbarColor->trackColor; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -280,6 +280,7 @@ inline void RenderStyle::setScrollTimelineNames(const Vector<AtomString>& names)
 inline void RenderStyle::setViewTimelineAxes(const Vector<ScrollAxis>& axes) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineAxes, axes); }
 inline void RenderStyle::setViewTimelineInsets(const Vector<ViewTimelineInsets>& insets) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineInsets, insets); }
 inline void RenderStyle::setViewTimelineNames(const Vector<AtomString>& names) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineNames, names); }
+inline void RenderStyle::setTimelineScope(const TimelineScope& scope) { SET_NESTED(m_nonInheritedData, rareData, timelineScope, scope); }
 inline void RenderStyle::setScrollbarColor(const std::optional<ScrollbarColor>& color) { SET(m_rareInheritedData, scrollbarColor, color); }
 inline void RenderStyle::setScrollbarThumbColor(const StyleColor& color) { m_rareInheritedData.access().scrollbarColor->thumbColor = color; }
 inline void RenderStyle::setScrollbarTrackColor(const StyleColor& color) { m_rareInheritedData.access().scrollbarColor->trackColor = color; }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -92,6 +92,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // viewTimelineAxes
     // viewTimelineInsets
     // viewTimelineNames
+    // timelineScope
     // scrollbarGutter
     , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
@@ -188,6 +189,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , viewTimelineAxes(o.viewTimelineAxes)
     , viewTimelineInsets(o.viewTimelineInsets)
     , viewTimelineNames(o.viewTimelineNames)
+    , timelineScope(o.timelineScope)
     , scrollbarGutter(o.scrollbarGutter)
     , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
@@ -289,6 +291,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && viewTimelineAxes == o.viewTimelineAxes
         && viewTimelineInsets == o.viewTimelineInsets
         && viewTimelineNames == o.viewTimelineNames
+        && timelineScope == o.timelineScope
         && scrollbarGutter == o.scrollbarGutter
         && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -47,6 +47,7 @@
 #include "StyleSelfAlignmentData.h"
 #include "StyleTextEdge.h"
 #include "TextDecorationThickness.h"
+#include "TimelineScope.h"
 #include "TouchAction.h"
 #include "TranslateTransformOperation.h"
 #include "ViewTimeline.h"
@@ -189,6 +190,8 @@ public:
     Vector<ScrollAxis> viewTimelineAxes;
     Vector<ViewTimelineInsets> viewTimelineInsets;
     Vector<AtomString> viewTimelineNames;
+
+    TimelineScope timelineScope;
 
     ScrollbarGutter scrollbarGutter;
     ScrollbarWidth scrollbarWidth { ScrollbarWidth::Auto };

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -238,6 +238,8 @@ public:
 
     static RefPtr<TimingFunction> convertTimingFunction(BuilderState&, const CSSValue&);
 
+    static TimelineScope convertTimelineScope(BuilderState&, const CSSValue&);
+
 private:
     friend class BuilderCustom;
 
@@ -2165,6 +2167,29 @@ inline RefPtr<TimingFunction> BuilderConverter::convertTimingFunction(BuilderSta
 {
     return createTimingFunction(value);
 }
+
+inline TimelineScope BuilderConverter::convertTimelineScope(BuilderState&, const CSSValue& value)
+{
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return { };
+        case CSSValueAll:
+            return { TimelineScope::Type::All, { } };
+        default:
+            return { TimelineScope::Type::Ident, { AtomString { primitiveValue->stringValue() } } };
+        }
+    }
+
+    auto* list = dynamicDowncast<CSSValueList>(value);
+    if (!list)
+        return { };
+
+    return { TimelineScope::Type::Ident, WTF::map(*list, [&](auto& item) {
+        return AtomString { downcast<CSSPrimitiveValue>(item).stringValue() };
+    }) };
+}
+
 
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### 9cdb5c7eeb7babecc1ad09adc8ded30a5ebd772e
<pre>
[scroll-animations] Add parsing support for timeline-scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=279634">https://bugs.webkit.org/show_bug.cgi?id=279634</a>
<a href="https://rdar.apple.com/135919980">rdar://135919980</a>

Reviewed by Tim Nguyen.

Add parsing support for timeline-scope property.

* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::TimelineScope::operator== const):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialTimelineScope):
(WebCore::RenderStyle::timelineScope const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setTimelineScope):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTimelineScope):

Canonical link: <a href="https://commits.webkit.org/284045@main">https://commits.webkit.org/284045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6776468bb2022bff75e305f1fbe15fb1160164ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71232 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53873 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15537 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16684 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15227 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61351 "Found 3 new test failures: webanimations/accelerated-translate-animation-underlying-transform-changed-in-flight.html webanimations/accelerated-translate-animation-with-transform.html webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11189 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61430 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2763 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10388 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42381 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43458 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->