### PR TITLE
[JSC] Align JIT and LLInt registers in x64

### DIFF
--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -388,7 +388,7 @@ public:
     static constexpr GPRReg nonArgGPR0 = X86Registers::r10; // regT5
     static constexpr GPRReg nonArgGPR1 = X86Registers::eax; // regT0
     static constexpr GPRReg returnValueGPR = X86Registers::eax; // regT0
-    static constexpr GPRReg returnValueGPR2 = X86Registers::edx; // regT1 or regT2
+    static constexpr GPRReg returnValueGPR2 = X86Registers::edx; // regT2
     static constexpr GPRReg nonPreservedNonReturnGPR = X86Registers::r10; // regT5
     static constexpr GPRReg nonPreservedNonArgumentGPR0 = X86Registers::r10; // regT5
     static constexpr GPRReg nonPreservedNonArgumentGPR1 = X86Registers::eax;

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -74,7 +74,7 @@
 #  - lr is defined on non-X86 architectures (ARM64, ARM64E, ARMv7, and CLOOP)
 #  and holds the return PC
 #
-#  - t0, t1, t2, t3, t4, and optionally t5, t6, and t7 are temporary registers that can get trashed on
+#  - t0, t1, t2, t3, t4, t5, and optionally t6 and t7 are temporary registers that can get trashed on
 #  calls, and are pairwise distinct registers. t4 holds the JS program counter, so use
 #  with caution in opcodes (actually, don't use it in opcodes at all, except as PC).
 #
@@ -526,8 +526,6 @@ macro llintOpWithProfile(opcodeName, opcodeStruct, fn)
         end)
     end)
 end
-
-const extraTempReg = t5
 
 # Constants for reasoning about value representation.
 const TagOffset = constexpr TagOffset

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -231,32 +231,32 @@ macro doVMEntry(makeCall)
 .copyHeaderLoop:
     # Copy the CodeBlock/Callee/ArgumentCountIncludingThis/|this| from protoCallFrame into the callee frame.
     if ARM64 or ARM64E
-        loadpairq (8 * 0)[protoCallFrame], extraTempReg, t3
-        storepairq extraTempReg, t3, CodeBlock + (8 * 0)[sp]
-        loadpairq (8 * 2)[protoCallFrame], extraTempReg, t3
-        storepairq extraTempReg, t3, CodeBlock + (8 * 2)[sp]
+        loadpairq (8 * 0)[protoCallFrame], t5, t3
+        storepairq t5, t3, CodeBlock + (8 * 0)[sp]
+        loadpairq (8 * 2)[protoCallFrame], t5, t3
+        storepairq t5, t3, CodeBlock + (8 * 2)[sp]
     else
-        loadq (8 * 0)[protoCallFrame], extraTempReg
-        storeq extraTempReg, CodeBlock + (8 * 0)[sp]
-        loadq (8 * 1)[protoCallFrame], extraTempReg
-        storeq extraTempReg, CodeBlock + (8 * 1)[sp]
-        loadq (8 * 2)[protoCallFrame], extraTempReg
-        storeq extraTempReg, CodeBlock + (8 * 2)[sp]
-        loadq (8 * 3)[protoCallFrame], extraTempReg
-        storeq extraTempReg, CodeBlock + (8 * 3)[sp]
+        loadq (8 * 0)[protoCallFrame], t5
+        storeq t5, CodeBlock + (8 * 0)[sp]
+        loadq (8 * 1)[protoCallFrame], t5
+        storeq t5, CodeBlock + (8 * 1)[sp]
+        loadq (8 * 2)[protoCallFrame], t5
+        storeq t5, CodeBlock + (8 * 2)[sp]
+        loadq (8 * 3)[protoCallFrame], t5
+        storeq t5, CodeBlock + (8 * 3)[sp]
     end
 
     loadi PayloadOffset + ProtoCallFrame::argCountAndCodeOriginValue[protoCallFrame], t4
     subi 1, t4
-    loadi ProtoCallFrame::paddedArgCount[protoCallFrame], extraTempReg
-    subi 1, extraTempReg
+    loadi ProtoCallFrame::paddedArgCount[protoCallFrame], t5
+    subi 1, t5
 
-    bieq t4, extraTempReg, .copyArgs
+    bieq t4, t5, .copyArgs
     move ValueUndefined, t3
 .fillExtraArgsLoop:
-    subi 1, extraTempReg
-    storeq t3, ThisArgumentOffset + 8[sp, extraTempReg, 8]
-    bineq t4, extraTempReg, .fillExtraArgsLoop
+    subi 1, t5
+    storeq t3, ThisArgumentOffset + 8[sp, t5, 8]
+    bineq t4, t5, .fillExtraArgsLoop
 
 .copyArgs:
     loadp ProtoCallFrame::args[protoCallFrame], t3
@@ -264,8 +264,8 @@ macro doVMEntry(makeCall)
 .copyArgsLoop:
     btiz t4, .copyArgsDone
     subi 1, t4
