### PR TITLE
Deploy more smart pointers in NetworkStorageManager.cpp

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -49,7 +49,7 @@ class UniqueIDBDatabaseConnection : public RefCounted<UniqueIDBDatabaseConnectio
 public:
     static Ref<UniqueIDBDatabaseConnection> create(UniqueIDBDatabase&, ServerOpenDBRequest&);
 
-    ~UniqueIDBDatabaseConnection();
+    WEBCORE_EXPORT ~UniqueIDBDatabaseConnection();
 
     const IDBResourceIdentifier& openRequestIdentifier() { return m_openRequestIdentifier; }
     UniqueIDBDatabase* database() { return m_database.get(); }

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -57,7 +57,7 @@ class UniqueIDBDatabaseTransaction : public CanMakeWeakPtr<UniqueIDBDatabaseTran
 public:
     static Ref<UniqueIDBDatabaseTransaction> create(UniqueIDBDatabaseConnection&, const IDBTransactionInfo&);
 
-    ~UniqueIDBDatabaseTransaction();
+    WEBCORE_EXPORT ~UniqueIDBDatabaseTransaction();
 
     UniqueIDBDatabaseConnection* databaseConnection() const;
     UniqueIDBDatabase* database() const;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -143,6 +143,9 @@ public:
 private:
     NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
     ~NetworkStorageManager();
+
+    RefPtr<NetworkProcess> protectedProcess() const;
+
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
@@ -255,6 +258,7 @@ private:
     };
     void performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
+    Ref<SuspendableWorkQueue> protectedWorkQueue() const WTF_RETURNS_CAPABILITY(m_queue.get());
     OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
     WebCore::IDBServer::UniqueIDBDatabaseTransaction* idbTransaction(const WebCore::IDBRequestData&);
     void setStorageSiteValidationEnabledInternal(bool);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -680,6 +680,11 @@ OriginQuotaManager& OriginStorageManager::quotaManager()
     return m_quotaManager.get();
 }
 
+Ref<OriginQuotaManager> OriginStorageManager::protectedQuotaManager()
+{
+    return m_quotaManager.get();
+}
+
 FileSystemStorageManager& OriginStorageManager::fileSystemStorageManager(FileSystemStorageHandleRegistry& registry)
 {
     return defaultBucket().fileSystemStorageManager(registry, [quotaManager = ThreadSafeWeakPtr { this->quotaManager() }](uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler) mutable {

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -35,11 +35,6 @@ namespace WebKit {
 class OriginStorageManager;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::OriginStorageManager> : std::true_type { };
-}
-
 namespace WebCore {
 struct ClientOrigin;
 struct StorageEstimate;
@@ -62,8 +57,9 @@ class StorageAreaRegistry;
 enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
-class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
+class OriginStorageManager final : public CanMakeWeakPtr<OriginStorageManager>, public CanMakeThreadSafeCheckedPtr<OriginStorageManager> {
     WTF_MAKE_TZONE_ALLOCATED(OriginStorageManager);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OriginStorageManager);
 public:
     static String originFileIdentifier();
 
@@ -74,6 +70,7 @@ public:
     WebCore::StorageEstimate estimate();
     const String& path() const { return m_path; }
     OriginQuotaManager& quotaManager();
+    Ref<OriginQuotaManager> protectedQuotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);
     FileSystemStorageManager* existingFileSystemStorageManager();
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);


### PR DESCRIPTION
#### 513e79a88e64b1507d1bfbcaec8b33a39edae8e3
<pre>
Deploy more smart pointers in NetworkStorageManager.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279558">https://bugs.webkit.org/show_bug.cgi?id=279558</a>

Reviewed by Sihui Liu.

Deployed more smart pointers in the file as warned by the clang static analyzer.

* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::protectedProcess const):
(WebKit::NetworkStorageManager::close):
(WebKit::NetworkStorageManager::stopReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::prepareForEviction):
(WebKit::NetworkStorageManager::protectedWorkQueue const):
(WebKit::NetworkStorageManager::originQuotaManagerParameters):
(WebKit::NetworkStorageManager::fetchRegistrableDomainsForPersist):
(WebKit::NetworkStorageManager::didFetchRegistrableDomainsForPersist):
(WebKit::NetworkStorageManager::persist):
(WebKit::NetworkStorageManager::resetStoragePersistedState):
(WebKit::NetworkStorageManager::clearStorageForWebPage):
(WebKit::NetworkStorageManager::cloneSessionStorageForWebPage):
(WebKit::NetworkStorageManager::didIncreaseQuota):
(WebKit::NetworkStorageManager::fetchData):
(WebKit::NetworkStorageManager::deleteData):
(WebKit::NetworkStorageManager::deleteDataModifiedSince):
(WebKit::NetworkStorageManager::deleteDataForRegistrableDomains):
(WebKit::NetworkStorageManager::moveData):
(WebKit::NetworkStorageManager::getOriginDirectory):
(WebKit::NetworkStorageManager::suspend):
(WebKit::NetworkStorageManager::resume):
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::syncLocalStorage):
(WebKit::NetworkStorageManager::registerTemporaryBlobFilePaths):
(WebKit::NetworkStorageManager::requestSpace):
(WebKit::NetworkStorageManager::setOriginQuotaRatioEnabledForTesting):
(WebKit::NetworkStorageManager::setStorageSiteValidationEnabled):
(WebKit::NetworkStorageManager::addAllowedSitesForConnection):
(WebKit::NetworkStorageManager::abortOpenAndUpgradeNeeded):
(WebKit::NetworkStorageManager::didFireVersionChangeEvent):
(WebKit::NetworkStorageManager::abortTransaction):
(WebKit::NetworkStorageManager::commitTransaction):
(WebKit::NetworkStorageManager::didFinishHandlingVersionChangeTransaction):
(WebKit::NetworkStorageManager::createObjectStore):
(WebKit::NetworkStorageManager::deleteObjectStore):
(WebKit::NetworkStorageManager::renameObjectStore):
(WebKit::NetworkStorageManager::clearObjectStore):
(WebKit::NetworkStorageManager::createIndex):
(WebKit::NetworkStorageManager::deleteIndex):
(WebKit::NetworkStorageManager::renameIndex):
(WebKit::NetworkStorageManager::putOrAdd):
(WebKit::NetworkStorageManager::getRecord):
(WebKit::NetworkStorageManager::getAllRecords):
(WebKit::NetworkStorageManager::getCount):
(WebKit::NetworkStorageManager::deleteRecord):
(WebKit::NetworkStorageManager::openCursor):
(WebKit::NetworkStorageManager::iterateCursor):
(WebKit::NetworkStorageManager::dispatchTaskToBackgroundFetchManager):
(WebKit::NetworkStorageManager::closeServiceWorkerRegistrationFiles):
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations):
(WebKit::NetworkStorageManager::updateServiceWorkerRegistrations):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::protectedQuotaManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
(WebKit::OriginStorageManager::path const): Deleted.
(WebKit::OriginStorageManager::originFileCreationTimestamp const): Deleted.
(WebKit::OriginStorageManager::setOriginFileCreationTimestamp): Deleted.
(WebKit::OriginStorageManager::includedInBackup const): Deleted.
(WebKit::OriginStorageManager::markIncludedInBackup): Deleted.

Canonical link: <a href="https://commits.webkit.org/283598@main">https://commits.webkit.org/283598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a4c7af4bf37472b426eae713107023a0d890e6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53497 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/12059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39141 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15170 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72514 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60910 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61145 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2440 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10126 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41960 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->