### PR TITLE
REGRESSION(283334@main): [GLIB] Script for updating third-party libs does not work anymore for flatpak

### DIFF
--- a/Tools/Scripts/update-webkitgtk-libs
+++ b/Tools/Scripts/update-webkitgtk-libs
@@ -26,6 +26,6 @@ if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
     system("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--gtk", @ARGV) == 0 or die $!;
 } elsif (defined $ENV{'WEBKIT_CROSS_TARGET'} or grep(/^--cross-target/, @ARGV)) {
     system("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV) == 0 or die $!;
-} elsif (shouldUseFlatpak()) {
+} elsif (!(defined $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'} && $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'})) {
     system("$scriptsDir/update-webkit-flatpak", @ARGV) == 0 or die $!;
 }

--- a/Tools/Scripts/update-webkitwpe-libs
+++ b/Tools/Scripts/update-webkitwpe-libs
@@ -26,6 +26,6 @@ if (defined $ENV{'WEBKIT_JHBUILD'} and $ENV{'WEBKIT_JHBUILD'}) {
     system("perl", "$scriptsDir/update-webkit-libs-jhbuild", "--wpe", @ARGV) == 0 or die $!;
 } elsif (defined $ENV{'WEBKIT_CROSS_TARGET'} or grep(/^--cross-target/, @ARGV)) {
     system("$scriptsDir/cross-toolchain-helper", "--build-toolchain", @ARGV) == 0 or die $!;
-} elsif (shouldUseFlatpak()) {
+} elsif (!(defined $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'} && $ENV{'WEBKIT_BUILD_USE_SYSTEM_LIBRARIES'})) {
     system("$scriptsDir/update-webkit-flatpak", @ARGV) == 0 or die $!;
 }


### PR DESCRIPTION
#### 6ddc6a2f2f12910ec32834a1dc70b93ab8ce0aeb
<pre>
REGRESSION(283334@main): [GLIB] Script for updating third-party libs does not work anymore for flatpak
<a href="https://bugs.webkit.org/show_bug.cgi?id=279660">https://bugs.webkit.org/show_bug.cgi?id=279660</a>

Reviewed by Nikolas Zimmermann.

Since 283334@main the scripts update-webkitgtk-libs and update-webkitwpe-libs
do nothing when using flatpak, this is because the call to the script
update-webkit-flatpak is now inside now a condition shouldUseFlatpak() that is
always false at the invocation of that script due to this two reasons:

 1. The subroutine shouldUseFlatpak() returns false if the port name is not
    specified, and this two scripts are usually called without parameters.
 2. Even if you call the script as in &quot;update-webkitgtk-libs --gtk&quot; then the
    subroutine shouldUseFlatpak() will only return true if the user flatpak
    is already installed, but it will not return true on the first run
    (aka no WebKitBuild dir) and we want to default to using flatpak unless
    the environment tells us to do something different.

* Tools/Scripts/update-webkitgtk-libs:
* Tools/Scripts/update-webkitwpe-libs:

Canonical link: <a href="https://commits.webkit.org/283621@main">https://commits.webkit.org/283621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bdc4675ae3477c79cc15066e5d4950f41bf8ed7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70873 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17971 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53589 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60980 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61179 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2487 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10140 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->