-    loadq [t3, t4, 8], extraTempReg
-    storeq extraTempReg, ThisArgumentOffset + 8[sp, t4, 8]
+    loadq [t3, t4, 8], t5
+    storeq t5, ThisArgumentOffset + 8[sp, t4, 8]
     jmp .copyArgsLoop
 
 .copyArgsDone:
@@ -282,7 +282,7 @@ macro doVMEntry(makeCall)
         storep cfr, VM::topEntryFrame[vm]
     end
 
-    checkStackPointerAlignment(extraTempReg, 0xbad0dc02)
+    checkStackPointerAlignment(t5, 0xbad0dc02)
 
     makeCall(entry, protoCallFrame, t3, t4)
 
@@ -323,10 +323,10 @@ _llint_throw_stack_overflow_error_from_vm_entry:
     vmEntryRecord(cfr, t4)
 
     loadp VMEntryRecord::m_vm[t4], vm
-    loadp VMEntryRecord::m_prevTopCallFrame[t4], extraTempReg
-    storep extraTempReg, VM::topCallFrame[vm]
-    loadp VMEntryRecord::m_prevTopEntryFrame[t4], extraTempReg
-    storep extraTempReg, VM::topEntryFrame[vm]
+    loadp VMEntryRecord::m_prevTopCallFrame[t4], t5
+    storep t5, VM::topCallFrame[vm]
+    loadp VMEntryRecord::m_prevTopEntryFrame[t4], t5
+    storep t5, VM::topEntryFrame[vm]
 
     move ValueUndefined, r0
 
@@ -381,10 +381,10 @@ op(llint_handle_uncaught_exception, macro ()
     vmEntryRecord(cfr, t2)
 
     loadp VMEntryRecord::m_vm[t2], t3
-    loadp VMEntryRecord::m_prevTopCallFrame[t2], extraTempReg
-    storep extraTempReg, VM::topCallFrame[t3]
-    loadp VMEntryRecord::m_prevTopEntryFrame[t2], extraTempReg
-    storep extraTempReg, VM::topEntryFrame[t3]
+    loadp VMEntryRecord::m_prevTopCallFrame[t2], t5
+    storep t5, VM::topCallFrame[t3]
+    loadp VMEntryRecord::m_prevTopEntryFrame[t2], t5
+    storep t5, VM::topEntryFrame[t3]
 
     move ValueUndefined, r0
 

--- a/Source/JavaScriptCore/llint/WebAssembly64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly64.asm
@@ -31,17 +31,17 @@ end)
 
 # Wasm specific bytecodes
 
-macro emitCheckAndPreparePointer(ctx, pointer, offset, size)
-    leap size - 1[pointer, offset], t5
-    bpb t5, boundsCheckingSize, .continuation
+macro emitCheckAndPreparePointer(ctx, pointer, offset, size, scratch)
+    leap size - 1[pointer, offset], scratch
+    bpb scratch, boundsCheckingSize, .continuation
     throwException(OutOfBoundsMemoryAccess)
 .continuation:
     addp memoryBase, pointer
 end
 
-macro emitCheckAndPreparePointerAddingOffset(ctx, pointer, offset, size)
-    leap size - 1[pointer, offset], t5
-    bpb t5, boundsCheckingSize, .continuation
+macro emitCheckAndPreparePointerAddingOffset(ctx, pointer, offset, size, scratch)
+    leap size - 1[pointer, offset], scratch
+    bpb scratch, boundsCheckingSize, .continuation
 .throw:
     throwException(OutOfBoundsMemoryAccess)
 .continuation:
@@ -49,9 +49,9 @@ macro emitCheckAndPreparePointerAddingOffset(ctx, pointer, offset, size)
     addp offset, pointer
 end
 
-macro emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, pointer, offset, size)
-    leap size - 1[pointer, offset], t5
-    bpb t5, boundsCheckingSize, .continuationInBounds
+macro emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, pointer, offset, size, scratch)
+    leap size - 1[pointer, offset], scratch
+    bpb scratch, boundsCheckingSize, .continuationInBounds
 .throwOOB:
     throwException(OutOfBoundsMemoryAccess)
 .continuationInBounds:
@@ -68,7 +68,7 @@ macro wasmLoadOp(name, struct, size, fn)
     wasmOp(name, struct, macro(ctx)
         mloadi(ctx, m_pointer, t0)
         wgetu(ctx, m_offset, t1)
-        emitCheckAndPreparePointer(ctx, t0, t1, size)
+        emitCheckAndPreparePointer(ctx, t0, t1, size, t5)
         fn([t0, t1], t2)
         returnq(ctx, t2)
     end)
