### PR TITLE
Stop using namespace std

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/tls.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/tls.cpp
@@ -20,7 +20,6 @@
 #    include <wrl/async.h>
 #    include <wrl/client.h>
 
-using namespace std;
 using namespace Windows::Foundation;
 using namespace ABI::Windows::System::Threading;
 

--- a/Source/WTF/icu/unicode/numfmt.h
+++ b/Source/WTF/icu/unicode/numfmt.h
@@ -78,7 +78,6 @@ class StringEnumeration;
  *    #include "unicode/numfmt.h"
  *    #include "unicode/unistr.h"
  *    #include "unicode/ustream.h"
- *    using namespace std;
  *    
  *    int main() {
  *        double myNumber = 7.0;
@@ -86,7 +85,7 @@ class StringEnumeration;
  *        UErrorCode success = U_ZERO_ERROR;
  *        NumberFormat* nf = NumberFormat::createInstance(success);
  *        nf->format(myNumber, myString);
- *        cout << " Example 1: " << myString << endl;
+ *        std::cout << " Example 1: " << myString << std::endl;
  *    }
  * \endcode
  * Note that there are additional factory methods within subclasses of

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
@@ -37,7 +37,6 @@
 #include "SharedBuffer.h"
 
 namespace WebCore {
-using namespace std;
 
 #if ENABLE(OPENTYPE_MATH)
 namespace OpenType {

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm
@@ -47,7 +47,6 @@
 #import <algorithm>
 
 using namespace WebCore;
-using namespace std;
 
 static Lock webFixedPositionContentDataLock;
 

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm
@@ -53,7 +53,6 @@
 #import <wtf/StdLibExtras.h>
 
 using namespace WebCore;
-using namespace std;
 
 static int comparePageRects(const void *key, const void *array);
 
@@ -273,7 +272,7 @@ static RetainPtr<CGColorRef> createCGColorWithDeviceWhite(CGFloat white, CGFloat
         _pageRects[i-1].origin.y = size.height;
 
         size.height += boxRect.size.height + PAGE_HEIGHT_INSET;
-        size.width = max(size.width, boxRect.size.width);
+        size.width = std::max(size.width, boxRect.size.width);
     }
     
     size.width += PAGE_WIDTH_INSET * 2.0;

--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
@@ -52,7 +52,6 @@
 #include <CommonCrypto/CommonDigest.h>
 #endif
 
-using namespace std;
 
 static void printPNG(CGImageRef image, const char* checksum, double scaleFactor)
 {

--- a/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
@@ -38,8 +38,6 @@
 #import <WebKit/WebNSURLExtras.h>
 #import <wtf/Assertions.h>
 
-using namespace std;
-
 @interface NSURL (DRTExtras)
 - (NSString *)_drt_descriptionSuitableForTestResult;
 @end
@@ -195,9 +193,9 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
         return nil;
 
     auto newRequest = adoptNS([request mutableCopy]);
-    const set<string>& clearHeaders = gTestRunner->willSendRequestClearHeaders();
-    for (set<string>::const_iterator header = clearHeaders.begin(); header != clearHeaders.end(); ++header) {
-        auto nsHeader = adoptNS([[NSString alloc] initWithUTF8String:header->c_str()]);
+    const auto& clearHeaders = gTestRunner->willSendRequestClearHeaders();
+    for (auto& header : clearHeaders) {
+        auto nsHeader = adoptNS([[NSString alloc] initWithUTF8String:header.c_str()]);
         [newRequest setValue:nil forHTTPHeaderField:nsHeader.get()];
     }
     if (auto* destination = gTestRunner->redirectionDestinationForURL([[url absoluteString] UTF8String]))

--- a/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
@@ -33,8 +33,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/MediaTime.h>
 
-using namespace std;
-
 namespace WTF {
 
 std::ostream& operator<<(std::ostream& out, const MediaTime& val)
@@ -165,10 +163,10 @@ TEST(WTF, MediaTime)
     EXPECT_EQ(MediaTime(6, 1), MediaTime(3, 1) * 2);
     EXPECT_EQ(MediaTime(0, 1), MediaTime(0, 1) * 2);
     EXPECT_EQ(MediaTime(int64_t(1) << 60, 1), MediaTime(int64_t(1) << 60, 2) * 2);
-    EXPECT_EQ(MediaTime::positiveInfiniteTime(), MediaTime(numeric_limits<int64_t>::max(), 1) * 2);
-    EXPECT_EQ(MediaTime::positiveInfiniteTime(), MediaTime(numeric_limits<int64_t>::min(), 1) * -2);
-    EXPECT_EQ(MediaTime::negativeInfiniteTime(), MediaTime(numeric_limits<int64_t>::max(), 1) * -2);
-    EXPECT_EQ(MediaTime::negativeInfiniteTime(), MediaTime(numeric_limits<int64_t>::min(), 1) * 2);
+    EXPECT_EQ(MediaTime::positiveInfiniteTime(), MediaTime(std::numeric_limits<int64_t>::max(), 1) * 2);
+    EXPECT_EQ(MediaTime::positiveInfiniteTime(), MediaTime(std::numeric_limits<int64_t>::min(), 1) * -2);
+    EXPECT_EQ(MediaTime::negativeInfiniteTime(), MediaTime(std::numeric_limits<int64_t>::max(), 1) * -2);
+    EXPECT_EQ(MediaTime::negativeInfiniteTime(), MediaTime(std::numeric_limits<int64_t>::min(), 1) * 2);
 
     // Constants
     EXPECT_EQ(MediaTime::zeroTime(), MediaTime(0, 1));
@@ -238,18 +236,18 @@ TEST(WTF, MediaTime)
     EXPECT_EQ(MediaTime::createWithDouble(-pow(2.0f, 64.0f)).toDouble(), -pow(2.0f, 64.0f));
     EXPECT_EQ(MediaTime::createWithDouble(pow(2.0, 63.0), 2).timeScale(), 1U);
     EXPECT_EQ(MediaTime::createWithDouble(pow(2.0, 63.0), 3).timeScale(), 1U);
-    EXPECT_EQ((MediaTime(numeric_limits<int64_t>::max(), 2) + MediaTime(numeric_limits<int64_t>::max(), 2)).timeScale(), 1U);
-    EXPECT_EQ((MediaTime(numeric_limits<int64_t>::min(), 2) - MediaTime(numeric_limits<int64_t>::max(), 2)).timeScale(), 1U);
-    EXPECT_EQ(MediaTime(numeric_limits<int64_t>::max(), 1) + MediaTime(numeric_limits<int64_t>::max(), 1), MediaTime::positiveInfiniteTime());
-    EXPECT_EQ(MediaTime(numeric_limits<int64_t>::min(), 1) + MediaTime(numeric_limits<int64_t>::min(), 1), MediaTime::negativeInfiniteTime());
-    EXPECT_EQ(MediaTime(numeric_limits<int64_t>::min(), 1) - MediaTime(numeric_limits<int64_t>::max(), 1), MediaTime::negativeInfiniteTime());
-    EXPECT_EQ(MediaTime(numeric_limits<int64_t>::max(), 1) - MediaTime(numeric_limits<int64_t>::min(), 1), MediaTime::positiveInfiniteTime());
-    EXPECT_EQ(MediaTime::createWithDouble(numeric_limits<double>::max()) + MediaTime::createWithDouble(numeric_limits<double>::max()), MediaTime::positiveInfiniteTime());
-    EXPECT_EQ(MediaTime::createWithDouble(numeric_limits<double>::lowest()) + MediaTime::createWithDouble(numeric_limits<double>::lowest()), MediaTime::negativeInfiniteTime());
-    EXPECT_EQ(MediaTime::createWithDouble(numeric_limits<double>::lowest()) - MediaTime::createWithDouble(numeric_limits<double>::max()), MediaTime::negativeInfiniteTime());
-    EXPECT_EQ(MediaTime::createWithDouble(numeric_limits<double>::max()) - MediaTime::createWithDouble(numeric_limits<double>::lowest()), MediaTime::positiveInfiniteTime());
-    EXPECT_NE(MediaTime::createWithDouble(numeric_limits<double>::max()), MediaTime::positiveInfiniteTime());
-    EXPECT_EQ(MediaTime::createWithDouble(numeric_limits<double>::max()) * 2, MediaTime::positiveInfiniteTime());
+    EXPECT_EQ((MediaTime(std::numeric_limits<int64_t>::max(), 2) + MediaTime(std::numeric_limits<int64_t>::max(), 2)).timeScale(), 1U);
+    EXPECT_EQ((MediaTime(std::numeric_limits<int64_t>::min(), 2) - MediaTime(std::numeric_limits<int64_t>::max(), 2)).timeScale(), 1U);
+    EXPECT_EQ(MediaTime(std::numeric_limits<int64_t>::max(), 1) + MediaTime(std::numeric_limits<int64_t>::max(), 1), MediaTime::positiveInfiniteTime());
+    EXPECT_EQ(MediaTime(std::numeric_limits<int64_t>::min(), 1) + MediaTime(std::numeric_limits<int64_t>::min(), 1), MediaTime::negativeInfiniteTime());
+    EXPECT_EQ(MediaTime(std::numeric_limits<int64_t>::min(), 1) - MediaTime(std::numeric_limits<int64_t>::max(), 1), MediaTime::negativeInfiniteTime());
+    EXPECT_EQ(MediaTime(std::numeric_limits<int64_t>::max(), 1) - MediaTime(std::numeric_limits<int64_t>::min(), 1), MediaTime::positiveInfiniteTime());
+    EXPECT_EQ(MediaTime::createWithDouble(std::numeric_limits<double>::max()) + MediaTime::createWithDouble(std::numeric_limits<double>::max()), MediaTime::positiveInfiniteTime());
+    EXPECT_EQ(MediaTime::createWithDouble(std::numeric_limits<double>::lowest()) + MediaTime::createWithDouble(std::numeric_limits<double>::lowest()), MediaTime::negativeInfiniteTime());
+    EXPECT_EQ(MediaTime::createWithDouble(std::numeric_limits<double>::lowest()) - MediaTime::createWithDouble(std::numeric_limits<double>::max()), MediaTime::negativeInfiniteTime());
+    EXPECT_EQ(MediaTime::createWithDouble(std::numeric_limits<double>::max()) - MediaTime::createWithDouble(std::numeric_limits<double>::lowest()), MediaTime::positiveInfiniteTime());
+    EXPECT_NE(MediaTime::createWithDouble(std::numeric_limits<double>::max()), MediaTime::positiveInfiniteTime());
+    EXPECT_EQ(MediaTime::createWithDouble(std::numeric_limits<double>::max()) * 2, MediaTime::positiveInfiniteTime());
 
     // Rounding
     EXPECT_EQ(MediaTime(1, 1).toTimeScale(2).timeValue(), 2);
@@ -313,9 +311,9 @@ TEST(WTF, MediaTime)
     EXPECT_EQ(MediaTime(-3, 2).toTimeScale(1, MediaTime::RoundingFlags::TowardNegativeInfinity).timeValue(), -2);
     EXPECT_EQ(MediaTime(-151, 100).toTimeScale(1, MediaTime::RoundingFlags::TowardNegativeInfinity).timeValue(), -2);
     EXPECT_EQ(MediaTime(-149, 100).toTimeScale(1, MediaTime::RoundingFlags::TowardNegativeInfinity).timeValue(), -2);
-    EXPECT_EQ(MediaTime(numeric_limits<int64_t>::max(), 1).toTimeScale(2), MediaTime::positiveInfiniteTime());
-    EXPECT_EQ(MediaTime(numeric_limits<int64_t>::min(), 1).toTimeScale(2), MediaTime::negativeInfiniteTime());
-    int64_t maxInt32 = numeric_limits<int32_t>::max();
+    EXPECT_EQ(MediaTime(std::numeric_limits<int64_t>::max(), 1).toTimeScale(2), MediaTime::positiveInfiniteTime());
+    EXPECT_EQ(MediaTime(std::numeric_limits<int64_t>::min(), 1).toTimeScale(2), MediaTime::negativeInfiniteTime());
+    int64_t maxInt32 = std::numeric_limits<int32_t>::max();
     EXPECT_EQ(MediaTime(maxInt32 * 2, 1).toTimeScale(2).timeValue(), maxInt32 * 4);
     int64_t bigInt = 1LL << 62;
     EXPECT_EQ(MediaTime(bigInt, 1U << 31).toTimeScale(1U << 29).timeValue(), bigInt / 4);

--- a/Tools/TestWebKitAPI/Tests/WebKit/Geolocation.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/Geolocation.cpp
@@ -35,8 +35,6 @@
 #include <string.h>
 #include <vector>
 
-using namespace std;
-
 namespace TestWebKitAPI {
 
 enum class GeolocationEvent {
@@ -46,7 +44,7 @@ enum class GeolocationEvent {
     DisableHighAccuracy
 };
 
-ostream& operator<<(ostream& outputStream, const GeolocationEvent& geolocationEvent)
+std::ostream& operator<<(std::ostream& outputStream, const GeolocationEvent& geolocationEvent)
 {
     switch (geolocationEvent) {
     case GeolocationEvent::StartUpdating:
@@ -66,7 +64,7 @@ ostream& operator<<(ostream& outputStream, const GeolocationEvent& geolocationEv
 }
 
 struct GeolocationStateTracker {
-    vector<GeolocationEvent> events;
+    std::vector<GeolocationEvent> events;
 
     virtual ~GeolocationStateTracker() { }
     virtual void eventsChanged() { }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -60,8 +60,6 @@
 #include <wtf/text/cf/StringConcatenateCF.h>
 #endif
 
-using namespace std;
-
 namespace WTF {
 
 template<> class StringTypeAdapter<WKStringRef> {

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -62,11 +62,9 @@
 #include <unistd.h>
 #endif
 
+namespace WTR {
 using namespace JSC;
 using namespace WebKit;
-using namespace std;
-
-namespace WTR {
 
 static void postPageMessage(const char* name, const WKRetainPtr<WKTypeRef>& body)
 {


### PR DESCRIPTION
#### 8d63cb9b8808f4617a9d0812704c59bb268a2f03
<pre>
Stop using namespace std
<a href="https://bugs.webkit.org/show_bug.cgi?id=279685">https://bugs.webkit.org/show_bug.cgi?id=279685</a>
<a href="https://rdar.apple.com/135967673">rdar://135967673</a>

Reviewed by Matthew Finkel.

It causes compile issues with things in other namespaces that have the same names
as things in namespace std, such as our span functions.

* Source/ThirdParty/ANGLE/src/common/tls.cpp:
* Source/WTF/icu/unicode/numfmt.h:
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
* Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm:
* Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm:
(-[WebPDFView _computePageRects]):
* Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp:
* Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm:
(-[ResourceLoadDelegate webView:resource:willSendRequest:redirectResponse:fromDataSource:]):
* Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp:
(TestWebKitAPI::TEST(WTF, MediaTime)):
* Tools/TestWebKitAPI/Tests/WebKit/Geolocation.cpp:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
* Tools/WebKitTestRunner/TestInvocation.cpp:

Canonical link: <a href="https://commits.webkit.org/283659@main">https://commits.webkit.org/283659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15525a4ef345a93c77d8824a4e204b36573873f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57898 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16402 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60029 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72651 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66160 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14980 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61235 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2549 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87928 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10160 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15476 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->