### PR TITLE
Annotate EME API message endpoints with feature flag

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -201,6 +201,12 @@ const Logger& RemoteCDMFactoryProxy::logger() const
 }
 #endif
 
+const SharedPreferencesForWebProcess& RemoteCDMFactoryProxy::sharedPreferencesForWebProcess() const
+{
+    auto gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get();
+    return gpuConnectionToWebProcess->sharedPreferencesForWebProcess();
+}
+
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -87,6 +87,7 @@ public:
     bool allowsExitUnderMemoryPressure() const;
 
     const String& mediaKeysStorageDirectory() const;
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
@@ -25,6 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
+[EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMFactoryProxy NotRefCounted {
     CreateCDM(String keySystem) -> (WebKit::RemoteCDMIdentifier identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
     SupportsKeySystem(String keySystem) -> (bool result) Synchronous

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -131,6 +131,11 @@ Ref<WebCore::CDMInstance> RemoteCDMInstanceProxy::protectedInstance() const
     return m_instance;
 }
 
+const SharedPreferencesForWebProcess& RemoteCDMInstanceProxy::sharedPreferencesForWebProcess() const
+{
+    return m_cdm->sharedPreferencesForWebProcess();
+}
+
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -62,6 +62,7 @@ public:
     const RemoteCDMInstanceConfiguration& configuration() const { return m_configuration.get(); }
     WebCore::CDMInstance& instance() { return m_instance; }
     Ref<WebCore::CDMInstance> protectedInstance() const;
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
 private:
     friend class RemoteCDMFactoryProxy;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in
@@ -25,6 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
+[EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMInstanceProxy NotRefCounted {
     CreateSession(uint64_t logIdentifier) -> (WebKit::RemoteCDMInstanceSessionIdentifier identifier) Synchronous
     InitializeWithConfiguration(struct WebCore::CDMKeySystemConfiguration configuration, enum:bool WebCore::CDMInstance::AllowDistinctiveIdentifiers distinctiveIdentifiersAllowed, enum:bool WebCore::CDMInstance::AllowPersistentState persistentStateAllowed) -> (enum:bool WebCore::CDMInstance::SuccessValue success)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -181,6 +181,11 @@ void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)
     gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::SessionIdChanged(sessionId), m_identifier);
 }
 
+const SharedPreferencesForWebProcess& RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess() const
+{
+    return m_cdm->sharedPreferencesForWebProcess();
+}
+
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -45,6 +45,7 @@ class RemoteCDMInstanceSessionProxy final : private IPC::MessageReceiver, privat
 public:
     static std::unique_ptr<RemoteCDMInstanceSessionProxy> create(WeakPtr<RemoteCDMProxy>&&, Ref<WebCore::CDMInstanceSession>&&, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier);
     virtual ~RemoteCDMInstanceSessionProxy();
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
 private:
     friend class RemoteCDMFactoryProxy;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
@@ -25,6 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
+[EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMInstanceSessionProxy NotRefCounted {
     SetLogIdentifier(uint64_t logIdentifier)
     RequestLicense(WebCore::CDMInstanceSession::LicenseType type, enum:bool WebCore::CDMKeyGroupingStrategy keyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> message, String sessionId, bool needsIndividualization, bool succeeded)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -116,6 +116,11 @@ void RemoteCDMProxy::setLogIdentifier(uint64_t logIdentifier)
 #endif
 }
 
+const SharedPreferencesForWebProcess& RemoteCDMProxy::sharedPreferencesForWebProcess() const
+{
+    return m_factory->sharedPreferencesForWebProcess();
+}
+
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -35,10 +35,6 @@
 #include <wtf/Forward.h>
 #include <wtf/UniqueRef.h>
 
-namespace WebKit {
-class RemoteCDMProxy;
-}
-
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteCDMProxy> : std::true_type { };
@@ -57,6 +53,7 @@ namespace WebKit {
 class RemoteCDMInstanceProxy;
 struct RemoteCDMInstanceConfiguration;
 struct RemoteCDMConfiguration;
+struct SharedPreferencesForWebProcess;
 
 class RemoteCDMProxy : public IPC::MessageReceiver {
 public:
@@ -70,6 +67,7 @@ public:
     bool supportsInitData(const AtomString&, const WebCore::SharedBuffer&);
     RefPtr<WebCore::SharedBuffer> sanitizeResponse(const WebCore::SharedBuffer& response);
     std::optional<String> sanitizeSessionId(const String& sessionId);
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in
@@ -25,6 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
+[EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMProxy NotRefCounted {
     GetSupportedConfiguration(struct WebCore::CDMKeySystemConfiguration candidateConfiguration, enum:bool WebCore::CDMPrivate::LocalStorageAccess access) -> (std::optional<WebCore::CDMKeySystemConfiguration> accumulatedConfiguration)
     CreateInstance() -> (WebKit::RemoteCDMInstanceIdentifier identifier, struct WebKit::RemoteCDMInstanceConfiguration configuration) Synchronous

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -81,9 +81,9 @@ messages -> RemoteMediaPlayerProxy {
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    CdmInstanceAttached(WebKit::RemoteCDMInstanceIdentifier instanceId)
-    CdmInstanceDetached(WebKit::RemoteCDMInstanceIdentifier instanceId)
-    AttemptToDecryptWithInstance(WebKit::RemoteCDMInstanceIdentifier instanceId)
+    [EnabledBy=EncryptedMediaAPIEnabled] CdmInstanceAttached(WebKit::RemoteCDMInstanceIdentifier instanceId)
+    [EnabledBy=EncryptedMediaAPIEnabled] CdmInstanceDetached(WebKit::RemoteCDMInstanceIdentifier instanceId)
+    [EnabledBy=EncryptedMediaAPIEnabled] AttemptToDecryptWithInstance(WebKit::RemoteCDMInstanceIdentifier instanceId)
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)


### PR DESCRIPTION
#### 8d66f089087d5cc02de384c915b53f4e4373d57d
<pre>
Annotate EME API message endpoints with feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=279690">https://bugs.webkit.org/show_bug.cgi?id=279690</a>
<a href="https://rdar.apple.com/135970619">rdar://135970619</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp:
(WebKit::RemoteCDMProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/283896@main">https://commits.webkit.org/283896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829471236e05b283fc5498124c7aedc265a94a70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71809 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18701 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70821 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17253 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11717 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11752 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/58657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9546 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45206 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/43758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->