@@ -89,7 +89,7 @@ macro wasmStoreOp(name, struct, size, fn)
     wasmOp(name, struct, macro(ctx)
         mloadi(ctx, m_pointer, t0)
         wgetu(ctx, m_offset, t1)
-        emitCheckAndPreparePointer(ctx, t0, t1, size)
+        emitCheckAndPreparePointer(ctx, t0, t1, size, t5)
         mloadq(ctx, m_value, t2)
         fn(t2, [t0, t1])
         dispatch(ctx)
@@ -916,7 +916,7 @@ macro wasmAtomicBinaryRMWOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, fni, fn
         mloadi(ctx, m_pointer, t3)
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_value, t0)
-        emitCheckAndPreparePointerAddingOffset(ctx, t3, t1, 1)
+        emitCheckAndPreparePointerAddingOffset(ctx, t3, t1, 1, t5)
         fnb(t0, [t3], t2, t5, t1)
         andq 0xff, t0 # FIXME: ZeroExtend8To64
         assert(macro(ok) bqbeq t0, 0xff, .ok end)
@@ -926,7 +926,7 @@ macro wasmAtomicBinaryRMWOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, fni, fn
         mloadi(ctx, m_pointer, t3)
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_value, t0)
-        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 2)
+        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 2, t5)
         fnh(t0, [t3], t2, t5, t1)
         andq 0xffff, t0 # FIXME: ZeroExtend16To64
         assert(macro(ok) bqbeq t0, 0xffff, .ok end)
@@ -936,7 +936,7 @@ macro wasmAtomicBinaryRMWOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, fni, fn
         mloadi(ctx, m_pointer, t3)
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_value, t0)
-        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 4)
+        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 4, t5)
         fni(t0, [t3], t2, t5, t1)
         assert(macro(ok) bqbeq t0, 0xffffffff, .ok end)
         returnq(ctx, t0)
@@ -945,7 +945,7 @@ macro wasmAtomicBinaryRMWOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, fni, fn
         mloadi(ctx, m_pointer, t3)
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_value, t0)
-        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 8)
+        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 8, t5)
         fnq(t0, [t3], t2, t5, t1)
         returnq(ctx, t0)
     end)
@@ -1166,7 +1166,7 @@ macro wasmAtomicCompareExchangeOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, f
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_expected, t0)
         mloadq(ctx, m_value, t2)
-        emitCheckAndPreparePointerAddingOffset(ctx, t3, t1, 1)
+        emitCheckAndPreparePointerAddingOffset(ctx, t3, t1, 1, t5)
         fnb(t0, t2, [t3], t5, t1)
         assert(macro(ok) bqbeq t0, 0xff, .ok end)
         returnq(ctx, t0)
@@ -1176,7 +1176,7 @@ macro wasmAtomicCompareExchangeOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, f
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_expected, t0)
         mloadq(ctx, m_value, t2)
-        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 2)
+        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 2, t5)
         fnh(t0, t2, [t3], t5, t1)
         assert(macro(ok) bqbeq t0, 0xffff, .ok end)
         returnq(ctx, t0)
@@ -1186,7 +1186,7 @@ macro wasmAtomicCompareExchangeOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, f
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_expected, t0)
         mloadq(ctx, m_value, t2)
-        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 4)
+        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 4, t5)
         fni(t0, t2, [t3], t5, t1)
         assert(macro(ok) bqbeq t0, 0xffffffff, .ok end)
         returnq(ctx, t0)
@@ -1196,7 +1196,7 @@ macro wasmAtomicCompareExchangeOps(lowerCaseOpcode, upperCaseOpcode, fnb, fnh, f
         wgetu(ctx, m_offset, t1)
         mloadq(ctx, m_expected, t0)
         mloadq(ctx, m_value, t2)
-        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 8)
+        emitCheckAndPreparePointerAddingOffsetWithAlignmentCheck(ctx, t3, t1, 8, t5)
         fnq(t0, t2, [t3], t5, t1)
         returnq(ctx, t0)
     end)


### PR DESCRIPTION
#### ed54aa241721571d1de5d06856825d2e4abeb32e
<pre>
[JSC] Align JIT and LLInt registers in x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=279642">https://bugs.webkit.org/show_bug.cgi?id=279642</a>
<a href="https://rdar.apple.com/135933164">rdar://135933164</a>

Reviewed by Ross Kirsling.

Let&apos;s align both. There is no reason having different namings anymore (no Windows).

* Source/JavaScriptCore/jit/GPRInfo.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/llint/WebAssembly64.asm:
* Source/JavaScriptCore/offlineasm/x86.rb:

Canonical link: <a href="https://commits.webkit.org/283620@main">https://commits.webkit.org/283620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c09b44a760cacd8efe88ae193c9115f437bb3e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17954 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53522 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15203 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16308 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/59935 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72557 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66066 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57868 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61167 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; 2 api tests failed or timed out; 2 api tests failed or timed out; Compiled WebKit; 2 api tests failed or timed out; Running analyze-api-tests-results") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2472 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87834 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10139 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42003 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15450 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->