### PR TITLE
Deploy more smart pointers in RemoteLayerTreeDrawingAreaProxy.mm and RemoteLayerTreeDrawingAreaProxyMac.mm

### DIFF
--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -201,7 +201,7 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
     CIImage *translatedImage = [croppedImage imageByApplyingTransform:CGAffineTransformMakeTranslation(-flippedInsetBadgeRect.origin.x, -flippedInsetBadgeRect.origin.y)];
 
     auto surfaceDimension = useSmallBadge ? smallBadgeDimension : largeBadgeDimension;
-    std::unique_ptr<IOSurface> badgeSurface = IOSurface::create(&IOSurfacePool::sharedPool(), { surfaceDimension, surfaceDimension }, DestinationColorSpace::SRGB());
+    std::unique_ptr<IOSurface> badgeSurface = IOSurface::create(&IOSurfacePool::sharedPoolSingleton(), { surfaceDimension, surfaceDimension }, DestinationColorSpace::SRGB());
     IOSurfaceRef surface = badgeSurface->surface();
     [ciContext render:translatedImage toIOSurface:surface bounds:badgeRect colorSpace:sRGBColorSpaceRef()];
     auto surfaceContext = badgeSurface->createPlatformContext();

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -62,7 +62,7 @@ void platformReleaseMemory(Critical)
     tileControllerMemoryHandler().trimUnparentedTilesToTarget(0);
 #endif
 
-    IOSurfacePool::sharedPool().discardAllSurfaces();
+    IOSurfacePool::sharedPoolSingleton().discardAllSurfaces();
 
 #if CACHE_SUBIMAGES
     CGSubimageCacheWithTimer::clear();
@@ -71,7 +71,7 @@ void platformReleaseMemory(Critical)
 
 void platformReleaseGraphicsMemory(Critical)
 {
-    IOSurfacePool::sharedPool().discardAllSurfaces();
+    IOSurfacePool::sharedPoolSingleton().discardAllSurfaces();
 
 #if CACHE_SUBIMAGES
     CGSubimageCacheWithTimer::clear();

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -61,7 +61,7 @@ IOSurfacePool::~IOSurfacePool()
     });
 }
 
-IOSurfacePool& IOSurfacePool::sharedPool()
+IOSurfacePool& IOSurfacePool::sharedPoolSingleton()
 {
     static LazyNeverDestroyed<IOSurfacePool> pool;
     static std::once_flag s_onceFlag;

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -50,7 +50,7 @@ class IOSurfacePool : public ThreadSafeRefCounted<IOSurfacePool> {
     friend class LazyNeverDestroyed<IOSurfacePool>;
 
 public:
-    WEBCORE_EXPORT static IOSurfacePool& sharedPool();
+    WEBCORE_EXPORT static IOSurfacePool& sharedPoolSingleton();
     WEBCORE_EXPORT static Ref<IOSurfacePool> create();
 
     WEBCORE_EXPORT ~IOSurfacePool();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -268,7 +268,7 @@ RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allo
 {
     auto purpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
     ImageBufferCreationContext creationContext;
-    creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPool();
+    creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPoolSingleton();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     if (m_parameters.includeDisplayList == IncludeDisplayList::Yes) {

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -61,6 +61,11 @@ Ref<WebPageProxy> DrawingAreaProxy::protectedWebPageProxy() const
     return m_webPageProxy.get();
 }
 
+Ref<WebProcessProxy> DrawingAreaProxy::protectedWebProcessProxy() const
+{
+    return m_webProcessProxy.get();
+}
+
 void DrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
 {
     for (auto& name : messageReceiverNames())

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -160,6 +160,7 @@ protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&, WebProcessProxy&);
 
     Ref<WebPageProxy> protectedWebPageProxy() const;
+    Ref<WebProcessProxy> protectedWebProcessProxy() const;
 
     DrawingAreaType m_type;
     WeakRef<WebPageProxy> m_webPageProxy;

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -54,6 +54,11 @@ RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy()
         m_drawingArea->removeRemotePageDrawingAreaProxy(*this);
 }
 
+Ref<WebProcessProxy> RemotePageDrawingAreaProxy::protectedProcess()
+{
+    return m_process;
+}
+
 void RemotePageDrawingAreaProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (m_drawingArea)

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -51,6 +51,7 @@ public:
     ~RemotePageDrawingAreaProxy();
 
     WebProcessProxy& process() { return m_process; }
+    Ref<WebProcessProxy> protectedProcess();
 
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
@@ -85,7 +85,7 @@ TEST(IOSurfacePoolTest, IOSurfacePoolNames)
 {
     auto initialPurpose = WebCore::RenderingPurpose::Unspecified;
     auto purpose = WebCore::RenderingPurpose::Canvas;
-    auto* pool = &WebCore::IOSurfacePool::sharedPool();
+    auto* pool = &WebCore::IOSurfacePool::sharedPoolSingleton();
 
     auto s1 = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::nameForRenderingPurpose(initialPurpose));
     EXPECT_EQ(WebCore::IOSurface::Name::ImageBufferShareableMapped, s1->name());


### PR DESCRIPTION
#### ac9a131fd34510608ef774838c48a9ebf73800c4
<pre>
Deploy more smart pointers in RemoteLayerTreeDrawingAreaProxy.mm and RemoteLayerTreeDrawingAreaProxyMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=279653">https://bugs.webkit.org/show_bug.cgi?id=279653</a>

Reviewed by Chris Dumez.

Deployed more smart pointers per clang static analyzer warnings.

Also renamed IOSurfacePool::sharedPool to IOSurfacePool::sharedPoolSingleton so that
the static analyzer will treat it as a singleton.

* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm:
(WebCore::ARKitBadgeSystemImage::draw const):
* Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm:
(WebCore::platformReleaseMemory):
(WebCore::platformReleaseGraphicsMemory):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::sharedPoolSingleton): Renamed from sharedPool.
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::protectedWebProcessProxy const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::sizeDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::deviceScaleFactorDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::indicatorLocation const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::indicatorScale const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate):
(WebKit::RemoteLayerTreeDrawingAreaProxy::windowKindDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDisplayLinkClient::displayLinkFired):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::colorSpaceDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::createFence):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
(WebKit::RemotePageDrawingAreaProxy::protectedProcess):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm:
(TestWebKitAPI::TEST(IOSurfacePoolTest, IOSurfacePoolNames)):

Canonical link: <a href="https://commits.webkit.org/283615@main">https://commits.webkit.org/283615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8237b092e4f49c36e716e3943a3d2224280a1115

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17961 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53529 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12086 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69895 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running checkout-pull-request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34159 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15212 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61172 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2480 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10135 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43087 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44270 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->