### PR TITLE
[css-anchor-position-1] Disable style sharing with anchor positioned elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-001-expected.txt
@@ -3,21 +3,11 @@ PASS .target 1
 PASS .target 2
 PASS .target 3
 PASS .target 4
-FAIL .target 5 assert_equals:
-<div class="target" data-offset-x="58" data-offset-y="14" data-expected-width="31" data-expected-height="31"></div>
-width expected 31 but got 769
-FAIL .target 6 assert_equals:
-<div class="target" data-offset-x="58" data-offset-y="14" data-expected-width="31" data-expected-height="31"></div>
-width expected 31 but got 769
-FAIL .target 7 assert_equals:
-<div class="target" data-offset-x="50" data-offset-y="14" data-expected-width="31" data-expected-height="31"></div>
-width expected 31 but got 769
-FAIL .target 8 assert_equals:
-<div class="target" data-offset-x="50" data-offset-y="9" data-expected-width="45" data-expected-height="43"></div>
-width expected 45 but got 769
-FAIL .target 9 assert_equals:
-<div class="target" data-offset-x="50" data-offset-y="9" data-expected-width="45" data-expected-height="43"></div>
-width expected 45 but got 769
+PASS .target 5
+PASS .target 6
+PASS .target 7
+PASS .target 8
+PASS .target 9
 PASS .target 10
 PASS .target 11
 PASS .target 12

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt
@@ -2,6 +2,6 @@
 FAIL anchor-position-borders-002 assert_array_equals: expected property 0 to be 726 but got 711 (expected array [726, 26, 742, 42] got [711, 26, 742, 57])
 FAIL anchor-position-borders-002 1 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 88, 736, 104] got [705, 88, 736, 119])
 PASS anchor-position-borders-002 2
-FAIL anchor-position-borders-002 3 assert_array_equals: expected property 0 to be 31 but got 705 (expected array [31, 215, 786, 255] got [705, 224, 736, 255])
-FAIL anchor-position-borders-002 4 assert_array_equals: expected property 0 to be 31 but got 699 (expected array [31, 282, 786, 349] got [699, 296, 730, 327])
+FAIL anchor-position-borders-002 3 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 224, 736, 240] got [705, 224, 736, 255])
+FAIL anchor-position-borders-002 4 assert_array_equals: expected property 0 to be 714 but got 699 (expected array [714, 296, 730, 312] got [699, 296, 730, 327])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
@@ -35,19 +35,15 @@ FAIL .target 12 assert_equals:
 width expected 100 but got 0
 FAIL .target 13 assert_equals:
 <span class="target target1-pos" data-offset-x="-20" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
-width expected 70 but got 40
+width expected 70 but got 10
 FAIL .target 14 assert_equals:
 <span class="target target1-size" data-offset-x="-20" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
 width expected 70 but got 0
-FAIL .target 15 assert_equals:
-<span class="target target1-pos" data-offset-x="0" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
-width expected 70 but got 100
+PASS .target 15
 FAIL .target 16 assert_equals:
 <span class="target target1-size" data-offset-x="0" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
 width expected 70 but got 0
-FAIL .target 17 assert_equals:
-<span class="target target1-pos" data-offset-x="0" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
-width expected 70 but got 100
+PASS .target 17
 FAIL .target 18 assert_equals:
 <span class="target target1-size" data-offset-x="0" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
 width expected 70 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002-expected.txt
@@ -1,5 +1,5 @@
 
 PASS target1 should scroll with anchor1
-FAIL target2 should scroll with anchor2 assert_equals: expected 155 but got 0
-FAIL target3 should scroll with anchor3 assert_equals: expected 270 but got 0
+FAIL target2 should scroll with anchor2 assert_equals: expected 155 but got 175
+FAIL target3 should scroll with anchor3 assert_equals: expected 270 but got 300
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004-expected.txt
@@ -2,7 +2,7 @@ before anchor after target
 
 before anchor after target
 
-FAIL Initial position of the targets assert_equals: expected 140 but got 0
+PASS Initial position of the targets
 FAIL #target1 should scroll with #anchor1 assert_equals: expected 120 but got 140
-FAIL #target2 should scroll with #anchor2 assert_equals: expected 100 but got 0
+FAIL #target2 should scroll with #anchor2 assert_equals: expected 100 but got 140
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-001-expected.txt
@@ -5,10 +5,10 @@ FAIL .target 2 assert_equals:
 offsetLeft expected 5 but got 155
 FAIL .target 3 assert_equals:
 <div class="target" data-offset-x="50" data-offset-y="35" data-expected-width="40" data-expected-height="15"></div>
-offsetLeft expected 50 but got 5
+offsetLeft expected 50 but got 150
 FAIL .target 4 assert_equals:
 <div class="target" data-offset-x="50" data-offset-y="20" data-expected-width="40" data-expected-height="15"></div>
-offsetLeft expected 50 but got 5
+offsetLeft expected 50 but got 150
 FAIL .target 5 assert_equals:
 <div class="target" data-offset-x="150" data-offset-y="25" data-expected-width="35" data-expected-height="40"></div>
 width expected 35 but got 40

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-004-expected.txt
@@ -2,5 +2,5 @@
 PASS .target 1
 FAIL .target 2 assert_equals:
 <div class="target" data-offset-x="200" data-expected-margin-left="10" data-expected-margin-right="0" data-expected-margin-top="0" data-expected-margin-bottom="10"></div>
-offsetLeft expected 200 but got 190
+offsetLeft expected 200 but got -20
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -162,6 +162,7 @@ public:
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData>& anchorElements() { return m_anchorElements; }
     AnchorPositionedStates& anchorPositionedStates() { return m_anchorPositionedStates; }
+    const AnchorPositionedStates& anchorPositionedStates() const { return m_anchorPositionedStates; }
     AnchorsForAnchorName& anchorsForAnchorName() { return m_anchorsForAnchorName; }
     void clearAnchorPositioningState();
 

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -293,6 +293,9 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
     if (&candidateElement == m_document->activeModalDialog() || &element == m_document->activeModalDialog())
         return false;
 
+    if (!m_document->styleScope().anchorPositionedStates().isEmptyIgnoringNullReferences())
+        return false;
+
 #if ENABLE(FULLSCREEN_API)
     if (CheckedPtr fullscreenManager = m_document->fullscreenManagerIfExists(); fullscreenManager && (&candidateElement == fullscreenManager->currentFullscreenElement() || &element == fullscreenManager->currentFullscreenElement()))
         return false;


### PR DESCRIPTION
#### 7785f2f7d2923e7a7d037a4a5b7a5c689ec23105
<pre>
[css-anchor-position-1] Disable style sharing with anchor positioned elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=279654">https://bugs.webkit.org/show_bug.cgi?id=279654</a>
<a href="https://rdar.apple.com/135939062">rdar://135939062</a>

Reviewed by Antoine Quint.

Style sharing can&apos;t deal with anchor positioning.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-004-expected.txt:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::canShareStyleWithElement const):

Disable if there are anchor positioned elements.

Canonical link: <a href="https://commits.webkit.org/283607@main">https://commits.webkit.org/283607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98e91e37fb8a9ae9e1d1cef590f6b4d57397e8bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17740 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12087 "Build is in progress. Recent messages:") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69897 "Build is in progress. Recent messages:OS: Sonoma (14.6), Xcode: 15.4; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57818 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16317 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72566 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14904 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57875 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61174 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14759 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2478 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->