### PR TITLE
Remove Quirk shouldDisableNavigatorStandaloneQuirk for oracle.com

### DIFF
--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -23,7 +23,7 @@
     Exposed=Window
 ] interface Navigator {
     // Non-standard.
-    [Conditional=NAVIGATOR_STANDALONE, DisabledByQuirk=shouldDisableNavigatorStandalone] readonly attribute boolean standalone;
+    [Conditional=NAVIGATOR_STANDALONE] readonly attribute boolean standalone;
 
     readonly attribute unsigned long long hardwareConcurrency;
 };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1622,19 +1622,6 @@ bool Quirks::needsDisableDOMPasteAccessQuirk() const
     return *m_needsDisableDOMPasteAccessQuirk;
 }
 
-// oracle.com rdar://117673533
-bool Quirks::shouldDisableNavigatorStandaloneQuirk() const
-{
-#if PLATFORM(MAC)
-    if (!needsQuirks())
-        return false;
-
-    if (isDomain("oracle.com"_s))
-        return true;
-#endif
-    return false;
-}
-
 bool Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const
 {
     if (!needsQuirks())

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -77,7 +77,6 @@ public:
     bool shouldHideSearchFieldResultsButton() const;
     bool shouldExposeShowModalDialog() const;
     bool shouldNavigatorPluginsBeEmpty() const;
-    bool shouldDisableNavigatorStandaloneQuirk() const;
 
     bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const;
     bool shouldFlipScreenDimensions() const;


### PR DESCRIPTION
#### 7333f8fe83984790a2dc41608a827355fa41d731
<pre>
Remove Quirk shouldDisableNavigatorStandaloneQuirk for oracle.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=279670">https://bugs.webkit.org/show_bug.cgi?id=279670</a>
<a href="https://rdar.apple.com/135948711">rdar://135948711</a>

Reviewed by Brent Fulgham.

navigator.standalone had been disabled through a Quirk for oracle.com.
The site was using it to identify exclusively the iPad and iOs with a
combination of maxTouchPoints, this was breaking the charts in Oracle.

There&apos;s no traces anymore of standalone in the oracle.com code
and the charts are working equally with or without site specific hacks.

* Source/WebCore/page/Navigator.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableNavigatorStandaloneQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/283728@main">https://commits.webkit.org/283728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/730e845c178993d9ae49f01924329e825bcbf9b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53630 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12102 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16339 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61033 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2498 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42034 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->