### PR TITLE
Use the correct bounding rect in SVGInlineTextBox::nodeAtPoint

### DIFF
--- a/LayoutTests/svg/hittest/text-vertical-expected.txt
+++ b/LayoutTests/svg/hittest/text-vertical-expected.txt
@@ -1,0 +1,4 @@
+MMMMMMMM
+
+PASS elementFromPoint(...) on vertical <svg:text>
+

--- a/LayoutTests/svg/hittest/text-vertical.html
+++ b/LayoutTests/svg/hittest/text-vertical.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>elementFromPoint(...) on vertical &lt;svg:text></title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ahem.js"></script>
+<style>
+body, html {
+  padding: 0;
+  margin: 0;
+}
+</style>
+<svg width="400" height="400">
+  <text x="200" y="50" writing-mode="tb" font-family="Ahem" font-size="50">MMMMMMMM</text>
+</svg>
+<script>
+test(function() {
+  var textElement = document.querySelector('text');
+  for (var y = 75; y < 400; y += 50)
+      assert_equals(document.elementFromPoint(200, y), textElement, "element @ (200," + y + ")");
+});
+</script>

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
- * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2016 Google Inc. All rights reserved.
  * Copyright (C) 2023, 2024 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
@@ -239,9 +239,8 @@ bool SVGInlineTextBox::nodeAtPoint(const HitTestRequest& request, HitTestResult&
     if (isVisibleToHitTesting(renderer().style(), request) || !hitRules.requireVisible) {
         if ((hitRules.canHitStroke && (renderer().style().svgStyle().hasStroke() || !hitRules.requireStroke))
             || (hitRules.canHitFill && (renderer().style().svgStyle().hasFill() || !hitRules.requireFill))) {
-            FloatPoint boxOrigin(x(), y());
-            boxOrigin.moveBy(accumulatedOffset);
-            FloatRect rect(boxOrigin, size());
+            FloatRect rect(topLeft(), FloatSize(logicalWidth(), logicalHeight()));
+            rect.moveBy(accumulatedOffset);
             if (locationInContainer.intersects(rect)) {
 
                 float scalingFactor = renderer().scalingFactor();


### PR DESCRIPTION
#### ace3c089eef49f9501a928fe5803c97723ac163e
<pre>
Use the correct bounding rect in SVGInlineTextBox::nodeAtPoint

<a href="https://bugs.webkit.org/show_bug.cgi?id=279692">https://bugs.webkit.org/show_bug.cgi?id=279692</a>
<a href="https://rdar.apple.com/135973175">rdar://135973175</a>

Reviewed by Simon Fraser.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/ccf72ce87493b653f3f1add48b2bd0a68108d35b">https://source.chromium.org/chromium/chromium/src/+/ccf72ce87493b653f3f1add48b2bd0a68108d35b</a>

This patch leverages &apos;loigcalWidth&apos; and &apos;logicalHeight&apos; instead of &apos;size&apos;
for hittesting to get correct bounding rect in cases of vertical writing modes.

* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::nodeAtPoint):
* LayoutTests/svg/hittest/text-vertical.html:
* LayoutTests/svg/hittest/text-vertical-expected.txt:

Canonical link: <a href="https://commits.webkit.org/283665@main">https://commits.webkit.org/283665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a19a7bcbc4d0b28df5b2671949caffdf6c2bb42b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18067 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53700 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12154 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57912 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10891 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61172 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61248 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14794 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2561 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44376 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->