### PR TITLE
Deploy more smart pointers in WebFullScreenManagerProxy.cpp

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -106,8 +106,8 @@ void WebFullScreenManagerProxy::didEnterFullScreen()
     webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::DidEnterFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
 
     if (webPageProxy->isControlledByAutomation()) {
-        if (auto* automationSession = webPageProxy->configuration().processPool().automationSession())
-            automationSession->didEnterFullScreenForPage(m_page);
+        if (RefPtr automationSession = webPageProxy->protectedConfiguration()->processPool().automationSession())
+            automationSession->didEnterFullScreenForPage(protectedPage());
     }
 }
 
@@ -139,11 +139,11 @@ void WebFullScreenManagerProxy::didExitFullScreen()
     m_fullscreenState = FullscreenState::NotInFullscreen;
     Ref webPageProxy = m_page.get();
     webPageProxy->fullscreenClient().didExitFullscreen(webPageProxy.ptr());
-    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::DidExitFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::DidExitFullScreen(), webPageProxy->webPageIDInMainFrameProcess());
     
     if (webPageProxy->isControlledByAutomation()) {
-        if (auto* automationSession = webPageProxy->protectedConfiguration()->processPool().automationSession())
-            automationSession->didExitFullScreenForPage(m_page);
+        if (RefPtr automationSession = webPageProxy->protectedConfiguration()->processPool().automationSession())
+            automationSession->didExitFullScreenForPage(protectedPage());
     }
     callCloseCompletionHandlers();
 }
@@ -180,25 +180,25 @@ void WebFullScreenManagerProxy::supportsFullScreen(bool withKeyboard, Completion
 void WebFullScreenManagerProxy::saveScrollPosition()
 {
     Ref webPageProxy = m_page.get();
-    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::SaveScrollPosition(), webPageProxy->webPageIDInMainFrameProcess());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::SaveScrollPosition(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::restoreScrollPosition()
 {
     Ref webPageProxy = m_page.get();
-    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::RestoreScrollPosition(), webPageProxy->webPageIDInMainFrameProcess());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::RestoreScrollPosition(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)
 {
     Ref webPageProxy = m_page.get();
-    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenInsets(insets), webPageProxy->webPageIDInMainFrameProcess());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::SetFullscreenInsets(insets), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
 {
     Ref webPageProxy = m_page.get();
-    webPageProxy->legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration), webPageProxy->webPageIDInMainFrameProcess());
+    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::close()


### PR DESCRIPTION
#### c9f2e510d4bb7b79ff5121e397e4a793baac2aa8
<pre>
Deploy more smart pointers in WebFullScreenManagerProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279650">https://bugs.webkit.org/show_bug.cgi?id=279650</a>

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::didEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen):
(WebKit::WebFullScreenManagerProxy::saveScrollPosition):
(WebKit::WebFullScreenManagerProxy::restoreScrollPosition):
(WebKit::WebFullScreenManagerProxy::setFullscreenInsets):
(WebKit::WebFullScreenManagerProxy::setFullscreenAutoHideDuration):

Canonical link: <a href="https://commits.webkit.org/283616@main">https://commits.webkit.org/283616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a1245654d3e6b16c0e94311aecb3859988450f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17952 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53521 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12085 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39174 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60932 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10808 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61166 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2468 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10137 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->