### PR TITLE
[GStreamer][DMABuf] Disable DMABufVideoSink when lacking texture_rg

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -529,6 +529,8 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.EXT_unpack_subimage = isExtensionSupported(extensionsString, "GL_EXT_unpack_subimage");
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
         m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
+        m_glExtensions.ARB_texture_rg = isExtensionSupported(extensionsString, "GL_ARB_texture_rg");
+        m_glExtensions.EXT_texture_rg = isExtensionSupported(extensionsString, "GL_EXT_texture_rg");
     });
     return m_glExtensions;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -80,6 +80,8 @@ public:
         bool EXT_unpack_subimage { false };
         bool APPLE_sync { false };
         bool OES_packed_depth_stencil { false };
+        bool ARB_texture_rg { false };
+        bool EXT_texture_rg { false };
     };
     const GLExtensions& glExtensions() const;
 


### PR DESCRIPTION
#### f45db857d2ece7f701575ff08402dae263e9c600
<pre>
[GStreamer][DMABuf] Disable DMABufVideoSink when lacking texture_rg
<a href="https://bugs.webkit.org/show_bug.cgi?id=279439">https://bugs.webkit.org/show_bug.cgi?id=279439</a>

Reviewed by NOBODY (OOPS!).

The DMABuf video sink has now superseded GLsink. However in its current
implementation it creates R8 GL_TEXTURE_2D textures, therefore introducing
an implicit dependency on texture_rg, rendering DMABuf video sink
unsuitable for legacy GPUs not supporting
GL_EXT_texture_rg/GL_ARB_texture_rg/OpenGL 3.0+.

This patch disables DMABufVideoSink when texture_rg is unavailable,
causing a fallback to the legacy implementation on affected devices.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const): cache texture_rg extension
support
* Source/WebCore/platform/graphics/egl/GLContext.h: texture_rg extension
  support declarations
* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkIsEnabled): Disable DMABufVideoSink when
texture_rg is unavailable
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f45db857d2ece7f701575ff08402dae263e9c600

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53633 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12105 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72594 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61039 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61196 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2502 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42040 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->