### PR TITLE
Adopt smart pointers in ViewTransitionTypeSet

### DIFF
--- a/Source/WebCore/dom/ViewTransitionTypeSet.cpp
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.cpp
@@ -52,9 +52,11 @@ void ViewTransitionTypeSet::initializeSetLike(DOMSetAdapter& setAdapter) const
 void ViewTransitionTypeSet::clearFromSetLike()
 {
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (m_document.documentElement()) {
+    if (!m_document)
+        return;
+    if (m_document->documentElement()) {
         styleInvalidation.emplace(
-            *m_document.documentElement(),
+            *m_document->documentElement(),
             CSSSelector::PseudoClass::ActiveViewTransitionType,
             Style::PseudoClassChangeInvalidation::AnyValue
         );
@@ -66,9 +68,11 @@ void ViewTransitionTypeSet::clearFromSetLike()
 void ViewTransitionTypeSet::addToSetLike(const AtomString& type)
 {
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (m_document.documentElement()) {
+    if (!m_document)
+        return;
+    if (m_document->documentElement()) {
         styleInvalidation.emplace(
-            *m_document.documentElement(),
+            *m_document->documentElement(),
             CSSSelector::PseudoClass::ActiveViewTransitionType,
             Style::PseudoClassChangeInvalidation::AnyValue
         );
@@ -80,9 +84,11 @@ void ViewTransitionTypeSet::addToSetLike(const AtomString& type)
 bool ViewTransitionTypeSet::removeFromSetLike(const AtomString& type)
 {
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (m_document.documentElement()) {
+    if (!m_document)
+        return false;
+    if (m_document->documentElement()) {
         styleInvalidation.emplace(
-            *m_document.documentElement(),
+            *m_document->documentElement(),
             CSSSelector::PseudoClass::ActiveViewTransitionType,
             Style::PseudoClassChangeInvalidation::AnyValue
         );

--- a/Source/WebCore/dom/ViewTransitionTypeSet.h
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.h
@@ -55,7 +55,7 @@ private:
     ViewTransitionTypeSet(Document&, Vector<AtomString>&&);
 
     ListHashSet<AtomString> m_typeSet;
-    Document& m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 }


### PR DESCRIPTION
#### 0754ad915f661bb92eab33e58710ab7871cef4ce
<pre>
Adopt smart pointers in ViewTransitionTypeSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=279673">https://bugs.webkit.org/show_bug.cgi?id=279673</a>

Reviewed by Chris Dumez.

Use a WeakPtr for Document instead of a raw reference.
ViewTransitionTypeSet might outlive the document, so
null-guard document accesses.

* Source/WebCore/dom/ViewTransitionTypeSet.cpp:
(WebCore::ViewTransitionTypeSet::clearFromSetLike):
(WebCore::ViewTransitionTypeSet::addToSetLike):
(WebCore::ViewTransitionTypeSet::removeFromSetLike):
* Source/WebCore/dom/ViewTransitionTypeSet.h:

Canonical link: <a href="https://commits.webkit.org/283804@main">https://commits.webkit.org/283804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16a5f13463c0064351808b7e4eaa4602f7ea80c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54012 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61446 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14936 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2863 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42536 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->