### PR TITLE
Remove JSEntrypointJITCallee

### DIFF
--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1050,8 +1050,7 @@ static String tierName(SamplingProfiler::StackFrame& frame)
                 return Tiers::wasmllint;
             case Wasm::CompilationMode::IPIntMode:
                 return Tiers::ipint;
-            case Wasm::CompilationMode::JSEntrypointJITMode:
-            case Wasm::CompilationMode::JITLessJSEntrypointMode:
+            case Wasm::CompilationMode::JSToWasmEntrypointMode:
             case Wasm::CompilationMode::JSToWasmICMode:
             case Wasm::CompilationMode::WasmToJSMode:
                 // Just say "Wasm" for now.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -89,7 +89,7 @@ private:
     Vector<std::unique_ptr<InternalFunction>> m_wasmInternalFunctions;
     Vector<std::unique_ptr<LinkBuffer>> m_wasmInternalFunctionLinkBuffers;
     Vector<Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>> m_exceptionHandlerLocations;
-    HashMap<uint32_t, std::tuple<RefPtr<JSEntrypointCallee>, std::unique_ptr<LinkBuffer>, std::unique_ptr<InternalFunction>>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions;
+    HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions WTF_GUARDED_BY_LOCK(m_lock);
     Vector<CompilationContext> m_compilationContexts;
     Vector<RefPtr<BBQCallee>> m_callees;
     Vector<Vector<CodeLocationLabel<WasmEntryPtrTag>>> m_allLoopEntrypoints;

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -130,81 +130,26 @@ protected:
 };
 
 class JSEntrypointCallee : public Callee {
-    WTF_MAKE_TZONE_ALLOCATED(JSEntrypointCallee);
-protected:
-    JS_EXPORT_PRIVATE JSEntrypointCallee(Wasm::CompilationMode mode) : Callee(mode) { }
-};
-
-class JSEntrypointJITCallee final : public JSEntrypointCallee {
-    WTF_MAKE_TZONE_ALLOCATED(JSEntrypointJITCallee);
+    WTF_MAKE_TZONE_ALLOCATED(JSEntrypointCallee);public:
 public:
     friend class Callee;
+    friend class JSC::LLIntOffsetsExtractor;
 
-#if ENABLE(JIT)
-    void setEntrypoint(Wasm::Entrypoint&&);
-#endif
-
-    static inline Ref<JSEntrypointJITCallee> create()
+    static inline Ref<JSEntrypointCallee> create(unsigned frameSize, TypeIndex typeIndex, bool usesSIMD)
     {
-        return adoptRef(*new JSEntrypointJITCallee);
-    }
-
-private:
-    inline JSEntrypointJITCallee()
-        : JSEntrypointCallee(Wasm::CompilationMode::JSEntrypointJITMode)
-    {
-    }
-
-#if ENABLE(JIT)
-    std::tuple<void*, void*> rangeImpl() const
-    {
-        void* start = m_entrypoint.compilation->codeRef().executableMemory()->start().untaggedPtr();
-        void* end = m_entrypoint.compilation->codeRef().executableMemory()->end().untaggedPtr();
-        return { start, end };
-    }
-
-    CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint.compilation->code().retagged<WasmEntryPtrTag>(); }
-
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_entrypoint.calleeSaveRegisters; }
-#else
-    std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
-    CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
-#endif
-
-#if ENABLE(JIT)
-    Wasm::Entrypoint m_entrypoint;
-#endif
-};
-
-class JITLessJSEntrypointCallee final : public JSEntrypointCallee {
-    WTF_MAKE_TZONE_ALLOCATED(JITLessJSEntrypointCallee);
-public:
-    static inline Ref<JITLessJSEntrypointCallee> create(unsigned frameSize, TypeIndex typeIndex, bool usesSIMD)
-    {
-        return adoptRef(*new JITLessJSEntrypointCallee(frameSize, typeIndex, usesSIMD));
-    }
-
-    inline bool hasReplacement() const { return !!m_replacementCallee; }
-
-    inline void setReplacement(RefPtr<Wasm::Callee> callee)
-    {
-        // Note that we can compile the same function with multiple memory modes, which can cause the JS->Wasm stub generator to
-        // race. That's fine, both stubs should do the same thing.
-        if (m_replacementCallee)
-            return;
-        ASSERT(callee);
-        m_replacementCallee = WTFMove(callee);
+        return adoptRef(*new JSEntrypointCallee(frameSize, typeIndex, usesSIMD));
     }
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const;
     static JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
 
-    static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, ident); }
-    static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, wasmCallee); }
-    static constexpr ptrdiff_t offsetOfWasmFunctionPrologue() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, wasmFunctionPrologue); }
-    static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, frameSize); }
+    void setReplacementTarget(CodePtr<WasmEntryPtrTag> replacement) { wasmFunctionPrologue = replacement; }
+
+    static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JSEntrypointCallee, ident); }
+    static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JSEntrypointCallee, wasmCallee); }
+    static constexpr ptrdiff_t offsetOfWasmFunctionPrologue() { return OBJECT_OFFSETOF(JSEntrypointCallee, wasmFunctionPrologue); }
+    static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JSEntrypointCallee, frameSize); }
 
     // Space for callee-saves; Not included in frameSize
     static constexpr unsigned SpillStackSpaceAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(3 * sizeof(UCPURegister));
