### PR TITLE
Address additional Web Extension API feedback for Swift.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
@@ -90,7 +90,7 @@ typedef NS_ENUM(NSInteger, WKWebExtensionContextPermissionStatus) {
     WKWebExtensionContextPermissionStatusRequestedExplicitly =  1,
     WKWebExtensionContextPermissionStatusGrantedImplicitly   =  2,
     WKWebExtensionContextPermissionStatusGrantedExplicitly   =  3,
-} NS_SWIFT_NAME(WKWebExtensionContext.PermissionState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} NS_SWIFT_NAME(WKWebExtensionContext.PermissionStatus) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -330,7 +330,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso permissionStatusForPermission:
  @seealso permissionStatusForPermission:inTab:
 */
-- (BOOL)hasPermission:(WKWebExtensionPermission)permission NS_SWIFT_UNAVAILABLE("Use tab version with nil");
+- (BOOL)hasPermission:(WKWebExtensionPermission)permission NS_SWIFT_NAME(hasPermission(_:));
 
 /*!
  @abstract Checks the specified permission against the currently granted permissions in a specific tab.
@@ -354,7 +354,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso permissionStatusForMatchPattern:
  @seealso permissionStatusForMatchPattern:inTab:
  */
-- (BOOL)hasAccessToURL:(NSURL *)url NS_SWIFT_UNAVAILABLE("Use tab version with nil");
+- (BOOL)hasAccessToURL:(NSURL *)url NS_SWIFT_NAME(hasAccess(to:));
 
 /*!
  @abstract Checks the specified URL against the currently granted permission match patterns in a specific tab.
@@ -413,7 +413,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso permissionStatusForPermission:inTab:
  @seealso hasPermission:
 */
