### PR TITLE
Improve HashTable::checkKey()

### DIFF
--- a/Source/JavaScriptCore/runtime/ImportMap.cpp
+++ b/Source/JavaScriptCore/runtime/ImportMap.cpp
@@ -265,7 +265,7 @@ Expected<void, String> ImportMap::registerImportMap(const SourceCode& sourceCode
 
 String ImportMap::integrityForURL(const URL& url) const
 {
-    return m_integrity.get(url);
+    return url.isNull() ? String() : m_integrity.get(url);
 }
 
 } // namespace JSC

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -408,7 +408,8 @@ Length AnchorPositionEvaluator::resolveAnchorValue(const BuilderState& builderSt
     String anchorString = anchorValue.anchorElementString();
     if (anchorString.isNull())
         anchorString = builderState.style().positionAnchor();
-    RefPtr anchorElement = anchorPositionedState.anchorElements.get(anchorString);
+
+    RefPtr anchorElement = anchorString.isNull() ? nullptr : anchorPositionedState.anchorElements.get(anchorString);
     if (!anchorElement) {
         // FIXME: Should rely on fallback, and also should behave as unset if fallback doesn't exist.
         // See: https://drafts.csswg.org/css-anchor-position-1/#valid-anchor-function


### PR DESCRIPTION
#### ed96717ba87eb2682e3ac06e5883417c1db58efc
<pre>
Improve HashTable::checkKey()
<a href="https://bugs.webkit.org/show_bug.cgi?id=279686">https://bugs.webkit.org/show_bug.cgi?id=279686</a>

Reviewed by Darin Adler.

update HashTable::checkKey() to rely on KeyTraits::isEmptyValue() &amp; KeyTraits::isDeletedValue()
whenever possible. This is better for performance as it avoids constructing those values to do
an `==` comparison. This also enables us to validate the key in more cases. We would previously
not do ANY validation of the key if `HashFunctions::safeToCompareToEmptyOrDeleted` was false.

* Source/WTF/wtf/HashTable.h:
(WTF::KeyTraits&gt;::checkKey):

Canonical link: <a href="https://commits.webkit.org/283670@main">https://commits.webkit.org/283670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda9a76bbecf048f02cdf77965ba7117dce45037

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19607 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71020 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53725 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70052 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57954 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15348 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16472 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60099 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72721 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66230 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15037 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61271 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8983 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2592 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/87998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10167 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42167 "Build is in progress. Recent messages:") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15488 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->