@@ -212,6 +157,11 @@ public:
     static constexpr unsigned RegisterStackSpaceAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(
         FPRInfo::numberOfArgumentRegisters * bytesForWidth(Width::Width64) + GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister));
 
+private:
+    JSEntrypointCallee(unsigned frameSize, TypeIndex, bool);
+
+    // FIXME: These should have accessors per WebKit style.
+public:
     const unsigned ident { 0xBF };
     const unsigned frameSize;
     // This must be initialized after the callee is created unfortunately.
@@ -220,11 +170,6 @@ public:
     // In the JIT case, we want to always call the llint prologue from a jit function.
     // In the no-jit case, we dont' care.
     CodePtr<WasmEntryPtrTag> wasmFunctionPrologue;
-
-private:
-    JITLessJSEntrypointCallee(unsigned frameSize, TypeIndex, bool);
-
-    RefPtr<Wasm::Callee> m_replacementCallee { nullptr };
 };
 
 class WasmToJSCallee final : public Callee {

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -91,7 +91,7 @@ public:
         return *callee;
     }
 
-    Callee& wasmEntrypointCalleeFromFunctionIndexSpace(const AbstractLocker&, unsigned functionIndexSpace)
+    Callee& wasmEntrypointCalleeFromFunctionIndexSpace(const AbstractLocker&, unsigned functionIndexSpace) WTF_REQUIRES_LOCK(m_lock)
     {
         ASSERT(runnable());
         RELEASE_ASSERT(functionIndexSpace >= functionImportCount());

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -36,8 +36,7 @@ enum class CompilationMode : uint8_t {
     BBQForOSREntryMode,
     OMGMode,
     OMGForOSREntryMode,
-    JSEntrypointJITMode,
-    JITLessJSEntrypointMode,
+    JSToWasmEntrypointMode,
     JSToWasmICMode,
     WasmToJSMode,
 };
@@ -49,8 +48,7 @@ constexpr inline bool isOSREntry(CompilationMode compilationMode)
     case CompilationMode::IPIntMode:
     case CompilationMode::BBQMode:
     case CompilationMode::OMGMode:
-    case CompilationMode::JSEntrypointJITMode:
-    case CompilationMode::JITLessJSEntrypointMode:
+    case CompilationMode::JSToWasmEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -71,8 +69,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
     case CompilationMode::OMGMode:
-    case CompilationMode::JSEntrypointJITMode:
-    case CompilationMode::JITLessJSEntrypointMode:
+    case CompilationMode::JSToWasmEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -90,8 +87,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::BBQForOSREntryMode:
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
-    case CompilationMode::JSEntrypointJITMode:
-    case CompilationMode::JITLessJSEntrypointMode:
+    case CompilationMode::JSToWasmEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -177,10 +177,10 @@ bool LLIntPlan::ensureEntrypoint(LLIntCallee&, unsigned functionIndex)
     RegisterAtOffsetList savedResultRegisters = wasmFrameConvention.computeResultsOffsetList();
     size_t totalFrameSize = wasmFrameConvention.headerAndArgumentStackSizeInBytes;
     totalFrameSize += savedResultRegisters.sizeOfAreaInBytes();
-    totalFrameSize += JITLessJSEntrypointCallee::RegisterStackSpaceAligned;
+    totalFrameSize += JSEntrypointCallee::RegisterStackSpaceAligned;
     totalFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(totalFrameSize);
 
-    m_entrypoints[functionIndex] = JITLessJSEntrypointCallee::create(totalFrameSize, typeIndex, m_moduleInformation->usesSIMD(functionIndex));
+    m_entrypoints[functionIndex] = JSEntrypointCallee::create(totalFrameSize, typeIndex, m_moduleInformation->usesSIMD(functionIndex));
     return true;
 }
 