-- (WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(WKWebExtensionPermission)permission NS_SWIFT_UNAVAILABLE("Use tab version with nil");
+- (WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(WKWebExtensionPermission)permission NS_SWIFT_NAME(permissionStatus(for:));
 
 /*!
  @abstract Checks the specified permission against the currently denied, granted, and requested permissions.
@@ -435,7 +435,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso setPermissionStatus:forPermission:expirationDate:
  @seealso setPermissionStatus:forPermission:inTab:
 */
-- (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forPermission:(WKWebExtensionPermission)permission NS_SWIFT_UNAVAILABLE("Use expirationDate version with nil");
+- (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forPermission:(WKWebExtensionPermission)permission NS_SWIFT_NAME(setPermissionStatus(_:for:));
 
 /*!
  @abstract Sets the status of a permission with a specific expiration date.
@@ -457,7 +457,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso permissionStatusForURL:inTab:
  @seealso hasAccessToURL:
 */
-- (WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url NS_SWIFT_UNAVAILABLE("Use tab version with nil");
+- (WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url NS_SWIFT_NAME(permissionStatus(for:));
 
 /*!
  @abstract Checks the specified URL against the currently denied, granted, and requested permission match patterns.
@@ -479,7 +479,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso setPermissionStatus:forURL:expirationDate:
  @seealso setPermissionStatus:forURL:inTab:
 */
-- (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url NS_SWIFT_UNAVAILABLE("Use expirationDate version with nil");
+- (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url NS_SWIFT_NAME(setPermissionStatus(_:for:));
 
 /*!
  @abstract Sets the permission status of a URL with a distant future expiration date.
@@ -501,7 +501,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso permissionStatusForMatchPattern:inTab:
  @seealso hasAccessToURL:inTab:
 */
-- (WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(WKWebExtensionMatchPattern *)pattern NS_SWIFT_UNAVAILABLE("Use tab version with nil");
+- (WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(WKWebExtensionMatchPattern *)pattern NS_SWIFT_NAME(permissionStatus(for:));
 
 /*!
  @abstract Checks the specified match pattern against the currently denied, granted, and requested permission match patterns.
@@ -523,7 +523,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso setPermissionStatus:forMatchPattern:expirationDate:
  @seealso setPermissionStatus:forMatchPattern:inTab:
 */
-- (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forMatchPattern:(WKWebExtensionMatchPattern *)pattern NS_SWIFT_UNAVAILABLE("Use expirationDate version with nil");
+- (void)setPermissionStatus:(WKWebExtensionContextPermissionStatus)status forMatchPattern:(WKWebExtensionMatchPattern *)pattern NS_SWIFT_NAME(setPermissionStatus(_:for:));
 
 /*!
  @abstract Sets the status of a match pattern with a specific expiration date.
@@ -729,7 +729,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @seealso didOpenTab:
  @seealso openTabs
  */
-- (void)didCloseTab:(id <WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing NS_SWIFT_NAME(didCloseTab(_:windowIsClosing:));
+- (void)didCloseTab:(id <WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Should be called by the app when a tab is activated to notify only this specific extension.
@@ -738,7 +738,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion This method informs only the specific extension of the tab activation. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
-- (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<WKWebExtensionTab>)previousTab NS_SWIFT_NAME(didActivateTab(_:previousActiveTab:));
+- (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<WKWebExtensionTab>)previousTab NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Should be called by the app when tabs are selected to fire appropriate events with only this extension.
@@ -746,7 +746,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion This method informs only the specific extension that tabs have been selected. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
-- (void)didSelectTabs:(NSSet<id <WKWebExtensionTab>> *)selectedTabs NS_SWIFT_NAME(didSelectTabs(_:));
+- (void)didSelectTabs:(NSArray<id <WKWebExtensionTab>> *)selectedTabs NS_SWIFT_NAME(didSelectTabs(_:));
 
 /*!
  @abstract Should be called by the app when tabs are deselected to fire appropriate events with only this extension.
@@ -754,7 +754,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion This method informs only the specific extension that tabs have been deselected. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
-- (void)didDeselectTabs:(NSSet<id <WKWebExtensionTab>> *)deselectedTabs NS_SWIFT_NAME(didDeselectTabs(_:));
+- (void)didDeselectTabs:(NSArray<id <WKWebExtensionTab>> *)deselectedTabs NS_SWIFT_NAME(didDeselectTabs(_:));
 
 /*!
  @abstract Should be called by the app when a tab is moved to fire appropriate events with only this extension.
@@ -765,7 +765,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  that a tab has been moved. If the intention is to inform all loaded extensions consistently, you should use the respective method on
  the extension controller instead.
  */
-- (void)didMoveTab:(id <WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
+- (void)didMoveTab:(id <WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <WKWebExtensionWindow>)oldWindow NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Should be called by the app when a tab is replaced by another tab to fire appropriate events with only this extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -356,8 +356,6 @@ static inline NSSet<WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtens
 - (BOOL)hasPermission:(WKWebExtensionPermission)permission inTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert([permission isKindOfClass:NSString.class]);
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
 
     return _webExtensionContext->hasPermission(permission, toImplNullable(tab, *_webExtensionContext).get());
 }
@@ -372,8 +370,6 @@ static inline NSSet<WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtens
 - (BOOL)hasAccessToURL:(NSURL *)url inTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
 
     return _webExtensionContext->hasPermission(url, toImplNullable(tab, *_webExtensionContext).get());
 }
@@ -431,8 +427,6 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 - (WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(WKWebExtensionPermission)permission inTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert([permission isKindOfClass:NSString.class]);
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
 
     return toAPI(_webExtensionContext->permissionState(permission, toImplNullable(tab, *_webExtensionContext).get()));
 }
@@ -463,8 +457,6 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 - (WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url inTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
 
     return toAPI(_webExtensionContext->permissionState(url, toImplNullable(tab, *_webExtensionContext).get()));
 }
@@ -495,8 +487,6 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 - (WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(WKWebExtensionMatchPattern *)pattern inTab:(id<WKWebExtensionTab>)tab
 {
     NSParameterAssert([pattern isKindOfClass:WKWebExtensionMatchPattern.class]);
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
 
     return toAPI(_webExtensionContext->permissionState(pattern._protectedWebExtensionMatchPattern, toImplNullable(tab, *_webExtensionContext).get()));
 }
@@ -551,17 +541,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 
 - (WKWebExtensionAction *)actionForTab:(id<WKWebExtensionTab>)tab
 {
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-
     return _webExtensionContext->getOrCreateAction(toImplNullable(tab, *_webExtensionContext).get())->wrapper();
 }
 
 - (void)performActionForTab:(id<WKWebExtensionTab>)tab
 {
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-
     _webExtensionContext->performAction(toImplNullable(tab, *_webExtensionContext).get(), WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
@@ -608,28 +592,28 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 
 - (NSArray<CocoaMenuItem *> *)menuItemsForTab:(id<WKWebExtensionTab>)tab
 {
-    NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(tab != nil);
 
     return _webExtensionContext->platformMenuItems(toImpl(tab, *_webExtensionContext));
 }
 
 - (void)userGesturePerformedInTab:(id<WKWebExtensionTab>)tab
 {
-    NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(tab != nil);
 
     _webExtensionContext->userGesturePerformed(toImpl(tab, *_webExtensionContext));
 }
 
 - (BOOL)hasActiveUserGestureInTab:(id<WKWebExtensionTab>)tab
 {
-    NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(tab != nil);
 
     return _webExtensionContext->hasActiveUserGesture(toImpl(tab, *_webExtensionContext));
 }
 
 - (void)clearUserGestureInTab:(id<WKWebExtensionTab>)tab
 {
-    NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(tab != nil);
 
     _webExtensionContext->clearUserGesture(toImpl(tab, *_webExtensionContext));
 }
@@ -691,23 +675,20 @@ static inline Ref<WebKit::WebExtensionWindow> toImpl(id<WKWebExtensionWindow> wi
 
 - (void)didOpenWindow:(id<WKWebExtensionWindow>)newWindow
 {
-    NSParameterAssert([newWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
+    NSParameterAssert(newWindow != nil);
 
     _webExtensionContext->didOpenWindow(toImpl(newWindow, *_webExtensionContext));
 }
 
 - (void)didCloseWindow:(id<WKWebExtensionWindow>)closedWindow
 {
-    NSParameterAssert([closedWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
+    NSParameterAssert(closedWindow != nil);
 
     _webExtensionContext->didCloseWindow(toImpl(closedWindow, *_webExtensionContext));
 }
 
 - (void)didFocusWindow:(id<WKWebExtensionWindow>)focusedWindow
 {
-    if (focusedWindow)
-        NSParameterAssert([focusedWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
-
     _webExtensionContext->didFocusWindow(focusedWindow ? toImpl(focusedWindow, *_webExtensionContext).ptr() : nullptr);
 }
 
@@ -721,69 +702,63 @@ static inline RefPtr<WebKit::WebExtensionTab> toImplNullable(id<WKWebExtensionTa
     return tab ? toImpl(tab, context).ptr() : nullptr;
 }
 
-static inline WebKit::WebExtensionContext::TabSet toImpl(NSSet<id<WKWebExtensionTab>> *tabs, WebKit::WebExtensionContext& context)
+static inline WebKit::WebExtensionContext::TabSet toImpl(NSArray<id<WKWebExtensionTab>> *tabs, WebKit::WebExtensionContext& context)
 {
     WebKit::WebExtensionContext::TabSet result;
     result.reserveInitialCapacity(tabs.count);
 
-    for (id tab in tabs) {
-        NSCParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    for (id tab in tabs)
         result.addVoid(context.getOrCreateTab(tab));
-    }
 
     return result;
 }
 
 - (void)didOpenTab:(id<WKWebExtensionTab>)newTab
 {
-    NSParameterAssert([newTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(newTab != nil);
 
     _webExtensionContext->didOpenTab(toImpl(newTab, *_webExtensionContext));
 }
 
 - (void)didCloseTab:(id<WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
 {
-    NSParameterAssert([closedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(closedTab != nil);
 
     _webExtensionContext->didCloseTab(toImpl(closedTab, *_webExtensionContext), windowIsClosing ? WebKit::WebExtensionContext::WindowIsClosing::Yes : WebKit::WebExtensionContext::WindowIsClosing::No);
 }
 
 - (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(id<WKWebExtensionTab>)previousTab
 {
-    NSParameterAssert([activatedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-    if (previousTab)
-        NSParameterAssert([previousTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(activatedTab != nil);
 
     _webExtensionContext->didActivateTab(toImpl(activatedTab, *_webExtensionContext), toImplNullable(previousTab, *_webExtensionContext).get());
 }
 
-- (void)didSelectTabs:(NSSet<id<WKWebExtensionTab>> *)selectedTabs
+- (void)didSelectTabs:(NSArray<id<WKWebExtensionTab>> *)selectedTabs
 {
-    NSParameterAssert([selectedTabs isKindOfClass:NSSet.class]);
+    NSParameterAssert([selectedTabs isKindOfClass:NSArray.class]);
 
     _webExtensionContext->didSelectOrDeselectTabs(toImpl(selectedTabs, *_webExtensionContext));
 }
 
-- (void)didDeselectTabs:(NSSet<id<WKWebExtensionTab>> *)deselectedTabs
+- (void)didDeselectTabs:(NSArray<id<WKWebExtensionTab>> *)deselectedTabs
 {
-    NSParameterAssert([deselectedTabs isKindOfClass:NSSet.class]);
+    NSParameterAssert([deselectedTabs isKindOfClass:NSArray.class]);
 
     _webExtensionContext->didSelectOrDeselectTabs(toImpl(deselectedTabs, *_webExtensionContext));
 }
 
 - (void)didMoveTab:(id<WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<WKWebExtensionWindow>)oldWindow
 {
-    NSParameterAssert([movedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-    if (oldWindow)
-        NSParameterAssert([oldWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
+    NSParameterAssert(movedTab != nil);
 
     _webExtensionContext->didMoveTab(toImpl(movedTab, *_webExtensionContext), index != NSNotFound ? index : notFound, oldWindow ? toImpl(oldWindow, *_webExtensionContext).ptr() : nullptr);
 }
 
 - (void)didReplaceTab:(id<WKWebExtensionTab>)oldTab withTab:(id<WKWebExtensionTab>)newTab
 {
-    NSParameterAssert([oldTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-    NSParameterAssert([newTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(oldTab != nil);
+    NSParameterAssert(newTab != nil);
 
     _webExtensionContext->didReplaceTab(toImpl(oldTab, *_webExtensionContext), toImpl(newTab, *_webExtensionContext));
 }
@@ -827,7 +802,7 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 
 - (void)didChangeTabProperties:(WKWebExtensionTabChangedProperties)properties forTab:(id<WKWebExtensionTab>)changedTab
 {
-    NSParameterAssert([changedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(changedTab != nil);
 
     _webExtensionContext->didChangeTabProperties(toImpl(changedTab, *_webExtensionContext), toImpl(properties));
 }
@@ -845,9 +820,6 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 - (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
 {
-    if (tab)
-        NSParameterAssert([tab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-
     if (RefPtr maybeSidebar = _webExtensionContext->getOrCreateSidebar(toImplNullable(tab, *_webExtensionContext)))
         return maybeSidebar->wrapper();
     return nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h
@@ -194,7 +194,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
  @seealso didOpenTab:
  */
-- (void)didCloseTab:(id <WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing NS_SWIFT_NAME(didCloseTab(_:windowIsClosing:));
+- (void)didCloseTab:(id <WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Should be called by the app when a tab is activated to notify all loaded web extensions.
@@ -203,7 +203,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion This method informs all loaded extensions of the tab activation, ensuring consistent state awareness across extensions.
  If the intention is to inform only a specific extension, use the respective method on that extension's context instead.
  */
-- (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<WKWebExtensionTab>)previousTab NS_SWIFT_NAME(didActivateTab(_:previousActiveTab:));
+- (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<WKWebExtensionTab>)previousTab NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Should be called by the app when tabs are selected to fire appropriate events with all loaded web extensions.
@@ -211,7 +211,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion This method informs all loaded extensions that tabs have been selected, ensuring consistent understanding across extensions.
  If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
  */
-- (void)didSelectTabs:(NSSet<id <WKWebExtensionTab>> *)selectedTabs NS_SWIFT_NAME(didSelectTabs(_:));
+- (void)didSelectTabs:(NSArray<id <WKWebExtensionTab>> *)selectedTabs NS_SWIFT_NAME(didSelectTabs(_:));
 
 /*!
  @abstract Should be called by the app when tabs are deselected to fire appropriate events with all loaded web extensions.
@@ -219,7 +219,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion This method informs all loaded extensions that tabs have been deselected, ensuring consistent understanding across extensions.
  If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
  */
-- (void)didDeselectTabs:(NSSet<id <WKWebExtensionTab>> *)deselectedTabs NS_SWIFT_NAME(didDeselectTabs(_:));
+- (void)didDeselectTabs:(NSArray<id <WKWebExtensionTab>> *)deselectedTabs NS_SWIFT_NAME(didDeselectTabs(_:));
 
 /*!
  @abstract Should be called by the app when a tab is moved to fire appropriate events with all loaded web extensions.
@@ -230,7 +230,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  If the window is staying the same, the current window should be specified. If the intention is to inform only a specific extension,
  use the respective method on that extension's context instead.
  */
-- (void)didMoveTab:(id <WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
+- (void)didMoveTab:(id <WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <WKWebExtensionWindow>)oldWindow NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Should be called by the app when a tab is replaced by another tab to fire appropriate events with all loaded web extensions.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
@@ -173,7 +173,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didOpenWindow:(id<WKWebExtensionWindow>)newWindow
 {
-    NSParameterAssert([newWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
+    NSParameterAssert(newWindow != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didOpenWindow:newWindow];
@@ -181,7 +181,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didCloseWindow:(id<WKWebExtensionWindow>)closedWindow
 {
-    NSParameterAssert([closedWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
+    NSParameterAssert(closedWindow != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didCloseWindow:closedWindow];
@@ -189,16 +189,13 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didFocusWindow:(id<WKWebExtensionWindow>)focusedWindow
 {
-    if (focusedWindow)
-        NSParameterAssert([focusedWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
-
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didFocusWindow:focusedWindow];
 }
 
 - (void)didOpenTab:(id<WKWebExtensionTab>)newTab
 {
-    NSParameterAssert([newTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(newTab != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didOpenTab:newTab];
@@ -206,7 +203,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didCloseTab:(id<WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
 {
-    NSParameterAssert([closedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(closedTab != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didCloseTab:closedTab windowIsClosing:windowIsClosing];
@@ -214,25 +211,23 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didActivateTab:(id<WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<WKWebExtensionTab>)previousTab
 {
-    NSParameterAssert([activatedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-    if (previousTab)
-        NSParameterAssert([previousTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(activatedTab != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didActivateTab:activatedTab previousActiveTab:previousTab];
 }
 
-- (void)didSelectTabs:(NSSet<id<WKWebExtensionTab>> *)selectedTabs
+- (void)didSelectTabs:(NSArray<id<WKWebExtensionTab>> *)selectedTabs
 {
-    NSParameterAssert([selectedTabs isKindOfClass:NSSet.class]);
+    NSParameterAssert([selectedTabs isKindOfClass:NSArray.class]);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didSelectTabs:selectedTabs];
 }
 
-- (void)didDeselectTabs:(NSSet<id<WKWebExtensionTab>> *)deselectedTabs
+- (void)didDeselectTabs:(NSArray<id<WKWebExtensionTab>> *)deselectedTabs
 {
-    NSParameterAssert([deselectedTabs isKindOfClass:NSSet.class]);
+    NSParameterAssert([deselectedTabs isKindOfClass:NSArray.class]);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didDeselectTabs:deselectedTabs];
@@ -240,9 +235,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didMoveTab:(id<WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<WKWebExtensionWindow>)oldWindow
 {
-    NSParameterAssert([movedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-    if (oldWindow)
-        NSParameterAssert([oldWindow conformsToProtocol:@protocol(WKWebExtensionWindow)]);
+    NSParameterAssert(movedTab != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didMoveTab:movedTab fromIndex:index inWindow:oldWindow];
@@ -250,8 +243,8 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didReplaceTab:(id<WKWebExtensionTab>)oldTab withTab:(id<WKWebExtensionTab>)newTab
 {
-    NSParameterAssert([oldTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
-    NSParameterAssert([newTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(oldTab != nil);
+    NSParameterAssert(newTab != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didReplaceTab:oldTab withTab:newTab];
@@ -259,7 +252,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)didChangeTabProperties:(WKWebExtensionTabChangedProperties)properties forTab:(id<WKWebExtensionTab>)changedTab
 {
-    NSParameterAssert([changedTab conformsToProtocol:@protocol(WKWebExtensionTab)]);
+    NSParameterAssert(changedTab != nil);
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didChangeTabProperties:properties forTab:changedTab];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
@@ -142,7 +142,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MatchPattern)
  @result A Boolean value indicating if pattern matches the specified URL.
  @seealso matchesURL:options:
  */
-- (BOOL)matchesURL:(nullable NSURL *)url NS_SWIFT_UNAVAILABLE("Use options version with empty options set");
+- (BOOL)matchesURL:(nullable NSURL *)url NS_SWIFT_NAME(matches(_:));
 
 /*!
  @abstract Matches the reciever pattern against the specified URL with options.
@@ -159,7 +159,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MatchPattern)
  @result A Boolean value indicating if receiver pattern matches the specified pattern.
  @seealso matchesPattern:options:
  */
-- (BOOL)matchesPattern:(nullable WKWebExtensionMatchPattern *)pattern NS_SWIFT_UNAVAILABLE("Use options version with empty options set");
+- (BOOL)matchesPattern:(nullable WKWebExtensionMatchPattern *)pattern NS_SWIFT_NAME(matches(_:));
 
 /*!
  @abstract Matches the receiver pattern against the specified pattern with options.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
@@ -86,7 +86,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MessagePort)
 - (void)sendMessage:(nullable id)message completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(sendMessage(_:completionHandler:));
 
 /*! @abstract Disconnects the port, terminating all further messages. */
-- (void)disconnect NS_SWIFT_UNAVAILABLE("Use throwing version with nil");
+- (void)disconnect;
 
 /*!
  @abstract Disconnects the port, terminating all further messages with an optional error.

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -76,3 +76,33 @@ extension WKWebView {
     }
 }
 #endif
+
+@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+extension WKWebExtensionController {
+    func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
+        __didClose(closedTab, windowIsClosing: windowIsClosing)
+    }
+
+    func didActivateTab(_ activatedTab: any WKWebExtensionTab, previousActiveTab previousTab: (any WKWebExtensionTab)? = nil) {
+        __didActivate(activatedTab, previousActiveTab: previousTab)
+    }
+
+    func didMoveTab(_ movedTab: any WKWebExtensionTab, from index: Int, in oldWindow: (any WKWebExtensionWindow)? = nil) {
+        __didMove(movedTab, from: index, in: oldWindow)
+    }
+}
+
+@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+extension WKWebExtensionContext {
+    func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
+        __didClose(closedTab, windowIsClosing: windowIsClosing)
+    }
+
+    func didActivateTab(_ activatedTab: any WKWebExtensionTab, previousActiveTab previousTab: (any WKWebExtensionTab)? = nil) {
+        __didActivate(activatedTab, previousActiveTab: previousTab)
+    }
+
+    func didMoveTab(_ movedTab: any WKWebExtensionTab, from index: Int, in oldWindow: (any WKWebExtensionWindow)? = nil) {
+        __didMove(movedTab, from: index, in: oldWindow)
+    }
+}

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -25,6 +25,8 @@
 
 #import <WebKit/WKWebExtensionContextPrivate.h>
 
+#define HAVE_WK_WEB_EXTENSION_CONTEXT_ARRAY_BASED_DID_SELECT_TABS 1
+
 WK_EXTERN
 @interface _WKWebExtensionContext : WKWebExtensionContext
 @end

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -562,9 +562,9 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         self->_selected = selected;
 
         if (selected)
-            [self->_extensionController didSelectTabs:[NSSet setWithObject:self]];
+            [self->_extensionController didSelectTabs:@[ self ]];
         else
-            [self->_extensionController didDeselectTabs:[NSSet setWithObject:self]];
+            [self->_extensionController didDeselectTabs:@[ self ]];
 
         completionHandler(nil);
     });


### PR DESCRIPTION
#### 9be0cc1962b926bda0d487fbdf23996dd0564aa9
<pre>
Address additional Web Extension API feedback for Swift.
<a href="https://webkit.org/b/279638">https://webkit.org/b/279638</a>
<a href="https://rdar.apple.com/problem/135959192">rdar://problem/135959192</a>

Reviewed by Jeff Miller.

Fixed the name for `WKWebExtensionContext.PermissionStatus`, which was missed in previous a rename.

Changed `didSelectTabs:` and `didDeselectTabs:` to take arrays instead of sets for better API ergonomics.

Removed all `NS_SWIFT_UNAVAILABLE` uses, so the optional parameter version is available to Swift without
the need to overlay many more methods.

Added some Swift overlays for `NS_REFINED_FOR_SWIFT` methods to give default values to optional parameters.

Dropped the remaining `conformsToProtocol:` checks in place of simple `nil` checks, as it is bad for
performance and not required as all our protocol methods are optional.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext hasPermission:inTab:]):
(-[WKWebExtensionContext hasAccessToURL:inTab:]):
(-[WKWebExtensionContext permissionStatusForPermission:inTab:]):
(-[WKWebExtensionContext permissionStatusForURL:inTab:]):
(-[WKWebExtensionContext permissionStatusForMatchPattern:inTab:]):
(-[WKWebExtensionContext actionForTab:]):
(-[WKWebExtensionContext performActionForTab:]):
(-[WKWebExtensionContext menuItemsForTab:]):
(-[WKWebExtensionContext userGesturePerformedInTab:]):
(-[WKWebExtensionContext hasActiveUserGestureInTab:]):
(-[WKWebExtensionContext clearUserGestureInTab:]):
(-[WKWebExtensionContext didOpenWindow:]):
(-[WKWebExtensionContext didCloseWindow:]):
(-[WKWebExtensionContext didFocusWindow:]):
(-[WKWebExtensionContext didOpenTab:]):
(-[WKWebExtensionContext didCloseTab:windowIsClosing:]):
(-[WKWebExtensionContext didActivateTab:previousActiveTab:]):
(-[WKWebExtensionContext didSelectTabs:]):
(-[WKWebExtensionContext didDeselectTabs:]):
(-[WKWebExtensionContext didMoveTab:fromIndex:inWindow:]):
(-[WKWebExtensionContext didReplaceTab:withTab:]):
(-[WKWebExtensionContext didChangeTabProperties:forTab:]):
(-[WKWebExtensionContext sidebarForTab:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm:
(-[WKWebExtensionController didOpenWindow:]):
(-[WKWebExtensionController didCloseWindow:]):
(-[WKWebExtensionController didFocusWindow:]):
(-[WKWebExtensionController didOpenTab:]):
(-[WKWebExtensionController didCloseTab:windowIsClosing:]):
(-[WKWebExtensionController didActivateTab:previousActiveTab:]):
(-[WKWebExtensionController didSelectTabs:]):
(-[WKWebExtensionController didDeselectTabs:]):
(-[WKWebExtensionController didMoveTab:fromIndex:inWindow:]):
(-[WKWebExtensionController didReplaceTab:withTab:]):
(-[WKWebExtensionController didChangeTabProperties:forTab:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h:
* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
(WKWebExtensionController.didCloseTab(_:windowIsClosing:)):
(WKWebExtensionController.didActivateTab(_:previousActiveTab:)):
(WKWebExtensionController.didMoveTab(_:from:in:)):
(WKWebExtensionContext.didCloseTab(_:windowIsClosing:)):
(WKWebExtensionContext.didActivateTab(_:previousActiveTab:)):
(WKWebExtensionContext.didMoveTab(_:from:in:)):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab setSelected:forWebExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/283658@main">https://commits.webkit.org/283658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b69e437a0a80cecb880d042c23fee095aa75c57c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17835 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12152 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57907 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15299 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16408 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14985 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57964 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8937 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2557 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10159 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->