@@ -209,8 +209,8 @@ void LLIntPlan::didCompleteCompilation()
             }
         }
         if (auto& callee = m_entrypoints[functionIndex]) {
-            if (callee->compilationMode() == CompilationMode::JITLessJSEntrypointMode)
-                static_cast<JITLessJSEntrypointCallee*>(callee.get())->wasmCallee = CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get());
+            if (callee->compilationMode() == CompilationMode::JSToWasmEntrypointMode)
+                static_cast<JSEntrypointCallee*>(callee.get())->wasmCallee = CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get());
             m_jsEntrypointCallees.add(functionIndex, callee);
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -200,43 +200,9 @@ void OMGPlan::work(CompilationEffort)
         }
     }
 
-    // Replace the LLInt interpreted entry callee. Note that we can do this after we publish our
-    // callee because calling into the LLInt should still work.
     auto* jsEntrypointCallee = m_calleeGroup->m_jsEntrypointCallees.get(m_functionIndex);
-    if (jsEntrypointCallee && jsEntrypointCallee->compilationMode() == CompilationMode::JITLessJSEntrypointMode && !static_cast<JITLessJSEntrypointCallee*>(jsEntrypointCallee)->hasReplacement()) {
-        ASSERT(!m_entrypoint);
-        Locker locker { m_lock };
-        TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
-        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-
-        auto callee = JSEntrypointJITCallee::create();
-        context.jsEntrypointJIT = makeUnique<CCallHelpers>();
-        Vector<UnlinkedWasmToWasmCall> newCall;
-        auto jsToWasmInternalFunction = createJSToWasmWrapper(*context.jsEntrypointJIT, callee.get(), nullptr, signature, &newCall, m_moduleInformation.get(), m_mode, m_functionIndex);
-        auto linkBuffer = makeUnique<LinkBuffer>(*context.jsEntrypointJIT, &callee.get(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);
-
-        if (linkBuffer->isValid()) {
-            jsToWasmInternalFunction->entrypoint.compilation = makeUnique<Compilation>(
-                FINALIZE_WASM_CODE(*linkBuffer, JITCompilationPtrTag, nullptr, "(ipint upgrade edition) JS->WebAssembly entrypoint[%i] %s", m_functionIndex, signature.toString().ascii().data()),
-                nullptr);
-
-            for (auto& call : newCall) {
-                CodePtr<WasmEntryPtrTag> entrypoint;
-                if (call.functionIndexSpace < m_moduleInformation->importFunctionCount())
-                    entrypoint = m_calleeGroup->m_wasmToWasmExitStubs[call.functionIndexSpace].code();
-                else
-                    entrypoint = m_calleeGroup->wasmEntrypointCalleeFromFunctionIndexSpace(locker, call.functionIndexSpace).entrypoint().retagged<WasmEntryPtrTag>();
-
-                MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
-            }
-
-            callee->setEntrypoint(WTFMove(jsToWasmInternalFunction->entrypoint));
-            // Note that we can compile the same function with multiple memory modes, which can cause this
-            // race. That's fine, both stubs should do the same thing.
-            static_cast<JITLessJSEntrypointCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
-            m_entrypoint = WTFMove(callee);
-        }
-    }
+    if (jsEntrypointCallee)
+        jsEntrypointCallee->setReplacementTarget(entrypoint);
 
     dataLogLnIf(WasmOMGPlanInternal::verbose, "Finished OMG ", m_functionIndex);
     Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.h
@@ -67,7 +67,6 @@ private:
     bool m_completed { false };
     std::optional<bool> m_hasExceptionHandlers;
     uint32_t m_functionIndex;
-    RefPtr<JSEntrypointCallee> m_entrypoint;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -102,12 +102,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, void,
     ASSERT(function);
     ASSERT(function->m_jsToWasmCallee->ident == 0xBF);
     ASSERT(function->m_jsToWasmCallee->typeIndex == function->typeIndex());
-    ASSERT(function->m_jsToWasmCallee->frameSize + JITLessJSEntrypointCallee::SpillStackSpaceAligned == (reinterpret_cast<uintptr_t>(cfr) - reinterpret_cast<uintptr_t>(sp)));
-    dataLogLnIf(WasmOperationsInternal::verbose, "operationJSToWasmEntryWrapperBuildFrame setting callee: ", RawHex(CalleeBits::encodeNativeCallee(function->m_jsToWasmCallee.get())));
+    ASSERT(function->m_jsToWasmCallee->frameSize + JSEntrypointCallee::SpillStackSpaceAligned == (reinterpret_cast<uintptr_t>(cfr) - reinterpret_cast<uintptr_t>(sp)));
+    dataLogLnIf(WasmOperationsInternal::verbose, "operationJSToWasmEntryWrapperBuildFrame setting callee: ", RawHex(CalleeBits::encodeNativeCallee(function->m_jsToWasmCallee.ptr())));
     dataLogLnIf(WasmOperationsInternal::verbose, "operationJSToWasmEntryWrapperBuildFrame wasm callee: ", RawHex(function->m_jsToWasmCallee->wasmCallee));
-    cfr->setCallee(function->m_jsToWasmCallee.get());
+    cfr->setCallee(function->m_jsToWasmCallee.ptr());
 
-    auto calleeSPOffsetFromFP = -(static_cast<intptr_t>(function->m_jsToWasmCallee->frameSize) + JITLessJSEntrypointCallee::SpillStackSpaceAligned - JITLessJSEntrypointCallee::RegisterStackSpaceAligned);
+    auto calleeSPOffsetFromFP = -(static_cast<intptr_t>(function->m_jsToWasmCallee->frameSize) + JSEntrypointCallee::SpillStackSpaceAligned - JSEntrypointCallee::RegisterStackSpaceAligned);
 
     const TypeDefinition& signature = TypeInformation::get(function->typeIndex()).expand();
     const FunctionSignature& functionSignature = *signature.as<FunctionSignature>();
@@ -162,7 +162,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
 
     uint64_t* registerSpace = reinterpret_cast<uint64_t*>(sp);
 
-    auto* callee = static_cast<JITLessJSEntrypointCallee*>(cfr->callee().asNativeCallee());
+    auto* callee = static_cast<JSEntrypointCallee*>(cfr->callee().asNativeCallee());
     ASSERT(callee->ident == 0xBF);
     auto* instance = cfr->wasmInstance();
     ASSERT(instance);
@@ -228,7 +228,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
         JSArray* resultArray = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, instance->globalObject()->arrayStructureForIndexingTypeDuringAllocation(indexingType), functionSignature.returnCount());
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-        auto calleeSPOffsetFromFP = -(static_cast<intptr_t>(callee->frameSize) + JITLessJSEntrypointCallee::SpillStackSpaceAligned - JITLessJSEntrypointCallee::RegisterStackSpaceAligned);
+        auto calleeSPOffsetFromFP = -(static_cast<intptr_t>(callee->frameSize) + JSEntrypointCallee::SpillStackSpaceAligned - JSEntrypointCallee::RegisterStackSpaceAligned);
 
         for (unsigned i = 0; i < functionSignature.returnCount(); ++i) {
             ValueLocation loc = wasmFrameConvention.results[i].location;

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -405,7 +405,6 @@ private:
     FunctionArgCount m_argCount;
     FunctionArgCount m_retCount;
 #if ENABLE(JIT)
-    // FIXME: We shouldn't need this instead WebAssemblyFunction should know, which registers it saved from the PC.
     mutable RefPtr<JSToWasmICCallee> m_jsToWasmICCallee;
     // FIXME: We should have a WTF::Once that uses ParkingLot and the low bits of a pointer as a lock and use that here.
     mutable Lock m_jitCodeLock;

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.h
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.h
@@ -47,7 +47,6 @@ class JSEntrypointCallee;
 void marshallJSResult(CCallHelpers& jit, const FunctionSignature&, const CallInformation& wasmFrameConvention, const RegisterAtOffsetList& savedResultRegisters, CCallHelpers::JumpList& exceptionChecks);
 std::shared_ptr<InternalFunction> createJSToWasmJITSharedCrashForSIMDParameters();
 std::shared_ptr<InternalFunction> createJSToWasmJITShared();
-std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers&, JSEntrypointCallee&, Callee*, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>*, const ModuleInformation&, MemoryMode, uint32_t functionIndex);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -146,8 +146,7 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
 WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
     : Base { vm, executable, globalObject, structure, instance, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation, &m_boxedWasmCallee, rtt.get() } }
     , m_boxedWasmCallee(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCalleeIfExists(wasmCallee)))
-    , m_jsEntrypoint { jsEntrypoint }
-    , m_jsToWasmCallee(jsEntrypoint.compilationMode() == Wasm::CompilationMode::JITLessJSEntrypointMode ? static_cast<Wasm::JITLessJSEntrypointCallee*>(&jsEntrypoint) : nullptr)
+    , m_jsToWasmCallee { jsEntrypoint }
 { }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -62,7 +62,7 @@ public:
     CodePtr<WasmEntryPtrTag> jsEntrypoint(ArityCheckMode arity)
     {
         ASSERT_UNUSED(arity, arity == ArityCheckNotRequired || arity == MustCheckArity);
-        return m_jsEntrypoint.entrypoint();
+        return m_jsToWasmCallee->entrypoint();
     }
 
     CodePtr<JSEntryPtrTag> jsCallICEntrypoint()
@@ -70,9 +70,9 @@ public:
 #if ENABLE(JIT)
         // Prep the entrypoint for the slow path.
         executable()->entrypointFor(CodeForCall, MustCheckArity);
-        if (!m_jsToWasmICCode)
-            m_jsToWasmICCode = signature().jsToWasmICEntrypoint();
-        return m_jsToWasmICCode;
+        if (!m_jsToWasmICJITCode)
+            m_jsToWasmICJITCode = signature().jsToWasmICEntrypoint();
+        return m_jsToWasmICJITCode;
 #else
         return nullptr;
 #endif
@@ -89,14 +89,10 @@ private:
 
     // This is the callee needed by LLInt/IPInt
     uintptr_t m_boxedWasmCallee;
-    // It's safe to just hold the raw callee because we have a reference
-    // to our Instance, which points to the Module that exported us, which
-    // ensures that the actual Signature/code doesn't get deallocated.
-    Wasm::JSEntrypointCallee& m_jsEntrypoint;
     // This let's the JS->Wasm interpreter find its metadata
-    RefPtr<Wasm::JITLessJSEntrypointCallee> m_jsToWasmCallee;
+    Ref<Wasm::JSEntrypointCallee> m_jsToWasmCallee;
 #if ENABLE(JIT)
-    CodePtr<JSEntryPtrTag> m_jsToWasmICCode;
+    CodePtr<JSEntryPtrTag> m_jsToWasmICJITCode;
 #endif
 };
 


### PR DESCRIPTION
#### ebb3d2de4c4bc1b2dd2158d0f96c7c45ba0c1d75
<pre>
Remove JSEntrypointJITCallee
<a href="https://bugs.webkit.org/show_bug.cgi?id=279674">https://bugs.webkit.org/show_bug.cgi?id=279674</a>
<a href="https://rdar.apple.com/135952475">rdar://135952475</a>

Reviewed by Yusuke Suzuki.

Now that we have the interpreted entrypoints and JIT IC handlers we no longer need
the legacy wasm entrypoints. This patch removes the old entrypoint and merges
JITLessJSEntrypointCallee into JSEntrypointCallee.

To make this work the higher tiers also now replace the previous call target with
the one they just compiled.

* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::tierName):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
(JSC::Wasm::BBQPlan::didCompleteCompilation):
(JSC::Wasm::BBQPlan::initializeCallees):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
(JSC::Wasm::JSEntrypointCallee::JSEntrypointCallee):
(JSC::Wasm::JSEntrypointJITCallee::setEntrypoint): Deleted.
(JSC::Wasm::JITLessJSEntrypointCallee::JITLessJSEntrypointCallee): Deleted.
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::JSEntrypointCallee::create):
(JSC::Wasm::JSEntrypointCallee::setReplacementTarget):
(JSC::Wasm::JSEntrypointCallee::offsetOfIdent):
(JSC::Wasm::JSEntrypointCallee::offsetOfWasmCallee):
(JSC::Wasm::JSEntrypointCallee::offsetOfWasmFunctionPrologue):
(JSC::Wasm::JSEntrypointCallee::offsetOfFrameSize):
(JSC::Wasm::JSEntrypointCallee::JSEntrypointCallee): Deleted.
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isOSREntry):
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::ensureEntrypoint):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::ensureEntrypoint):
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOMGPlan.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmJITShared):
(JSC::Wasm::createJSToWasmWrapper): Deleted.
* Source/JavaScriptCore/wasm/js/JSToWasm.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::m_jsToWasmCallee): Deleted.
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:

Canonical link: <a href="https://commits.webkit.org/283638@main">https://commits.webkit.org/283638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd5bdab8a2681b5a8a84618accf4411d3eae7d80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19520 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17811 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/70933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/12136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57883 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/70933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15275 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/60012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72634 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66143 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10855 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61222 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8915 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87911 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10148 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->