### PR TITLE
[WebGPU] Debug assertion in RenderBundleEncoder::currentRenderCommand() fails when RenderBundle has zero commands

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279693-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279693-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279693.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279693.html
@@ -1,0 +1,17835 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAU1tZGF0AAAAHgYFGkdWStxcTEM/lO/FETzRQ6gB/8zM/wIABr//gAAAAFgluCAfgCzoj//8eCyKIA6ld6GiWNMysFDzQ6B0eKZOHCoYx/qDmAAASsGxgpD9GOyUuV2X2TbC82uSHQykVbKdIl1ez0Y4oBd1ThIi3aGA3KgFgNuFlMbMAAAAOSHhCF8BCiSBNYLgmz0HwAQXT4VwcYONVAlh4AfvmC+QzGhM3au6JfZPbp1BU7asdTUtdCSp7qYAgAAAADEBqIGJv/ScwzAAAAMAGlAAAEzAU4oa5OqOZ7A19laXo9z4wmN5AIMC+Bng8wq4gYWAAAAAIyHiEEv/ALCyQLLgyyaz3DSqW6o67AfmaWoR6vWvjVy2XAE0AAAAKgGow4//9JdwIAAAAwABBwAAAwLwAnIyzNPkAA24JECMAwYUMKmFVDGQYAAAA7xtb292AAAAbG12aGQAAAAA4ueqKuLnqioAAAJYAAALuAABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAADSHRyYWsAAABcdGtoZAAAAA/i56oq4ueqKgAAAAEAAAAAAAALuAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAABAAAAAQAAAAAAAER0YXB0AAAAFGNsZWYAAAAAAQAAAAEAAAAAAAAUcHJvZgAAAAABAAAAAQAAAAAAABRlbm9mAAAAAAEAAAABAAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAALuAAAAAAAAQAAAAACfG1kaWEAAAAgbWRoZAAAAADi56oq4ueqKgAAAlgAAAu4VcQAAAAAADFoZGxyAAAAAG1obHJ2aWRlYXBwbAAAAAAAAAAAEENvcmUgTWVkaWEgVmlkZW8AAAIjbWluZgAAABR2bWhkAAAAAQBAgACAAIAAAAAAOGhkbHIAAAAAZGhscmFsaXNhcHBsAAAAAAAAAAAXQ29yZSBNZWRpYSBEYXRhIEhhbmRsZXIAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMYWxpcwAAAAEAAAGrc3RibAAAAKZzdHNkAAAAAAAAAAEAAACWYXZjMQAAAAAAAAABAAAAAAAAAAAAAAIAAAACAAEAAQAASAAAAEgAAAAAAAAAAQVILjI2NAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAACphdmNDAWQADf/hAA8nZAANrFYoEAhpqEiAMBABAAQo7jyw/fj4AAAAABJjb2xybmNsYwAJABAABgAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAACWAAAAAH///2oAAAAAQAAAlgAAAAB///9qAAAACBjc2xnAAAAAAAAAlj///2oAAACWAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBgQGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAH4AAAA9AAAANQAAACcAAAAuAAAAJHN0Y28AAAAAAAAABQAAACQAAACiAAAA3wAAARQAAAE7`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAhhtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAAC/KAGvMIOaEBz0weFg6msTd9j0L/avD/sl7IgSkpn/9xOY1tEVrSAVkQfmLSq+FKe+AjZI3DPkmDAqe84kr8Qr3WlvT/qcZsAKtkV2pn0AvK90bCNHi4PqTdBqD4AAEqHI/FOhfAkX5WJgOZ+JJb4eSQrIQwPbLUf2Xe7GqbaqxFGQ3R3tkvqHmCdUgtsyynxWigU6pFc3QuRmyzp7Mvcukwv8uVAAALvJUJ/oIzRHd56FQGpAAAFiAPeAAARcCQgAAABLAgHQeCgeL5BBEdF1Yvd0KgUMk3wO626qPaAAHx/PIwBJHSzycAD8ATl8C0drHVylfIw4AICNing4AfGpqM6J8XtJBAxuXXyEIvdKAAAASAIB4PCQPIPL6QQQlVcWIJKE9AKJCLTkLARtpnzVgAXj4Oy/sAi5FxGZ1yQf4iCHU0ADhFxUfYAKA01Ge8xoXIANHzl1+vd+xwAAAEMCAeB4mHoeg8PphBCVFpmgkgf4AwTI7hd8BUD17GEHczw5E+AODxRbDCwb4qDFYBZ8rLg4D8AcHlrYH5iAEuFWwP+YAAAARAIB4WjQeg8B6+mEEJUq3OCSB/gDBMjuF3wFQPXsYQdzPU2+0fJPdwOqDg8d5qPngJg3bJg6Fn/5F7NUejAcSRnAEX+gAAAEPm1vb3YAAABsbXZoZAAAAADi56k/4uepPwAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAPKdHJhawAAAFx0a2hkAAAAD+LnqT/i56k/AAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAAL+bWRpYQAAACBtZGhkAAAAAOLnqT/i56k/AAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAqVtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAi1zdGJsAAAA63N0c2QAAAAAAAAAAQAAANtodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAb2h2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALA6AAAQAYQAEMAf//AWAAAAMAsAAAAwAAAwBaFcCQoQABACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUBEgcAgogABAAdEAcAsvBTJAAAAEmNvbHJuY2xjAAEAEgAHAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAOYAAABPAAAATAAAAEcAAABIAAAAJHN0Y28AAAAAAAAABQAAACQAAAEKAAABWQAAAaUAAAHs`,
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindingsPerBindGroup: 1000,
+    maxUniformBufferBindingSize: 117361015,
+    maxStorageBufferBindingSize: 147038495,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1f61e}\u{1f920}\u09b1\ue4c7\u8243\u13cb\u{1fa16}\u0349',
+  entries: [
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 462});
+let texture0 = device0.createTexture({
+  label: '\u0672\u06a6\u{1f81c}\u0035\uf8c3',
+  size: [329, 24, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture0.createView({dimension: '2d-array'});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\u7092\u3c8e\u03f6'});
+let commandEncoder1 = device0.createCommandEncoder({});
+let texture1 = device0.createTexture({
+  label: '\u8800\u09c2\u{1fa93}\u97dd\u4f2d\u0da5\u0ecf\u4c34',
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let video0 = await videoWithData(112);
+let buffer0 = device0.createBuffer({size: 1143, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView1 = texture1.createView({label: '\u9bc2\u{1ff34}', dimension: '2d'});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 19,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 589,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 168, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+  ],
+});
+let sampler0 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.7760,
+  compare: 'greater',
+  maxAnisotropy: 6,
+});
+let texture2 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'astc-12x12-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler1 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 13.71,
+  lodMaxClamp: 57.19,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView1}]});
+let texture3 = device0.createTexture({
+  size: {width: 329, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView2 = texture1.createView({dimension: '2d-array'});
+let sampler2 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.30,
+  compare: 'less',
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(1546), 15, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 192, new DataView(new ArrayBuffer(2997)), 52, 40);
+} catch {}
+let imageData0 = new ImageData(4, 104);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer1 = device0.createBuffer({
+  label: '\u7385\u0ae5\uf395\u{1fb4e}\u322a\u03f9',
+  size: 47178,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+let textureView3 = texture3.createView({mipLevelCount: 1});
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(2760), 340, 0);
+} catch {}
+await gc();
+let canvas0 = document.createElement('canvas');
+let texture4 = device0.createTexture({
+  size: [150, 24, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler3 = device0.createSampler({
+  label: '\u0dfd\uc052\u1ca2\u0d71\u03be\u0983\u8c6e\u407a\uaaac',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.87,
+  lodMaxClamp: 67.06,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(2007), 120, 0);
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 443});
+let textureView4 = texture0.createView({dimension: '2d-array'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(494), 29, 0);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 17, y: 10, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 992 */
+  offset: 992,
+  bytesPerRow: 512,
+  rowsPerImage: 101,
+  buffer: buffer0,
+}, {width: 3, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.label = '\u0974\u{1f777}\u{1fd80}\u3e83\u6830\ucaaf';
+} catch {}
+let buffer2 = device0.createBuffer({size: 8974, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder4 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 1},
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView5 = texture1.createView({dimension: '2d-array', arrayLayerCount: 1});
+let sampler4 = device0.createSampler({
+  label: '\u{1f930}\u{1fafb}\uef36',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.60,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(1903), 12, 0);
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 12, y: 4, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1144 */
+  offset: 1144,
+  buffer: buffer1,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4020, new Int16Array(4300), 16, 740);
+} catch {}
+await gc();
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u0731\u0f0d\u7848\u486a\ued5e\ufb08\u03ad\u0306',
+  entries: [
+    {
+      binding: 28,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder5 = device0.createCommandEncoder({});
+let computePassEncoder3 = commandEncoder3.beginComputePass({});
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 212 */
+  offset: 212,
+  bytesPerRow: 768,
+  rowsPerImage: 141,
+  buffer: buffer2,
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let buffer3 = device0.createBuffer({size: 13222, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandBuffer0 = commandEncoder5.finish({});
+let computePassEncoder4 = commandEncoder4.beginComputePass({label: '\u0827\u05a5\u{1fa33}\u2d0a\u{1ff01}\uc9d6\ued26\ua7f8'});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 160);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let buffer4 = device0.createBuffer({
+  size: 50885,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 118});
+let textureView6 = texture5.createView({});
+let computePassEncoder5 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(0, 8);
+document.body.prepend(video0);
+let buffer5 = device0.createBuffer({size: 2139, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder7 = device0.createCommandEncoder({});
+let texture6 = device0.createTexture({
+  size: [2, 2, 12],
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView7 = texture1.createView({label: '\u2376\u0385\u6902', format: 'r32float'});
+let sampler5 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.30,
+  lodMaxClamp: 74.79,
+  maxAnisotropy: 14,
+});
+try {
+commandEncoder7.resolveQuerySet(querySet0, 6, 91, buffer3, 768);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let computePassEncoder6 = commandEncoder7.beginComputePass({});
+try {
+buffer5.unmap();
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]});
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 4, new Int16Array(11611), 359, 564);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let sampler6 = device0.createSampler({
+  label: '\u005e\u1515\u476a\u0798\u042a\u{1fa23}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 55.86,
+  lodMaxClamp: 94.32,
+  compare: 'greater',
+});
+try {
+commandEncoder8.copyBufferToBuffer(buffer1, 4876, buffer5, 368, 16);
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer5, 36, 536);
+} catch {}
+try {
+window.someLabel = sampler4.label;
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 73 max align: 1 */
+struct T0 {
+  @align(1) @size(73) f0: array<vec2i>,
+}
+@group(0) @binding(80) var st0: texture_storage_2d<r32float, read_write>;
+@group(1) @binding(80) var st1: texture_storage_3d<r32uint, read_write>;
+@group(2) @binding(80) var st2: texture_storage_2d<r32float, read_write>;
+struct VertexOutput0 {
+  @location(9) f0: vec2u,
+  @location(11) f1: f16,
+  @location(12) f2: vec2i,
+  @location(15) @interpolate(flat, center) f3: vec2i,
+  @location(1) @interpolate(flat) f4: u32,
+  @location(6) @interpolate(linear, centroid) f5: vec2h,
+  @builtin(position) f6: vec4f,
+  @location(14) f7: vec2f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f2 = vec2i(34, 35);
+  return out;
+}
+struct FragmentOutput0 {
+  @location(7) @interpolate(flat) f0: vec2f,
+  @location(0) @interpolate(perspective, centroid) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0() {
+  if bool(textureLoad(st0, vec2i())[0]) {
+    return;
+  }
+  if bool(textureLoad(st1, vec3i())[1]) {
+    textureStore(st0, vec2i(), vec4f(0.1217, 0.06508, 0.3978, 0.01886));
+  }
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  label: '\u{1f716}\u196f\u8442\u03f7\u06e2\ua30b\u7327\u35bd\u0689\u2b9f',
+  size: [2880],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 47.40,
+  lodMaxClamp: 75.56,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(368), 268, 0);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 724 */
+  offset: 724,
+  buffer: buffer1,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 32, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 128, new DataView(new ArrayBuffer(20480)), 2765, 672);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let buffer6 = device0.createBuffer({
+  size: 8652,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet3 = device0.createQuerySet({
+  label: '\ub49b\u{1ff8b}\u1bcf\u08af\u098f\u{1fcf9}\u{1ff40}\ube74\u0c9a',
+  type: 'occlusion',
+  count: 977,
+});
+let texture8 = device0.createTexture({
+  size: [600, 96, 179],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView8 = texture1.createView({});
+let computePassEncoder7 = commandEncoder8.beginComputePass({label: '\u585c\ufd61\u27fc\u{1f7d9}\ub77c\ue97d\u3bbf\u3307\u0f13\ud3b9'});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.98,
+  lodMaxClamp: 76.70,
+});
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 90,
+      visibility: 0,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup1 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView8}]});
+let texture9 = device0.createTexture({
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder8 = commandEncoder9.beginComputePass({label: '\u3f6c\u358d\u{1f6fe}'});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture10 = device0.createTexture({
+  size: {width: 600, height: 96, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture11 = device0.createTexture({
+  size: {width: 75, height: 12, depthOrArrayLayers: 5},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView9 = texture10.createView({label: '\u0c89\u0f0e', dimension: '2d-array'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup1, new Uint32Array(1294), 39, 0);
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder9 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup1);
+} catch {}
+let promise0 = shaderModule0.getCompilationInfo();
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 54 max align: 2 */
+struct T0 {
+  @align(2) @size(54) f0: array<array<f32, 1>>,
+}
+/* target size: 54 max align: 2 */
+struct T1 {
+  @align(2) @size(8) f0: atomic<i32>,
+  @align(2) f1: array<array<atomic<u32>, 1>, 1>,
+  @align(2) f2: atomic<u32>,
+  @align(1) @size(8) f3: array<atomic<u32>, 1>,
+  @align(2) @size(30) f4: vec3i,
+}
+@group(0) @binding(28) var<storage, read_write> buffer7: array<T1, 1>;
+struct S0 {
+  @builtin(vertex_index) f0: u32,
+  @builtin(instance_index) f1: u32,
+  @location(7) @interpolate(linear, center) f2: f32,
+  @location(9) f3: i32,
+  @location(15) f4: f16,
+  @location(6) @interpolate(flat, center) f5: vec4u,
+  @location(0) @interpolate(flat) f6: vec4i,
+  @location(13) f7: vec3h,
+  @location(12) @interpolate(flat, centroid) f8: vec2f,
+  @location(10) f9: vec4f,
+  @location(4) f10: vec2h,
+  @location(1) @interpolate(flat) f11: i32,
+  @location(8) f12: vec2f
+}
+struct VertexOutput1 {
+  @builtin(position) f8: vec4f
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3i, a1: S0, @location(2) a2: vec3i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  _ = a1.f12;
+  _ = a1.f2;
+  _ = a1.f5;
+  return out;
+}
+struct FragmentOutput1 {
+  @location(0) @interpolate(flat, centroid) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  _ = buffer7[0].f3;
+  _ = atomicExchange(&buffer7[0].f0, 352);
+  _ = buffer7[0].f1[0][0];
+  _ = atomicExchange(&buffer7[0].f2, 160);
+  _ = buffer7[0].f0;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+@compute @workgroup_size(2, 2, 1)
+fn compute1(@builtin(global_invocation_id) a0: vec3u, @builtin(local_invocation_index) a1: u32) {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView10 = texture12.createView({baseArrayLayer: 0});
+let texture13 = device0.createTexture({size: {width: 720}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup1, new Uint32Array(1804), 57, 0);
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 28, resource: {buffer: buffer6, offset: 1536}}]});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video0);
+let commandEncoder11 = device0.createCommandEncoder({label: '\ufdfd\u6907\uc8e0\u056d\ua638\u039c'});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 590});
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 36, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 1280,
+  buffer: buffer6,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup3 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 90, resource: textureView10}]});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture14 = device0.createTexture({
+  size: [600, 96, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder10 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup3, new Uint32Array(4211), 566, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 652, new BigUint64Array(6307), 1021, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 15, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(481).fill(119), /* required buffer size: 481 */
+{offset: 481, bytesPerRow: 1565}, {width: 91, height: 25, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer1 = commandEncoder12.finish({});
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 90.51,
+  lodMaxClamp: 93.21,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(1516), 47, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let imageData1 = new ImageData(4, 20);
+let commandEncoder13 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder13.beginComputePass({label: '\ua3cf\u0909\u{1f848}\u5401\u09b6\u579e\u{1ff77}\u{1fcd7}\u{1fa91}\u6ad7\ubf01'});
+let commandEncoder14 = device0.createCommandEncoder();
+let texture15 = device0.createTexture({
+  size: [2, 2, 297],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler10 = device0.createSampler({
+  label: '\uabfb\uc00a\u077a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.19,
+  lodMaxClamp: 95.79,
+  compare: 'never',
+});
+try {
+  await promise0;
+} catch {}
+let texture16 = device0.createTexture({
+  size: {width: 659, height: 48, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture17 = device0.createTexture({
+  size: [300],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView11 = texture12.createView({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(642), 5, 0);
+} catch {}
+let imageData2 = new ImageData(8, 12);
+let bindGroup4 = device0.createBindGroup({
+  label: '\u{1fa02}\u{1fb49}\u01d8',
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer4, offset: 9216, size: 3404}}],
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({
+  size: [600],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture19 = gpuCanvasContext0.getCurrentTexture();
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView12 = texture15.createView({format: 'rgb10a2unorm', mipLevelCount: 1});
+let computePassEncoder12 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+await gc();
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView13 = texture0.createView({});
+let computePassEncoder13 = commandEncoder16.beginComputePass();
+let renderPassEncoder0 = commandEncoder14.beginRenderPass({colorAttachments: [{view: textureView12, depthSlice: 11, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(1.6305095164307506, 0.9131893714078101, 0.0284089878732458, 0.7734580693568436, 0.784004561495834, 0.9654182324852681);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 2_442, 175);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let computePassEncoder14 = commandEncoder17.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(638);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer3, 2_300, 170);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.append(video0);
+let commandEncoder18 = device0.createCommandEncoder({label: '\u0117\u24b0\u{1f62b}\ub72f\u{1fc91}\u8667'});
+let texture20 = device0.createTexture({
+  size: [82, 6, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture21 = device0.createTexture({
+  size: [2880, 4, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView14 = texture12.createView({dimension: '2d-array'});
+let computePassEncoder15 = commandEncoder18.beginComputePass({label: '\u0649\u01ea\u{1f8f4}\u{1fa5f}\u5ecf\udce0\u0835\u0dc6'});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(3456), 810, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint16', 6_150, 10_213);
+} catch {}
+try {
+querySet3.destroy();
+} catch {}
+canvas0.width = 1103;
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'bt709'} });
+let buffer8 = device0.createBuffer({
+  size: 3436,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture22 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 12},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup3, new Uint32Array(2952), 2_808, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  label: '\u0d4d\ueeb0',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {cullMode: 'front'},
+});
+let texture23 = device0.createTexture({
+  size: {width: 150},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 27 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 588, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 8 max align: 8 */
+struct T0 {
+  @align(1) @size(8) f0: array<atomic<u32>>,
+}
+/* target size: 8 max align: 8 */
+struct T1 {
+  @size(8) f0: atomic<i32>,
+}
+@group(2) @binding(80) var st5: texture_storage_1d<r32uint, read_write>;
+@group(1) @binding(80) var st4: texture_storage_1d<r32uint, read_write>;
+@group(0) @binding(80) var st3: texture_storage_1d<r32float, read_write>;
+struct VertexOutput2 {
+  @location(10) f9: i32,
+  @location(4) @interpolate(flat, center) f10: vec4h,
+  @builtin(position) f11: vec4f,
+  @location(13) f12: vec4i,
+  @location(15) @interpolate(flat, centroid) f13: vec4i
+}
+
+@vertex
+fn vertex0() -> VertexOutput2 {
+  var out: VertexOutput2;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) @interpolate(flat) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+  _ = textureLoad(st5, 0);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder19 = device0.createCommandEncoder({});
+let sampler11 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 29.01,
+  lodMaxClamp: 58.30,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(2927), 647, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 0, 2_996);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 102, y: 72 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 419, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer9 = device0.createBuffer({
+  size: 17821,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder20 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(175), 42, 0);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer5, 60, 140);
+} catch {}
+let buffer10 = device0.createBuffer({
+  label: '\u0b38\u{1fca3}\u{1f97f}\u77eb\u{1f771}\u{1f67e}\ub506\u0cd8\u{1f7b6}',
+  size: 6864,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer0, 132, 32);
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'logSqrt'} });
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer6, offset: 512, size: 2456}}],
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let textureView15 = texture12.createView({dimension: '2d-array', aspect: 'all'});
+let textureView16 = texture12.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder16 = commandEncoder21.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer1, 12100, buffer6, 140, 3888);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 208, new Float32Array(14106), 589, 12);
+} catch {}
+try {
+adapter0.label = '\u{1f96e}\u{1fddf}\u088e\u00ac\uc050\u08b2\u0e08\uff9f\ua1e4\u{1fab0}';
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({
+  size: [150, 24, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder17 = commandEncoder22.beginComputePass();
+let renderPassEncoder1 = commandEncoder19.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 5,
+  clearValue: { r: 558.8, g: -733.7, b: -669.7, a: -724.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup5, new Uint32Array(2844), 404, 0);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 157, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2388 widthInBlocks: 597 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1156 */
+  offset: 1156,
+  bytesPerRow: 2816,
+  buffer: buffer9,
+}, {width: 597, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  size: {width: 360},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView17 = texture24.createView({
+  label: '\uc34d\u0349\u0d72\u0967\u{1f9d1}\u7543\u{1f8dc}\u{1f6f0}',
+  format: 'rgb10a2unorm',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+let computePassEncoder18 = commandEncoder20.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint16', 622, 228);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3328, new DataView(new ArrayBuffer(8680)), 3203, 436);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 26, y: 7, z: 0},
+  aspect: 'all',
+}, new Uint8Array(377).fill(18), /* required buffer size: 377 */
+{offset: 377, bytesPerRow: 34}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let texture26 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView18 = texture25.createView({baseMipLevel: 0});
+let sampler12 = device0.createSampler({
+  label: '\u{1f6e9}\u{1fbcc}\u0304\ua7f0\ued46\u9f95',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.91,
+  lodMaxClamp: 96.45,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, undefined, 447_500_782, 167_214_681);
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(8, 20);
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 271, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData3 = new ImageData(24, 84);
+let texture27 = device0.createTexture({
+  size: {width: 164},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture28 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder19 = commandEncoder23.beginComputePass({});
+let sampler13 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.07,
+  lodMaxClamp: 76.94,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup5, new Uint32Array(368), 72, 0);
+} catch {}
+document.body.append(canvas0);
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'smpte240m'} });
+let texture29 = device0.createTexture({
+  size: [720, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView19 = texture25.createView({label: '\u{1fa34}\u949a\u967c\u{1ffa9}', format: 'rgb10a2unorm'});
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 35.56,
+  lodMaxClamp: 42.10,
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(1930), 399, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule0, constants: {}}});
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 589, resource: {buffer: buffer9, offset: 4608, size: 674}},
+    {binding: 19, resource: textureView6},
+    {binding: 168, resource: sampler10},
+  ],
+});
+let commandEncoder24 = device0.createCommandEncoder({});
+let computePassEncoder20 = commandEncoder24.beginComputePass({label: '\u90e3\u0883\u0ec8\ue152\u{1f688}\u{1fefb}\uee53'});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(1844), 1_202, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint32', 14_848, 18_621);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(32_785).fill(132), /* required buffer size: 32_785 */
+{offset: 214, bytesPerRow: 77, rowsPerImage: 9}, {width: 0, height: 0, depthOrArrayLayers: 48});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 148}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 28 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder25.finish({});
+let texture30 = device0.createTexture({
+  label: '\u{1fe93}\u09cc\u9b66\u6467\u17c8',
+  size: [2],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView20 = texture9.createView({label: '\u0f40\u0657\u0d2c\u7ed1\u0b09\u{1f809}', aspect: 'all', baseMipLevel: 0});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(0, bindGroup3, new Uint32Array(124), 34, 0);
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let texture31 = device0.createTexture({
+  size: [150, 24, 15],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder2 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 178,
+  clearValue: { r: 322.8, g: 760.9, b: -617.3, a: 47.30, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 632523012,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+let promise1 = shaderModule1.getCompilationInfo();
+document.body.prepend(video0);
+let buffer11 = device0.createBuffer({
+  label: '\u6154\u{1f656}\u{1fa1f}\uc525\u3c12\u{1f79f}\ufcf7\u0025\u5220\ud50c',
+  size: 9510,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder27.beginComputePass();
+let renderPassEncoder3 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 76,
+  clearValue: { r: 681.7, g: 773.9, b: -179.4, a: -570.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 168733421,
+});
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup0, new Uint32Array(1137), 129, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 1_756, 62);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt470m', transfer: 'log'} });
+let bindGroup7 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView8}]});
+let buffer12 = device0.createBuffer({size: 6468, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(2, bindGroup0, new Uint32Array(237), 8, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer9, 0);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u{1ffdb}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(62).fill(118), /* required buffer size: 62 */
+{offset: 62}, {width: 112, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer4, offset: 15104, size: 11628}}],
+});
+let texture32 = device0.createTexture({
+  size: {width: 1440},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler15 = device0.createSampler({
+  label: '\u12d7\ue456\u420b',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.12,
+  lodMaxClamp: 92.96,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup3, new Uint32Array(211), 2, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5, new Uint32Array(663), 1, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint16', 4_042, 393);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'astc-12x12-unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+sampler15.label = '\u0ddd\u0548';
+} catch {}
+let bindGroup9 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView8}]});
+let texture33 = device0.createTexture({
+  label: '\u7801\u3b11\u09b7\u{1ffc0}\u0d37\uf695\uf1fd\u0ebf',
+  size: [164, 12, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView21 = texture30.createView({baseArrayLayer: 0});
+let sampler16 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.008,
+  lodMaxClamp: 41.74,
+});
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 3_208, 2_926);
+} catch {}
+let buffer13 = device0.createBuffer({
+  size: 23857,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(2847), 942, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let computePassEncoder22 = commandEncoder28.beginComputePass({});
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 7_976, 6_198);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer4, 0, 2_663);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 1629, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 168, resource: sampler10},
+    {binding: 589, resource: {buffer: buffer9, offset: 256, size: 1296}},
+    {binding: 19, resource: textureView17},
+  ],
+});
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture34 = device0.createTexture({
+  label: '\u04eb\u2852\uaa20\u{1fe18}\u5dad\u98d2\u1013\ufe76',
+  size: [659, 48, 1],
+  mipLevelCount: 8,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder23 = commandEncoder29.beginComputePass({});
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(2257), 402, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(31, 24, 341_702_840, 1_899_720_157);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 456);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 589, resource: {buffer: buffer9, offset: 3328, size: 2052}},
+    {binding: 19, resource: textureView3},
+    {binding: 168, resource: sampler6},
+  ],
+});
+let commandEncoder30 = device0.createCommandEncoder({label: '\ud259\uc3ce\u72bf\u00f8\u3284\u009a\u{1fbc9}\u{1f681}'});
+let textureView22 = texture11.createView({dimension: '3d', format: 'rgb10a2unorm'});
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer8, 920);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 5208, new BigUint64Array(707), 184, 72);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 16 max align: 16 */
+struct T0 {
+  @align(2) @size(16) f0: array<i32, 1>,
+}
+/* target size: 69 max align: 1 */
+struct T1 {
+  @align(1) @size(12) f0: vec2h,
+  @align(1) @size(54) f1: mat3x4h,
+  @align(1) @size(3) f2: array<array<array<f16, 1>, 1>>,
+}
+/* target size: 7 max align: 1 */
+struct T2 {
+  @align(1) @size(7) f0: atomic<i32>,
+}
+/* target size: 8 max align: 8 */
+struct T3 {
+  f0: array<array<array<array<vec2u, 1>, 1>, 1>, 1>,
+}
+/* target size: 34 max align: 2 */
+struct T4 {
+  @align(2) @size(16) f0: array<array<vec2u, 1>, 1>,
+  @align(2) f1: i32,
+  @align(2) @size(10) f2: atomic<u32>,
+  @align(1) f3: array<atomic<i32>, 1>,
+}
+/* target size: 8 max align: 8 */
+struct T5 {
+  @size(8) f0: array<atomic<u32>>,
+}
+@group(0) @binding(80) var st6: texture_storage_3d<r32float, read_write>;
+@group(1) @binding(80) var st7: texture_storage_2d_array<r32uint, read_write>;
+@group(2) @binding(80) var st8: texture_storage_2d<r32float, read_write>;
+struct VertexOutput3 {
+  @builtin(position) f14: vec4f
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec3u, @location(3) a1: vec3f, @location(8) a2: i32) -> VertexOutput3 {
+  var out: VertexOutput3;
+  if bool(a0[0]) {
+    var v: vec4f;
+  }
+  out.f14 = vec4f(bitcast<f32>(a2));
+  return out;
+}
+struct FragmentOutput2 {
+  @location(5) @interpolate(linear) f0: vec2f,
+  @location(0) @interpolate(perspective) f1: vec4f
+}
+
+@fragment
+fn fragment0(@location(14) @interpolate(flat) a0: vec2f) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  return out;
+}
+struct FragmentOutput3 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment1(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4f) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  _ = a1;
+  if a0 {
+    discard;
+  }
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(workgroup_id) a0: vec3u) {
+  _ = textureLoad(st7, vec2i(), 0);
+  if bool(a0[0]) {
+    textureStore(st8, vec2i(), vec4f(0.2846, 0.04950, 0.06842, 0.00779));
+  }
+  if bool(a0[0]) {
+    textureStore(st7, vec2i(), 0, vec4u(14, 151, 529, 1));
+  }
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder24 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 168);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer9);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let texture35 = device0.createTexture({
+  size: {width: 720},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup3, new Uint32Array(1206), 179, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup1, new Uint32Array(1091), 33, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 96);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer4, 0, 3_751);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+try {
+buffer13.label = '\u02ee\u029b\ub734\u{1fe05}\u4406';
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let texture36 = device0.createTexture({
+  size: [150, 24, 1],
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder4 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 4,
+  clearValue: { r: -181.3, g: 961.3, b: 859.0, a: 684.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 326418651,
+});
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 1_264);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(40).fill(30), /* required buffer size: 40 */
+{offset: 40}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer14 = device0.createBuffer({size: 1922, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView23 = texture21.createView({dimension: '2d-array'});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(78, 107, 1, 118_834_383, 551_243_548);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 1_964);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint16', 1_012, 12_157);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 316, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture37 = device0.createTexture({
+  label: '\u0463\u{1f7bd}\ua6aa\u04f3\ude6c\ud981\u7c21\u{1fc01}\u25f8\u1a78',
+  size: [720],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(58);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(15, 195, 5, 22_617_354, 795_210_407);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 22_088, 1_074);
+} catch {}
+let promise2 = shaderModule1.getCompilationInfo();
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await promise1;
+} catch {}
+document.body.prepend(video0);
+await gc();
+let textureView24 = texture22.createView({dimension: 'cube-array', aspect: 'all', arrayLayerCount: 6});
+let sampler17 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 99.16,
+  lodMaxClamp: 99.94,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup7, new Uint32Array(631), 112, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let buffer15 = device0.createBuffer({size: 6181, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder32 = device0.createCommandEncoder();
+let texture38 = device0.createTexture({
+  label: '\u35f7\u{1f63a}\u0e78\u9d00\u0fd7\u06b5\u3c9d\u0454',
+  size: {width: 82, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(3, 24, 12, 88_758_966, 1_450_636_263);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 1_392, 753);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+let buffer16 = device0.createBuffer({
+  size: 19488,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let computePassEncoder25 = commandEncoder32.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup6, new Uint32Array(2817), 1_597, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(3, 6, 11, 579_733_117, 148_330_600);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 88);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let texture39 = device0.createTexture({
+  label: '\uc2aa\u1aa6\u0f2f\u24a8',
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2unorm'],
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup1, new Uint32Array(1006), 224, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.draw(227, 7, 267_657_663, 199_267_606);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer16, 5_720);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint16', 4_586, 5_492);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 168, resource: sampler2},
+    {binding: 589, resource: {buffer: buffer9, offset: 3328, size: 2819}},
+    {binding: 19, resource: textureView6},
+  ],
+});
+let externalTexture0 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(5, 56, 2, 150_630_924, 2_026_963_154);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 208);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer16, 5_340);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+canvas0.width = 3097;
+let commandEncoder33 = device0.createCommandEncoder({});
+let renderPassEncoder5 = commandEncoder33.beginRenderPass({
+  label: '\u0733\u600f\u{1f944}\u08bb\u1cf5\u0079\u{1f824}',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 149,
+  clearValue: { r: 89.80, g: 898.7, b: -877.1, a: 308.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 192);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer13, 'uint32', 18_592, 1_672);
+} catch {}
+let buffer17 = device0.createBuffer({size: 9102, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder34 = device0.createCommandEncoder({label: '\ud960\u0e7b\u14d2\u06f0\u0b3a\u1d4f\u0c4f\u1ad8\u6e81\u{1f977}'});
+let textureView25 = texture22.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder26 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer16, 1_100);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer4, 0, 3_100);
+} catch {}
+let texture40 = device0.createTexture({
+  label: '\u{1f81b}\ud3b8\u42c2\u47db\ue353\u02d6\u{1f9bd}',
+  size: {width: 164},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView26 = texture11.createView({});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer13, 'uint32', 4_628, 6_102);
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer9, offset: 9984, size: 880}}],
+});
+let buffer18 = device0.createBuffer({size: 3223, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder35 = device0.createCommandEncoder({label: '\u038c\u396d\u04fa\ub3fe\uf84c\u58ce\u{1fb19}'});
+let texture41 = device0.createTexture({
+  size: [720, 1, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.draw(258, 775, 145_716_232, 327_334_689);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(13, 43, 58, -2_081_212_586, 972_796_893);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer16, 1_220);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer13, 'uint16', 5_078, 5_408);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet3, 240, 23, buffer17, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 26},
+  aspect: 'all',
+}, new Uint8Array(47_323).fill(199), /* required buffer size: 47_323 */
+{offset: 283, bytesPerRow: 28, rowsPerImage: 42}, {width: 0, height: 0, depthOrArrayLayers: 41});
+} catch {}
+let sampler18 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.41,
+  lodMaxClamp: 29.87,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup6, new Uint32Array(319), 53, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(144, 35, 233, -1_480_472_327, 1_026_031_649);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer16, 2_144);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer13, 0, 3_120);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 48, new Float32Array(2788), 35, 676);
+} catch {}
+let imageBitmap0 = await createImageBitmap(canvas0);
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 90, resource: textureView10}]});
+let commandEncoder36 = device0.createCommandEncoder({});
+let textureView27 = texture34.createView({baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer16, 264); };
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer16, 2_140);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 238, 8_214);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer9);
+} catch {}
+let renderPassEncoder6 = commandEncoder35.beginRenderPass({
+  label: '\u{1fd25}\u1f33\uf518\u41ea\u{1f78a}\u0752\u309f\u{1fb24}',
+  colorAttachments: [{
+  view: textureView23,
+  clearValue: { r: 571.3, g: 36.69, b: -33.53, a: 527.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup13, new Uint32Array(1133), 363, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer8, 1_144);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\ue56c\ua299\u03f9\u135d\u9f39\u{1f714}\u0674\u9304\u4213\ua261\u9b8a',
+  entries: [
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 234,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 374,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView28 = texture28.createView({format: 'rgba8unorm'});
+let texture42 = device0.createTexture({
+  label: '\u6d02\u4bf6\uba40\u0cee\uf918\u{1f83c}\u4e9e\u548a\u{1fccf}\u067e\u1686',
+  size: {width: 659, height: 48, depthOrArrayLayers: 37},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder27 = commandEncoder36.beginComputePass();
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1f88d}\u{1fa58}\u08f3\u0345\u0ee9\u3f86',
+  colorFormats: ['rgb10a2unorm'],
+  depthReadOnly: true,
+});
+let sampler19 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.24,
+  lodMaxClamp: 98.99,
+  compare: 'always',
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup10, new Uint32Array(1177), 40, 0);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(339), 20, 0);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint32', 25_044, 811);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline0);
+} catch {}
+let pipeline2 = device0.createComputePipeline({
+  label: '\u199d\u2e21\u0190\u3694',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, constants: {}},
+});
+let buffer19 = device0.createBuffer({size: 10636, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder37 = device0.createCommandEncoder();
+let texture43 = device0.createTexture({
+  label: '\ud144\u{1fabb}\u{1f88e}\ua1ae\u0974\u0f8b',
+  size: {width: 150},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView29 = texture17.createView({aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder28 = commandEncoder37.beginComputePass();
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({label: '\u0f8e\u0a3f\u82a1', colorFormats: ['rgb10a2unorm'], stencilReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup1, new Uint32Array(3043), 95, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer15, 688);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint16', 4_164, 3_414);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, undefined, 0, 229_882_183);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint32', 5_944, 2_056);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer6, 116, 906);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let buffer20 = device0.createBuffer({
+  size: 16185,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(1534), 27, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder2.draw(131, 5, 476_514_138, 303_446_594);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(2_082, 180, 462, 13_364_254, 513_196_636);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 456);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 1_068);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline0);
+} catch {}
+let img0 = await imageWithData(29, 57, '#10101010', '#20202020');
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'film', transfer: 'gamma22curve'} });
+let textureView30 = texture17.createView({});
+let sampler20 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 6.060, compare: 'never'});
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(342, 270, 451, 508_118_393, 61_731_920);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint32', 1_480, 5_591);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer6, 'uint16', 964, 665);
+} catch {}
+let imageData4 = new ImageData(72, 8);
+let commandEncoder38 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+  size: {width: 2880},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture45 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle0 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup4, new Uint32Array(583), 178, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.draw(52, 171, 250_771_945, 1_263_166_679);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer19, 864);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 368);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint16', 236, 1_954);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(0, buffer20, 3_420);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule0, constants: {}}});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData5 = new ImageData(4, 140);
+let commandEncoder39 = device0.createCommandEncoder();
+let computePassEncoder29 = commandEncoder38.beginComputePass({});
+let renderPassEncoder7 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 261,
+  clearValue: { r: -52.00, g: 787.0, b: -916.2, a: 987.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup10, new Uint32Array(2313), 173, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup12, new Uint32Array(721), 238, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.draw(227, 140, 146_011_771, 43_013_263);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint32', 368, 300);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer13, 'uint32', 2_948, 2_847);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+renderBundleEncoder0.insertDebugMarker('\u00d7');
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({});
+let renderPassEncoder8 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 185,
+  clearValue: { r: -305.4, g: -128.9, b: 240.6, a: 60.96, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer16, 1_056); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(2495), 531, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(44, 315, 1_845_744_276, 2_823_629_560);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(392, 104, 92, -1_867_002_578, 4_294_967_191);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(3, bindGroup13, new Uint32Array(2946), 537, 0);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView31 = texture41.createView({
+  label: '\u0b58\u{1fdfa}\ue0b6\u8cd8\u110c\u{1fcda}\u2876',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let texture46 = device0.createTexture({
+  size: [720, 1, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder30 = commandEncoder41.beginComputePass({});
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup7, new Uint32Array(2752), 251, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(107, 41, 490_150_115, 670_287_902);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(30, 655, 15, 12_369_125, 158_469_322);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer8, 1_828);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer20, 'uint32', 556, 205);
+} catch {}
+await gc();
+let promise3 = adapter0.requestAdapterInfo();
+let bindGroup15 = device0.createBindGroup({
+  label: '\u0ebc\u0326\u01e8\u0450\ud2a7\u19e8\u{1fd08}\u35b3',
+  layout: bindGroupLayout0,
+  entries: [{binding: 80, resource: textureView1}],
+});
+let textureView32 = texture22.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.draw(135, 315, 144_449_662, 269_657_123);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 52);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer13, 'uint32', 3_004, 9_587);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer3, 4_608, 298);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup3, new Uint32Array(286), 66, 0);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline0);
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture47 = device0.createTexture({
+  label: '\u08cc\u02f0\u0889\u1174\u{1fa98}\u0cbd\uaf81',
+  size: [82, 6, 174],
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView33 = texture35.createView({});
+let renderPassEncoder9 = commandEncoder42.beginRenderPass({
+  label: '\u03d4\uea5d\u956d\u1e88\u7525\u{1f9e1}\u004c',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 47,
+  clearValue: { r: 180.7, g: 135.9, b: -486.5, a: -197.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle1 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 1_212);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer9);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule2, buffers: []},
+  primitive: {topology: 'point-list'},
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(154), 108, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(245, 132, 224, 721_320_471, 1_080_799_187);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 2_700);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer8, 84);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer13, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video0);
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture48 = device0.createTexture({
+  label: '\u9504\u3370\u9f7e\u050f',
+  size: {width: 300, height: 48, depthOrArrayLayers: 3},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView34 = texture47.createView({});
+let renderPassEncoder10 = commandEncoder43.beginRenderPass({
+  colorAttachments: [{
+  view: textureView23,
+  clearValue: { r: -329.0, g: -48.45, b: 109.2, a: -548.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.draw(236, 583, 483_993_933, 1_068_177_966);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 2_492);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+let imageData6 = new ImageData(40, 28);
+let buffer21 = device0.createBuffer({
+  label: '\u0220\u27d4\u1fd6\u778a\ua191\ude7e\u78fd\u0c55\u48eb\uc8b9\u06dd',
+  size: 5052,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture49 = device0.createTexture({size: {width: 360}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup6, new Uint32Array(83), 26, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(63, 24, 1_697_290_801, 444_491_255);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(2, 55, 5, 258_248_369, 2_523_648_374);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer8, 300);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 495});
+let texture50 = device0.createTexture({
+  size: [164, 12, 1],
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder31 = commandEncoder44.beginComputePass({});
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 44.19,
+  lodMaxClamp: 63.53,
+});
+try {
+computePassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder2.draw(37, 77, 222_734_659, 43_418_353);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer15, 472);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 45 max align: 1 */
+struct T0 {
+  @align(1) @size(45) f0: array<array<array<array<vec4h, 1>, 1>, 1>>,
+}
+/* target size: 27 max align: 1 */
+struct T1 {
+  @align(1) @size(16) f0: vec3u,
+  @align(1) f1: vec2h,
+  @align(1) @size(7) f2: atomic<u32>,
+}
+@group(2) @binding(80) var st11: texture_storage_2d<r32float, read_write>;
+@group(0) @binding(80) var st9: texture_storage_2d<r32float, read_write>;
+@group(1) @binding(80) var st10: texture_storage_2d_array<r32float, read_write>;
+struct VertexOutput4 {
+  @location(1) @interpolate(perspective, center) f15: vec3h,
+  @builtin(position) f16: vec4f,
+  @location(3) f17: vec3f,
+  @location(5) f18: vec2u,
+  @location(15) @interpolate(flat) f19: vec4u
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3u, @location(11) @interpolate(flat) a1: vec2h, @location(0) a2: u32, @location(10) a3: vec2f) -> VertexOutput4 {
+  var out: VertexOutput4;
+  if bool(a3[0]) {
+    out.f16 = a3.rggg;
+  }
+  return out;
+}
+struct S1 {
+  @location(3) f0: vec3f,
+  @location(15) @interpolate(flat) f1: vec4u
+}
+struct FragmentOutput4 {
+  @location(4) f0: vec3f,
+  @builtin(sample_mask) f1: u32,
+  @location(5) f2: vec3u,
+  @location(0) f3: vec4f
+}
+
+@fragment
+fn fragment0(a0: S1) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  _ = a0.f1;
+  if bool(a0.f0[2]) {
+    out.f3 = bitcast<vec4f>(a0.f1);
+  }
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  _ = textureLoad(st10, vec2i(), 0);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer22 = device0.createBuffer({size: 11538, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder45 = device0.createCommandEncoder({});
+let renderPassEncoder11 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -643.8, g: -174.1, b: -982.8, a: 659.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 42, y: 24, z: 0},
+  aspect: 'all',
+}, new Uint8Array(62_463).fill(13), /* required buffer size: 62_463 */
+{offset: 43, bytesPerRow: 44, rowsPerImage: 101}, {width: 7, height: 5, depthOrArrayLayers: 15});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u{1f7b2}\u{1f8d0}\u0a0e\u5d93\u0f70\u0574\u5ebb',
+  layout: bindGroupLayout0,
+  entries: [{binding: 80, resource: textureView13}],
+});
+let buffer23 = device0.createBuffer({
+  size: 4048,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder46 = device0.createCommandEncoder({label: '\uc549\u07ee\ud0fd\u53ac\uacdc\uf218\u0e11'});
+let textureView35 = texture28.createView({aspect: 'all'});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup7, new Uint32Array(67), 24, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup10, new Uint32Array(294), 9, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer15, 12);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer22, 260, buffer5, 36, 248);
+} catch {}
+document.body.append(img0);
+let buffer24 = device0.createBuffer({size: 32108, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture51 = device0.createTexture({
+  size: [164, 12, 1],
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm'],
+});
+let computePassEncoder32 = commandEncoder46.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup12, new Uint32Array(849), 34, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer21, 248);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer16, 1_924);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let imageData7 = new ImageData(8, 48);
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture52 = device0.createTexture({
+  size: [164, 12, 658],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 1_264);
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({label: '\u0339\u2d54'});
+let renderPassEncoder12 = commandEncoder47.beginRenderPass({colorAttachments: [{view: textureView27, loadOp: 'load', storeOp: 'discard'}]});
+let sampler22 = device0.createSampler({
+  label: '\u65c8\u7156\u0e79\u6bb9\u50aa\u074d\u{1fa2e}\u0db7\u937c\u{1f9c0}\u05db',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 83.59,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup3, new Uint32Array(1982), 102, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer16, 100); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer15, 608);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer1, 'uint16', 540, 6_053);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment1',
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 28,
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 3},
+          {format: 'uint8x4', offset: 0, shaderLocation: 0},
+          {format: 'sint16x4', offset: 0, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list'},
+});
+document.body.prepend(canvas0);
+canvas0.width = 221;
+let texture53 = device0.createTexture({
+  size: {width: 720, height: 1, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView36 = texture11.createView({label: '\u0e37\u{1f70f}\u8d7c\u{1fd40}\u0a47\uadb8\u{1fdc3}\u5af2\u0c47\u1af5'});
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.draw(77, 298, 1_282_952_361, 683_390_702);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(8, 152, 29, -1_868_169_047, 62_137_227);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer20);
+} catch {}
+video0.width = 10;
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 598,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView37 = texture34.createView({mipLevelCount: 2, baseArrayLayer: 0});
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.515,
+  lodMaxClamp: 85.05,
+  compare: 'never',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder29.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 32.34, g: 284.0, b: 943.7, a: 395.1, });
+} catch {}
+try {
+renderPassEncoder0.draw(96, 16, 186_703_376, 74_532_142);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(268, 173, 147, 594_929_444, 218_302_481);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer8, 'uint16', 558, 27);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer23, 96);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let bindGroup17 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView7}]});
+let texture54 = device0.createTexture({
+  label: '\u9122\u57c9\u{1ff67}\u0fb6\u0673\u39ee\ubf45\ud9d7',
+  size: [300],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let textureView38 = texture44.createView({format: 'rgb10a2unorm', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler24 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 39.74,
+  lodMaxClamp: 45.72,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer8, 76); };
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup17, new Uint32Array(416), 32, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(498, 149, 937_904_752, 1_112_523_649);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(9, 144, 4, -1_519_719_491, 506_151_392);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer15, 1_224);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView39 = texture32.createView({baseMipLevel: 0});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup4, new Uint32Array(686), 8, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.draw(538, 3, 1_541_751_723, 3_354_328);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer8, 160);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(162).fill(97), /* required buffer size: 162 */
+{offset: 162, bytesPerRow: 232}, {width: 14, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder38.label;
+} catch {}
+let buffer25 = device0.createBuffer({
+  size: 2776,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup7, new Uint32Array(90), 1, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup10, new Uint32Array(520), 45, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 1_828);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint32', 1_616, 621);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup9, new Uint32Array(33), 1, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer13, 'uint16', 4_420, 34);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u8b29\u0f18\u8cef\u{1fe22}\u002c', bindGroupLayouts: [bindGroupLayout4]});
+let commandEncoder48 = device0.createCommandEncoder();
+let texture55 = device0.createTexture({
+  label: '\ucd44\u{1fc30}\u0bb8\ue3c4\u41a4\u069f\u3e15\ud701\u066a\uc469\ubc31',
+  size: {width: 2880, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup13, new Uint32Array(4056), 998, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(202, 13, 193, -1_945_969_339, 1_024_607_584);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture56 = device0.createTexture({
+  label: '\u7c37\u{1f98c}\ue7b8\u{1f87f}\u6311\u0b8f\u{1fa1b}\ud5fc\uf44c',
+  size: [164, 12, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView40 = texture20.createView({dimension: '2d-array'});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer16, 960); };
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer16, 568);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4388 */
+  offset: 4388,
+  buffer: buffer10,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 468, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 8620,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let renderPassEncoder13 = commandEncoder48.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 46,
+  clearValue: { r: 758.7, g: -590.3, b: 570.6, a: 30.41, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer16, 4_216); };
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer21, 1_824);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup16, new Uint32Array(1010), 30, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer4, 'uint32', 6_632, 5_669);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u0380');
+} catch {}
+try {
+renderBundleEncoder2.insertDebugMarker('\ubefe');
+} catch {}
+let bindGroup18 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView8}]});
+let commandEncoder49 = device0.createCommandEncoder();
+let computePassEncoder33 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(3, bindGroup4, new Uint32Array(1987), 229, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(13, 60, 15, 39_281_229, 1_134_108_566);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5, buffer3, 0, 1_957);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 72, new Int16Array(299), 52, 36);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+adapter0.label = '\u6e95\u022f\u07c6\u{1fcdc}\u{1fa59}';
+} catch {}
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 90, resource: textureView20}]});
+let texture57 = device0.createTexture({
+  size: {width: 2880, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView41 = texture48.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup1, new Uint32Array(730), 39, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.draw(347, 74, 939_131_962, 1_156_945_140);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer19, 3_148);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer1, 'uint32', 6_712, 4_553);
+} catch {}
+try {
+texture26.destroy();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let videoFrame5 = new VideoFrame(videoFrame0, {timestamp: 0});
+let commandEncoder50 = device0.createCommandEncoder();
+let texture58 = device0.createTexture({
+  size: [2880, 4, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder14 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{
+  view: textureView23,
+  clearValue: { r: -254.0, g: 336.9, b: -837.8, a: 529.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+let renderBundle2 = renderBundleEncoder2.finish({});
+let externalTexture1 = device0.importExternalTexture({source: video0});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup11, new Uint32Array(2401), 511, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle1, renderBundle0, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.draw(39, 125, 478_104_639, 482_732_055);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 4_412);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer25, 0);
+} catch {}
+await gc();
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+/* target size: 12 max align: 4 */
+struct T0 {
+  f0: atomic<i32>,
+  @size(8) f1: atomic<i32>,
+}
+/* target size: 119 max align: 1 */
+struct T1 {
+  @align(1) @size(119) f0: array<mat2x2h>,
+}
+/* target size: 17 max align: 1 */
+struct T2 {
+  @align(1) @size(17) f0: array<array<f16, 1>>,
+}
+/* target size: 8 max align: 8 */
+struct T3 {
+  @size(8) f0: array<vec2h, 1>,
+}
+/* target size: 8 max align: 8 */
+struct T4 {
+  f0: T3,
+}
+@group(0) @binding(49) var st12: texture_storage_2d_array<rg32sint, write>;
+@group(0) @binding(234) var sam0: sampler;
+@group(0) @binding(374) var st13: texture_storage_2d<rgba8snorm, read>;
+@group(0) @binding(15) var tex0: texture_depth_cube_array;
+struct S2 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) @interpolate(perspective) f1: vec3h,
+  @builtin(front_facing) f2: bool,
+  @location(3) f3: vec3f,
+  @location(5) f4: vec2u
+}
+struct FragmentOutput5 {
+  @location(0) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+  @location(5) @interpolate(flat) f2: vec3u
+}
+
+@fragment
+fn fragment0(a0: S2) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  _ = textureLoad(st13, vec2i());
+  _ = a0.f3;
+  if bool(a0.f4[0]) {
+    out.f1 = u32(a0.f2);
+  }
+  return out;
+}
+struct FragmentOutput6 {
+  @location(0) f0: vec4f,
+  @location(3) f1: vec3u
+}
+
+@fragment
+fn fragment1(@location(12) @interpolate(flat, centroid) a0: vec2i) -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  return out;
+}
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(num_workgroups) a0: vec3u) {
+}`,
+  sourceMap: {},
+});
+let buffer27 = device0.createBuffer({
+  size: 1520,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture59 = device0.createTexture({
+  size: [150, 24, 146],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer26, 1_708); };
+} catch {}
+try {
+renderPassEncoder0.draw(163, 46, 1_379_202_287, 105_278_238);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer21, 1_096);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer19, 368);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'astc-10x5-unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture60 = device0.createTexture({size: [659], dimension: '1d', format: 'r32uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u3598\ue59d\u06a3\u0363\ua5d8\uc5f0\u0615\u6ff4\uc9fa\uc734\u083b',
+  colorFormats: ['rgb10a2unorm'],
+  stencilReadOnly: true,
+});
+let sampler25 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 37.25,
+  lodMaxClamp: 40.62,
+});
+try {
+computePassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(246, 408, 46, -1_671_282_748, 342_225_657);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 424);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer4, 'uint32', 1_888, 11_948);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline4);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 184,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 187,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let texture61 = device0.createTexture({
+  size: {width: 720, height: 1, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler26 = device0.createSampler({
+  label: '\u093a\u0482\u{1fdc4}\ue9af',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.50,
+  lodMaxClamp: 96.41,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup8, new Uint32Array(7338), 3_662, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -277.3, g: -604.2, b: 73.12, a: -237.5, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 2_516);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 3_972, 8_446);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, buffer13, 4_056, 7_065);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas0);
+let textureView42 = texture61.createView({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: true});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup9, new Uint32Array(218), 19, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(363, 75, 99_718_389, 505_560_537);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(7, 29, 2, 492_711_019, 452_771_610);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup13, new Uint32Array(932), 22, 0);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\u{1fd82}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let buffer28 = device0.createBuffer({
+  label: '\u7960\u{1fc15}\uad28\u{1f7df}\ue0c3\uc1f0\ucfc0\u{1fef0}\uec7a\ud027\u0750',
+  size: 776,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture62 = device0.createTexture({
+  size: [600, 96, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -192.8, g: 567.5, b: 144.3, a: -884.8, });
+} catch {}
+try {
+renderPassEncoder6.setViewport(465.04216919462556, 2.2611228625869795, 275.8476298761777, 1.1885449171939508, 0.8949620082591845, 0.9832125065957904);
+} catch {}
+try {
+renderPassEncoder0.draw(111, 330, 823_197_495, 354_697_002);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer19, 5_576);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 2_672, 2_303);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+document.body.append(video0);
+let renderBundle4 = renderBundleEncoder4.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(156, 364, 235, 413_317_947, 388_906_840);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer15, 320);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 190,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView43 = texture34.createView({baseMipLevel: 4, mipLevelCount: 1});
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+document.body.append(video0);
+let texture63 = device0.createTexture({
+  label: '\u053b\u67f6\u5344\ubdc5\u2456\u{1f72c}\u{1f6ca}',
+  size: {width: 659},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler27 = device0.createSampler({
+  label: '\u61f3\u25f3\u{1f797}\u2221\u9a75\u{1f998}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.72,
+  lodMaxClamp: 68.98,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer15, 40); };
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(784);
+} catch {}
+try {
+renderPassEncoder2.draw(7, 103, 166_452_412, 1_603_811_103);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer26, 'uint16', 2_022, 537);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u{1ff67}');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData8 = new ImageData(28, 256);
+let commandEncoder51 = device0.createCommandEncoder();
+let computePassEncoder34 = commandEncoder51.beginComputePass({});
+let sampler28 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.47,
+  lodMaxClamp: 94.21,
+  maxAnisotropy: 8,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder7.setViewport(0.2730755925069712, 1.8970560032706294, 0.39505084576296395, 0.035111632997385823, 0.243111973580715, 0.7600152692660341);
+} catch {}
+try {
+renderPassEncoder0.draw(228, 92, 1_860_273_493, 336_422_265);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer15, 292);
+} catch {}
+let buffer29 = device0.createBuffer({size: 7880, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+try {
+renderPassEncoder0.drawIndexed(5, 319, 4, -1_565_276_778, 1_374_329_771);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer21, 64);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint32', 312, 3_576);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer6, 64, 291);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let buffer30 = device0.createBuffer({
+  size: 38516,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder52 = device0.createCommandEncoder({});
+let textureView44 = texture58.createView({label: '\u0cd6\u{1feae}\u01ab\u0a5f', format: 'rgb10a2unorm', baseMipLevel: 0, mipLevelCount: 1});
+let renderPassEncoder15 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 372.8, g: 598.1, b: 199.0, a: 173.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 52318295,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup18, new Uint32Array(3230), 1_232, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(201, 14, 303_138_271, 251_023_607);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(19, 100, 1, -1_997_863_758, 1_174_820_820);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer19, 128);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1452, new DataView(new ArrayBuffer(18175)), 11005, 652);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture64 = device0.createTexture({
+  size: {width: 75},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder16 = commandEncoder53.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -530.3, g: 993.4, b: -72.68, a: 539.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler29 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.85,
+  lodMaxClamp: 98.79,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup9, new Uint32Array(517), 102, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 212, 202, 358_933_349, 369_065_431);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+renderPassEncoder2.draw(143, 24, 229_506_985, 1_034_647_546);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 1_488);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 1_956);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer23, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise4;
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let imageData9 = new ImageData(12, 212);
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte240m', transfer: 'log'} });
+let buffer31 = device0.createBuffer({
+  size: 13320,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet6 = device0.createQuerySet({label: '\u6046\u961d\u{1fe34}\uf879\ub572\u{1f800}', type: 'occlusion', count: 268});
+let texture65 = device0.createTexture({
+  size: {width: 600, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup7, new Uint32Array(1206), 256, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup8, new Uint32Array(1114), 225, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(147, 81, 828_096_415, 103_969_505);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 424, new BigUint64Array(1396), 17, 248);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(3, bindGroup12, new Uint32Array(278), 80, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2, renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(1.549799600905873, 0.8126215227269211, 0.11258726317838613, 0.9183251331302565, 0.7357454219233819, 0.8965724265963582);
+} catch {}
+try {
+renderPassEncoder0.draw(21, 11, 334_426_485, 1_315_288_552);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(341, 26, 609, 287_783_491, 2_130_182_646);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer16, 3_768);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer21, 'uint16', 704, 12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 280, new BigUint64Array(4168), 250, 84);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'film', transfer: 'iec61966-2-1'} });
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer6, offset: 256, size: 912}}],
+});
+let textureView45 = texture17.createView({label: '\ue159\u0e2f', format: 'rgb10a2unorm', baseMipLevel: 0});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 268, 0, 552_725_705, 352_217_394);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer20, 'uint16', 6, 1_376);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 13, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(168).fill(51), /* required buffer size: 168 */
+{offset: 168, bytesPerRow: 522, rowsPerImage: 8}, {width: 31, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer32 = device0.createBuffer({size: 11548, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let commandEncoder54 = device0.createCommandEncoder({});
+let computePassEncoder35 = commandEncoder54.beginComputePass({});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.05,
+  lodMaxClamp: 93.14,
+  compare: 'never',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.draw(188, 94, 764_867_797, 283_135_719);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer23, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 88, new DataView(new ArrayBuffer(7438)), 2612, 444);
+} catch {}
+let buffer33 = device0.createBuffer({
+  size: 25096,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture66 = device0.createTexture({size: [164], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let textureView46 = texture11.createView({mipLevelCount: 1});
+let sampler31 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 23.64,
+  lodMaxClamp: 51.35,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer26, 'uint32', 36, 197);
+} catch {}
+let texture67 = device0.createTexture({
+  size: [150, 24, 1],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture68 = device0.createTexture({size: [8, 5, 1], format: 'astc-8x5-unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup6, new Uint32Array(3530), 588, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup20, new Uint32Array(236), 11, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(1.925307470569754, 1.5831013035643067, 0.0002450487447390862, 0.2398021177566733, 0.7486169039603174, 0.774590418177564);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 7_320);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 880, new Float32Array(10839), 945, 96);
+} catch {}
+document.body.append(video0);
+let buffer34 = device0.createBuffer({size: 1913, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder55 = device0.createCommandEncoder({});
+let textureView47 = texture67.createView({});
+let computePassEncoder36 = commandEncoder55.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup10, new Uint32Array(1344), 752, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle2, renderBundle2, renderBundle2, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.draw(107, 88, 822_187_731, 1_749_393_516);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer26, 'uint16', 2_404, 221);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer20, 1_120, 779);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video0);
+await gc();
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 16 max align: 16 */
+struct T0 {
+  @size(16) f0: array<atomic<i32>>,
+}
+/* target size: 8 max align: 8 */
+struct T1 {
+  @align(1) @size(8) f0: vec2h,
+}
+@group(0) @binding(49) var st14: texture_storage_2d_array<r32float, write>;
+@group(0) @binding(374) var st15: texture_storage_2d_array<rgba16float, read>;
+@group(0) @binding(15) var tex1: texture_depth_2d_array;
+@group(0) @binding(234) var sam1: sampler;
+struct VertexOutput5 {
+  @builtin(position) f20: vec4f
+}
+
+@vertex
+fn vertex0(@location(2) @interpolate(flat) a0: vec2i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  _ = a0;
+  if bool(textureSampleLevel(tex1, sam1, vec2f(), 0i, 0i)) {
+    var v: vec4f;
+  }
+  return out;
+}
+struct FragmentOutput7 {
+  @location(0) @interpolate(flat) f0: vec4f,
+  @location(3) @interpolate(flat) f1: vec2i,
+  @location(5) @interpolate(flat, centroid) f2: vec2f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = textureLoad(st15, vec2i(), 0);
+}`,
+});
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 234, resource: sampler25},
+    {binding: 49, resource: textureView4},
+    {binding: 374, resource: textureView35},
+    {binding: 15, resource: textureView16},
+  ],
+});
+let buffer35 = device0.createBuffer({
+  label: '\u0ac8\uffc4\u{1f856}\u0934\uf1a3\u4508\u5eaa\u{1f632}\u05b8\u2cf5\u070d',
+  size: 6738,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView48 = texture31.createView({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.draw(279, 39, 363_424_453, 1_326_383_941);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer17, 1_828);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer21, 32);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, entryPoint: 'compute1', constants: {}}});
+let bindGroup22 = device0.createBindGroup({
+  label: '\u0e88\u0265\u2177',
+  layout: bindGroupLayout8,
+  entries: [{binding: 190, resource: textureView7}],
+});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.970,
+  lodMaxClamp: 78.95,
+});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 202, 0, 355_697_344, 1_459_036_512);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer21, 1_204);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer8, 216);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  label: '\u832a\uda8b\u2a07\u82c9\u3215\ueec6\u0024\u{1f8b4}',
+  layout: bindGroupLayout7,
+  entries: [{binding: 184, resource: {buffer: buffer23, offset: 256}}, {binding: 187, resource: textureView42}],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+let renderBundle5 = renderBundleEncoder5.finish({label: '\u09af\u{1f83d}\u2a6e\ufa99\u83d9'});
+let sampler33 = device0.createSampler({
+  label: '\uab5a\u0188\u916f\u1530',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 53.98,
+  lodMaxClamp: 74.13,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.draw(175, 199, 453_893_720, 264_060_599);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer21, 208);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 234, resource: sampler14},
+    {binding: 374, resource: textureView28},
+    {binding: 15, resource: textureView42},
+    {binding: 49, resource: textureView4},
+  ],
+});
+let texture69 = device0.createTexture({
+  size: [2880, 4, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer33, 196, 2_759);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer19, 916); };
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 53},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 517, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = buffer31.label;
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup18, new Uint32Array(879), 104, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer33, 5_348);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 3_640);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer3, 1_232, 1_222);
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 1,
+  origin: {x: 271, y: 21, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 3, y: 1, z: 1},
+  aspect: 'all',
+},
+{width: 9, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder();
+let computePassEncoder37 = commandEncoder56.beginComputePass({label: '\ufb0f\u2b13\u3657\u0db1\u0528\u7a01\u619f\u098d\u1082\u{1f782}\u{1f824}'});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup6, new Uint32Array(1727), 216, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup24, new Uint32Array(709), 20, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(295, 31, 747_141_561, 613_554_382);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(36, 182, 1, 781_268_398, 815_906_823);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4_294_967_294, undefined, 2_627_388_578, 242_752_341);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(43).fill(48), /* required buffer size: 43 */
+{offset: 43}, {width: 1204, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture70 = device0.createTexture({size: [2, 2, 12], format: 'rgb10a2unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+try {
+renderPassEncoder3.draw(258, 449, 1_356_502_241, 483_492_511);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer17, 496);
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({label: '\uc622\u07d0\uef68'});
+let textureView49 = texture62.createView({mipLevelCount: 1});
+let renderPassEncoder17 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 0,
+  clearValue: { r: -920.3, g: 373.3, b: 560.4, a: -834.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], stencilReadOnly: true});
+let renderBundle6 = renderBundleEncoder6.finish();
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(20, 6, 73, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(116, 40, 81_986_996, 611_148_771);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer21, 2032, buffer1, 44, 128);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 4, y: 13, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 136 */
+  offset: 136,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {width: 40, height: 74, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\uf72a');
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer4, offset: 512, size: 7196}}],
+});
+let computePassEncoder38 = commandEncoder58.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup7, new Uint32Array(8848), 3_226, 0);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(88, 13, 12, 1);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(1, 153, 20, 686_248_372, 3_887_247_679);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer26, 'uint32', 536, 2_019);
+} catch {}
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.14,
+  lodMaxClamp: 97.16,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder2.drawIndexed(0, 25, 0, 186_835_037, 141_878_379);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer33, 1_908);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+let buffer36 = device0.createBuffer({size: 33412, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder59 = device0.createCommandEncoder({});
+let computePassEncoder39 = commandEncoder59.beginComputePass({label: '\ubfcc\u0624\u5e44\u03c4\u0581\u09fa'});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle2, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(9, 1, 4, 11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 568, new BigUint64Array(3426), 1206, 104);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 659, height: 48, depthOrArrayLayers: 37}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 334, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture2 = device0.importExternalTexture({label: '\u9dd2\u143c', source: videoFrame6});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup12, new Uint32Array(4875), 1_103, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup10, new Uint32Array(110), 2, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(52, 128, 9_304_360, 754_561_424);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer33, 2_008);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 316);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'log'} });
+let bindGroup26 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView1}]});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4, bindGroupLayout6]});
+let commandEncoder60 = device0.createCommandEncoder({});
+let computePassEncoder40 = commandEncoder60.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup4, new Uint32Array(1908), 204, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(0, 1, 1_300_035_915, 105_455_347);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 1, 1, 148_112_733, 1_119_361_639);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 2_028);
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 234, resource: sampler11},
+    {binding: 374, resource: textureView35},
+    {binding: 15, resource: textureView42},
+    {binding: 49, resource: textureView2},
+  ],
+});
+let sampler35 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.266,
+  lodMaxClamp: 21.14,
+  compare: 'greater-equal',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder40.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer8, 368);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 168, new Float32Array(18909), 1603, 68);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'gamma22curve'} });
+let bindGroup28 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView7}]});
+let texture71 = device0.createTexture({
+  size: [329, 24, 1],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+try {
+computePassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 31, 2, 716_935_733, 915_221_773);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer33, 3_432);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 1256, new Int16Array(2916), 343, 336);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let imageData10 = new ImageData(76, 68);
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView24}]});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup13, new Uint32Array(1607), 451, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 0, 4_243);
+} catch {}
+let arrayBuffer2 = buffer33.getMappedRange();
+document.body.prepend(img0);
+let texture72 = device0.createTexture({
+  size: {width: 75},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 700);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer20, 'uint32', 400, 1_873);
+} catch {}
+try {
+renderPassEncoder0.pushDebugGroup('\u02f2');
+} catch {}
+try {
+renderPassEncoder0.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(266).fill(28), /* required buffer size: 266 */
+{offset: 266, bytesPerRow: 249}, {width: 24, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 51 max align: 1 */
+struct T0 {
+  @align(1) @size(51) f0: array<f16>,
+}
+@group(1) @binding(64) var<storage, read_write> buffer37: T0;
+@group(0) @binding(374) var st17: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(234) var sam2: sampler;
+@group(0) @binding(49) var st16: texture_storage_2d_array<r32float, write>;
+@group(0) @binding(15) var tex2: texture_cube<i32>;
+struct VertexOutput6 {
+  @location(12) f21: vec4i,
+  @location(10) f22: vec2i,
+  @builtin(position) f23: vec4f,
+  @location(2) @interpolate(perspective, sample) f24: vec3h
+}
+
+@vertex
+fn vertex0() -> VertexOutput6 {
+  var out: VertexOutput6;
+  return out;
+}
+struct VertexOutput7 {
+  @builtin(position) f25: vec4f
+}
+
+@vertex
+fn vertex1(@location(8) a0: vec4i) -> VertexOutput7 {
+  var out: VertexOutput7;
+  return out;
+}
+struct VertexOutput8 {
+  @location(1) f26: vec3h,
+  @builtin(position) f27: vec4f,
+  @location(11) f28: vec2i,
+  @location(14) f29: i32
+}
+
+@vertex
+fn vertex2() -> VertexOutput8 {
+  var out: VertexOutput8;
+  return out;
+}
+struct FragmentOutput8 {
+  @location(0) f0: vec4i,
+  @location(1) f1: i32
+}
+
+@fragment
+fn fragment0(@location(12) @interpolate(flat, centroid) a0: vec2i) -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  _ = buffer37.f0;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = buffer37.f0;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup30 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView13}]});
+let buffer38 = device0.createBuffer({
+  size: 2791,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let sampler36 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.38,
+  lodMaxClamp: 60.65,
+  compare: 'greater',
+  maxAnisotropy: 6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer21, 1_684); };
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup29, new Uint32Array(564), 10, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer27, 88);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer33, 'uint16', 852, 813);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer8, 600); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer21, 540);
+} catch {}
+video0.height = 40;
+let buffer39 = device0.createBuffer({
+  size: 9429,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder0.draw(62, 46, 725_380_239, 288_472_775);
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule4,
+    buffers: [
+      {
+        arrayStride: 488,
+        attributes: [
+          {format: 'float32x2', offset: 36, shaderLocation: 10},
+          {format: 'uint32x3', offset: 20, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 276, shaderLocation: 11},
+          {format: 'uint16x2', offset: 12, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(212, 13);
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.44,
+  lodMaxClamp: 52.96,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(3, bindGroup30, new Uint32Array(4820), 1_836, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(7, 81, 0, 276_396_102, 1_500_725_605);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 1_740);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer40 = device0.createBuffer({size: 10405, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder61 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({
+  size: [164, 12, 1],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle2, renderBundle0, renderBundle2, renderBundle2, renderBundle2, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(1.8013534030344511, 1.002980540528928, 0.10884621020809879, 0.36798458563393227, 0.4322180447725763, 0.5767859604470452);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer38, 416);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer26, 'uint32', 4_092, 402);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+await gc();
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], stencilReadOnly: true});
+try {
+renderPassEncoder2.draw(213, 116, 237_143_041, 1_293_876_168);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 51, 0, -2_086_958_055, 883_838_251);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 104);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 1_668);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer21, 'uint32', 52, 2_985);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup14, []);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer27, 4, buffer26, 1832, 632);
+} catch {}
+await gc();
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 234, resource: sampler14},
+    {binding: 49, resource: textureView4},
+    {binding: 15, resource: textureView16},
+    {binding: 374, resource: textureView28},
+  ],
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView50 = texture38.createView({format: 'rg32float', mipLevelCount: 1});
+let computePassEncoder41 = commandEncoder62.beginComputePass({});
+let renderBundle7 = renderBundleEncoder7.finish();
+try {
+computePassEncoder14.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 12, 1, 113_782_603, 69_201_654);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 140);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 41, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3728 */
+  offset: 3728,
+  buffer: buffer9,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup32 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView24}]});
+let pipelineLayout7 = device0.createPipelineLayout({label: '\u0ddd\ue77e\u002a\ua12c', bindGroupLayouts: []});
+let computePassEncoder42 = commandEncoder61.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder2.drawIndirect(buffer19, 76);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer21, 'uint32', 940, 15);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer31, 0, 1_295);
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule6, constants: {}}});
+let textureView51 = texture36.createView({
+  label: '\u82be\u2104\uad06\u{1f952}\u2ad5\u0e35\u{1f61c}\u0e4c\u9a63\u{1fcd9}',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+let sampler38 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.70,
+  lodMaxClamp: 67.53,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder42.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder0.draw(118, 738, 833_400_747, 2_595_086_446);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(7, 85, 47, 560_324_541, 974_996_425);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer26, 5_400);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer40, 2_072);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer31, 1_896, 329);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup31, new Uint32Array(1247), 55, 0);
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture74 = device0.createTexture({
+  label: '\u3e00\u1c7e\u0d98',
+  size: {width: 1440, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder43 = commandEncoder63.beginComputePass({});
+try {
+renderPassEncoder2.drawIndexed(1, 0, 5, 257_409_492, 445_067_373);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 600);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 2_068);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer39, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup24, new Uint32Array(292), 76, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video1 = await videoWithData(28);
+let imageData11 = new ImageData(72, 8);
+let buffer41 = device0.createBuffer({
+  size: 6475,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder64 = device0.createCommandEncoder();
+let texture75 = device0.createTexture({
+  size: [2880],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder18 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView23,
+  clearValue: { r: 886.3, g: 912.6, b: -611.7, a: 493.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 165041506,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], stencilReadOnly: true});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup19, new Uint32Array(3261), 201, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer40, 8);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 768);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer31, 3_092, 1_146);
+} catch {}
+try {
+adapter0.label = '\u{1f954}\u085f\u3b22\u7532\ub831\u6fb1\u{1f9ab}\u{1f896}';
+} catch {}
+let texture76 = device0.createTexture({
+  size: [659, 48, 1],
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle8 = renderBundleEncoder9.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer40, 2_208); };
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1, 174, 21, 29_624_016, 1_274_281_416);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer19, 724);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 564);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer4, 'uint32', 5_788, 2_741);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+let imageData12 = new ImageData(20, 4);
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'gamma28curve'} });
+let bindGroup33 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 598, resource: {buffer: buffer26, offset: 256}}]});
+let commandEncoder65 = device0.createCommandEncoder();
+let sampler39 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 84.72,
+  lodMaxClamp: 99.20,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup26, new Uint32Array(1969), 190, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.draw(290, 59, 2_079_341_813, 1_157_173_198);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup1, new Uint32Array(1859), 167, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet0, 73, 30, buffer35, 2048);
+} catch {}
+document.body.append(canvas0);
+let texture77 = device0.createTexture({
+  size: [82],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup13, new Uint32Array(565), 13, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer13, 'uint16', 9_124, 2_138);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup20, new Uint32Array(619), 29, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer30, 4_204);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 75, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 8, y: 3 },
+  flipY: true,
+}, {
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer42 = device0.createBuffer({
+  size: 194,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true});
+let externalTexture3 = device0.importExternalTexture({label: '\u891f\u544c', source: video0});
+try {
+renderPassEncoder2.draw(26, 24, 3_386_950_954, 280_130_250);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 74, 0, 207_803_886, 237_131_136);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer27, 'uint16', 76, 399);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer39, offset: 1792, size: 816}}],
+});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 2389});
+let computePassEncoder44 = commandEncoder65.beginComputePass({});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(0, bindGroup9, new Uint32Array(635), 87, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(228), 143, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(193, 41, 420_536_303, 65_498_062);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer25);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, colorSpace: 'srgb'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 2,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(566).fill(147), /* required buffer size: 566 */
+{offset: 566, bytesPerRow: 19}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+window.someLabel = textureView5.label;
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({});
+let textureView52 = texture12.createView({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup22, new Uint32Array(1270), 546, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(19, 221, 3, 66_886_297, 750_872_488);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer41, 760);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 1_008);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer6, 'uint32', 4_504, 970);
+} catch {}
+document.body.prepend(img0);
+let imageBitmap1 = await createImageBitmap(videoFrame2);
+let buffer43 = device0.createBuffer({
+  label: '\u01a6\u00d0\ue573\ubbf9\u{1fe0c}\u09b9\u0226\u24f9\u01dc\u{1fde0}\u{1fc71}',
+  size: 37476,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let sampler40 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.07,
+  lodMaxClamp: 75.30,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup1, new Uint32Array(1269), 64, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup34, new Uint32Array(1146), 208, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 17, 0, 237_974_582, 1_602_207_812);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer33, 880);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer4, 'uint32', 9_992, 3_819);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer33, 4_144, 2_009);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup29, new Uint32Array(338), 6, 0);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 82, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 94, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder45 = commandEncoder66.beginComputePass({});
+let renderBundle9 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup30, new Uint32Array(1799), 10, 0);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 57, 1, 193_361_507, 1_021_218_654);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer26, 1_456);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup19, new Uint32Array(274), 13, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer21, 'uint32', 1_232, 77);
+} catch {}
+let imageData13 = new ImageData(24, 20);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let texture78 = device0.createTexture({
+  label: '\u{1fde4}\u{1fa5e}\ucd95\u0032\uf6b2\u07e8\u{1fd01}\u00d2\u00ad\u{1ff1c}',
+  size: [164, 12, 1],
+  mipLevelCount: 4,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView53 = texture34.createView({baseMipLevel: 1, mipLevelCount: 3});
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.89,
+  lodMaxClamp: 85.84,
+  compare: 'less',
+});
+try {
+computePassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup1, new Uint32Array(7), 0, 0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(2239.033632522668, 0.9028405916517586, 121.08832340949864, 2.2921072228922035, 0.8684074676109135, 0.9105831475751095);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer42, 40);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer30, 0, 8_278);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(562), 24, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1652, new Float32Array(27343), 3010, 516);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup35 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView32}]});
+let buffer44 = device0.createBuffer({size: 4524, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder67 = device0.createCommandEncoder({});
+let texture79 = device0.createTexture({
+  label: '\u1e94\uae1d',
+  size: [360, 1, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView54 = texture23.createView({});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder5.setViewport(0.9386239969241326, 1.9246597790756488, 0.7626821117227068, 0.017838531679916152, 0.5634271071825455, 0.7471913316477027);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer38, 84);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer6, 'uint32', 1_392, 363);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(3, buffer39, 0, 1_273);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  label: '\u09a6\uc523\u9a87\u5168\u1f67\u0685\u437b\u1b2c\u{1fceb}',
+  code: `
+enable f16;
+/* target size: 85 max align: 1 */
+struct T0 {
+  @align(1) @size(25) f0: atomic<u32>,
+  @align(1) @size(8) f1: array<i32, 1>,
+  @align(1) f2: mat2x4h,
+  @align(1) @size(36) f3: array<array<atomic<u32>, 1>>,
+}
+@group(0) @binding(80) var st18: texture_storage_3d<r32sint, read_write>;
+@group(1) @binding(80) var st19: texture_storage_2d<r32float, read_write>;
+@group(2) @binding(80) var st20: texture_storage_2d<r32float, read_write>;
+struct FragmentOutput9 {
+  @location(1) @interpolate(flat, center) f0: vec2i,
+  @location(0) @interpolate(flat) f1: vec4i
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  return out;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(local_invocation_id) a0: vec3u) {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 187, resource: textureView42},
+    {binding: 184, resource: {buffer: buffer8, offset: 256, size: 771}},
+  ],
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let textureView55 = texture41.createView({mipLevelCount: 1});
+let sampler42 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 97.87,
+  lodMaxClamp: 99.73,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup12, new Uint32Array(408), 46, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 1_856);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer15, 408);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer33, 'uint16', 3_990, 5_246);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup36, new Uint32Array(550), 79, 0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer33, 2_240, 1_343);
+} catch {}
+try {
+computePassEncoder39.pushDebugGroup('\u3f3c');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 157, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(229).fill(22), /* required buffer size: 229 */
+{offset: 229, bytesPerRow: 136, rowsPerImage: 53}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder46 = commandEncoder68.beginComputePass({});
+let renderBundle10 = renderBundleEncoder11.finish({});
+let sampler43 = device0.createSampler({
+  label: '\u98f0\ubc7f\u{1fd58}\u0800',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.70,
+  lodMaxClamp: 34.47,
+  maxAnisotropy: 3,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer42, 76); };
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer42, 'uint16', 72, 2);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder67.copyTextureToBuffer({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 204, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 972 widthInBlocks: 972 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9 */
+  offset: 9,
+  buffer: buffer34,
+}, {width: 972, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer45 = device0.createBuffer({
+  label: '\u5fce\ufe4e\u{1f91b}\u04bd\u3d3b\ub8a8\u0ede\u3270\u944f',
+  size: 12461,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture80 = device0.createTexture({
+  label: '\u0661\ucf67\u5a9f\u374b\u329f\u0266\ue1af\u{1f72b}\u17b6',
+  size: {width: 2880, height: 4, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder47 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup15, new Uint32Array(855), 204, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle3, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer15, 2_556);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer8, 212);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer20, 'uint32', 4_844, 437);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer31);
+} catch {}
+let texture81 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 1},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView56 = texture76.createView({label: '\u0017\u051b\u053b\u649f', dimension: '2d'});
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(42);
+} catch {}
+try {
+renderPassEncoder2.draw(226, 85, 832_712_418, 45_346_500);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer8, 1_344);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer45, 3_448);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer39, 0, 555);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup10, new Uint32Array(3007), 55, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpteSt4281', transfer: 'log'} });
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder69 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 158});
+let computePassEncoder48 = commandEncoder69.beginComputePass({});
+let sampler44 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.66,
+  lodMaxClamp: 88.65,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder48.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup29, new Uint32Array(610), 47, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer31);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup1, new Uint32Array(393), 26, 0);
+} catch {}
+try {
+for (let i = 0; i < 10459; ++i) { if (i%1000 === 0) await device0.queue.onSubmittedWorkDone(); for (let j = 0; j < 313; ++j) renderBundleEncoder8.draw(0); renderBundleEncoder8.setPipeline(pipeline7); renderBundleEncoder8.setPipeline(pipeline4); };
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(2, 12, 8, 257_405_808, 1_285_731_030);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer20, 'uint32', 908, 3_023);
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({});
+let computePassEncoder49 = commandEncoder70.beginComputePass();
+let renderBundle11 = renderBundleEncoder8.finish({});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(0, bindGroup3, new Uint32Array(2092), 461, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.draw(92, 8, 1_030_515_456, 12_825_433);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 1_308, 22_647);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 51 max align: 1 */
+struct T0 {
+  @align(1) @size(42) f0: mat2x4h,
+  @align(1) f1: i32,
+  @align(1) @size(5) f2: i32,
+}
+@group(0) @binding(374) var st22: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(234) var sam3: sampler;
+@group(1) @binding(64) var<storage, read_write> buffer46: array<T0>;
+@group(0) @binding(15) var tex3: texture_3d<i32>;
+@group(0) @binding(49) var st21: texture_storage_2d<rgba32uint, write>;
+struct VertexOutput9 {
+  @location(8) f30: vec4u,
+  @builtin(position) f31: vec4f,
+  @location(5) @interpolate(flat) f32: vec2i,
+  @location(15) f33: vec3i,
+  @location(9) @interpolate(flat, sample) f34: vec2u
+}
+
+@vertex
+fn vertex0(@location(3) @interpolate(flat) a0: vec4h) -> VertexOutput9 {
+  var out: VertexOutput9;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+  if bool(buffer46[arrayLength(&buffer46)].f2) {
+    return;
+  }
+  if bool(textureLoad(st22, vec2i())[1]) {
+    buffer46[12345].f1 &= i32(-91);
+  }
+}`,
+  hints: {},
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 933});
+let texture82 = device0.createTexture({
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup19, new Uint32Array(2088), 80, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 255, 0, 107_202_023, 713_089_920);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer41, 3_624);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer39, 0);
+} catch {}
+let buffer47 = device0.createBuffer({
+  size: 430,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder2.draw(58, 239, 1_277_468_478, 119_978_379);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 25, 0, 38_859_209, 206_635_565);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder39.popDebugGroup();
+} catch {}
+let img1 = await imageWithData(12, 7, '#10101010', '#20202020');
+let bindGroup37 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 28, resource: {buffer: buffer36, offset: 12032}}]});
+let commandEncoder72 = device0.createCommandEncoder({});
+let sampler45 = device0.createSampler({
+  label: '\u72ed\u0769\u{1ff0f}\u0b13',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.52,
+  lodMaxClamp: 82.33,
+  compare: 'not-equal',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1_489, 210, 692, -1_920_670_320, 992_648_483);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video0);
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView57 = texture6.createView({label: '\u763b\u3a27\u{1f975}\u0f7e\u{1fbf0}\u97a8\u{1f7d5}', dimension: 'cube', baseArrayLayer: 1});
+try {
+renderPassEncoder0.draw(29, 307, 624_484_074, 97_452_594);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({});
+let computePassEncoder50 = commandEncoder71.beginComputePass({});
+let externalTexture5 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup1, new Uint32Array(1880), 841, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(228);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle3, renderBundle3, renderBundle9, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(97, 219, 0, 519_623_095, 223_460_083);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2960 */
+  offset: 2960,
+  buffer: buffer18,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder51 = commandEncoder72.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup10, new Uint32Array(4326), 72, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.draw(32, 139, 41_036_795, 515_318_429);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer20, 'uint32', 2_040, 7_005);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer32, 6052, buffer1, 3176, 460);
+} catch {}
+document.body.prepend(img1);
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let promise7 = adapter0.requestAdapterInfo();
+let commandEncoder75 = device0.createCommandEncoder();
+let texture83 = device0.createTexture({
+  size: {width: 659, height: 48, depthOrArrayLayers: 471},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder75.beginComputePass({});
+try {
+computePassEncoder52.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup34, new Uint32Array(755), 164, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(114, 29, 513_648_934, 2_110_251_946);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 124, 0, 555_772_026, 348_259_306);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer27, 36);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer6, 708, 1_552);
+} catch {}
+let imageData14 = new ImageData(16, 4);
+let buffer48 = device0.createBuffer({
+  size: 16718,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder76 = device0.createCommandEncoder();
+try {
+computePassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer26, 4_712);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+  await promise7;
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder();
+let texture84 = device0.createTexture({size: [360, 1, 1], dimension: '2d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+try {
+computePassEncoder50.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup7, new Uint32Array(245), 7, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(4, 52, 138, 17_366_591, 96_358_576);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer6, 'uint32', 80, 1_647);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer9, 856);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 84, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(18).fill(6), /* required buffer size: 18 */
+{offset: 18}, {width: 196, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let textureView58 = texture57.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer19, 2_412);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer41, 172);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 248 */
+  offset: 248,
+  buffer: buffer12,
+}, {
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture85 = device0.createTexture({
+  size: [360, 1, 1],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder53 = commandEncoder78.beginComputePass();
+try {
+computePassEncoder48.setBindGroup(3, bindGroup29, new Uint32Array(916), 238, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder4.draw(1, 92, 739_894_573, 900_877_197);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 548);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer20, 'uint16', 6_658, 170);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder();
+let textureView59 = texture63.createView({aspect: 'all'});
+let computePassEncoder54 = commandEncoder74.beginComputePass({});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.draw(27, 170, 118_289_149, 44_922_504);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1_144, 19, 383, 35_491_401, 1_027_269_263);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 404);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 312);
+} catch {}
+let bindGroup38 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 90, resource: textureView10}]});
+let textureView60 = texture70.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let computePassEncoder55 = commandEncoder79.beginComputePass();
+let sampler46 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 75.52,
+  compare: 'never',
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup32, new Uint32Array(3539), 235, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(381, 5, 20_308_200, 44_765_680);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(59, 262, 1, 759_853_960, 1_189_526_966);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer19, 2_764);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 2620, new Int16Array(629), 409, 8);
+} catch {}
+document.body.append(img0);
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 374, resource: textureView28},
+    {binding: 234, resource: sampler24},
+    {binding: 49, resource: textureView2},
+    {binding: 15, resource: textureView16},
+  ],
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let textureView61 = texture67.createView({aspect: 'all'});
+let computePassEncoder56 = commandEncoder80.beginComputePass({label: '\u{1fcb9}\u0914\ucfde\u02a6\u775e\u4721\ua704\u6025\u088e'});
+let sampler47 = device0.createSampler({addressModeW: 'mirror-repeat', mipmapFilter: 'nearest', lodMinClamp: 27.74});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup5, new Uint32Array(4042), 157, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup26, new Uint32Array(2823), 468, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer41, 120);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture86 = device0.createTexture({
+  label: '\ua665\udf6f\u08d7\u21e9\u423a\u0648\uea0a\u{1f62a}\u0405',
+  size: [82, 6, 132],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture6 = device0.importExternalTexture({source: video1});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup18, new Uint32Array(1520), 362, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(52, 114, 132_852_222, 327_427_433);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1_027, 132, 1_114, 864_033_808, 882_791_754);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 848);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer26, 'uint32', 964, 38);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer31, 3_064, 1_470);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 2732 widthInBlocks: 683 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1656 */
+  offset: 1656,
+  buffer: buffer22,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 683, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 644, new Float32Array(8412), 178, 1036);
+} catch {}
+let buffer49 = device0.createBuffer({
+  label: '\u8641\u01ee\u793d\u2a58\u0117\u5573\u3482\u{1f9dc}\u229d\u{1fe0f}\ude4d',
+  size: 52723,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let textureView62 = texture67.createView({});
+let texture87 = device0.createTexture({
+  label: '\u{1f7a9}\u{1fc23}',
+  size: [1440, 2, 1],
+  mipLevelCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder19 = commandEncoder76.beginRenderPass({colorAttachments: [{view: textureView12, depthSlice: 187, loadOp: 'load', storeOp: 'store'}]});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder55.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer26, 248);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup21, []);
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(buffer12, 748, buffer26, 1372, 1448);
+} catch {}
+try {
+commandEncoder81.resolveQuerySet(querySet4, 95, 22, buffer24, 512);
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let texture88 = device0.createTexture({
+  size: {width: 1440},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroupsIndirect(buffer45, 88); };
+} catch {}
+try {
+renderPassEncoder4.draw(18, 221, 1_013_405_178, 1_578_946_103);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 98, 0, 422_640_973, 659_170_568);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup4, new Uint32Array(2476), 256, 0);
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 228, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 688 widthInBlocks: 688 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 609 */
+  offset: 609,
+  bytesPerRow: 1792,
+  buffer: buffer34,
+}, {width: 688, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup40 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 64, resource: {buffer: buffer30, offset: 2304}}]});
+let commandEncoder83 = device0.createCommandEncoder({});
+let computePassEncoder57 = commandEncoder73.beginComputePass();
+try {
+computePassEncoder56.setBindGroup(0, bindGroup20, new Uint32Array(1325), 34, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 173, 1, 39_568_659, 1_088_878_588);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer16, 3_076);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup4, new Uint32Array(2394), 146, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(60).fill(39), /* required buffer size: 60 */
+{offset: 60, bytesPerRow: 453}, {width: 27, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 1167, y: 1 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture89 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder58 = commandEncoder84.beginComputePass({});
+let renderBundle12 = renderBundleEncoder12.finish({label: '\ue6e9\u0345\u0066\u82ab\u0474\u06e0\ua50f\uab97\u7bc1\u9f3e'});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(1, bindGroup20, new Uint32Array(763), 39, 0);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup20, new Uint32Array(2270), 775, 0);
+} catch {}
+try {
+renderPassEncoder13.setViewport(0.5211561249868246, 1.484537691978992, 0.2210386942211099, 0.24727019542052747, 0.0663787650578701, 0.19788777948802821);
+} catch {}
+try {
+renderPassEncoder2.draw(126, 42, 392_799_831, 3_032_373_348);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(95, 286, 29, 416_321_489, 3_659_980_473);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u{1fb4f}');
+} catch {}
+document.body.append(canvas0);
+let canvas1 = document.createElement('canvas');
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte240m', transfer: 'smpteSt4281'} });
+let computePassEncoder59 = commandEncoder77.beginComputePass({label: '\ucc05\u78dc'});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup7, new Uint32Array(2483), 65, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup9, new Uint32Array(696), 219, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(36, 4, 152, 65_204_447, 127_393_701);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer19, 488);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 664);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 107, y: 13, z: 0},
+  aspect: 'all',
+}, new Uint8Array(510).fill(94), /* required buffer size: 510 */
+{offset: 510, bytesPerRow: 309, rowsPerImage: 94}, {width: 57, height: 53, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 169});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer21, 780);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer49, 'uint16', 5_896, 711);
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer26);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup15, new Uint32Array(515), 144, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer19, 2_116);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer13, 'uint16', 14_522, 328);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer13);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer45, 4416, buffer44, 172, 924);
+} catch {}
+try {
+commandEncoder81.copyTextureToTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 206, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 11, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 224, new BigUint64Array(11244), 842, 172);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 24, depthOrArrayLayers: 15}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup41 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView13}]});
+let texture90 = device0.createTexture({
+  label: '\u1b63\uf3b5\u07df\u2d34\u393d\u2d00\u05c5',
+  size: [659, 48, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder60 = commandEncoder85.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup36, new Uint32Array(702), 82, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(62.06336250001556, 2.8819494227706755, 2629.5339479836216, 1.0976259206411252, 0.4476884961031329, 0.4853292582738292);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer26, 1_524);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer45, 372);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(119).fill(113), /* required buffer size: 119 */
+{offset: 119}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.draw(62, 83, 644_350_550, 340_327_190);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer45, 1728, buffer6, 4180, 240);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let computePassEncoder61 = commandEncoder82.beginComputePass({label: '\ue2b2\u{1fffc}\u04bf\u6da5'});
+try {
+computePassEncoder34.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup9, new Uint32Array(1166), 20, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.draw(194, 203, 105_261_123, 480_553_484);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer16, 524);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer42, 0);
+} catch {}
+let arrayBuffer3 = buffer29.getMappedRange();
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule6, targets: [{format: 'bgra8unorm-srgb', writeMask: 0}]},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [{arrayStride: 1076, attributes: [{format: 'sint32x4', offset: 56, shaderLocation: 2}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front'},
+});
+await gc();
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView63 = texture5.createView({});
+let computePassEncoder62 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder54.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.draw(158, 1, 858_993_371, 93_644_179);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer38, 168);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer8, 'uint32', 1_256, 357);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer50 = device0.createBuffer({
+  label: '\u6796\u{1fc90}\u{1fd52}\u0e34\uf630',
+  size: 14517,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup6, new Uint32Array(89), 6, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1, 2, 1); };
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(19, 76, 3, 88_349_356, 453_384_884);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer13, 'uint16', 14_636, 7_040);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 4, y: 14 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(118, 95);
+let commandEncoder88 = device0.createCommandEncoder({});
+let textureView64 = texture66.createView({baseMipLevel: 0});
+let computePassEncoder63 = commandEncoder88.beginComputePass({});
+try {
+computePassEncoder63.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(45).fill(179), /* required buffer size: 45 */
+{offset: 45, bytesPerRow: 87}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.height = 26;
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer30, offset: 3584, size: 3568}}],
+});
+let computePassEncoder64 = commandEncoder87.beginComputePass({label: '\u098a\u78ce\u010c\u{1f944}'});
+let renderPassEncoder20 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{
+  view: textureView51,
+  clearValue: { r: 25.27, g: 762.3, b: 794.5, a: -550.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder62.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.draw(15, 130, 2_294_860_339, 1_023_039_423);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer40, 3_204);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer13, 'uint32', 9_608, 181);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let buffer51 = device0.createBuffer({
+  size: 36203,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder89 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder81.finish({});
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.draw(105, 656, 259_435_603, 668_369_055);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer13, 'uint32', 4_396, 383);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 258, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'etc2-rgb8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer52 = device0.createBuffer({
+  label: '\uf96e\u0038\u3b21\u06ae\uab40',
+  size: 21136,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView65 = texture6.createView({
+  label: '\uf33d\u76f4\u9354\u{1f90e}\uc941\u086d\u197b\u3dbf\u0ed5\u08b6',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 6,
+});
+try {
+computePassEncoder64.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder2.draw(110, 60, 5_849_157, 329_644_241);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(55, 199, 9, -2_102_260_732, 1_434_937_938);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer50, 472);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer41, 524);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline5);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let texture91 = device0.createTexture({
+  size: [600, 96, 88],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder65 = commandEncoder89.beginComputePass({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 64.61,
+  lodMaxClamp: 77.95,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 3_752);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder43.pushDebugGroup('\u717d');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 2, depthOrArrayLayers: 297}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 129},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroupsIndirect(buffer17, 1_784); };
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup42, new Uint32Array(1030), 33, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(70, 158, 1_584_079_485, 1_216_202_892);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 23, 0, 473_253_181, 1_484_660_078);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer19, 804);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer48, 672);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer1, 'uint16', 8_502, 12_525);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer45, 1472, buffer1, 3220, 440);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u22dc');
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder();
+let querySet11 = device0.createQuerySet({label: '\u0a17\u0033\u4ce3\u015f\u0aa4\u8501\ua133\ue275', type: 'occlusion', count: 506});
+let texture92 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let renderPassEncoder21 = commandEncoder87.beginRenderPass({colorAttachments: [{view: textureView23, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder30.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder0.draw(465, 23, 755_154_492, 1_441_474_446);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 81, 1, 331_849_629, 692_175_380);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 2_284);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(buffer16, 3712, buffer15, 1640, 1388);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 40, new Float32Array(8691), 647, 56);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+document.body.prepend(canvas1);
+let textureView66 = texture60.createView({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.06,
+  lodMaxClamp: 44.85,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup22, new Uint32Array(331), 85, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 324.2, g: 411.1, b: 152.3, a: 744.8, });
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer40, 4_620);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer42, 0, 26);
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 416 */
+  offset: 416,
+  buffer: buffer14,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 16 max align: 16 */
+struct T0 {
+  @align(1) f0: array<array<f16, 1>, 8>,
+}
+@group(2) @binding(80) var st25: texture_storage_3d<r32float, read_write>;
+@group(0) @binding(80) var st23: texture_storage_3d<r32float, read_write>;
+@group(1) @binding(80) var st24: texture_storage_1d<r32uint, read_write>;
+struct VertexOutput10 {
+  @builtin(position) f35: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput10 {
+  var out: VertexOutput10;
+  return out;
+}
+struct FragmentOutput10 {
+  @location(0) @interpolate(linear, center) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+  @builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  out.f1 += u32(84);
+  return out;
+}
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup43 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 589, resource: {buffer: buffer45, offset: 1280, size: 677}},
+    {binding: 19, resource: textureView53},
+    {binding: 168, resource: sampler0},
+  ],
+});
+let texture93 = device0.createTexture({
+  size: [659, 48, 1],
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder10.draw(14, 192, 1_485_048_715, 599_993_867);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(8, 60, 169, 293_732_595, 449_747_352);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer41, 2_236);
+} catch {}
+let promise8 = shaderModule7.getCompilationInfo();
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1296 */
+  offset: 1296,
+  buffer: buffer12,
+}, {
+  texture: texture78,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 101, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(61).fill(25), /* required buffer size: 61 */
+{offset: 61, bytesPerRow: 746}, {width: 185, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 148}
+*/
+{
+  source: imageData9,
+  origin: { x: 6, y: 107 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 40},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 187, resource: textureView62},
+    {binding: 184, resource: {buffer: buffer42, offset: 0, size: 3}},
+  ],
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup17, new Uint32Array(2071), 18, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(333, 122, 1_541_090_704, 1_664_979_225);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(30, 88, 49, 67_065_533, 810_664_162);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer8, 412);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(buffer48, 804, buffer33, 1228, 64);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  label: '\u7ac2\u{1f837}\u08d8\u3503\u05df\u34f4\u0d46\ued54\u{1f8f2}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer6, offset: 1280}}],
+});
+let buffer53 = device0.createBuffer({
+  size: 2519,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder91 = device0.createCommandEncoder({});
+let textureView67 = texture67.createView({});
+let computePassEncoder66 = commandEncoder90.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer15, 400); };
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup35);
+} catch {}
+let buffer54 = device0.createBuffer({size: 3940, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let computePassEncoder67 = commandEncoder91.beginComputePass();
+let renderPassEncoder22 = commandEncoder15.beginRenderPass({
+  colorAttachments: [{view: textureView48, depthSlice: 0, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 94665991,
+});
+try {
+computePassEncoder67.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup4, new Uint32Array(484), 124, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 373, 0, 48_515_501, 369_166_387);
+} catch {}
+try {
+buffer41.destroy();
+} catch {}
+let gpuCanvasContext3 = canvas1.getContext('webgpu');
+let commandEncoder92 = device0.createCommandEncoder({});
+let textureView68 = texture88.createView({format: 'rgb10a2unorm'});
+let sampler50 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMinClamp: 36.17, lodMaxClamp: 76.83});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup13, new Uint32Array(16), 2, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup44, new Uint32Array(394), 34, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(35, 226, 5, 423_332_223, 685_810_259);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer16, 7_492);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer27, 'uint32', 608, 60);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer35, 0, 843);
+} catch {}
+try {
+querySet0.destroy();
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 187, resource: textureView42},
+    {binding: 184, resource: {buffer: buffer13, offset: 7168, size: 867}},
+  ],
+});
+let texture94 = device0.createTexture({
+  size: [150, 24, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler51 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 54.36,
+  lodMaxClamp: 91.59,
+});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer50, 'uint32', 116, 416);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+let computePassEncoder68 = commandEncoder92.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer51, 840); };
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 34, 0, -1_515_364_187, 1_383_819_192);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer33, 7_160);
+} catch {}
+try {
+computePassEncoder43.popDebugGroup();
+} catch {}
+let textureView69 = texture60.createView({mipLevelCount: 1});
+let texture95 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup19, new Uint32Array(3515), 855, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup14, new Uint32Array(832), 370, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(9, 284, 18, -2_134_165_268, 290_123_071);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer27, 'uint16', 662, 96);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler52 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.80,
+  lodMaxClamp: 68.27,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder10.draw(179, 197, 193_408_779, 833_515_047);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(3, 343, 0, 326_721_791, 3_452_527_516);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer27, 120);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer13, 'uint32', 6_564, 4_527);
+} catch {}
+let imageData15 = new ImageData(96, 20);
+let externalTexture7 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer16, 4_212); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer33, 2_048);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({label: '\u961c\u12fa'});
+let textureView70 = texture76.createView({mipLevelCount: 1});
+let computePassEncoder69 = commandEncoder93.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer38, 452);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder59.pushDebugGroup('\uda72');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 172, new Float32Array(1097));
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let bindGroup47 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 184, resource: {buffer: buffer52, offset: 1280}}, {binding: 187, resource: textureView42}],
+});
+let commandEncoder94 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder94.finish({label: '\ud416\u{1fc7a}\u0e4e\u26b6\u0ce1\u{1f9a5}\u0659\ueaa8\u5c3f\u{1f779}\u{1fa07}'});
+try {
+renderPassEncoder8.draw(8, 240, 111_946_577, 471_053_403);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  label: '\u6fc2\u1b22\u0cce\u001b\u0d81\u0aec\u{1fbc7}\u875b\u0a91',
+  layout: bindGroupLayout6,
+  entries: [{binding: 64, resource: {buffer: buffer51, offset: 3584, size: 1288}}],
+});
+let texture96 = device0.createTexture({
+  size: {width: 600, height: 96, depthOrArrayLayers: 138},
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup28, new Uint32Array(358), 27, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup4, new Uint32Array(2221), 302, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(135, 376, 319_011_773, 104_452_194);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(127, 111, 20, 65_945_748, 319_093_158);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer50, 2_548);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer27, 276);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer42, 'uint16', 10, 1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1120, new DataView(new ArrayBuffer(4254)), 144, 96);
+} catch {}
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'r16sint'], depthReadOnly: true, stencilReadOnly: false});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder2.executeBundles([renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 165.7, g: 346.6, b: 131.9, a: 904.3, });
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 67, 8, 381_932_540, 680_471_738);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer16, 564);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint16', 488, 232);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(0, buffer3, 68);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder70 = commandEncoder95.beginComputePass({});
+try {
+computePassEncoder70.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder0.draw(3, 319, 631_627_382, 359_880_525);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer38, 196);
+} catch {}
+let arrayBuffer4 = buffer23.getMappedRange(632);
+let imageData16 = new ImageData(44, 56);
+let commandEncoder96 = device0.createCommandEncoder({});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(52);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(51, 99, 20_753, 1_604_722_670);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer16, 2_980);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer53, 0, 24);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer21, 212, buffer53, 540, 108);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2748 */
+  offset: 2748,
+  rowsPerImage: 214,
+  buffer: buffer21,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u0702');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let computePassEncoder71 = commandEncoder96.beginComputePass({});
+let sampler53 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.76,
+  lodMaxClamp: 87.23,
+});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(3, bindGroup10, new Uint32Array(94), 7, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup20, new Uint32Array(9899), 498, 0);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.draw(23, 553, 3_454_246, 167_004_480);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 417, 0, -2_074_630_226, 708_999_359);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer8, 536);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 1_048);
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 187, resource: textureView42},
+    {binding: 184, resource: {buffer: buffer9, offset: 2560, size: 2888}},
+  ],
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({size: [150, 24, 46], dimension: '3d', format: 'rgba32float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder72 = commandEncoder97.beginComputePass({});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(2, bindGroup25, new Uint32Array(266), 9, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup19, new Uint32Array(18), 15, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(92, 93, 13, 78_335_908, 10_793_153);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer40, 344);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer23, 0, 521);
+} catch {}
+let texture98 = device0.createTexture({
+  label: '\u0da6\u{1ffe8}',
+  size: [720],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer40, 56);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline7);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(30, 719);
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder98 = device0.createCommandEncoder({});
+let textureView71 = texture79.createView({label: '\ud6e6\u{1ff04}\u0cdf\ua6fb\u053c\u1d73\u295f', dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder73 = commandEncoder98.beginComputePass({});
+try {
+computePassEncoder71.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 973.9, g: -52.16, b: -735.4, a: 24.85, });
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer33, 44);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+offscreenCanvas0.height = 512;
+try {
+computePassEncoder55.setBindGroup(3, bindGroup22, new Uint32Array(2066), 83, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup29, new Uint32Array(1570), 815, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer17, 164);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer42, 'uint16', 34, 1);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer31);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+computePassEncoder59.popDebugGroup();
+} catch {}
+try {
+computePassEncoder32.setBindGroup(1, bindGroup48, new Uint32Array(1194), 78, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 183, 0, 63_588_128, 79_783_483);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer26, 'uint32', 888, 651);
+} catch {}
+try {
+computePassEncoder72.insertDebugMarker('\u0bd8');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 8},
+  aspect: 'all',
+}, new Uint8Array(1_240_495).fill(31), /* required buffer size: 1_240_495 */
+{offset: 121, bytesPerRow: 1021, rowsPerImage: 86}, {width: 55, height: 11, depthOrArrayLayers: 15});
+} catch {}
+let imageData17 = new ImageData(28, 116);
+let bindGroup50 = device0.createBindGroup({
+  label: '\u0ac1\u2657\ueac1\u061f\u7d83\u7390\u3937\u0453\u03ea',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 184, resource: {buffer: buffer42, offset: 0, size: 21}},
+    {binding: 187, resource: textureView47},
+  ],
+});
+try {
+computePassEncoder3.dispatchWorkgroupsIndirect(buffer51, 4_232);
+} catch {}
+try {
+renderPassEncoder4.draw(61, 123, 787_685_585, 385_798_176);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 227, 0, 48_618_550, 997_576_530);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer48, 9_504);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer49, 'uint16', 1_146, 2_699);
+} catch {}
+let buffer55 = device0.createBuffer({size: 4283, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder99 = device0.createCommandEncoder({});
+let computePassEncoder74 = commandEncoder99.beginComputePass({});
+let sampler54 = device0.createSampler({
+  label: '\u041d\u5d93\u0caf\u0f94\u{1faf6}\u700a\u08d5\u4610\uebb2\uaffe',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.03,
+  lodMaxClamp: 83.01,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer8, 'uint32', 736, 298);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder();
+let sampler55 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.17,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup35, new Uint32Array(590), 308, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer40, 2_664);
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer21, 192, buffer0, 268, 228);
+} catch {}
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  size: [600, 96, 1],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView72 = texture28.createView({label: '\u771a\u0c5f\u9a33\u{1fac8}\u8845\u4665\u0b77\u0765'});
+let computePassEncoder75 = commandEncoder101.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup3, new Uint32Array(507), 56, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(3, 111, 11, -2_111_637_838, 146_279_187);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer52, 3_600);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer27, 'uint32', 236, 39);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer27, 152, buffer48, 1584, 616);
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 600 */
+  offset: 600,
+  bytesPerRow: 256,
+  buffer: buffer30,
+}, {
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder100.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 28, y: 0, z: 30},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'smpte240m'} });
+let commandEncoder102 = device0.createCommandEncoder({label: '\u0af9\u{1f649}\ue37a'});
+let texture100 = device0.createTexture({
+  size: {width: 82, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView73 = texture79.createView({dimension: '2d-array', format: 'rgb10a2unorm', mipLevelCount: 1});
+let computePassEncoder76 = commandEncoder100.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer27, 40); };
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer52, 8_056);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer15, 440);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer49, 'uint16', 18, 1_891);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+computePassEncoder32.pushDebugGroup('\u01cd');
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 234, resource: sampler13},
+    {binding: 49, resource: textureView5},
+    {binding: 374, resource: textureView28},
+    {binding: 15, resource: textureView16},
+  ],
+});
+let commandEncoder103 = device0.createCommandEncoder({});
+let texture101 = device0.createTexture({
+  size: [75, 12, 353],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder77 = commandEncoder103.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.draw(488, 60, 1_153_578_754, 226_862_852);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer26, 'uint32', 7_028, 642);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 64, resource: {buffer: buffer42, offset: 0, size: 44}}],
+});
+let computePassEncoder78 = commandEncoder102.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer15, 592);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer1, 'uint32', 10_276, 3_519);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 329, height: 24, depthOrArrayLayers: 18}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 27, y: 2, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 335,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 633,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 130,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 444,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let textureView74 = texture93.createView({baseMipLevel: 0});
+let textureView75 = texture25.createView({});
+let sampler56 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', magFilter: 'nearest', compare: 'not-equal'});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup6, new Uint32Array(715), 272, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 168, 0, 254_214_338, 2_520_966_474);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 1_888);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let arrayBuffer5 = buffer29.getMappedRange(7880, 0);
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 81,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 315,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 347,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer56 = device0.createBuffer({
+  size: 28503,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: {width: 82},
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder79 = commandEncoder104.beginComputePass({});
+let sampler57 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 33.21, lodMaxClamp: 42.95});
+try {
+computePassEncoder79.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder4.draw(122, 3, 1_080_097_930, 88_341_024);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 155, 0, 5_570_529, 269_996_998);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer15, 1_612);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer26, 'uint32', 1_908, 30);
+} catch {}
+let videoFrame15 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let bindGroup53 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer9, offset: 1024, size: 1260}}],
+});
+let commandEncoder105 = device0.createCommandEncoder({label: '\u60a4\u04f5'});
+let textureView76 = texture4.createView({dimension: '2d-array'});
+let texture103 = device0.createTexture({
+  size: [2, 2, 12],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder80 = commandEncoder105.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer26, 1_200); };
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.draw(88, 23, 947_278_348, 118_588_161);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder32.popDebugGroup();
+} catch {}
+let img2 = await imageWithData(68, 22, '#10101010', '#20202020');
+let commandEncoder106 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: [150],
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture105 = device0.createTexture({size: {width: 720}, dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder81 = commandEncoder106.beginComputePass();
+let sampler58 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 80.68,
+  lodMaxClamp: 89.58,
+});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer53, 56);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer27, 92);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer51);
+} catch {}
+let buffer57 = device0.createBuffer({
+  size: 1909,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView77 = texture104.createView({dimension: '1d'});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup9, new Uint32Array(113), 69, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 79, 1, 104_410_667, 268_713_625);
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer26, offset: 4864, size: 680}}],
+});
+let commandEncoder107 = device0.createCommandEncoder();
+let texture106 = device0.createTexture({
+  size: [600, 96, 1],
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup19, new Uint32Array(1784), 679, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.draw(277, 12, 56_023_772, 42_376_553);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer40, 1_272);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 140, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({});
+let texture107 = device0.createTexture({
+  size: {width: 329},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture108 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder81.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 228, 0, 69_265_797, 811_909_554);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer45, 1_696);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer48, 5_520);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer55, 0, 343);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+  /* bytesInLastRow: 196 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 444 */
+  offset: 444,
+  buffer: buffer48,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 50, y: 6, z: 1},
+  aspect: 'all',
+}, {width: 49, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet7, 24, 1, buffer4, 6144);
+} catch {}
+try {
+externalTexture0.label = '\u{1f798}\u9d87\u03b5\uced9\uced4\u3ab8\u896b\ua8fd\u1a13\u6104';
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 380,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroup55 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 187, resource: textureView67},
+    {binding: 184, resource: {buffer: buffer23, offset: 1024, size: 151}},
+  ],
+});
+let textureView78 = texture104.createView({dimension: '1d'});
+let renderPassEncoder23 = commandEncoder108.beginRenderPass({
+  label: '\u0098\u087a\u32b4\uf308\u{1fca7}\u0bbb\u530e\u787e\u0d0b',
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 0,
+  clearValue: { r: -468.8, g: -115.6, b: 371.8, a: -941.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 134615779,
+});
+let sampler59 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.157,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder2.draw(277, 19, 1_885_898_603, 350_405_746);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 392, 0, 255_247_742, 1_932_215_868);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer13, 'uint16', 2_904, 4_552);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 996 */
+  offset: 996,
+  bytesPerRow: 512,
+  buffer: buffer10,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 42, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\ueb11');
+} catch {}
+try {
+texture29.label = '\u054a\u{1fe3f}\u{1fc4c}\u0f19';
+} catch {}
+let buffer58 = device0.createBuffer({size: 19112, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView79 = texture106.createView({
+  label: '\u0184\u2ead\u09db\uc2c2\u0711\u3fe9\u244c\u0fcb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder82 = commandEncoder107.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(162), 8, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(4); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup12, new Uint32Array(1419), 329, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer16, 2_188);
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 589, resource: {buffer: buffer42, offset: 0, size: 78}},
+    {binding: 168, resource: sampler46},
+    {binding: 19, resource: textureView63},
+  ],
+});
+let commandEncoder109 = device0.createCommandEncoder({});
+let texture109 = device0.createTexture({
+  size: {width: 75},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder83 = commandEncoder109.beginComputePass({});
+try {
+renderPassEncoder3.drawIndexed(116, 30, 39, 388_716_760, 1_325_038_918);
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 184, resource: {buffer: buffer20, offset: 4864, size: 736}},
+    {binding: 187, resource: textureView67},
+  ],
+});
+let buffer59 = device0.createBuffer({
+  size: 1301,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture110 = device0.createTexture({
+  size: [360],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer50, 5_456); };
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(255, 19, 106, 891_414_995, 1_072_801_283);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer42, 4);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer40, 1_156);
+} catch {}
+let bindGroup58 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 598, resource: {buffer: buffer19, offset: 512}}]});
+let buffer60 = device0.createBuffer({
+  size: 3820,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture111 = device0.createTexture({
+  size: [82],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'display-p3'});
+try {
+computePassEncoder26.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup50, new Uint32Array(475), 83, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(96, 71, 17, 242_158_072, 1_411_344_296);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer41, 1_844);
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 64, resource: {buffer: buffer21, offset: 0, size: 1244}}],
+});
+let textureView80 = texture107.createView({
+  label: '\u{1f802}\u0cd1\u0c00\u{1fe9e}\uc8f7\u{1f7f2}\u3278\ue12f\u0143\ub9b5\ufda1',
+  baseArrayLayer: 0,
+});
+let texture112 = gpuCanvasContext2.getCurrentTexture();
+let textureView81 = texture27.createView({});
+let sampler60 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.18,
+  lodMaxClamp: 35.02,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder83.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup22, new Uint32Array(140), 44, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer33, 'uint32', 5_732, 4_385);
+} catch {}
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+let renderBundle14 = renderBundleEncoder14.finish({label: '\u0bf4\u{1fee8}\u0670\uf138\u660d\u026d\u08c7\u{1fdfb}'});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup53, new Uint32Array(1578), 250, 0);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 17364,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup36, new Uint32Array(546), 173, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 29, 0, 404_628_192, 101_464_693);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer42, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer59, 'uint16', 174, 95);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 335, resource: textureView10},
+    {binding: 633, resource: textureView79},
+    {binding: 139, resource: textureView27},
+    {binding: 41, resource: textureView79},
+    {binding: 80, resource: textureView74},
+    {binding: 3, resource: textureView80},
+    {binding: 78, resource: textureView50},
+    {binding: 130, resource: {buffer: buffer52, offset: 0, size: 3736}},
+    {binding: 444, resource: textureView49},
+    {binding: 169, resource: textureView76},
+    {binding: 83, resource: {buffer: buffer39, offset: 1536, size: 1488}},
+  ],
+});
+let buffer62 = device0.createBuffer({size: 16403, usage: GPUBufferUsage.MAP_WRITE});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.prepend(img1);
+let bindGroup61 = device0.createBindGroup({
+  label: '\u{1fad3}\u008a\ued1d',
+  layout: bindGroupLayout9,
+  entries: [{binding: 92, resource: textureView32}],
+});
+let textureView82 = texture8.createView({label: '\ud450\u8df4\u5313\u{1fdd0}\uec7f\u8659\u1a4d\u0990\u00e6\u062d', aspect: 'all'});
+try {
+renderPassEncoder2.draw(106, 104, 114_649_976, 1_155_302_996);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer33, 3_644);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(2, buffer35, 0, 452);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 40, new BigUint64Array(11662), 884, 44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(227).fill(83), /* required buffer size: 227 */
+{offset: 227}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 444, resource: textureView44},
+    {binding: 3, resource: textureView80},
+    {binding: 335, resource: textureView20},
+    {binding: 633, resource: textureView79},
+    {binding: 169, resource: textureView76},
+    {binding: 41, resource: textureView79},
+    {binding: 83, resource: {buffer: buffer6, offset: 512}},
+    {binding: 130, resource: {buffer: buffer30, offset: 6144}},
+    {binding: 80, resource: textureView74},
+    {binding: 78, resource: textureView56},
+    {binding: 139, resource: textureView49},
+  ],
+});
+let texture113 = device0.createTexture({
+  size: [150, 24, 17],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.draw(114, 27, 2_429_736_548, 399_410_242);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(3, 5, 1, 477_447_017, 826_141_946);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer21, 824);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer26, 296);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer42, 'uint16', 98, 15);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+querySet3.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 4},
+  aspect: 'all',
+}, new Uint8Array(1_063).fill(18), /* required buffer size: 1_063 */
+{offset: 37, bytesPerRow: 54, rowsPerImage: 19}, {width: 3, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView13}]});
+let buffer63 = device0.createBuffer({
+  label: '\u0a47\udec5\u2cb0\u0cab\u6a2b\u6434\u{1ff10}\u{1f715}',
+  size: 10082,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 68});
+let texture114 = device0.createTexture({
+  size: [2],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer39);
+} catch {}
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.53,
+  lodMaxClamp: 94.02,
+});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup63, new Uint32Array(1730), 17, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -289.1, g: 596.3, b: 716.1, a: 95.22, });
+} catch {}
+try {
+renderPassEncoder3.draw(38, 62, 191_077_240, 548_709_721);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 177, 0, 92_279_919, 1_143_039_785);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer49, 21_748);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, undefined, 34_039_185, 168_111_582);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u{1fd9b}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\ufaf5\u{1f9fa}\ua52a\u06ae\uc09c\u02b5\u09e3\ub266',
+  entries: [
+    {
+      binding: 168,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture115 = device0.createTexture({
+  size: {width: 1440, height: 2, depthOrArrayLayers: 51},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView83 = texture55.createView({mipLevelCount: 1});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer41, 992);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture116 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 1},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView84 = texture50.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.draw(64, 340, 373_651_607, 367_895_697);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 205, 0, 496_536_008, 997_883_890);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer49, 20_700);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer16, 6_000);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer13, 'uint16', 1_120, 3_930);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 1356, new Int16Array(3921), 1124, 300);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.append(video0);
+let buffer64 = device0.createBuffer({
+  size: 376,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder111 = device0.createCommandEncoder({label: '\u0020\ud251\ua7ae'});
+let computePassEncoder84 = commandEncoder111.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup17, new Uint32Array(2588), 423, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer19, 3_340);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer49, 516);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer23, 444);
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 300 widthInBlocks: 150 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 364 */
+  offset: 364,
+  bytesPerRow: 512,
+  buffer: buffer53,
+}, {width: 150, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 257, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+try {
+computePassEncoder61.label = '\ub5a3\ue522\u7832\u{1f71b}\u3000\u{1fd75}\u0c5c\u0d58';
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  label: '\u4527\u8e13\u8386\u0d51\u973e\u78e8\u8383\uca83\u{1fedf}',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 168, resource: sampler23},
+    {binding: 19, resource: textureView63},
+    {binding: 589, resource: {buffer: buffer23, offset: 512, size: 1527}},
+  ],
+});
+let textureView85 = texture115.createView({baseMipLevel: 1, mipLevelCount: 1});
+let sampler62 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.271,
+  compare: 'equal',
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup14, new Uint32Array(205), 55, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.draw(128, 74, 190_501_697, 536_808_844);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 96, 4, 237_113_511, 404_342_193);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer19, 268);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer8, 'uint16', 1_292, 184);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2248 */
+  offset: 2248,
+  rowsPerImage: 114,
+  buffer: buffer10,
+}, {
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 228, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(27).fill(109), /* required buffer size: 27 */
+{offset: 27, bytesPerRow: 266}, {width: 57, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 106, resource: {buffer: buffer30, offset: 18688, size: 1339}},
+    {binding: 347, resource: textureView79},
+    {binding: 66, resource: textureView74},
+    {binding: 81, resource: textureView32},
+    {binding: 315, resource: {buffer: buffer51, offset: 1024, size: 24}},
+    {binding: 48, resource: textureView78},
+    {binding: 59, resource: textureView69},
+    {binding: 21, resource: {buffer: buffer38, offset: 0, size: 1212}},
+  ],
+});
+let buffer65 = device0.createBuffer({
+  label: '\u{1fc3c}\u{1fdc7}\u{1f95b}',
+  size: 2540,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let texture117 = device0.createTexture({
+  label: '\ua888\u0944\u05ac\u05b3\u0877\u0ce1\u5d7f\u{1fab0}\u081f\u{1fcbf}\ub365',
+  size: [300, 48, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth16unorm'],
+});
+let textureView86 = texture100.createView({dimension: '2d-array'});
+let computePassEncoder85 = commandEncoder110.beginComputePass();
+let sampler63 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 83.74,
+  lodMaxClamp: 91.24,
+});
+try {
+computePassEncoder85.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup65, new Uint32Array(315), 181, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(99, 32, 160_699_014, 45_913_897);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer42, 16);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u0d75');
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u0b32\ub080',
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 1843});
+let textureView87 = texture65.createView({mipLevelCount: 1});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder0.draw(9, 292, 91_849_669, 962_222_025);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer48, 1_416);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer42, 'uint16', 0, 22);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView88 = texture4.createView({dimension: '2d-array'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup35, new Uint32Array(4050), 681, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer60, 828);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+document.body.append(img2);
+let commandEncoder112 = device0.createCommandEncoder({label: '\u12b7\u9e9c\u71a6\u62d1\u9029\u0375\u1bc2\ueff3\u{1fa07}\u7f84\u{1f769}'});
+let computePassEncoder86 = commandEncoder112.beginComputePass();
+try {
+computePassEncoder3.dispatchWorkgroups(1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer41, 1_444); };
+} catch {}
+try {
+renderPassEncoder15.setViewport(6.382173887787396, 13.51732301520109, 125.752252103935, 7.694746620281777, 0.7696651751593993, 0.9280434181817896);
+} catch {}
+try {
+renderPassEncoder3.draw(136, 12, 106_657_824, 119_286_567);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer56, 12_568);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer59, 'uint16', 198, 227);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer30, 0, 1_603);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let texture118 = device0.createTexture({
+  size: {width: 1440, height: 2, depthOrArrayLayers: 570},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(1, bindGroup21, new Uint32Array(1392), 259, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker('\u0e05');
+} catch {}
+let bindGroup66 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView1}]});
+let texture119 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 479},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder4.draw(128, 304, 416_839_991, 454_611_970);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 153, 0, -1_895_675_496, 239_469_914);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer41, 1_008);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise10;
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({});
+let texture120 = device0.createTexture({
+  size: {width: 2880, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.draw(43, 67, 167_653_022, 239_999_976);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData18 = new ImageData(56, 40);
+let buffer66 = device0.createBuffer({
+  size: 19888,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder114 = device0.createCommandEncoder();
+let computePassEncoder87 = commandEncoder113.beginComputePass({});
+let sampler64 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.53,
+  lodMaxClamp: 99.46,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup12, new Uint32Array(736), 62, 0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer15, 2_300);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint16', 3_980, 8_992);
+} catch {}
+let textureView89 = texture106.createView({mipLevelCount: 1});
+let textureView90 = texture61.createView({dimension: '2d-array'});
+let computePassEncoder88 = commandEncoder114.beginComputePass({label: '\u0ac9\u8b00\u0d25\u05e5\u6b75\u1f9e\u072a'});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup31, new Uint32Array(4539), 1_676, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle4, renderBundle0, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer63, 5_248);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer23, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 184, new DataView(new ArrayBuffer(10052)), 806, 500);
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({label: '\u02b2\u3879\u2676\u075f\ue666\u071b\u{1fda2}\u090a'});
+let texture121 = device0.createTexture({size: {width: 2880}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder89 = commandEncoder115.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup15, new Uint32Array(242), 53, 0);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup57, new Uint32Array(688), 40, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(2_606, 145, 33, 6_621_143, 1_178_829_919);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 232);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer50, 0, 7_794);
+} catch {}
+let promise11 = shaderModule6.getCompilationInfo();
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let buffer67 = device0.createBuffer({
+  size: 10409,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder116.beginComputePass({});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup13, new Uint32Array(2173), 613, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(94, 37, 236, 1_174_994_766, 271_491_638);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer19, 996);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer50, 136, 1_094);
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  label: '\u4239\u{1fd62}\ufdd0\u3052\u{1fdbd}\u07f7\ud256',
+  layout: bindGroupLayout8,
+  entries: [{binding: 190, resource: textureView7}],
+});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 663});
+let sampler65 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.49,
+  lodMaxClamp: 60.74,
+});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup38, new Uint32Array(1445), 98, 0);
+} catch {}
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer16, 2_692);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer19, 3_496);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer50, 'uint32', 14_304, 115);
+} catch {}
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 428 */
+  offset: 428,
+  rowsPerImage: 655,
+  buffer: buffer53,
+}, {
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video1);
+let buffer68 = device0.createBuffer({
+  size: 2241,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 219});
+let computePassEncoder91 = commandEncoder92.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({source: video1});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer48, 3_904); };
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.draw(303, 249, 88_830_022, 1_263_940_094);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer53, 376);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+document.body.prepend(video0);
+let promise12 = adapter0.requestAdapterInfo();
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 368, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder118 = device0.createCommandEncoder();
+let textureView91 = texture95.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let sampler66 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.48,
+  lodMaxClamp: 88.67,
+  maxAnisotropy: 20,
+});
+let externalTexture11 = device0.importExternalTexture({label: '\u77e8\ud935\u{1ff32}\uf962\u07c6\u0249\ua716\u0563\u257d\u{1ff6b}', source: videoFrame10});
+try {
+computePassEncoder91.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup6, new Uint32Array(2550), 47, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer48, 3_564);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer27, 'uint16', 26, 599);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 440, new Int16Array(9214));
+} catch {}
+let computePassEncoder92 = commandEncoder117.beginComputePass({});
+try {
+computePassEncoder89.setBindGroup(1, bindGroup52, new Uint32Array(2679), 18, 0);
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder4.draw(51, 122, 269_268_112, 562_448_707);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer53, 444);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer50, 1_924);
+} catch {}
+try {
+commandEncoder118.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 75, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 684, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup68 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView24}]});
+let buffer69 = device0.createBuffer({size: 12743, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder119 = device0.createCommandEncoder();
+let textureView92 = texture110.createView({});
+try {
+computePassEncoder90.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup21, new Uint32Array(481), 67, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer42, 88);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer6, 'uint32', 524, 196);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 3,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let video2 = await videoWithData(100);
+let bindGroup69 = device0.createBindGroup({
+  label: '\u9eb1\u09f0\ua8d7\u{1fc4a}',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 15, resource: {buffer: buffer6, offset: 768, size: 252}},
+    {binding: 0, resource: textureView3},
+  ],
+});
+let buffer70 = device0.createBuffer({
+  size: 3258,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder120 = device0.createCommandEncoder({});
+let renderPassEncoder24 = commandEncoder120.beginRenderPass({
+  colorAttachments: [{
+  view: textureView86,
+  clearValue: { r: 872.4, g: 748.2, b: -190.8, a: 835.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup64, new Uint32Array(210), 41, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(1_414, 11, 628, 80_386_762, 249_638_281);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer42, 20);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder();
+let texture122 = device0.createTexture({
+  label: '\uf9ca\u{1fb4f}\u0df4\u{1f6a2}\u0a9e\u0ee7\uea94\u6290\u{1f8ec}\u{1f983}',
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView93 = texture121.createView({label: '\ufb15\uba73\ub716', dimension: '1d'});
+try {
+computePassEncoder92.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle9, renderBundle0, renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder3.draw(46, 1, 1_509_679_870, 1_071_994_285);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(256, 60, 1_583, 726_070_579, 2_609_773_941);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer8, 'uint32', 1_536, 208);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer71 = device0.createBuffer({
+  size: 13563,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder93 = commandEncoder118.beginComputePass();
+let renderPassEncoder25 = commandEncoder119.beginRenderPass({
+  colorAttachments: [{
+  view: textureView86,
+  clearValue: { r: -890.7, g: 110.5, b: 996.9, a: -142.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 122390179,
+});
+let sampler67 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.609,
+  lodMaxClamp: 72.35,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder93.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup7, new Uint32Array(814), 67, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(374, 206, 0, 142_534_684, 126_047_489);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer6, 'uint32', 1_120, 1_028);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer70);
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 9, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData19 = new ImageData(4, 56);
+let pipelineLayout11 = device0.createPipelineLayout({label: '\uc03b\ued06\u522b\u8836\ufc36\u80bb\u{1f6e8}\ud1c3\u0ab5\u{1f953}', bindGroupLayouts: []});
+let commandEncoder122 = device0.createCommandEncoder({});
+let renderPassEncoder26 = commandEncoder121.beginRenderPass({
+  label: '\u6e49\u{1f904}\u{1fbce}\u{1fa40}\u0fbe\u0f5e\u{1f9e4}\ud1f0\u01cc\ub174\u{1ffcc}',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 120,
+  clearValue: { r: -349.4, g: 379.4, b: -37.37, a: -53.50, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder89.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle9, renderBundle0]);
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 83, resource: {buffer: buffer9, offset: 1024, size: 1092}},
+    {binding: 130, resource: {buffer: buffer58, offset: 0, size: 416}},
+    {binding: 335, resource: textureView11},
+    {binding: 633, resource: textureView89},
+    {binding: 80, resource: textureView74},
+    {binding: 3, resource: textureView80},
+    {binding: 169, resource: textureView88},
+    {binding: 41, resource: textureView89},
+    {binding: 444, resource: textureView6},
+    {binding: 78, resource: textureView70},
+    {binding: 139, resource: textureView63},
+  ],
+});
+let commandEncoder123 = device0.createCommandEncoder();
+let texture123 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 100},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(3, bindGroup27, new Uint32Array(1797), 397, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 236, 0, 129_870_040, 1_056_486_642);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer57, 160);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer60, 276);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer20, 'uint32', 144, 447);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  label: '\u0534\u8c91\u{1f88d}\u{1fc82}\u3b6d',
+  code: `
+enable f16;
+/* target size: 6 max align: 2 */
+struct T0 {
+  @align(2) @size(6) f0: array<u32, 1>,
+}
+@group(0) @binding(234) var sam4: sampler;
+@group(0) @binding(49) var st26: texture_storage_2d_array<r32float, write>;
+@group(0) @binding(374) var st27: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(15) var tex4: texture_depth_cube_array;
+struct FragmentOutput11 {
+  @location(0) f0: vec4f,
+  @location(5) @interpolate(flat) f1: vec2i
+}
+
+@fragment
+fn fragment0(@location(15) @interpolate(flat, centroid) a0: vec4u) -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  textureStore(st26, vec2i(), 0, vec4f(0.07372, 0.1111, 0.2320, 0.08167));
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer72 = device0.createBuffer({
+  size: 520,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 349});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup43, new Uint32Array(2331), 1_220, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder4.setViewport(1.2802783393089365, 0.2172001669305097, 0.4051008463841231, 0.5983344076192693, 0.043960291335062185, 0.3388815613823228);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(1_953, 195, 85, 173_152_461, 1_476_732_809);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer26, 88);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer70, 412);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer30, 6_464, 3_451);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup8, new Uint32Array(2967), 841, 0);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 742 */
+  offset: 742,
+  buffer: buffer18,
+}, {
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 119, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder123.resolveQuerySet(querySet4, 1, 17, buffer11, 2560);
+} catch {}
+let buffer73 = device0.createBuffer({
+  size: 30585,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle15 = renderBundleEncoder15.finish();
+try {
+computePassEncoder83.setBindGroup(3, bindGroup10, new Uint32Array(3280), 356, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup67, new Uint32Array(67), 13, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 22, 0, 333_638_313, 568_752_642);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer53, 116);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline9);
+} catch {}
+document.body.append(video2);
+let commandEncoder124 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: {width: 600, height: 96, depthOrArrayLayers: 121},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderPassEncoder27 = commandEncoder122.beginRenderPass({colorAttachments: [{view: textureView48, depthSlice: 13, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer42, 44);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer30, 6_172, 3_332);
+} catch {}
+try {
+commandEncoder123.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 172, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3612 */
+  offset: 3612,
+  buffer: buffer73,
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 168, resource: sampler6},
+    {binding: 589, resource: {buffer: buffer41, offset: 768, size: 411}},
+    {binding: 19, resource: textureView27},
+  ],
+});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 132});
+let computePassEncoder94 = commandEncoder123.beginComputePass({label: '\u7311\u20a2\uad98\u839b\u0ec2\ue5b2\uaccc\uddac\uebd9\u{1fbd0}'});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup28, new Uint32Array(343), 22, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(19, 131, 1_083_235_861, 138_228_937);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 11, 0, -1_956_601_266, 222_100_604);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder124.resolveQuerySet(querySet5, 9, 55, buffer56, 12288);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let textureView94 = texture32.createView({});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup38, []);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup8, new Uint32Array(1641), 597, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle1, renderBundle9, renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(0.8791538774222274, 0.3738124642944425, 0.7646714922508838, 1.4109775599523702, 0.8511685667847928, 0.9713743832702074);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 33, 0, 400_784_412, 377_537_159);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer38, 388);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer60, 420);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer39, 1_148, 800);
+} catch {}
+let arrayBuffer6 = buffer54.getMappedRange(0, 88);
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer74 = device0.createBuffer({size: 29749, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView95 = texture118.createView({});
+let sampler68 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 71.33,
+  lodMaxClamp: 98.33,
+});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder0.draw(59, 11, 1_677_179_220, 1_004_205_926);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 262, 0, -1_881_764_603, 989_755_587);
+} catch {}
+try {
+computePassEncoder14.pushDebugGroup('\u47ee');
+} catch {}
+await gc();
+let textureView96 = texture107.createView({label: '\u4b57\u{1fbec}\u{1ffc8}\u10c4\u93ea\u3c1a\u0ee4\u{1fa4a}\u0715\u{1fb10}\ub0ad'});
+let texture125 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder4.drawIndexed(69, 457, 185, -1_885_366_790, 3_386_248_462);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer53, 228);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 69, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(368).fill(118), /* required buffer size: 368 */
+{offset: 368, bytesPerRow: 141}, {width: 13, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video0);
+let texture126 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 571},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture127 = device0.createTexture({
+  size: [2],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView97 = texture54.createView({mipLevelCount: 1});
+let sampler69 = device0.createSampler({
+  label: '\u{1f981}\u{1fbe2}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.30,
+  lodMaxClamp: 16.80,
+  compare: 'less-equal',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder8.draw(243, 192, 429_574_488, 543_941_754);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(109, 115, 1_417, -2_113_968_793, 2_436_737_344);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer15, 468);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer40, 336);
+} catch {}
+let arrayBuffer7 = buffer66.getMappedRange(6888, 412);
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 816 */
+  offset: 816,
+  rowsPerImage: 309,
+  buffer: buffer51,
+}, {width: 46, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData20 = new ImageData(16, 36);
+try {
+device0.label = '\u28b3\u{1fa06}\u01f7\u7c75\uc768';
+} catch {}
+let texture128 = device0.createTexture({
+  size: {width: 300, height: 48, depthOrArrayLayers: 61},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture129 = device0.createTexture({
+  label: '\u6754\u0ccc\u199b',
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder28 = commandEncoder124.beginRenderPass({
+  label: '\u2629\u7fcc\u{1f998}\u{1f9c4}\u9337\u0b3c\ub41a\ue10c\u64ac\u{1fa55}\u0e8b',
+  colorAttachments: [{view: textureView86, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer50, 140); };
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(847, 127, 561, 231_028_172, 1_633_578_548);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer67, 'uint16', 4_040, 2_184);
+} catch {}
+let textureView98 = texture126.createView({});
+let texture130 = device0.createTexture({
+  size: [164, 12, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView99 = texture100.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder95 = commandEncoder125.beginComputePass({label: '\u{1fcd4}\u3608\u4c39\u1acb\u059f\u{1fa99}\u0925'});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup4, new Uint32Array(5471), 153, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 182, 0, -1_656_967_339, 636_326_159);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer27, 'uint32', 136, 141);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer75 = device0.createBuffer({
+  label: '\ucff9\u074f\u{1fbf8}\u{1fe54}\u{1f821}',
+  size: 31757,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView100 = texture110.createView({label: '\u{1ff43}\u0a33', aspect: 'all', baseMipLevel: 0});
+let textureView101 = texture109.createView({format: 'rg32sint'});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(2, bindGroup42, new Uint32Array(229), 32, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.draw(217, 214, 407_990_977, 246_098_365);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer60, 120);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData3,
+  origin: { x: 1, y: 22 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 25, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 90, resource: textureView20}]});
+let buffer76 = device0.createBuffer({
+  size: 3475,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView102 = texture84.createView({dimension: '2d-array'});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(0, bindGroup52, new Uint32Array(263), 28, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup50, new Uint32Array(956), 3, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer53, 'uint16', 70, 93);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+computePassEncoder6.pushDebugGroup('\u0e96');
+} catch {}
+await gc();
+try {
+renderPassEncoder14.setViewport(1445.1315237228443, 0.6676021042479752, 283.0562992466295, 1.3891220165892584, 0.0584104210095886, 0.4948134819778847);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(16, 381, 378, 191_567_853, 154_319_195);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer42, 24);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer1, 'uint32', 14_900, 7_519);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({});
+let textureView103 = texture128.createView({format: 'rg32sint'});
+let texture131 = device0.createTexture({
+  label: '\u40e0\u{1fc0a}\u0d44\ua48a\u0014\u567e\u85e3\u{1fb77}\u{1fa1f}',
+  size: [164, 12, 1],
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder8.draw(52, 407, 116_988_265, 218_140_534);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.draw(36, 236, 2_910_969_552, 1_467_841_696);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(5, 13, 11, -456_759_542, 747_901_765);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer33, 4_188);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint16', 804, 54);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer33, 0, 954);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer58, 5672, new Int16Array(18117), 823, 1064);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(346).fill(106), /* required buffer size: 346 */
+{offset: 346, rowsPerImage: 107}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+let commandEncoder128 = device0.createCommandEncoder({});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup29, new Uint32Array(5352), 889, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup11, new Uint32Array(2930), 60, 0);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder0.draw(29, 477, 1_366_554_594, 109_220_196);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer63, 2_036);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer55, 0, 2_718);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(90).fill(79), /* required buffer size: 90 */
+{offset: 90, bytesPerRow: 178}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 92, resource: {buffer: buffer19, offset: 2048, size: 808}}],
+});
+let buffer77 = device0.createBuffer({
+  size: 24288,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let texture132 = device0.createTexture({
+  size: [2880, 4, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView104 = texture71.createView({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup63, new Uint32Array(1218), 364, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle2, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder8.draw(122, 38, 323_635_278, 792_595_094);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 228, 0, 1_077_052_319, 135_966_353);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer8, 244);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup73, new Uint32Array(1698), 412, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(596, 342, 84, -2_034_698_129, 733_744_821);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer15, 1_076);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer33, 4_612);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer4, 'uint32', 876, 4_286);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u61ec');
+} catch {}
+let imageData21 = new ImageData(8, 24);
+let texture133 = gpuCanvasContext0.getCurrentTexture();
+let textureView105 = texture103.createView({dimension: 'cube'});
+let sampler70 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder0.draw(230, 255, 223_784_963, 37_426_227);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 35, 0, 52_286_085, 98_748_380);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer66, 644);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 365, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(249), /* required buffer size: 6 */
+{offset: 6}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({});
+let commandBuffer5 = commandEncoder127.finish();
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+renderPassEncoder8.draw(175, 32, 1_881_100_084, 1_620_808_262);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer70, 60);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer41, 708);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+texture39.destroy();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 248, new Float32Array(21056), 126, 68);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1440, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup74 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 92, resource: {buffer: buffer64, offset: 0}}]});
+let buffer78 = device0.createBuffer({size: 16304, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+let commandEncoder132 = device0.createCommandEncoder();
+let textureView106 = texture84.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder96 = commandEncoder132.beginComputePass({});
+try {
+computePassEncoder96.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.draw(398, 29, 406_154_979, 161_319_666);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(681, 17, 435, -2_122_493_170, 409_256_956);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer51, 6_196);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let textureView107 = texture49.createView({dimension: '1d', mipLevelCount: 1});
+let computePassEncoder97 = commandEncoder129.beginComputePass({label: '\u6b6f\u085a\u75f8'});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup26, new Uint32Array(4051), 175, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(251, 155, 52_606_038, 326_460_942);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer67, 928);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer38, 332);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer58, 1_736, 2_744);
+} catch {}
+let videoFrame16 = new VideoFrame(img0, {timestamp: 0});
+let textureView108 = texture118.createView({label: '\u522b\u660b\u{1f82b}', format: 'rgba32sint', mipLevelCount: 1});
+let renderPassEncoder29 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 236,
+  clearValue: { r: -60.58, g: -832.9, b: 971.5, a: -3.134, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder97.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup15, new Uint32Array(248), 63, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(189, 45, 720, 518_045_508, 342_000_041);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer30, 6_792);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 17, resource: {buffer: buffer73, offset: 2048, size: 2325}},
+    {binding: 380, resource: textureView74},
+  ],
+});
+let commandEncoder133 = device0.createCommandEncoder({label: '\u{1ff9a}\ufefe\ue313\u01a1\uea53\u0798\u0299\ue4b5\u8475\u{1fbd3}\u17ed'});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder3.draw(297, 414, 790_738_008, 268_872_069);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 152, new Float32Array(12062), 287, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(32).fill(196), /* required buffer size: 32 */
+{offset: 32, bytesPerRow: 34}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 148}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 19, y: 35 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt709', transfer: 'smpteSt4281'} });
+try {
+adapter0.label = '\u3be5\ud917\u1a88';
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: vec2h,
+}
+/* target size: 51 max align: 1 */
+struct T1 {
+  @align(1) @size(32) f0: mat3x3h,
+  @align(1) @size(8) f1: atomic<i32>,
+  @align(1) @size(11) f2: array<atomic<u32>>,
+}
+/* target size: 122 max align: 2 */
+struct T2 {
+  @align(2) @size(8) f0: T0,
+  @size(16) f1: f16,
+  @align(2) @size(28) f2: array<T0, 1>,
+  @align(2) f3: T0,
+  @align(2) @size(16) f4: T0,
+  @align(2) f5: u32,
+  @align(2) f6: array<f32, 4>,
+  @align(1) @size(30) f7: T0,
+}
+/* target size: 51 max align: 1 */
+struct T3 {
+  @align(1) @size(51) f0: array<array<T0, 1>>,
+}
+@group(0) @binding(15) var tex5: texture_cube_array<i32>;
+@group(0) @binding(49) var st28: texture_storage_1d<r32sint, write>;
+@group(1) @binding(64) var<storage, read_write> buffer79: T3;
+@group(0) @binding(234) var sam5: sampler;
+@group(0) @binding(374) var st29: texture_storage_1d<rgba32float, read>;
+struct VertexOutput11 {
+  @builtin(position) f36: vec4f
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32) -> VertexOutput11 {
+  var out: VertexOutput11;
+  _ = textureGather(0, tex5, sam5, vec3f(), 0);
+  if bool(textureGather(1, tex5, sam5, vec3f(), 0)[3]) {
+    var v: vec4f;
+  }
+  return out;
+}
+struct VertexOutput12 {
+  @location(7) f37: vec2i,
+  @location(3) @interpolate(flat, sample) f38: u32,
+  @builtin(position) f39: vec4f
+}
+
+@vertex
+fn vertex1(@location(11) a0: vec2f, @location(4) a1: i32) -> VertexOutput12 {
+  var out: VertexOutput12;
+  return out;
+}
+struct S3 {
+  @location(6) @interpolate(linear, centroid) f0: vec2h
+}
+struct S4 {
+  @location(15) @interpolate(flat, center) f0: vec2i,
+  @location(1) @interpolate(flat) f1: u32
+}
+struct FragmentOutput12 {
+  @location(0) @interpolate(flat) f0: vec4f
+}
+
+@fragment
+fn fragment0(a0: S3, @location(11) a1: f16, @location(12) a2: vec2i, a3: S4, @builtin(position) a4: vec4f) -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  _ = a4;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = buffer79.f0[arrayLength(&buffer79.f0) - 1];
+  _ = buffer79.f0;
+  _ = arrayLength(&buffer79.f0);
+  textureStore(st28, 0, vec4i(146, 15, 298, 22));
+}`,
+  hints: {},
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  size: [1554, 65, 1],
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder98 = commandEncoder130.beginComputePass({});
+try {
+computePassEncoder98.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup30, new Uint32Array(3284), 555, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer17, 680);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+computePassEncoder6.popDebugGroup();
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder76.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\uf042\u{1fa8d}\u8df4\u2243\u06f1\u8035',
+  entries: [
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let texture135 = device0.createTexture({
+  size: {width: 150},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.98,
+  lodMaxClamp: 94.17,
+});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder8.draw(6, 177, 1_061_833_129, 127_634_741);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(542, 783, 421, 641_987_310, 1_301_371_120);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer42, 16);
+} catch {}
+try {
+commandEncoder133.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3504 */
+  offset: 3504,
+  rowsPerImage: 715,
+  buffer: buffer30,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'jedecP22Phosphors', transfer: 'iec6196624'} });
+let buffer80 = device0.createBuffer({
+  label: '\u1862\ub943\u{1ffc4}\u66c1',
+  size: 2829,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture136 = device0.createTexture({
+  label: '\u{1ffeb}\u1ff2',
+  size: [360],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder99 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder99.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup20, new Uint32Array(4111), 1_716, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer72, 48);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer42, 20);
+} catch {}
+let promise14 = shaderModule2.getCompilationInfo();
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let imageData22 = new ImageData(4, 32);
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 380, resource: textureView74},
+    {binding: 17, resource: {buffer: buffer80, offset: 0, size: 861}},
+  ],
+});
+let buffer81 = device0.createBuffer({size: 1938, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder135 = device0.createCommandEncoder({});
+let textureView109 = texture136.createView({});
+let texture137 = device0.createTexture({
+  size: [75, 12, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler72 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 15.21,
+});
+try {
+renderPassEncoder18.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(9, 3, 79, 80_418_323, 725_321_577);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 162, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(286).fill(118), /* required buffer size: 286 */
+{offset: 286, rowsPerImage: 0}, {width: 62, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer72, 52);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer42, 'uint32', 68, 52);
+} catch {}
+try {
+buffer70.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder();
+let textureView110 = texture95.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler73 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 82.67,
+  lodMaxClamp: 93.07,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup19, new Uint32Array(103), 3, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer56, 968);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer17, 16);
+} catch {}
+try {
+  await shaderModule10.getCompilationInfo();
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 135,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture138 = device0.createTexture({
+  size: {width: 82, height: 6, depthOrArrayLayers: 1316},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture139 = device0.createTexture({
+  label: '\ue87e\u{1f99b}',
+  size: {width: 75, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView111 = texture35.createView({format: 'rgb10a2unorm', arrayLayerCount: 1});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder8.setViewport(1.0779061027219623, 1.169835326061518, 0.1529145368206669, 0.4365369316992639, 0.40770078509216146, 0.8499519649698997);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(10, 382, 90, 173_383_686, 489_299_257);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer49, 'uint16', 12_810, 7_062);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer68, 192, 16);
+} catch {}
+let buffer82 = device0.createBuffer({
+  label: '\uc0b0\u03e9\u48e8\u0d14\u{1fd97}\u5d5c\u{1f6a1}\u{1fab9}',
+  size: 2924,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView112 = texture138.createView({aspect: 'all'});
+let texture140 = device0.createTexture({
+  size: [300, 48, 403],
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView113 = texture103.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 6});
+try {
+computePassEncoder87.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(2, bindGroup7, new Uint32Array(327), 25, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer45, 2_704);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer47, 68, 1);
+} catch {}
+try {
+computePassEncoder61.pushDebugGroup('\ub049');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 344, new Int16Array(11747), 405, 96);
+} catch {}
+video0.width = 22;
+let imageData23 = new ImageData(24, 92);
+let commandEncoder137 = device0.createCommandEncoder({});
+let computePassEncoder100 = commandEncoder131.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup18, new Uint32Array(2581), 58, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 472, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer83 = device0.createBuffer({size: 9812, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView114 = texture61.createView({dimension: '2d-array', format: 'r32uint'});
+let sampler74 = device0.createSampler({
+  label: '\u0cf5\u5b14',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.682,
+  lodMaxClamp: 19.57,
+  compare: 'never',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer33, 1_164); };
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer72, 36);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer26, 512);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer8, 'uint16', 22, 74);
+} catch {}
+let texture141 = device0.createTexture({
+  size: {width: 164},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder3.drawIndexed(419, 13, 138, 49_734_772, 1_649_023_994);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer33, 'uint32', 5_956, 4_150);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder35.pushDebugGroup('\u7f80');
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 28, resource: {buffer: buffer65, offset: 1792, size: 92}}],
+});
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer84 = device0.createBuffer({label: '\ue818\u03fe\u{1f650}\ucce3\u{1f692}', size: 6225, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder138 = device0.createCommandEncoder();
+let textureView115 = texture85.createView({dimension: '2d-array', baseMipLevel: 0});
+let computePassEncoder101 = commandEncoder137.beginComputePass();
+try {
+computePassEncoder101.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer56, 3_732);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 148}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let shaderModule13 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 54 max align: 2 */
+struct T0 {
+  @align(2) f0: vec2h,
+  @align(2) @size(8) f1: atomic<u32>,
+  @align(2) @size(42) f2: mat2x3f,
+}
+/* target size: 54 max align: 2 */
+struct T1 {
+  @align(2) f0: atomic<i32>,
+  @align(1) @size(50) f1: array<atomic<i32>>,
+}
+@group(0) @binding(28) var<storage, read_write> buffer85: T0;
+struct VertexOutput13 {
+  @location(7) @interpolate(perspective) f40: vec4h,
+  @location(4) f41: vec3h,
+  @builtin(position) f42: vec4f,
+  @location(10) f43: f16,
+  @location(8) @interpolate(flat, centroid) f44: vec4i
+}
+
+@vertex
+fn vertex0() -> VertexOutput13 {
+  var out: VertexOutput13;
+  return out;
+}
+struct FragmentOutput13 {
+  @location(0) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  _ = buffer85.f0;
+  _ = buffer85.f2;
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0() {
+}`,
+  hints: {},
+});
+let bindGroup78 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView13}]});
+let pipelineLayout15 = device0.createPipelineLayout({label: '\u0b2d\u{1fbaa}\u0d93\u{1f91d}\ua4c4', bindGroupLayouts: []});
+let textureView116 = texture11.createView({format: 'rgb10a2unorm'});
+let computePassEncoder102 = commandEncoder138.beginComputePass({});
+let renderPassEncoder30 = commandEncoder133.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 2,
+  clearValue: { r: 393.3, g: 375.0, b: 683.3, a: 839.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 125943185,
+});
+let sampler75 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 50.96,
+  lodMaxClamp: 51.37,
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup74, new Uint32Array(3921), 195, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup42, new Uint32Array(6320), 20, 0);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(505);
+} catch {}
+try {
+renderPassEncoder7.setViewport(1.7737957443695223, 1.6111215268549464, 0.09490738803793344, 0.3187580173717878, 0.12624666104280347, 0.6914166671197826);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer72, 48);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer65, 676);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'r16sint']});
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 7, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 344, new BigUint64Array(8011), 468, 696);
+} catch {}
+try {
+computePassEncoder84.setBindGroup(2, bindGroup20, new Uint32Array(2900), 2_224, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer38, 4); };
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.draw(92, 160, 1_455_298_044, 118_612_976);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(25, 305, 81, 193_457_151, 87_266_411);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer33, 204);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer13, 'uint16', 3_680, 2_044);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup17, new Uint32Array(4354), 1_057, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer59, 'uint16', 260, 596);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer35, 0);
+} catch {}
+document.body.prepend(img2);
+let textureView117 = texture91.createView({});
+let computePassEncoder103 = commandEncoder136.beginComputePass({});
+let renderBundle16 = renderBundleEncoder16.finish({});
+let sampler76 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.47,
+  lodMaxClamp: 46.25,
+  compare: 'less',
+  maxAnisotropy: 7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer57, 420); };
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder8.draw(42, 118, 1_325_558_112, 501_175_962);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer15, 40);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline9);
+} catch {}
+try {
+texture63.destroy();
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+computePassEncoder14.popDebugGroup();
+} catch {}
+let texture142 = device0.createTexture({
+  size: [164],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let computePassEncoder104 = commandEncoder134.beginComputePass({});
+let renderPassEncoder31 = commandEncoder135.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 212,
+  clearValue: { r: -9.697, g: -398.2, b: -934.8, a: -31.50, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler77 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 76.10,
+  lodMaxClamp: 87.07,
+  compare: 'greater-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroupsIndirect(buffer50, 612); };
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder0.draw(87, 83, 139_319_022, 348_742_876);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 185, 0, 169_423_459, 940_091_670);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer21, 'uint16', 306, 198);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer68);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas2);
+let buffer86 = device0.createBuffer({
+  size: 14151,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture143 = device0.createTexture({
+  size: {width: 720, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder103.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(35);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(246, 0, 512, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer21, 8);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer53, 'uint16', 36, 329);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer71, 0, 2_052);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 252,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 685});
+let textureView118 = texture28.createView({dimension: '2d-array'});
+let textureView119 = texture14.createView({label: '\u7a0f\u03bf\u0b54\u7854\ua4d4\u3db6', dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder62.setBindGroup(2, bindGroup6, new Uint32Array(3121), 712, 0);
+} catch {}
+try {
+computePassEncoder56.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup67, new Uint32Array(282), 1, 0);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(9, 126, 123_709_837, 354_246_138);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer65, 120);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer33, 1_296);
+} catch {}
+let buffer87 = device0.createBuffer({size: 10035, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture144 = device0.createTexture({
+  size: {width: 329, height: 24, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView120 = texture42.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+computePassEncoder75.setBindGroup(3, bindGroup35, new Uint32Array(2413), 300, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup19, new Uint32Array(742), 27, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(232, 12, 893_071_186, 661_663_991);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer15, 2_832);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer42, 'uint16', 46, 7);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer60);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 9 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder139 = device0.createCommandEncoder();
+let computePassEncoder105 = commandEncoder139.beginComputePass({});
+try {
+computePassEncoder105.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(127);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.draw(509, 11, 326_358_817, 1_074_467_401);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer72, 88);
+} catch {}
+let bindGroup79 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView1}]});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup68, []);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer42, 56, 14);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'gamma22curve'} });
+let bindGroup80 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView24}]});
+let buffer88 = device0.createBuffer({size: 21, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler78 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 27.39,
+  lodMaxClamp: 84.71,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup57, new Uint32Array(887), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer53, 28); };
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.3160767874353765, 0.2597295085809763, 1.5121205580154022, 1.1470037081481035, 0.5063282461349343, 0.857429814032075);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(100, 754, 3, 751_768, 302_941_378);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer40, 8);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer75, 0, 815);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise14;
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({});
+let textureView121 = texture78.createView({dimension: '2d', mipLevelCount: 1});
+let texture145 = device0.createTexture({
+  label: '\uaf43\uc355',
+  size: {width: 300, height: 48, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder106 = commandEncoder140.beginComputePass({label: '\u05ee\u6560\u84e5\u4384\u{1f8d7}\uaab1\u0f67\u0da4\ue941'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'r16sint'], depthReadOnly: true});
+let renderBundle17 = renderBundleEncoder17.finish({});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 26, 0, 528_129_527, 195_017_778);
+} catch {}
+let arrayBuffer8 = buffer61.getMappedRange(7824, 804);
+try {
+device0.queue.writeBuffer(buffer29, 3860, new DataView(new ArrayBuffer(11985)), 2540, 648);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let video3 = await videoWithData(19);
+let bindGroup81 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 135, resource: textureView112}]});
+let texture146 = device0.createTexture({
+  label: '\ub3b9\u6c47\u59ec\u1825\u{1f672}',
+  size: [659],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture147 = device0.createTexture({
+  label: '\u0449\u50da\u9732\u{1ff9b}\u{1f60d}\u8ccc\u2ee9\u{1fb5a}\u0b1c\u555d\u776f',
+  size: {width: 1440, height: 2, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(2, 2, 1); };
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(18, 104, 59, 742_971_838, 1_548_273_296);
+} catch {}
+let arrayBuffer9 = buffer54.getMappedRange(88, 768);
+let buffer89 = device0.createBuffer({
+  size: 1737,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder141 = device0.createCommandEncoder({});
+let computePassEncoder107 = commandEncoder141.beginComputePass({});
+let sampler79 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.95,
+  lodMaxClamp: 74.77,
+  maxAnisotropy: 4,
+});
+let externalTexture12 = device0.importExternalTexture({source: video2});
+try {
+renderPassEncoder18.setIndexBuffer(buffer59, 'uint32', 64, 8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup82 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 67, resource: textureView109}]});
+let commandEncoder142 = device0.createCommandEncoder({});
+let textureView122 = texture104.createView({});
+let computePassEncoder108 = commandEncoder142.beginComputePass({});
+try {
+renderPassEncoder8.drawIndexed(12, 99, 90, -1_970_644_918, 106_047_425);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer82, 1_600);
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let texture148 = device0.createTexture({
+  size: {width: 1440, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup44, new Uint32Array(1607), 380, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(743, 21, 10, 163_683_061, 804_345_066);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer73, 0);
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 508 widthInBlocks: 127 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 512,
+  buffer: buffer33,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 114, y: 26, z: 0},
+  aspect: 'all',
+}, {width: 127, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder143.resolveQuerySet(querySet3, 4, 3, buffer24, 3328);
+} catch {}
+try {
+computePassEncoder41.insertDebugMarker('\u05c7');
+} catch {}
+let bindGroup83 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 168, resource: textureView74}]});
+let renderPassEncoder32 = commandEncoder143.beginRenderPass({colorAttachments: [{view: textureView115, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer50, 1_848); };
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer38, 492);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise15;
+} catch {}
+try {
+computePassEncoder24.setBindGroup(1, bindGroup28, new Uint32Array(776), 379, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer8, 'uint16', 1_852, 353);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer58, 0);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+document.body.prepend(img2);
+video2.height = 35;
+await gc();
+try {
+computePassEncoder43.setBindGroup(1, bindGroup28, new Uint32Array(983), 273, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(90);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle0, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer26, 616);
+} catch {}
+try {
+computePassEncoder80.insertDebugMarker('\u024e');
+} catch {}
+let img3 = await imageWithData(29, 64, '#10101010', '#20202020');
+let commandEncoder144 = device0.createCommandEncoder({});
+let texture149 = device0.createTexture({
+  size: [300],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView123 = texture146.createView({label: '\uf44d\ua146\u08b6\u0545\u{1fa5d}\u{1f74f}\u{1ff6d}\u97c0\u8582\u0dde'});
+let computePassEncoder109 = commandEncoder144.beginComputePass({label: '\uacca\u{1fbce}\u47b2\u0b99\u72ca\u046b\uc217'});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer52, 952); };
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup3, new Uint32Array(2255), 822, 0);
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant({ r: -275.8, g: -863.7, b: -304.7, a: -602.6, });
+} catch {}
+try {
+renderPassEncoder8.draw(122, 15, 274_924_079, 542_971_167);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let renderPassEncoder33 = commandEncoder145.beginRenderPass({
+  label: '\u0027\uf6c1\u25db',
+  colorAttachments: [{view: textureView85, depthSlice: 7, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 344133529,
+});
+let sampler80 = device0.createSampler({
+  label: '\u0033\uc3e1\uead0\u0f0b\u{1f67a}\u2416\u6234\u01fa\u67de\ud9b4',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.00,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(0, bindGroup32, new Uint32Array(4729), 1_500, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 141, 0, 917_030_332, 2_610_014_906);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u5d50');
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let buffer90 = device0.createBuffer({size: 2559, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture150 = device0.createTexture({
+  label: '\u057d\u80b2\u1a6c\u{1fd09}\u{1f7d4}\u8d56\u7941\u0cff\u0503\ube79\u608c',
+  size: {width: 600, height: 96, depthOrArrayLayers: 50},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView124 = texture46.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer67, 308); };
+} catch {}
+try {
+renderPassEncoder0.draw(405, 286, 291_539_782, 541_882_848);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer33, 10_188);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer6, 1_192, 128);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let textureView125 = texture145.createView({aspect: 'depth-only'});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.96,
+  lodMaxClamp: 87.87,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 29, 0, 28_681_511, 2_327_117_748);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, undefined);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let commandEncoder146 = device0.createCommandEncoder({label: '\u0cb8\ufd3f'});
+let textureView126 = texture8.createView({});
+let computePassEncoder110 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder62.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer50, 'uint16', 5_860, 1_127);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+let textureView127 = texture140.createView({});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup68, new Uint32Array(418), 47, 0);
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup28, new Uint32Array(3315), 5, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(9, 29, 0, 123_833_302, 1_043_385_154);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer86, 0, 38);
+} catch {}
+let buffer91 = device0.createBuffer({
+  size: 45,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(108, 720, 1_302, 198_815_340, 3_047_932_314);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer52, 2_200);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer49, 9_340);
+} catch {}
+try {
+computePassEncoder61.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let textureView128 = texture95.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder3.draw(83, 188, 331_489_015, 1_259_618_181);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 25, 0, 721_820_678, 963_083_747);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer33, 6_372);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer50, 'uint32', 852, 1_982);
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  label: '\u4931\u0e70',
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 66, resource: textureView74},
+    {binding: 315, resource: {buffer: buffer57, offset: 0, size: 256}},
+    {binding: 81, resource: textureView32},
+    {binding: 106, resource: {buffer: buffer47, offset: 0, size: 101}},
+    {binding: 21, resource: {buffer: buffer51, offset: 12032, size: 4824}},
+    {binding: 48, resource: textureView122},
+    {binding: 347, resource: textureView79},
+    {binding: 59, resource: textureView66},
+  ],
+});
+let buffer92 = device0.createBuffer({
+  size: 8347,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder147 = device0.createCommandEncoder();
+let textureView129 = texture74.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder111 = commandEncoder147.beginComputePass({});
+try {
+computePassEncoder73.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder33.setBlendConstant({ r: -430.7, g: 588.7, b: -504.9, a: 510.6, });
+} catch {}
+try {
+renderPassEncoder3.draw(22, 71, 1_798_263_597, 196_696_105);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 45, 0, 637_683_152, 211_517_127);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer45, 1_544);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder148 = device0.createCommandEncoder({});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup16, new Uint32Array(2308), 124, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(270, 122, 1_855, 74_395_227, 396_563_546);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer65, 1_056);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer72, 32);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer86, 1_808, 1_462);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let textureView130 = texture110.createView({});
+let computePassEncoder112 = commandEncoder148.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(140, 286, 658, 229_271_690, 773_503_115);
+} catch {}
+try {
+computePassEncoder35.popDebugGroup();
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder();
+let textureView131 = texture117.createView({});
+let textureView132 = texture119.createView({format: 'rgba32float'});
+let computePassEncoder113 = commandEncoder149.beginComputePass({});
+try {
+computePassEncoder113.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.draw(83, 99, 169_342_927, 531_262_935);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 73, 7, 141_127_201, 917_800_222);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer60, 572);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u32be');
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let buffer93 = device0.createBuffer({
+  label: '\u0e6a\u0a02',
+  size: 3920,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView133 = texture102.createView({});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 220, 0, 301_934_054, 103_361_040);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer48, 208);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer60, 72);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+await gc();
+try {
+computePassEncoder0.setBindGroup(3, bindGroup31, new Uint32Array(536), 337, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer17, 336); };
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup54, new Uint32Array(333), 67, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(81, 40, 37_176_977, 511_732_780);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer19, 892);
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder({label: '\u7a41\u8223\u9026\u2143\udfad\u0188\u{1f783}\u4fa7'});
+let textureView134 = texture2.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(25, 443, 19, 1_713_300_166, 723_089_755);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer58, 0, 4_671);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 41, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(172).fill(213), /* required buffer size: 172 */
+{offset: 172, bytesPerRow: 508, rowsPerImage: 18}, {width: 115, height: 8, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let computePassEncoder114 = commandEncoder150.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer19, 580); };
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(151, 3, 521_669_592, 3_159_622_933);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(29, 84, 217, 131_899_726, 1_014_245_322);
+} catch {}
+try {
+buffer60.destroy();
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 133, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(135).fill(197), /* required buffer size: 135 */
+{offset: 135}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder({});
+let texture151 = device0.createTexture({
+  size: [164, 12, 484],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder34 = commandEncoder151.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  depthSlice: 443,
+  clearValue: { r: 412.5, g: 160.6, b: 763.7, a: -248.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView91, depthClearValue: -8.978404347622664, depthReadOnly: true},
+});
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup5, new Uint32Array(677), 44, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(281, 381, 73, 263_010_274, 529_236_301);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 2628, new DataView(new ArrayBuffer(1619)), 1072, 16);
+} catch {}
+let imageData24 = new ImageData(8, 56);
+let commandEncoder152 = device0.createCommandEncoder({});
+let texture152 = device0.createTexture({
+  size: [2880, 4, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler82 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.49,
+  lodMaxClamp: 98.92,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder17.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(47, 139, 2, 147_832_817, 27_458_274);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, buffer66, 0);
+} catch {}
+try {
+buffer39.label = '\u{1f973}\ueada\ub3ed\ufed9\u012b\u8256\u36cf\u0c73\ua257\u0073\ue8ca';
+} catch {}
+let textureView135 = texture138.createView({});
+let computePassEncoder115 = commandEncoder152.beginComputePass({});
+let sampler83 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 4.941,
+  lodMaxClamp: 98.72,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder0.dispatchWorkgroupsIndirect(buffer40, 1_880);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder0.draw(72, 5, 244_211_982, 6_520_326);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer40, 'uint32', 596, 822);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4_294_967_294, undefined, 759_464_712, 74_258_199);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise16;
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder();
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 314});
+let computePassEncoder116 = commandEncoder153.beginComputePass({});
+try {
+computePassEncoder116.setBindGroup(0, bindGroup61, new Uint32Array(831), 138, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup74, new Uint32Array(1034), 128, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer33, 5_376);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(382).fill(8), /* required buffer size: 382 */
+{offset: 382, bytesPerRow: 144}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'hlg'} });
+try {
+computePassEncoder116.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.draw(84, 142, 225_674_562, 1_531_738_870);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 130, 0, -1_361_918_863, 281_322_670);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer16, 5_452);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(84).fill(219), /* required buffer size: 84 */
+{offset: 84}, {width: 69, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 3,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ufc6a\ueae8\u0f1b\u04f3\u{1fda3}\u78dd\u04fa\uc917';
+} catch {}
+let buffer94 = device0.createBuffer({
+  label: '\ub513\u6160\u0f7d\u0b85',
+  size: 13476,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm']});
+let sampler84 = device0.createSampler({
+  label: '\u0614\uc0da',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.54,
+  compare: 'greater',
+});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup9, new Uint32Array(3122), 868, 0);
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup10, new Uint32Array(2306), 1_521, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle1, renderBundle0, renderBundle3, renderBundle1, renderBundle4, renderBundle1, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.draw(502, 311, 589_430_592, 706_430_185);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer51, 0, 7_189);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer76, 'uint32', 616, 1_076);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup85 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer64, offset: 0, size: 4}}],
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup80);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup32, []);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer19, 132);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer20, 'uint32', 356, 1_822);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup63, new Uint32Array(518), 23, 0);
+} catch {}
+try {
+  await buffer74.mapAsync(GPUMapMode.READ, 0, 3780);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 23 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise17;
+} catch {}
+await gc();
+let texture153 = gpuCanvasContext4.getCurrentTexture();
+let renderBundle18 = renderBundleEncoder18.finish();
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup8, new Uint32Array(131), 32, 0);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 383.4, g: 305.0, b: -199.5, a: 21.74, });
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer78, 5_988);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint16', 294, 1_061);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer86, 0, 4_678);
+} catch {}
+let arrayBuffer10 = buffer66.getMappedRange(7896, 220);
+let commandEncoder154 = device0.createCommandEncoder({});
+let texture154 = device0.createTexture({
+  size: [75, 12, 5],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let computePassEncoder117 = commandEncoder154.beginComputePass({});
+let sampler85 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.08,
+  lodMaxClamp: 92.97,
+});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup75);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer65, 468);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer60, 'uint16', 666, 691);
+} catch {}
+let buffer95 = device0.createBuffer({size: 1640, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder155 = device0.createCommandEncoder({});
+let textureView136 = texture60.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let externalTexture13 = device0.importExternalTexture({source: video1});
+try {
+renderPassEncoder8.drawIndexed(76, 234, 9, 61_826_118, 470_561_986);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder155.copyBufferToTexture({
+  /* bytesInLastRow: 1344 widthInBlocks: 84 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 880 */
+  offset: 880,
+  rowsPerImage: 91,
+  buffer: buffer18,
+}, {
+  texture: texture146,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 84, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img4 = await imageWithData(141, 42, '#10101010', '#20202020');
+let shaderModule14 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 28 max align: 4 */
+struct T0 {
+  @size(28) f0: array<atomic<u32>>,
+}
+/* target size: 178 max align: 2 */
+struct T1 {
+  @align(2) @size(178) f0: array<atomic<u32>>,
+}
+/* target size: 139 max align: 1 */
+struct T2 {
+  @align(1) @size(139) f0: array<mat4x3f>,
+}
+@group(0) @binding(234) var sam6: sampler;
+@group(0) @binding(49) var st30: texture_storage_1d<rgba16float, write>;
+@group(0) @binding(15) var tex6: texture_depth_2d;
+@group(0) @binding(374) var st31: texture_storage_2d<rgba8unorm, read>;
+struct VertexOutput14 {
+  @builtin(position) f45: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput14 {
+  var out: VertexOutput14;
+  return out;
+}
+struct VertexOutput15 {
+  @location(0) @interpolate(flat, sample) f46: vec2i,
+  @location(8) f47: vec4u,
+  @location(14) f48: vec2u,
+  @builtin(position) f49: vec4f,
+  @location(13) f50: vec2h
+}
+
+@vertex
+fn vertex1(@location(7) @interpolate(perspective) a0: f32, @location(3) a1: vec2h, @location(2) @interpolate(linear) a2: vec3f, @location(11) @interpolate(perspective) a3: vec3h) -> VertexOutput15 {
+  var out: VertexOutput15;
+  _ = textureGather(tex6, sam6, vec2f(), vec2i());
+  return out;
+}
+struct FragmentOutput14 {
+  @location(0) f0: vec4f,
+  @location(5) f1: vec4f,
+  @builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0(@location(1) @interpolate(perspective) a0: vec3h, @location(3) @interpolate(flat, center) a1: vec3f) -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  textureStore(st30, 0, vec4f(0.08080, 0.03690, 0.08469, 0.1164));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+  _ = textureLoad(st31, vec2i());
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture155 = device0.createTexture({
+  label: '\uebfe\ub4dc\ub157\u763a\u792c\u0c6d\u{1f86d}\u0a6e\u0ea8\u{1f89d}\u01d5',
+  size: {width: 600, height: 96, depthOrArrayLayers: 560},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView137 = texture0.createView({dimension: '2d-array', format: 'r32float'});
+let computePassEncoder118 = commandEncoder155.beginComputePass({});
+try {
+renderPassEncoder17.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.draw(4, 23, 387_116_998, 157_657_738);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(63, 87, 47, -2_049_912_626, 465_264_045);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer57, 492);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 10264, new Float32Array(1386), 123, 4);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+await gc();
+let bindGroup86 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 135, resource: textureView112}]});
+let commandEncoder156 = device0.createCommandEncoder({});
+let texture156 = device0.createTexture({
+  label: '\u310d\udaab\u02d0\u4168\u36a1',
+  size: {width: 2, height: 2, depthOrArrayLayers: 21},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView138 = texture16.createView({format: 'rgba32uint'});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup68, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer72, 36); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup30, new Uint32Array(1034), 761, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(38, 84, 368_886_949, 325_376_529);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer57, 360);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 17_224, 1_498);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer53, 0, 182);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let buffer96 = device0.createBuffer({size: 177, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroupsIndirect(buffer17, 3_152); };
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup76);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(31, 137, 47, 200_332_424, 776_953_945);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer15, 3_544);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer19, 2_288);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(474, 28);
+let commandEncoder157 = device0.createCommandEncoder({});
+let texture157 = device0.createTexture({
+  size: {width: 329, height: 24, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView139 = texture148.createView({label: '\uebf0\ud317\u6f45\u0bb0\u06f2\u{1fc83}\u0531\u{1ff99}\ubb70\u38d1\uf30f', baseArrayLayer: 0});
+let renderPassEncoder35 = commandEncoder156.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  depthSlice: 343,
+  clearValue: { r: 166.5, g: 886.6, b: -21.38, a: 300.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView91,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 68252895,
+});
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup22, new Uint32Array(180), 1, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(31, 219, 61, 258_430_148, 203_044_437);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer73, 328);
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer49, 1908, 18460);
+} catch {}
+try {
+commandEncoder157.resolveQuerySet(querySet8, 21, 46, buffer24, 8192);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+/* target size: 43 max align: 1 */
+struct T0 {
+  @align(1) @size(3) f0: f16,
+  @align(1) @size(40) f1: array<atomic<i32>>,
+}
+@group(0) @binding(49) var st32: texture_storage_1d<rgba32float, write>;
+@group(0) @binding(374) var st33: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(234) var sam7: sampler;
+@group(0) @binding(15) var tex7: texture_2d<u32>;
+struct VertexOutput16 {
+  @location(0) @interpolate(flat, center) f51: i32,
+  @location(3) @interpolate(perspective, sample) f52: vec3f,
+  @location(11) f53: u32,
+  @builtin(position) f54: vec4f
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2f, @location(2) a1: vec3u) -> VertexOutput16 {
+  var out: VertexOutput16;
+  out.f52 = bitcast<vec3f>(textureGather(0, tex7, sam7, vec2f()).ywx);
+  return out;
+}
+struct FragmentOutput15 {
+  @location(1) @interpolate(linear) f0: vec3f,
+  @location(3) f1: vec3f,
+  @location(0) f2: vec4f,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  if bool(textureLoad(st33, vec2i())[3]) {
+    textureStore(st32, 0, vec4f(0.07618, 0.06026, 0.6390, 0.00006));
+  }
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let computePassEncoder119 = commandEncoder158.beginComputePass({label: '\u067a\u0349\uf8d0\uc171\ube51'});
+try {
+computePassEncoder118.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer73, 5_380);
+} catch {}
+let imageData25 = new ImageData(20, 16);
+let commandEncoder159 = device0.createCommandEncoder({});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer49, 22_708); };
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle9, renderBundle18, renderBundle0, renderBundle2]);
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({label: '\u33d3\u7d48\u01b2\u{1f997}\u{1f9aa}', bindGroupLayouts: []});
+let texture158 = device0.createTexture({size: {width: 82}, dimension: '1d', format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder120 = commandEncoder159.beginComputePass({});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup15, new Uint32Array(1878), 149, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(8, 43, 46, 224_327_825, 86_759_202);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer51, 908);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer11 = buffer77.getMappedRange();
+try {
+commandEncoder157.copyBufferToBuffer(buffer64, 60, buffer43, 7620, 4);
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer51, 4640, 2292);
+} catch {}
+let buffer97 = device0.createBuffer({size: 317, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let textureView140 = texture155.createView({mipLevelCount: 1});
+let sampler86 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.861,
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer60, 3_276); };
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup41, new Uint32Array(4032), 1_177, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(18, 46, 11, 478_019_164, 264_297_957);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer19, 408);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {mask: 0x153ccaf0},
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 504,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 24, shaderLocation: 1},
+          {format: 'sint32x3', offset: 12, shaderLocation: 0},
+          {format: 'float32x3', offset: 124, shaderLocation: 13},
+          {format: 'sint8x4', offset: 68, shaderLocation: 2},
+          {format: 'sint32', offset: 48, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 40, shaderLocation: 7},
+          {format: 'float32', offset: 196, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 36, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 10},
+          {format: 'uint32x2', offset: 16, shaderLocation: 6},
+          {format: 'sint16x4', offset: 0, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 12},
+          {format: 'float32x2', offset: 124, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: false},
+});
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'log'} });
+try {
+renderPassEncoder22.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer19, 6_064);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer82, 'uint32', 560, 418);
+} catch {}
+let buffer98 = device0.createBuffer({size: 5139, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder160 = device0.createCommandEncoder();
+let texture159 = device0.createTexture({
+  label: '\u0946\u0075\u0dfd\u{1fbe2}\uc257\u9dcc\uaeda',
+  size: {width: 1440, height: 2, depthOrArrayLayers: 596},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder121 = commandEncoder160.beginComputePass({});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(9, 73, 47, 122_196_662, 17_141_178);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder157.resolveQuerySet(querySet1, 442, 0, buffer87, 2816);
+} catch {}
+let gpuCanvasContext5 = canvas3.getContext('webgpu');
+let shaderModule16 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 4 max align: 4 */
+struct T0 {
+  f0: u32,
+}
+@group(0) @binding(234) var sam8: sampler;
+@group(0) @binding(374) var st35: texture_storage_2d<r32uint, read>;
+@group(0) @binding(15) var tex8: texture_depth_cube;
+@group(0) @binding(49) var st34: texture_storage_2d_array<r32float, write>;
+struct VertexOutput17 {
+  @location(6) @interpolate(flat) f55: vec2u,
+  @builtin(position) f56: vec4f
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3f, @location(6) @interpolate(flat, sample) a1: vec4h, @location(12) a2: vec3i) -> VertexOutput17 {
+  var out: VertexOutput17;
+  _ = a1;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+}`,
+  hints: {},
+});
+let commandEncoder161 = device0.createCommandEncoder({});
+let texture160 = device0.createTexture({
+  size: [164, 12, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture161 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder121.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup38, new Uint32Array(6597), 213, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(6, 63, 74_654_742, 136_352_378);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer72, 12);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer17, 676);
+} catch {}
+let imageData26 = new ImageData(20, 60);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 102,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let sampler87 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 63.40,
+  lodMaxClamp: 94.00,
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup0, new Uint32Array(2066), 48, 0);
+} catch {}
+try {
+commandEncoder161.copyBufferToBuffer(buffer95, 636, buffer13, 328, 356);
+} catch {}
+let texture162 = device0.createTexture({
+  label: '\u570d\u0fde\u{1ff98}\u7cbe\u8101',
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler88 = device0.createSampler({
+  label: '\u0d2f\u0fcb\ue013\u{1fecd}\u06a8\ub16b\u3fca\u{1fb26}\u{1fa05}\uc5fc\u0889',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 43.25,
+});
+try {
+computePassEncoder106.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroupsIndirect(buffer67, 6_212); };
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant({ r: 723.1, g: 330.5, b: 63.11, a: -730.1, });
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(34, 62, 57, -1_945_497_117, 256_741_388);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer80, 72);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 1060, new Int16Array(20330), 480, 716);
+} catch {}
+let imageData27 = new ImageData(20, 8);
+let buffer99 = device0.createBuffer({
+  size: 4156,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder162 = device0.createCommandEncoder({label: '\u959f\uf1fa\ude0a\u0870\uc30f\u0edc\u58f6\u12cd\u84e3'});
+let computePassEncoder122 = commandEncoder162.beginComputePass({label: '\u045b\u507e\u{1fd78}\u83b0'});
+let renderPassEncoder36 = commandEncoder161.beginRenderPass({colorAttachments: [{view: textureView104, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup86, new Uint32Array(5034), 293, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder6.setViewport(1093.633535211568, 3.7216241057830572, 146.65236096386172, 0.0013866202635035296, 0.8582726673097886, 0.9046485408621482);
+} catch {}
+try {
+renderPassEncoder8.draw(154, 52, 2_045_617_415, 149_911_910);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(67, 15, 3, 135_929_301, 588_774_213);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer15, 84);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer97, 'uint16', 28, 5);
+} catch {}
+let renderPassEncoder37 = commandEncoder157.beginRenderPass({
+  label: '\uf4f2\udcc2\u{1fdb7}\u0c7f\u01e5\ud8ec',
+  colorAttachments: [{
+  view: textureView86,
+  clearValue: { r: -656.3, g: 616.8, b: 679.3, a: -338.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData23,
+  origin: { x: 6, y: 5 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder({});
+let textureView141 = texture15.createView({mipLevelCount: 1});
+let renderPassEncoder38 = commandEncoder163.beginRenderPass({
+  colorAttachments: [{view: textureView132, depthSlice: 283, loadOp: 'load', storeOp: 'store'}],
+  depthStencilAttachment: {view: textureView128, depthLoadOp: 'load', depthStoreOp: 'store'},
+  maxDrawCount: 588929002,
+});
+let sampler89 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.080,
+  lodMaxClamp: 31.17,
+});
+try {
+renderPassEncoder29.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder8.draw(274, 83, 661_316_937, 498_660_928);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(24, 127, 109, 689_733_462, 1_276_785_476);
+} catch {}
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 137});
+try {
+computePassEncoder122.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer17, 1_008);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder164 = device0.createCommandEncoder({label: '\uf026\u0365\u03e7\u02f5\u00d3'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish();
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup79);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle11, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(183, 2, 48, 248_542_725, 330_696_521);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer52, 1_232);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer65, 112);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer87, 3780, buffer1, 8584, 424);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 15, resource: {buffer: buffer21, offset: 256, size: 640}},
+    {binding: 0, resource: textureView50},
+  ],
+});
+let pipelineLayout17 = device0.createPipelineLayout({label: '\u663b\u0c1b\u{1ff8e}\u{1fad8}\u{1fe93}', bindGroupLayouts: []});
+let textureView142 = texture78.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder123 = commandEncoder164.beginComputePass();
+try {
+computePassEncoder93.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer65, 280);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+let texture163 = device0.createTexture({
+  size: [720, 1, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.drawIndexed(4, 142, 21, 511_160_709, 989_964_859);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer21, 616);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+document.body.append(video0);
+await gc();
+let buffer100 = device0.createBuffer({
+  size: 9833,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder165 = device0.createCommandEncoder({});
+let computePassEncoder124 = commandEncoder165.beginComputePass({});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(5, 33, 0, 137_863_967, 330_003_904);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer56, 3_756);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup88 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 90, resource: textureView11}]});
+let commandEncoder166 = device0.createCommandEncoder({});
+let textureView143 = texture102.createView({});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(102, 54, 28, 586_369_563, 1_148_807_639);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer50, 'uint16', 2_042, 687);
+} catch {}
+try {
+querySet16.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 8, y: 0 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  label: '\uacaf\u1702\ucc39\u1bdc\u4d63\uc05a\u66c3\u8516\u08c9\u01c6',
+  layout: bindGroupLayout13,
+  entries: [{binding: 168, resource: textureView74}],
+});
+let buffer101 = device0.createBuffer({
+  size: 16171,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView144 = texture109.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let sampler90 = device0.createSampler({
+  label: '\u42db\u0ea0\u4454\ud5a4\u{1fe75}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 4.787,
+  lodMaxClamp: 95.03,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle3, renderBundle0, renderBundle9, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder35.setViewport(243.75154887317288, 6.3827254564228255, 4.1545320402377826, 7.427079834019456, 0.015302543692971793, 0.8542108953188547);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer48, 448);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer45, 3_136);
+} catch {}
+try {
+texture29.destroy();
+} catch {}
+try {
+commandEncoder166.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 904 */
+  offset: 904,
+  bytesPerRow: 512,
+  rowsPerImage: 47,
+  buffer: buffer22,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 108, y: 13, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder167 = device0.createCommandEncoder({});
+let texture164 = device0.createTexture({
+  size: {width: 600, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder125 = commandEncoder167.beginComputePass();
+let renderPassEncoder39 = commandEncoder166.beginRenderPass({
+  colorAttachments: [{
+  view: textureView83,
+  clearValue: { r: -657.6, g: -223.6, b: -756.7, a: 5.743, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 38261801,
+});
+let sampler91 = device0.createSampler({
+  label: '\u0001\u4228\u{1fec9}\ubf39\u13e4\u470c\u0e74\uaade\u0672',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 85.68,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup18, new Uint32Array(232), 69, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer101, 2_344); };
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.draw(145, 43, 257_898_376, 936_914_573);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer33, 684);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer48, 4_772);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer53, 'uint32', 48, 1_182);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(451).fill(45), /* required buffer size: 451 */
+{offset: 451}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout17]});
+let commandEncoder168 = device0.createCommandEncoder({});
+let texture165 = device0.createTexture({
+  size: [300, 48, 1],
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView145 = texture157.createView({baseMipLevel: 0});
+let computePassEncoder126 = commandEncoder168.beginComputePass({});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup86, new Uint32Array(1715), 38, 0);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(3, 0, 19, 0);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer39);
+} catch {}
+let arrayBuffer12 = buffer78.getMappedRange();
+try {
+renderPassEncoder11.insertDebugMarker('\uc839');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 2468, new Int16Array(9055), 672, 1824);
+} catch {}
+let textureView146 = texture83.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup70, new Uint32Array(1522), 380, 0);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(37, 12, 3, 2);
+} catch {}
+try {
+renderPassEncoder24.setViewport(50.179310979569735, 4.5748940261046585, 3.9320646705784266, 0.9984514275671209, 0.0790438074860973, 0.42234160629144873);
+} catch {}
+try {
+renderPassEncoder3.draw(262, 30, 347_259_795, 673_473_652);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer21, 1_036);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer76, 'uint16', 4, 631);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let imageData28 = new ImageData(160, 60);
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer26, 320); };
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer100, 564);
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 91,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer102 = device0.createBuffer({
+  size: 10276,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 236});
+let sampler92 = device0.createSampler({
+  label: '\ucd99\u8f59\u03ee\uc9f2\uad4a\u3d9f\u0658',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.65,
+  lodMaxClamp: 98.92,
+  compare: 'less',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder116.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup67, new Uint32Array(826), 0, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(44, 2, 92, 551_659_052, 198_595_395);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer78, 172);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let texture166 = device0.createTexture({
+  size: {width: 720, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView147 = texture155.createView({mipLevelCount: 1});
+let computePassEncoder127 = commandEncoder153.beginComputePass({});
+try {
+computePassEncoder127.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer38, 32);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, undefined);
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder({label: '\ua9b2\u4d6c\u072f\u5292\u09d3\u{1fc34}\ub913\u738c\ue55e\u8250\uea0a'});
+let computePassEncoder128 = commandEncoder169.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(1, bindGroup83, new Uint32Array(275), 3, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(215, 64, 333_831_409, 248_400_462);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(40, 154, 41, 331_233_789, 2_891_469_220);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer20, 'uint32', 728, 4_075);
+} catch {}
+try {
+  await buffer44.mapAsync(GPUMapMode.READ, 80, 644);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteRp431', transfer: 'log'} });
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 369,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+computePassEncoder87.setBindGroup(1, bindGroup63, new Uint32Array(90), 4, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup16, new Uint32Array(2819), 727, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer27, 44);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let texture167 = device0.createTexture({
+  label: '\u0b8d\uc238\u0e4b\u7a1f\u2f1a\uc5af\u07dc',
+  size: [659, 48, 36],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let externalTexture14 = device0.importExternalTexture({source: video3});
+try {
+computePassEncoder121.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer42, 8);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer48, 1_512);
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({});
+let sampler93 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.18,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup83);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup42, new Uint32Array(1143), 48, 0);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(58, 3, 5, 3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(73, 83, 5, -2_049_912_434, 57_107_869);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer45, 1_748);
+} catch {}
+try {
+commandEncoder170.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 70 */
+  offset: 70,
+  rowsPerImage: 383,
+  buffer: buffer60,
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder({label: '\ud935\u45d3\u{1f9f6}\u779a\ua0f7\u{1fe12}\uc523\u0b1e\u75ea\u916a'});
+let texture168 = device0.createTexture({
+  size: [2880],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView148 = texture67.createView({dimension: '2d'});
+let computePassEncoder129 = commandEncoder171.beginComputePass({});
+let renderPassEncoder40 = commandEncoder170.beginRenderPass({
+  label: '\u{1f655}\u2395',
+  colorAttachments: [{view: textureView48, depthSlice: 2, loadOp: 'load', storeOp: 'store'}],
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder119.setBindGroup(3, bindGroup51, new Uint32Array(699), 1, 0);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(24, 214, 10, 15_800_364, 135_040_816);
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageData3);
+try {
+computePassEncoder22.setBindGroup(0, bindGroup5, new Uint32Array(1896), 318, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(44, 309, 278_627_760, 83_092_508);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer76, 'uint32', 988, 106);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer70);
+} catch {}
+let arrayBuffer13 = buffer102.getMappedRange(3240, 656);
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(298).fill(48), /* required buffer size: 298 */
+{offset: 298, bytesPerRow: 95, rowsPerImage: 52}, {width: 40, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture169 = device0.createTexture({
+  size: [164],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup86);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup85, new Uint32Array(1098), 138, 0);
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(0, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(66, 193, 173_475_763, 1_409_360_284);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(27, 1, 2, 188_014_249, 49_891_043);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer21, 1_944);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer61, 1_688);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({});
+let renderPassEncoder41 = commandEncoder172.beginRenderPass({
+  label: '\ueb8f\u8970\u09b5\u8c91\udc3c\u04e5\u861d',
+  colorAttachments: [{
+  view: textureView43,
+  clearValue: { r: 283.0, g: 172.8, b: -970.0, a: -839.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler94 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.531,
+  lodMaxClamp: 84.18,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup26, new Uint32Array(182), 38, 0);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(171, 1, 20, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer51, 4_032);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer93, 0, 556);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 3004, new BigUint64Array(2633), 118, 240);
+} catch {}
+document.body.append(video2);
+let imageData29 = new ImageData(112, 16);
+let bindGroup90 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 102, resource: textureView28}]});
+let buffer103 = device0.createBuffer({size: 17428, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let externalTexture15 = device0.importExternalTexture({source: video2});
+try {
+renderPassEncoder3.draw(87, 378, 1_840_813_381, 120_683_982);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(3, 9, 11, 232_183_348, 213_729_829);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer68, 816);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer40, 704);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer70, 564);
+} catch {}
+await gc();
+let textureView149 = texture69.createView({mipLevelCount: 1});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup61, new Uint32Array(5327), 731, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer65, 408); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup50, []);
+} catch {}
+try {
+renderPassEncoder17.setViewport(284.4021280480056, 11.79643322766205, 15.03747421202583, 22.11653743684152, 0.5085604683719953, 0.8805593281519726);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer49, 2_196);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer50, 1_020);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline0);
+} catch {}
+let bindGroup91 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView1}]});
+let commandEncoder173 = device0.createCommandEncoder({});
+let texture170 = device0.createTexture({
+  size: [600, 96, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder27.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer56, 6_988);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer102, 'uint32', 844, 601);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture170,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'depth-only',
+}, new Uint8Array(71).fill(111), /* required buffer size: 71 */
+{offset: 71}, {width: 600, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup92 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 28, resource: {buffer: buffer21, offset: 512}}]});
+let buffer104 = device0.createBuffer({
+  size: 1545,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder130 = commandEncoder173.beginComputePass({label: '\u3736\u0b12\udc77\u3354\u0145\u08df\ue599\u9ff6\u0b2d\ue938'});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer57, 152); };
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 9, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(607).fill(198), /* required buffer size: 607 */
+{offset: 607}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = textureView57.label;
+} catch {}
+let buffer105 = device0.createBuffer({
+  size: 10178,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder174 = device0.createCommandEncoder({});
+let texture171 = device0.createTexture({
+  size: {width: 150, height: 24, depthOrArrayLayers: 24},
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView150 = texture43.createView({});
+let renderPassEncoder42 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView127,
+  depthSlice: 354,
+  clearValue: { r: 546.0, g: -484.3, b: -326.5, a: 767.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup90);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup65, new Uint32Array(2864), 101, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer27, 216);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer40, 52);
+} catch {}
+let commandEncoder175 = device0.createCommandEncoder({label: '\u4ce7\u0994\u2c68\u{1fffc}\u1317'});
+let computePassEncoder131 = commandEncoder175.beginComputePass({});
+let sampler95 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.96,
+  lodMaxClamp: 87.60,
+});
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder0.draw(119, 129, 73_796_658, 1_507_668_245);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer104, 40);
+} catch {}
+try {
+buffer100.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture172 = device0.createTexture({
+  label: '\u4f6b\ue1ee',
+  size: {width: 659, height: 48, depthOrArrayLayers: 481},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder26.dispatchWorkgroupsIndirect(buffer70, 2_036);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup75, new Uint32Array(173), 8, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer17, 2_116);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer75, 0, 642);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1440, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 36, y: 6 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 157, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video4 = await videoWithData(105);
+let bindGroup93 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView7}]});
+let texture173 = device0.createTexture({
+  size: [360, 1, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler96 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 53.66,
+  lodMaxClamp: 84.67,
+});
+try {
+computePassEncoder123.setBindGroup(2, bindGroup19, new Uint32Array(2035), 456, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer102, 1_396); };
+} catch {}
+try {
+renderPassEncoder8.draw(186, 72, 280_506_094, 61_781_577);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer26, 356);
+} catch {}
+let arrayBuffer14 = buffer61.getMappedRange(680, 708);
+try {
+device0.queue.writeBuffer(buffer29, 920, new Float32Array(14138), 433, 120);
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u07aa\ud38d\u6ff5\uc24c\uc277\u0f53\u40ad\u5d2a\u{1fbef}\u{1f700}',
+  entries: [
+    {
+      binding: 457,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer106 = device0.createBuffer({
+  label: '\u4e6a\u904b\u5c52',
+  size: 17640,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler97 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 22.58,
+});
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder0.draw(94, 264, 138_718_637, 72_092_687);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer17, 132);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+try {
+window.someLabel = commandEncoder122.label;
+} catch {}
+let textureView151 = texture56.createView({mipLevelCount: 1});
+let computePassEncoder132 = commandEncoder100.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer66, 13_692); };
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup85, new Uint32Array(1437), 442, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(79, 82, 1_214_178_390, 213_837_844);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(47, 222, 48, -2_112_463_762, 521_523_590);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer73, 4_240);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer82, 'uint16', 90, 62);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline9);
+} catch {}
+let commandEncoder176 = device0.createCommandEncoder({});
+let renderPassEncoder43 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{view: textureView132, depthSlice: 313, loadOp: 'load', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView128,
+    depthClearValue: 0.36221489807880647,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 6140,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet11,
+});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame2});
+try {
+renderPassEncoder3.draw(139, 37, 736_170_734, 2_305_010_193);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer107 = device0.createBuffer({
+  size: 4345,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 6});
+let texture174 = device0.createTexture({size: {width: 150}, dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView152 = texture164.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup54, new Uint32Array(6052), 1_210, 0);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(1, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(295, 89, 801_425_976, 27_920_527);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(41, 127, 5, 410_693_575, 209_308_904);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 744, new BigUint64Array(1885), 483, 48);
+} catch {}
+let buffer108 = device0.createBuffer({
+  size: 2916,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandEncoder177 = device0.createCommandEncoder({});
+let renderPassEncoder44 = commandEncoder177.beginRenderPass({
+  colorAttachments: [{
+  view: textureView43,
+  clearValue: { r: -814.6, g: -354.8, b: -938.0, a: -168.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u{1fd5f}\u0a8f\ueb78\u0195\u{1fadf}',
+  colorFormats: ['rgba32float'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+});
+try {
+computePassEncoder131.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.draw(598, 133, 560_576_160, 379_595_362);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer52, 512);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer21, 'uint16', 186, 464);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer68);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer40, 'uint16', 710, 41);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 3,
+  origin: {x: 11, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(37).fill(12), /* required buffer size: 37 */
+{offset: 37}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture8.label = '\u119e\u008c\u0d09';
+} catch {}
+let textureView153 = texture85.createView({dimension: '2d-array'});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer15, 440); };
+} catch {}
+try {
+renderPassEncoder3.draw(114, 353, 1_000_577_493, 314_187_264);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(70, 21, 8, 723_274_141, 149_716_765);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer107, 532);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer67, 0, 4_840);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup77, new Uint32Array(666), 18, 0);
+} catch {}
+try {
+buffer95.unmap();
+} catch {}
+let texture175 = device0.createTexture({size: [75, 12, 1], format: 'depth16unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let sampler98 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.93,
+  lodMaxClamp: 91.14,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder41.setViewport(2.3167413378224255, 2.9914886692178566, 26.379119722197956, 0.006065844267394649, 0.5230669824912908, 0.8171814276798959);
+} catch {}
+try {
+renderPassEncoder0.draw(19, 56, 2_600_989_275, 336_850_000);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer21, 424);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 9}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder178 = device0.createCommandEncoder({label: '\u015b\u3dcd\u05a6\ud4ff\u1813\u6040'});
+let textureView154 = texture117.createView({dimension: '2d-array'});
+let computePassEncoder133 = commandEncoder178.beginComputePass({});
+let renderBundle22 = renderBundleEncoder22.finish();
+let sampler99 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.639,
+  lodMaxClamp: 12.30,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder112.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup75);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(62, 19, 5, 6);
+} catch {}
+try {
+renderPassEncoder7.draw(53, 2, 35_949_468, 967_660_526);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline7);
+} catch {}
+await gc();
+let commandEncoder179 = device0.createCommandEncoder({});
+let computePassEncoder134 = commandEncoder179.beginComputePass({});
+let sampler100 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.27,
+  lodMaxClamp: 60.70,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer100, 1_292);
+} catch {}
+try {
+buffer80.destroy();
+} catch {}
+try {
+window.someLabel = sampler37.label;
+} catch {}
+let buffer109 = device0.createBuffer({size: 22861, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder180 = device0.createCommandEncoder({});
+let renderPassEncoder45 = commandEncoder180.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  clearValue: { r: -514.8, g: -474.4, b: 584.0, a: -44.56, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup66, new Uint32Array(773), 33, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup87, new Uint32Array(1808), 76, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(49, 274, 63, 590_479_760, 2_601_304_627);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline7);
+} catch {}
+let texture176 = device0.createTexture({
+  size: [659],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer27, 180);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer75, 0, 23_883);
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'bt2020_12bit'} });
+try {
+computePassEncoder133.setBindGroup(0, bindGroup61, new Uint32Array(4233), 782, 0);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.draw(371, 64, 3_550_307_321, 1_309_471_401);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(23, 172, 38, 889_182_182, 251_337_230);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer73, 10_480);
+} catch {}
+try {
+computePassEncoder112.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup85);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 189.8, g: -322.5, b: 107.8, a: 113.0, });
+} catch {}
+try {
+renderPassEncoder7.draw(50, 136, 1_591_994_782, 2_724_585_155);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer70, 1_448);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer38, 620);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+adapter0.label = '\u931c\ue41c\uf2f2\ucdb0\u0289\ua6a2\u0085\u00a1';
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({label: '\u{1fa07}\ufe83\u64f2\u0cc3\u85e7\u{1fb09}\u024f\u19e8\u{1fda3}\u{1f63d}\u40b7'});
+let textureView155 = texture93.createView({
+  label: '\u1a48\u{1f842}\u7293\ub677\u0ff0\u0a16\ua50d\u07f1\ub754\u08e1',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder135 = commandEncoder181.beginComputePass();
+try {
+computePassEncoder123.setBindGroup(3, bindGroup86, new Uint32Array(300), 5, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(89, 2, 1_884_314_398, 977_827_448);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(7, buffer25);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 2393,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder0.draw(4, 112, 0, 165_881_625);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(25, 249, 4, -1_907_180_004, 878_110_537);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer8, 'uint16', 582, 122);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer56, 5_520);
+} catch {}
+let texture177 = device0.createTexture({
+  size: {width: 1440, height: 2, depthOrArrayLayers: 109},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder135.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline0);
+} catch {}
+let bindGroup94 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 135, resource: textureView135}]});
+let buffer111 = device0.createBuffer({
+  size: 140,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView156 = texture141.createView({label: '\u397c\u0322\u0813\u97aa\u067b\u3704\u9ac8\u8737\u{1f6aa}\ueb1b', aspect: 'all'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({label: '\u048f\u958c\u99ca', colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder122.setBindGroup(3, bindGroup65, new Uint32Array(2504), 300, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer65, 80); };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup56, new Uint32Array(3037), 1_507, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer40, 920);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer55, 0, 95);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer111, 'uint32', 40, 8);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+await gc();
+let bindGroup95 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 67, resource: textureView109}]});
+try {
+computePassEncoder135.setBindGroup(2, bindGroup64, new Uint32Array(932), 20, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.draw(0, 107, 4, 343_841_174);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(32, 236, 80, -2_041_956_872, 28_625_951);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer23, 524, 258);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup52, new Uint32Array(4005), 891, 0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView157 = texture92.createView({arrayLayerCount: 1});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup69, new Uint32Array(3461), 2_300, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer13, 'uint32', 4_200, 1_431);
+} catch {}
+document.body.prepend(canvas3);
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'gamma22curve'} });
+let bindGroup96 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 135, resource: textureView135}]});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture178 = device0.createTexture({size: [600], dimension: '1d', format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let textureView158 = texture176.createView({});
+let sampler101 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.38,
+  lodMaxClamp: 43.73,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder8.draw(275, 4, 102_612_883, 433_856_675);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer99, 472);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup55, new Uint32Array(403), 137, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer30);
+} catch {}
+let buffer112 = device0.createBuffer({
+  size: 7392,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder182 = device0.createCommandEncoder();
+let computePassEncoder136 = commandEncoder182.beginComputePass({});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup82);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup95, new Uint32Array(4826), 629, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(143, 251, 8, -1_296_212_625, 2_085_299_476);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer102, 328);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer108, 56);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup39, new Uint32Array(18), 0, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer66, 2_744, 2_461);
+} catch {}
+try {
+  await shaderModule16.getCompilationInfo();
+} catch {}
+try {
+adapter0.label = '\u0f27\u0142\u1484\u06d4\u63bf';
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [{binding: 91, resource: sampler69}, {binding: 1, resource: textureView52}],
+});
+let commandEncoder183 = device0.createCommandEncoder({});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 532});
+let texture179 = device0.createTexture({
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(3, bindGroup42, new Uint32Array(844), 4, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup42, new Uint32Array(1868), 339, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder0.draw(0, 228, 0, 168_536_337);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(40, 17, 20, 1_180_569_805, 745_242_961);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer21, 1_000);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup56, new Uint32Array(253), 55, 0);
+} catch {}
+let commandEncoder184 = device0.createCommandEncoder({});
+let textureView159 = texture80.createView({label: '\u00b2\u0ffc\u0f15\u30f2\u871b\u511f\u5262\u3d2b\u015e\ubbb4\u{1fd6c}', arrayLayerCount: 1});
+let computePassEncoder137 = commandEncoder184.beginComputePass({});
+let renderPassEncoder46 = commandEncoder183.beginRenderPass({
+  label: '\u8960\u0bf7\ucb0d\u{1ff9b}\u0989\u{1fbeb}\u0b45',
+  colorAttachments: [{
+  view: textureView132,
+  depthSlice: 25,
+  clearValue: { r: 255.8, g: 581.4, b: -483.1, a: -831.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView128,
+    depthClearValue: -7.848998907749694,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 53812,
+  },
+});
+try {
+computePassEncoder121.dispatchWorkgroupsIndirect(buffer68, 128);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer111, 0, 19);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer53, 'uint16', 246, 718);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 187, resource: textureView61},
+    {binding: 184, resource: {buffer: buffer101, offset: 1792, size: 407}},
+  ],
+});
+let buffer113 = device0.createBuffer({
+  size: 52244,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder185 = device0.createCommandEncoder({});
+let texture180 = device0.createTexture({
+  size: [150, 24, 277],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder47 = commandEncoder185.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  clearValue: { r: 824.1, g: -237.9, b: -357.7, a: -251.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup63, new Uint32Array(830), 203, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(295, 235, 396_855_274, 1_055_783_944);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer65, 684);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer26, 'uint32', 2_656, 209);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `
+enable f16;
+/* target size: 114 max align: 2 */
+struct T0 {
+  @align(2) f0: array<array<vec2u, 1>, 6>,
+  @align(2) @size(16) f1: array<array<i32, 1>, 1>,
+  @size(50) f2: f16,
+}
+/* target size: 51 max align: 1 */
+struct T1 {
+  @align(1) f0: array<vec2h, 2>,
+  @align(1) f1: atomic<i32>,
+  @align(1) @size(8) f2: array<f32, 1>,
+  @align(1) f3: atomic<u32>,
+  @align(1) @size(27) f4: atomic<i32>,
+}
+/* target size: 16 max align: 16 */
+struct T2 {
+  @size(16) f0: array<vec2h, 1>,
+}
+@group(1) @binding(64) var<storage, read_write> buffer114: array<T1>;
+@group(0) @binding(15) var tex9: texture_cube_array<f32>;
+@group(0) @binding(374) var st37: texture_storage_2d<rgba16sint, read>;
+@group(0) @binding(49) var st36: texture_storage_2d_array<r32float, write>;
+@group(0) @binding(234) var sam9: sampler;
+struct S5 {
+  @location(4) @interpolate(flat) f0: vec3f
+}
+struct S6 {
+  @location(8) f0: vec4u,
+  @location(5) f1: f32
+}
+struct VertexOutput18 {
+  @builtin(position) f57: vec4f,
+  @location(2) @interpolate(perspective, sample) f58: vec2h,
+  @location(15) f59: f16,
+  @location(9) f60: vec4h,
+  @location(14) f61: vec4f,
+  @location(0) @interpolate(perspective, sample) f62: vec4f,
+  @location(1) @interpolate(flat) f63: u32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(7) a1: vec4h, @location(12) a2: vec2i, @location(14) a3: vec4u, @location(9) a4: vec2h, @location(13) a5: vec3f, a6: S5, @location(15) a7: vec2u, @location(0) a8: vec4f, @location(3) a9: vec4f, a10: S6, @location(1) a11: vec3f) -> VertexOutput18 {
+  var out: VertexOutput18;
+  _ = textureGather(0, tex9, sam9, vec3f(), 0);
+  _ = a3;
+  _ = a5;
+  out.f60 += vec4h(-55657.8);
+  return out;
+}
+struct S7 {
+  @builtin(local_invocation_index) f0: u32
+}
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(a0: S7) {
+  _ = textureLoad(st37, vec2i());
+  _ = buffer114[arrayLength(&buffer114)].f3;
+  _ = atomicExchange(&buffer114[arrayLength(&buffer114)].f1, 175);
+  if bool(atomicExchange(&buffer114[arrayLength(&buffer114)].f3, 95)) {
+    textureStore(st36, vec2i(), 0, vec4f(0.04195, 0.09704, 0.3255, 0.09194));
+  }
+}`,
+  hints: {},
+});
+let commandEncoder186 = device0.createCommandEncoder();
+let computePassEncoder138 = commandEncoder186.beginComputePass({});
+let renderBundle24 = renderBundleEncoder24.finish({});
+let sampler102 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.35,
+  compare: 'not-equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup79);
+} catch {}
+try {
+computePassEncoder83.setBindGroup(1, bindGroup80, new Uint32Array(2955), 98, 0);
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer65, 64);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer80, 352);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer68, 216, 844);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 2,
+  origin: {x: 142, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder187 = device0.createCommandEncoder({});
+let texture181 = device0.createTexture({
+  size: [164, 12, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler103 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup68);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer53, 284);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer99, 888);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer104, 260);
+} catch {}
+try {
+window.someLabel = textureView49.label;
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder({});
+let texture182 = device0.createTexture({label: '\ua703\uf375', size: [2, 2, 12], format: 'depth16unorm', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder139 = commandEncoder188.beginComputePass({});
+let sampler104 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 64.64,
+});
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer45, 1_196);
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+try {
+commandEncoder187.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 55, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder187.clearBuffer(buffer75, 2544, 19892);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData30 = new ImageData(60, 16);
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder189 = device0.createCommandEncoder({});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 604});
+let texture183 = device0.createTexture({
+  size: {width: 75, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView160 = texture129.createView({aspect: 'all', mipLevelCount: 1});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthStencilFormat: 'depth16unorm', depthReadOnly: true});
+let renderBundle25 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup73, new Uint32Array(3744), 608, 0);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder187.copyTextureToTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 150, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup99 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 380, resource: textureView74},
+    {binding: 17, resource: {buffer: buffer11, offset: 1536, size: 1942}},
+  ],
+});
+let commandEncoder190 = device0.createCommandEncoder({});
+let texture184 = device0.createTexture({
+  size: {width: 82, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder48 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 2,
+  clearValue: { r: 498.9, g: -939.1, b: -434.3, a: -876.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet24,
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup61, new Uint32Array(5513), 1_784, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer59, 'uint16', 10, 61);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer70);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup86, new Uint32Array(2109), 32, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer42, 'uint32', 84, 14);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline11);
+} catch {}
+let arrayBuffer15 = buffer25.getMappedRange(0, 28);
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 48, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 98, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder191 = device0.createCommandEncoder();
+let commandBuffer6 = commandEncoder190.finish({});
+let textureView161 = texture103.createView({dimension: 'cube', baseArrayLayer: 0});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(1, bindGroup6, new Uint32Array(313), 36, 0);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(62, 460, 76, 6_838_698, 1_323_825_106);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer56, 3_196);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer68, 560);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline7);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 28, resource: {buffer: buffer94, offset: 1024}}]});
+let commandEncoder192 = device0.createCommandEncoder({});
+let textureView162 = texture176.createView({});
+let externalTexture17 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder99.setBindGroup(2, bindGroup77, new Uint32Array(1230), 123, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup82, new Uint32Array(27), 1, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle0, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(25, 37, 64, 467_492_531, 12_242_264);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer49, 536);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(0, buffer107, 0, 4_345);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer3, 3_428, 75);
+} catch {}
+try {
+commandEncoder189.copyBufferToBuffer(buffer87, 1724, buffer32, 412, 324);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData31 = new ImageData(88, 72);
+let commandEncoder193 = device0.createCommandEncoder({});
+let texture185 = device0.createTexture({
+  size: [150, 24, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup21, new Uint32Array(1103), 540, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(0, 89, 0, 3_028_045_620);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer52, 8_176);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup97);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(7, buffer71, 0, 1_839);
+} catch {}
+try {
+computePassEncoder58.insertDebugMarker('\ud765');
+} catch {}
+let buffer115 = device0.createBuffer({size: 1026, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView163 = texture36.createView({format: 'rgb10a2unorm', mipLevelCount: 1});
+let computePassEncoder140 = commandEncoder194.beginComputePass({});
+let renderBundle26 = renderBundleEncoder26.finish({});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup81, new Uint32Array(2789), 531, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(17, 48, 71, -1_884_009_760, 1_492_928_788);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer67, 2_984);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(0, buffer106);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder192.copyBufferToBuffer(buffer64, 12, buffer71, 312, 160);
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  label: '\u7b87\u084f\u0943\u3702\u0c42\u7393\u{1fdc6}',
+  layout: bindGroupLayout21,
+  entries: [{binding: 102, resource: textureView58}],
+});
+let commandEncoder195 = device0.createCommandEncoder({label: '\u0549\u0114\u0f1b\u02d0'});
+let texture186 = device0.createTexture({
+  label: '\u43ee\ucb85',
+  size: [360, 1, 1],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler105 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 17.09,
+});
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup55, new Uint32Array(2796), 3, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer57, 972);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer91, 'uint32', 0, 3);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline4);
+} catch {}
+document.body.prepend(img4);
+let buffer116 = device0.createBuffer({
+  size: 5164,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet25 = device0.createQuerySet({
+  label: '\u7057\u6c66\u1cf6\u61e9\u3e5e\u00b3\u9d66\u03d8\u704a\u8e40\u7bcb',
+  type: 'occlusion',
+  count: 90,
+});
+let textureView164 = texture157.createView({dimension: '2d-array'});
+try {
+computePassEncoder140.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer26, 3_348);
+} catch {}
+try {
+commandEncoder189.copyBufferToBuffer(buffer48, 1724, buffer26, 2412, 588);
+} catch {}
+let buffer117 = device0.createBuffer({
+  size: 695,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture187 = gpuCanvasContext1.getCurrentTexture();
+let textureView165 = texture126.createView({label: '\u1632\u0f76\u{1ff03}\u7a8a\u6598\u063b\u0420\u04d2'});
+let computePassEncoder141 = commandEncoder192.beginComputePass();
+let sampler106 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 69.20});
+try {
+computePassEncoder137.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup38, new Uint32Array(223), 60, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(197, 7, 184_372_188, 1_104_517_620);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer57, 96);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer103, 'uint32', 2_416, 1_940);
+} catch {}
+try {
+commandEncoder189.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 380 */
+  offset: 380,
+  buffer: buffer12,
+}, {
+  texture: texture184,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder191.resolveQuerySet(querySet3, 318, 37, buffer68, 0);
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'bt2020_10bit'} });
+let bindGroup102 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 80, resource: textureView13}]});
+let commandEncoder196 = device0.createCommandEncoder({label: '\u1e87\u5471\u{1ffc6}\ub178'});
+let computePassEncoder142 = commandEncoder195.beginComputePass({});
+try {
+computePassEncoder142.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer111, 'uint16', 18, 4);
+} catch {}
+try {
+commandEncoder196.copyTextureToBuffer({
+  texture: texture163,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 396 widthInBlocks: 99 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5664 */
+  offset: 5664,
+  buffer: buffer69,
+}, {width: 99, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup103 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 102, resource: textureView53}]});
+let commandEncoder197 = device0.createCommandEncoder({});
+let texture188 = device0.createTexture({
+  size: {width: 360},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler107 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.20,
+  lodMaxClamp: 99.46,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup48, new Uint32Array(1705), 445, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder8.draw(93, 19, 563_520_447, 909_633_878);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(117, 77, 35, 33_839_671, 49_803_366);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer73, 6_300);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer41, 1_200);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder197.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6380 */
+  offset: 6380,
+  buffer: buffer87,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder196.copyTextureToTexture({
+  texture: texture142,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 1678});
+let renderPassEncoder49 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView99,
+  clearValue: { r: 114.0, g: -21.27, b: 31.69, a: 381.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb'], sampleCount: 1, depthReadOnly: true});
+let renderBundle27 = renderBundleEncoder27.finish({});
+try {
+renderPassEncoder3.drawIndexed(60, 169, 16, -2_108_393_607, 97_705_228);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder198 = device0.createCommandEncoder({});
+let sampler108 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.73,
+  lodMaxClamp: 73.54,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup44, new Uint32Array(802), 105, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 52, 49, 40_703_315, 247_695_837);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(6, buffer104, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(393).fill(66), /* required buffer size: 393 */
+{offset: 393}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture189 = device0.createTexture({
+  size: {width: 659, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder142.setBindGroup(0, bindGroup80);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup88, new Uint32Array(397), 295, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer117, 96);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video0.width = 86;
+let video5 = await videoWithData(40);
+let commandEncoder199 = device0.createCommandEncoder({});
+let texture190 = device0.createTexture({
+  size: {width: 164, height: 12, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup20, new Uint32Array(499), 10, 0);
+} catch {}
+try {
+renderPassEncoder44.beginOcclusionQuery(53);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer1, 'uint16', 4_048, 8_761);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer33, 0, 2_573);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u{1f7d8}');
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder();
+let querySet27 = device0.createQuerySet({label: '\uc292\u72a9\u{1fe26}', type: 'occlusion', count: 6});
+let textureView166 = texture22.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let computePassEncoder143 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(3, bindGroup73, new Uint32Array(628), 29, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer60, 516); };
+} catch {}
+try {
+renderPassEncoder8.draw(13, 294, 577_696_721, 266_814_234);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(232, 30, 17, 1_001_884_785, 210_316_816);
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer48, 268, buffer56, 432, 4660);
+} catch {}
+let buffer118 = device0.createBuffer({
+  label: '\u260b\u08d7\ua1ad\ua6b9\u8021\u{1f6cd}\u0775\u3c76\uca5d',
+  size: 5181,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture191 = device0.createTexture({
+  label: '\u{1fd68}\u0e4d',
+  size: {width: 659, height: 48, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView167 = texture130.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder144 = commandEncoder197.beginComputePass();
+let renderPassEncoder50 = commandEncoder189.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  depthSlice: 474,
+  clearValue: { r: 170.2, g: -428.5, b: 66.60, a: 276.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView91,
+    depthClearValue: 0.6768138467556092,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 2234,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 343938974,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer67, 352); };
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup102, []);
+} catch {}
+try {
+renderPassEncoder3.draw(69, 565, 381_083_708, 1_530_645_169);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer68, 132);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer86, 'uint32', 300, 1_453);
+} catch {}
+try {
+commandEncoder200.copyTextureToBuffer({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 12, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 114 widthInBlocks: 57 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5086 */
+  offset: 5086,
+  buffer: buffer49,
+}, {width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 438, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(112).fill(38), /* required buffer size: 112 */
+{offset: 112, bytesPerRow: 22}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 95, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView168 = texture152.createView({label: '\u{1fb53}\u0d6f\u0994\u5e52\ub164', dimension: '2d-array'});
+let computePassEncoder145 = commandEncoder200.beginComputePass();
+let renderPassEncoder51 = commandEncoder196.beginRenderPass({
+  colorAttachments: [{
+  view: textureView127,
+  depthSlice: 376,
+  clearValue: { r: -87.73, g: 955.2, b: 320.5, a: -145.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 155528931,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer40, 4_940); };
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer18, 16, buffer9, 13360, 80);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView169 = texture13.createView({});
+let renderPassEncoder52 = commandEncoder199.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 14,
+  clearValue: { r: 80.74, g: 418.9, b: -141.2, a: -497.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler109 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 49.47,
+  lodMaxClamp: 55.40,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup82);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(2, bindGroup65, new Uint32Array(5800), 253, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.draw(113, 314, 862_437_228, 223_497_879);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(12, 73, 40, 490_591_645, 429_665_489);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer17, 2_568);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer102, 'uint32', 2_180, 1_384);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder198.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 114, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 104 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  buffer: buffer29,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker('\uf11c');
+} catch {}
+let buffer119 = device0.createBuffer({
+  size: 13574,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder201 = device0.createCommandEncoder();
+let textureView170 = texture28.createView({dimension: '2d-array'});
+let renderPassEncoder53 = commandEncoder201.beginRenderPass({
+  colorAttachments: [{
+  view: textureView149,
+  clearValue: { r: -723.6, g: 832.2, b: 934.4, a: 707.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup57, new Uint32Array(2199), 217, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(13, 65, 681_414_394, 496_349_995);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture167,
+  mipLevel: 1,
+  origin: {x: 34, y: 1, z: 2},
+  aspect: 'all',
+}, new Uint8Array(107_447).fill(250), /* required buffer size: 107_447 */
+{offset: 47, bytesPerRow: 450, rowsPerImage: 119}, {width: 75, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpteRp431', transfer: 'logSqrt'} });
+let computePassEncoder146 = commandEncoder198.beginComputePass({});
+try {
+computePassEncoder145.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.draw(31, 23, 357_447_295, 499_511_281);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer40, 3_700);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer70, 540);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer110, 0, 924);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 64, resource: {buffer: buffer70, offset: 256, size: 444}}],
+});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 441});
+let sampler110 = device0.createSampler({
+  label: '\u0f58\u0887\ud292',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.74,
+});
+try {
+computePassEncoder121.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder109.setBindGroup(1, bindGroup64, new Uint32Array(2906), 437, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup101, new Uint32Array(199), 14, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(20, 25, 428_339_229, 1_518_920_828);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(29, 90, 23, 448_239_705, 404_363_605);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer51, 11_960);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer75, 0);
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  label: '\u0a3a\u{1fdfd}\ucb7b\u0eff\ueef7\ua539\uc509',
+  layout: bindGroupLayout16,
+  entries: [{binding: 73, resource: textureView108}, {binding: 92, resource: textureView165}],
+});
+let buffer120 = device0.createBuffer({
+  size: 12364,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder202 = device0.createCommandEncoder({label: '\u0597\u2cc8\ua854\u5d6d\uffab\u7e60\u0dd3\u04b9\u1b44'});
+let computePassEncoder147 = commandEncoder202.beginComputePass({});
+try {
+renderPassEncoder49.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder44.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.draw(233, 30, 67_114_551, 373_842_346);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(4, 109, 84, -1_985_713_627, 248_752_830);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.draw(23, 410, 590_267_197, 584_158_089);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(9, 125, 48, 732_854_452, 132_512_740);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer27, 332);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer92, 'uint32', 1_372, 1_219);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, undefined, 170_048_980, 178_028_216);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470m', transfer: 'iec6196624'} });
+let commandEncoder204 = device0.createCommandEncoder({});
+let texture192 = device0.createTexture({
+  size: [600, 96, 1],
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder148 = commandEncoder203.beginComputePass({});
+try {
+computePassEncoder148.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup70, new Uint32Array(355), 6, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle25]);
+} catch {}
+try {
+renderPassEncoder3.draw(15, 110, 1_100_828_168, 302_823_810);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(5, 14, 12, 632_355_138, 147_563_201);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer38, 856);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer39, 128);
+} catch {}
+try {
+commandEncoder204.copyBufferToBuffer(buffer53, 48, buffer69, 764, 776);
+} catch {}
+let buffer121 = device0.createBuffer({size: 21180, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let textureView171 = texture92.createView({});
+let textureView172 = texture180.createView({mipLevelCount: 1});
+let computePassEncoder149 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder117.setBindGroup(0, bindGroup31, new Uint32Array(1472), 136, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup54, new Uint32Array(1252), 171, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(73, 47, 141_833_159, 657_264_013);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer61, 1_912);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer53, 260);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.prepend(video4);
+let bindGroup106 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 190, resource: textureView13}]});
+let buffer122 = device0.createBuffer({
+  size: 1266,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.69,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder39.setIndexBuffer(buffer27, 'uint16', 0, 185);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(4_294_967_295, undefined, 197_703_050, 261_377_630);
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt2020', transfer: 'log'} });
+let videoFrame29 = new VideoFrame(videoFrame19, {timestamp: 0});
+let commandEncoder205 = device0.createCommandEncoder();
+let textureView173 = texture185.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder150 = commandEncoder205.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup52, []);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer105, 768);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'jedecP22Phosphors', transfer: 'bt709'} });
+let texture193 = device0.createTexture({
+  label: '\u{1f845}\u{1f6c9}\u4cb8\u0c75\u47b9\udeea\u5db0\ud429\uf45d',
+  size: {width: 82},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler112 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 35.91,
+  lodMaxClamp: 87.76,
+});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup94, new Uint32Array(70), 30, 0);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer78, 5_468);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer71);
+} catch {}
+let imageData32 = new ImageData(20, 36);
+let texture194 = device0.createTexture({
+  size: [75, 12, 1],
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView174 = texture107.createView({label: '\u{1febf}\uf7dd\u16f6\u2534', mipLevelCount: 1});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(48, 248, 62, 498_356_878, 549_009_938);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer113, 1_660);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer42, 20);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, buffer68, 332);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 5208, new Float32Array(11864), 3875, 4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 346, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video2);
+let bindGroup107 = device0.createBindGroup({
+  label: '\u0f4a\uaa25\u062f\u94ff\ud876\u010d\u7c1d',
+  layout: bindGroupLayout6,
+  entries: [{binding: 64, resource: {buffer: buffer94, offset: 2560}}],
+});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 169});
+let sampler113 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.91,
+  lodMaxClamp: 95.32,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder3.draw(28, 62, 609_760_923, 349_979_774);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer60, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer67, 'uint32', 4_516, 3_408);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 24, depthOrArrayLayers: 15}
+*/
+{
+  source: img2,
+  origin: { x: 3, y: 13 },
+  flipY: false,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 8, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let buffer123 = device0.createBuffer({
+  size: 18064,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler114 = device0.createSampler({
+  label: '\u09d1\u12c6',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.20,
+  compare: 'equal',
+});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(3, bindGroup41, new Uint32Array(3752), 1_964, 0);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder52.setScissorRect(0, 4, 137, 4);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(126, 243, 157, -2_052_349_278, 26_989_632);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer60, 364);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer105, 'uint16', 736, 1_032);
+} catch {}
+let bindGroup108 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 135, resource: textureView112}]});
+let texture195 = device0.createTexture({
+  size: {width: 164, height: 12, depthOrArrayLayers: 166},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup80, []);
+} catch {}
+try {
+renderPassEncoder7.draw(185, 364, 108_425_442, 341_326_392);
+} catch {}
+let imageData33 = new ImageData(12, 28);
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout22]});
+let buffer124 = device0.createBuffer({
+  size: 29016,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder206 = device0.createCommandEncoder({});
+let textureView175 = texture152.createView({});
+let renderPassEncoder54 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{view: textureView173, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet21,
+});
+let sampler115 = device0.createSampler({
+  label: '\u{1fe9b}\u0f12\uc2cb\u1d8a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.45,
+  lodMaxClamp: 73.25,
+});
+try {
+computePassEncoder14.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup95, new Uint32Array(2689), 98, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle18, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.draw(101, 46, 2_179_911_616, 2_221_879_927);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer108, 216);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer103, 2_232);
+} catch {}
+await gc();
+try {
+computePassEncoder128.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup98, new Uint32Array(548), 27, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer8, 488);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer13, 'uint16', 2_104, 6_628);
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule16, constants: {}}});
+let commandEncoder207 = device0.createCommandEncoder({});
+let textureView176 = texture122.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder151 = commandEncoder207.beginComputePass({});
+let sampler116 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 51.37,
+  lodMaxClamp: 78.23,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer51, 3_840); };
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder38.setViewport(257.2873122841211, 15.705347614957297, 11.289603900673288, 16.382863046754846, 0.01804777971533389, 0.5002700254910066);
+} catch {}
+try {
+renderPassEncoder3.draw(10, 17, 447_807_905, 871_855_353);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder208 = device0.createCommandEncoder({});
+let textureView177 = texture185.createView({label: '\u2018\u0c23\u4d42\u{1ff10}', dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder152 = commandEncoder208.beginComputePass();
+try {
+computePassEncoder150.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -814.5, g: 163.1, b: 337.3, a: 836.2, });
+} catch {}
+try {
+renderPassEncoder3.draw(117, 74, 351_630_397, 1_921_398_167);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(40, 29, 61, 381_054_685, 535_213_943);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer104, 632);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer56, 5_640);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer73, 0, 13_952);
+} catch {}
+let arrayBuffer16 = buffer66.getMappedRange(0, 1600);
+let commandEncoder209 = device0.createCommandEncoder();
+let commandBuffer7 = commandEncoder209.finish();
+let texture196 = device0.createTexture({
+  size: [600, 96, 1],
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup43, new Uint32Array(4136), 229, 0);
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(24, 816, 24, 396_729_820, 1_252_507_971);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer116, 'uint32', 60, 264);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+document.body.append(img1);
+video0.height = 86;
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 92, resource: textureView103}, {binding: 73, resource: textureView108}],
+});
+let pipelineLayout23 = device0.createPipelineLayout({label: '\u{1fc1f}\u{1fb0b}\u{1f76b}\u{1f69f}\u2ff3\ufdc3\u20de\ua040\u091c', bindGroupLayouts: []});
+let buffer125 = device0.createBuffer({
+  label: '\u43b4\u0342\u0d3e\uc6a6\ucf28\u{1fd1c}\u0632\u0b6b\u{1f6ea}\u0859\u8894',
+  size: 48,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder210 = device0.createCommandEncoder({label: '\u0be6\u4238\ub7b2\u04b7\uc53a\u0e21'});
+let textureView178 = texture196.createView({aspect: 'all'});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer119, 188); };
+} catch {}
+try {
+computePassEncoder121.end();
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup96, new Uint32Array(2066), 252, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer51, 532);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer103, 2_748);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer30, 12_960, 22_112);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+commandEncoder160.copyBufferToBuffer(buffer16, 1692, buffer33, 11140, 1276);
+} catch {}
+try {
+commandEncoder210.clearBuffer(buffer38, 1564, 112);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 102, resource: textureView55}]});
+let sampler117 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.37,
+  lodMaxClamp: 60.62,
+  compare: 'equal',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder146.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer27, 180);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer102, 2_936);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(0, buffer102, 792, 2_862);
+} catch {}
+try {
+commandEncoder210.copyTextureToBuffer({
+  texture: texture185,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 34 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 451 */
+  offset: 451,
+  buffer: buffer117,
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule16, constants: {}}});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let img5 = await imageWithData(3, 44, '#10101010', '#20202020');
+let bindGroup111 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 67, resource: textureView123}]});
+let computePassEncoder153 = commandEncoder160.beginComputePass({label: '\u6903\u7362\u{1f8c6}\udf1c\u3e66\u60d5\u01e1'});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup74, new Uint32Array(318), 0, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer119, 1_208);
+} catch {}
+let arrayBuffer17 = buffer108.getMappedRange(72);
+try {
+device0.queue.writeBuffer(buffer13, 7564, new Int16Array(40638), 9540, 128);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup112 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView32}]});
+let computePassEncoder154 = commandEncoder210.beginComputePass({label: '\u338a\u0e8c\u6bbb\u{1f71a}\uc62d\u0b4d\u653c\u0357\u05b3\u86cb'});
+try {
+computePassEncoder128.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer58, 0, 223);
+} catch {}
+let texture197 = device0.createTexture({
+  label: '\u0e03\u0764\u0e88\ud33d\u0bc0\ua0e8\u0047',
+  size: {width: 75, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder153.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder40.setViewport(26.94324888660311, 16.541668308863883, 53.587543902223445, 2.111123873773678, 0.24433556713611082, 0.5910652555936265);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(160, 75, 232, 509_420_221, 458_033_835);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer117, 88);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer102, 352);
+} catch {}
+document.body.append(canvas3);
+let bindGroup113 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 169, resource: textureView76},
+    {binding: 139, resource: textureView56},
+    {binding: 3, resource: textureView130},
+    {binding: 83, resource: {buffer: buffer4, offset: 5888, size: 6664}},
+    {binding: 78, resource: textureView56},
+    {binding: 633, resource: textureView89},
+    {binding: 41, resource: textureView79},
+    {binding: 444, resource: textureView58},
+    {binding: 335, resource: textureView52},
+    {binding: 80, resource: textureView131},
+    {binding: 130, resource: {buffer: buffer64, offset: 0}},
+  ],
+});
+let texture198 = device0.createTexture({
+  label: '\u0ff5\u31d6\u826b\u25a8\u96c1\u8f0f\u9aae\u7a89\u{1fcf7}',
+  size: {width: 600, height: 96, depthOrArrayLayers: 866},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder109.setBindGroup(3, bindGroup85, new Uint32Array(933), 106, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(29, 1_000, 275_086_671, 215_245_743);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer70, 268);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 456});
+let sampler118 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 94.30});
+try {
+computePassEncoder125.setBindGroup(2, bindGroup0, new Uint32Array(1523), 82, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup67);
+} catch {}
+try {
+renderPassEncoder7.draw(2, 66, 168_368_401, 120_311_424);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer26, 3_212);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline9);
+} catch {}
+let arrayBuffer18 = buffer65.getMappedRange();
+try {
+computePassEncoder48.pushDebugGroup('\u2969');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.prepend(video5);
+let imageBitmap3 = await createImageBitmap(video5);
+try {
+computePassEncoder101.setBindGroup(3, bindGroup52, new Uint32Array(74), 26, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup96);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(50);
+} catch {}
+try {
+renderPassEncoder7.draw(176, 122, 2_032_106_137, 471_829_706);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer52, 6_648);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(0, buffer73, 3_128, 8_770);
+} catch {}
+document.body.prepend(video2);
+let bindGroup114 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView32}]});
+let texture199 = device0.createTexture({
+  size: [659, 48, 1],
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(1, bindGroup106, new Uint32Array(502), 26, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup98);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer21, 140);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer102, 'uint32', 816, 2_112);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer35, 296, 103);
+} catch {}
+let arrayBuffer19 = buffer111.getMappedRange();
+try {
+computePassEncoder48.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(672).fill(202), /* required buffer size: 672 */
+{offset: 672, bytesPerRow: 96, rowsPerImage: 20}, {width: 5, height: 4, depthOrArrayLayers: 0});
+} catch {}
+canvas3.width = 106;
+await gc();
+try {
+adapter0.label = '\u824e\u662e\u786b\u3fa8\u054d\u59b7\u0e6f\u{1f82e}\ue300\u{1f705}';
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder({});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup24, new Uint32Array(1778), 787, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer33, 2_020);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer17, 1_244);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer123, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+  await buffer90.mapAsync(GPUMapMode.READ, 0, 44);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  label: '\u3d24\u6eed\u37de',
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 17, resource: {buffer: buffer20, offset: 1280, size: 9089}},
+    {binding: 380, resource: textureView175},
+  ],
+});
+let querySet31 = device0.createQuerySet({
+  label: '\ued3f\u4593\u0c1b\udc77\u{1ffa8}\u{1ff41}\u9cb7\u0f30\u0d46\u141f',
+  type: 'occlusion',
+  count: 386,
+});
+let texture200 = gpuCanvasContext3.getCurrentTexture();
+let textureView179 = texture58.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let sampler119 = device0.createSampler({
+  label: '\u5768\u266f\u{1fc7c}\u0ab7\u{1f6a4}\u1aad\ua704\uea2b\ueb21\u23a4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 87.08,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder131.setBindGroup(1, bindGroup103);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer60, 1_404);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer67, 3_296);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(1, buffer101, 2_852);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer120, 452, new BigUint64Array(65));
+} catch {}
+let commandEncoder212 = device0.createCommandEncoder({});
+let computePassEncoder155 = commandEncoder212.beginComputePass();
+try {
+computePassEncoder144.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer40, 2_416); };
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup81, []);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup73, new Uint32Array(425), 11, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(11, 192, 315_876_455, 1_477_895_368);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(86, 275, 22, -1_922_348_164, 566_520_486);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer82, 1_524);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer111, 'uint32', 104, 4);
+} catch {}
+let arrayBuffer20 = buffer99.getMappedRange(0, 268);
+let bindGroup116 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 102, resource: textureView179}]});
+let buffer126 = device0.createBuffer({
+  size: 36214,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder213 = device0.createCommandEncoder({});
+let texture201 = device0.createTexture({
+  size: {width: 659, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder156 = commandEncoder211.beginComputePass({});
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder3.draw(500, 218, 1_126_079_279, 39_972_574);
+} catch {}
+let arrayBuffer21 = buffer112.getMappedRange(88, 1980);
+try {
+commandEncoder213.copyBufferToTexture({
+  /* bytesInLastRow: 208 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4672 */
+  offset: 4672,
+  buffer: buffer12,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder213.copyTextureToBuffer({
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 361, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 352 widthInBlocks: 88 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2484 */
+  offset: 2484,
+  rowsPerImage: 212,
+  buffer: buffer33,
+}, {width: 88, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer127 = device0.createBuffer({
+  size: 21184,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder214 = device0.createCommandEncoder();
+try {
+computePassEncoder105.setBindGroup(0, bindGroup27, []);
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.draw(67, 51, 577_796_766, 268_487_909);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(165, 67, 31, 113_752_921, 5_039_558);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+computePassEncoder127.insertDebugMarker('\ua672');
+} catch {}
+let buffer128 = device0.createBuffer({
+  size: 9391,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder54.beginOcclusionQuery(31);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(130, 321, 12, -2_126_056_023, 610_077_555);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer40, 176);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer106, 'uint32', 388, 4_786);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4_294_967_294, undefined, 0, 2_207_632_775);
+} catch {}
+await gc();
+let texture202 = device0.createTexture({
+  label: '\u{1f942}\u{1f66f}\ud657\u5867\u345b',
+  size: [1440, 2, 1],
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler120 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 46.24,
+  lodMaxClamp: 64.08,
+  compare: 'always',
+});
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer102, 20);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer108, 168);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer3, 0, 632);
+} catch {}
+let buffer129 = device0.createBuffer({
+  size: 36851,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder215 = device0.createCommandEncoder({});
+let texture203 = device0.createTexture({size: [150], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder157 = commandEncoder214.beginComputePass();
+try {
+computePassEncoder99.setBindGroup(0, bindGroup65, new Uint32Array(3132), 407, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer101, 1_424); };
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.draw(5, 142, 836_255_791, 370_543_548);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(5, 450, 10, 274_554_026, 313_778_474);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer113, 'uint16', 2_164, 8_433);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(7, buffer112, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(543).fill(75), /* required buffer size: 543 */
+{offset: 543, bytesPerRow: 157, rowsPerImage: 34}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer130 = device0.createBuffer({
+  label: '\u09c4\u5b3a\u0445\u39b0\u063c\u{1f644}\u0ed3\u42b1',
+  size: 10324,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 446});
+let renderPassEncoder55 = commandEncoder213.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  depthSlice: 124,
+  clearValue: { r: -319.0, g: 809.2, b: -801.6, a: -398.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView91,
+    depthClearValue: 4.513340206536039,
+    depthReadOnly: true,
+    stencilClearValue: 18185,
+    stencilReadOnly: false,
+  },
+});
+try {
+renderPassEncoder3.drawIndexed(56, 71, 62, 464_209_829, 1_264_975_126);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer107, 1_160);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+computePassEncoder82.setBindGroup(2, bindGroup114, new Uint32Array(4682), 1_469, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup99, []);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup1, new Uint32Array(523), 166, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle25, renderBundle22, renderBundle25, renderBundle25, renderBundle22, renderBundle22, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder0.draw(0, 94, 1, 213_392_876);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer72, 100);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer68, 'uint16', 10, 56);
+} catch {}
+try {
+commandEncoder215.copyBufferToBuffer(buffer112, 384, buffer5, 184, 4);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(21, 22);
+let texture204 = device0.createTexture({size: {width: 164}, dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.STORAGE_BINDING});
+let renderPassEncoder56 = commandEncoder215.beginRenderPass({
+  colorAttachments: [{
+  view: textureView127,
+  depthSlice: 105,
+  clearValue: { r: -273.9, g: -255.3, b: -544.7, a: 946.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+renderPassEncoder7.draw(37, 4, 43_757_330, 490_923_937);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(1, 16, 3, 31_213_890, 2_168_264_350);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer72, 84);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer50, 'uint16', 2_592, 6_052);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas4.getContext('webgpu');
+document.body.prepend(canvas0);
+offscreenCanvas3.width = 1453;
+let promise22 = adapter0.requestAdapterInfo();
+let buffer131 = device0.createBuffer({
+  size: 3740,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let texture205 = device0.createTexture({
+  size: [150, 24, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView180 = texture181.createView({dimension: '2d-array', format: 'rgba32float'});
+let sampler121 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.89,
+  lodMaxClamp: 74.97,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder125.setBindGroup(1, bindGroup46, new Uint32Array(877), 58, 0);
+} catch {}
+try {
+renderPassEncoder54.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer16, 884);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer47, 0, 31);
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder();
+let texture206 = device0.createTexture({
+  size: [2, 2, 12],
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup108, new Uint32Array(115), 2, 0);
+} catch {}
+try {
+renderPassEncoder51.setViewport(79.23516394473455, 24.110448571092054, 56.350454707932116, 8.536787192871614, 0.726584555244047, 0.9605764349779561);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer126, 'uint16', 4_072, 1_349);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder217 = device0.createCommandEncoder();
+let sampler122 = device0.createSampler({
+  label: '\u{1fb9f}\ufdfd\u{1f836}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 68.32,
+  lodMaxClamp: 98.64,
+  compare: 'less',
+});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup99);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(0, 411, 0, 336_778_222);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer115, 'uint32', 92, 120);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer113, 18_380);
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+commandEncoder217.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1488 */
+  offset: 1488,
+  buffer: buffer48,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 55, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 390,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup117 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 92, resource: textureView166}]});
+let texture207 = device0.createTexture({
+  size: [164, 12, 177],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView181 = texture175.createView({format: 'depth16unorm'});
+let computePassEncoder158 = commandEncoder217.beginComputePass({label: '\u1f63\u{1fd29}\u{1f7b0}\u{1f886}\u{1fdc6}\uda86\u{1f785}\ua83f\u4573\u{1fdb3}'});
+let sampler123 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.29,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup116, []);
+} catch {}
+try {
+renderPassEncoder50.setStencilReference(875);
+} catch {}
+try {
+renderPassEncoder3.draw(52, 80, 6_584_394, 1_782_489_973);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer41, 1_408);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer27, 44);
+} catch {}
+try {
+commandEncoder216.resolveQuerySet(querySet3, 252, 9, buffer99, 256);
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  label: '\u{1fe5a}\u44fe\u{1f8b9}\ueef6',
+  layout: bindGroupLayout5,
+  entries: [{binding: 598, resource: {buffer: buffer120, offset: 512}}],
+});
+let buffer132 = device0.createBuffer({
+  size: 10750,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder218 = device0.createCommandEncoder({});
+let sampler124 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.134,
+  lodMaxClamp: 11.96,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(3); };
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.draw(3, 110, 197_914_108, 900_970_537);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer119, 4_076);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u9a06\u0d06\u0a73\u{1f86a}\u0af9\u51d8\u0ea1\ud254\u0921';
+} catch {}
+let textureView182 = texture109.createView({baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup78);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder8.draw(124, 134, 2_084_033_300, 133_961_451);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(11, 17, 0, -1_840_213_231, 654_011_236);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(2, bindGroup110, new Uint32Array(199), 28, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer82, 796);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer42, 0);
+} catch {}
+try {
+commandEncoder218.copyTextureToBuffer({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 19, y: 12, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2893 */
+  offset: 2893,
+  bytesPerRow: 256,
+  rowsPerImage: 451,
+  buffer: buffer32,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let renderPassEncoder57 = commandEncoder216.beginRenderPass({
+  colorAttachments: [{
+  view: textureView86,
+  clearValue: { r: 671.9, g: -572.8, b: 457.7, a: 175.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 194670359,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup41, []);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+buffer81.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let buffer133 = device0.createBuffer({
+  size: 7014,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandBuffer8 = commandEncoder218.finish();
+let sampler125 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.33,
+  lodMaxClamp: 82.30,
+});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer27, 12);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder71.pushDebugGroup('\u127c');
+} catch {}
+let buffer134 = device0.createBuffer({
+  label: '\u0271\u{1fc81}\u0bb0\u0382\u0c0d\u0d30\u0129\u005d',
+  size: 13408,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture208 = device0.createTexture({
+  size: {width: 1440, height: 2, depthOrArrayLayers: 1},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView183 = texture71.createView({dimension: '2d-array'});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthStencilFormat: 'depth16unorm'});
+try {
+renderPassEncoder8.draw(230, 103, 162_948_332, 379_723_261);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(508, 64, 71, -1_961_846_575, 646_723_345);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer42, 44);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer129, 8_016, 468);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup16, new Uint32Array(927), 26, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder({});
+let sampler126 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 36.38,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup12, new Uint32Array(440), 226, 0);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle27, renderBundle27, renderBundle8, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(95, 91, 84, 115_162_116, 110_823_518);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer117, 460);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer102, 696, 1_853);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup48, new Uint32Array(1563), 247, 0);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer97, 'uint16', 88, 30);
+} catch {}
+await gc();
+let computePassEncoder159 = commandEncoder219.beginComputePass({});
+let renderBundle28 = renderBundleEncoder28.finish({label: '\u3b61\ua4e6\uff13\u5904\u{1fa61}\u{1f8fc}\ud43a\ud916'});
+try {
+computePassEncoder159.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup82, new Uint32Array(3574), 825, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(118, 236, 9, -1_781_065_006, 331_780_753);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer102, 2_224);
+} catch {}
+let commandEncoder220 = device0.createCommandEncoder({});
+let texture209 = device0.createTexture({size: [75, 12, 1], mipLevelCount: 2, format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder160 = commandEncoder220.beginComputePass({});
+let sampler127 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 75.61,
+  lodMaxClamp: 97.98,
+});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder3.draw(17, 24, 1_148_190_009, 1_119_985_374);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer127, 'uint16', 310, 463);
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  multisample: {mask: 0xe979fee},
+  fragment: {
+  module: shaderModule13,
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 220,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 32, shaderLocation: 9},
+          {format: 'sint32x2', offset: 24, shaderLocation: 14},
+          {format: 'float16x4', offset: 32, shaderLocation: 7},
+          {format: 'float16x2', offset: 76, shaderLocation: 13},
+          {format: 'uint16x2', offset: 20, shaderLocation: 6},
+          {format: 'sint32', offset: 20, shaderLocation: 2},
+          {format: 'sint8x4', offset: 24, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 8},
+          {format: 'float32x3', offset: 56, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 10},
+          {format: 'sint16x4', offset: 4, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 440,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x2', offset: 56, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+try {
+  await promise22;
+} catch {}
+let externalTexture19 = device0.importExternalTexture({label: '\u{1fb0f}\u203c\u48b4\uadbc\u4ced', source: video4});
+try {
+computePassEncoder137.setBindGroup(0, bindGroup31, new Uint32Array(1084), 252, 0);
+} catch {}
+try {
+computePassEncoder26.dispatchWorkgroupsIndirect(buffer108, 420);
+} catch {}
+try {
+renderPassEncoder3.draw(142, 164, 190_897_911, 198_611_664);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(25, 161, 82, 932_607_547, 311_620_417);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer126, 'uint16', 8_062, 1_010);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55); };
+} catch {}
+let buffer135 = device0.createBuffer({size: 8767, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+try {
+renderPassEncoder31.executeBundles([renderBundle18, renderBundle3, renderBundle21, renderBundle24, renderBundle24, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder5.draw(261, 9, 128_290_854, 210_832_363);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer129, 2_424);
+} catch {}
+let buffer136 = device0.createBuffer({size: 7185, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture210 = device0.createTexture({
+  size: [720, 1, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView184 = texture114.createView({dimension: '1d', baseArrayLayer: 0});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup30, new Uint32Array(1167), 133, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(160, 492, 254_824_496, 209_169_738);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(7, 157, 7, 582_513_837, 222_381_045);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer65, 460);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4, buffer106);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup119 = device0.createBindGroup({layout: bindGroupLayout25, entries: [{binding: 106, resource: textureView74}]});
+let commandEncoder221 = device0.createCommandEncoder({});
+let texture211 = device0.createTexture({
+  size: [659, 48, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer49, 14_716);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline9);
+} catch {}
+let arrayBuffer22 = buffer74.getMappedRange(0, 708);
+try {
+device0.queue.writeBuffer(buffer43, 3620, new Float32Array(11193), 1588, 576);
+} catch {}
+let computePassEncoder161 = commandEncoder221.beginComputePass({label: '\u91ca\udb96\u26b4\ub028\u0cb3\u08b4\u{1faaf}\u304e'});
+let sampler128 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 51.68,
+  lodMaxClamp: 97.88,
+  compare: 'greater',
+});
+try {
+computePassEncoder160.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.draw(0, 102, 1, 517_351_522);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1, 177, 324, 537_615_793, 95_260_163);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer65, 316);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer56, 0, 340);
+} catch {}
+try {
+computePassEncoder131.insertDebugMarker('\uc0fa');
+} catch {}
+let buffer137 = device0.createBuffer({size: 1853, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture212 = gpuCanvasContext2.getCurrentTexture();
+let sampler129 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.40,
+});
+try {
+computePassEncoder161.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup49, new Uint32Array(1260), 1, 0);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(318);
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: []});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 518});
+let texture213 = device0.createTexture({size: {width: 300}, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder104.setBindGroup(1, bindGroup36, new Uint32Array(1380), 689, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer132, 2_660);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer118);
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({label: '\u0404\u495a\u0342\uaa75\u2ff5\u4607', bindGroupLayouts: []});
+let buffer138 = device0.createBuffer({
+  size: 20017,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder222 = device0.createCommandEncoder({});
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup10, new Uint32Array(1753), 22, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 450, 2, -1_841_366_535, 101_450_814);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer17, 736);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer126, 'uint32', 13_136, 3_135);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture214 = device0.createTexture({
+  size: {width: 75, height: 12, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView185 = texture83.createView({dimension: '3d', mipLevelCount: 1});
+let renderPassEncoder58 = commandEncoder222.beginRenderPass({
+  colorAttachments: [{
+  view: textureView183,
+  clearValue: { r: -447.8, g: -479.4, b: -861.7, a: -841.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 115820723,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer61, 148); };
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(89, 84, 159, -1_985_069_924, 224_994_655);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer57, 568);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer51, 6_624);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline4);
+} catch {}
+let bindGroup120 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 92, resource: {buffer: buffer39, offset: 0, size: 1176}}],
+});
+try {
+computePassEncoder126.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup105);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle7, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(48, 294, 11, 450_313_323, 84_641_714);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer120, 1_768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 488, new DataView(new ArrayBuffer(4933)), 1230, 24);
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  label: '\uf7f9\u03af\u{1fd15}\ub783\u9653\uf283\u019b\ub361\u665b',
+  entries: [
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup121 = device0.createBindGroup({
+  label: '\u0415\u0b7e\uafc1\u{1f951}\u0b94',
+  layout: bindGroupLayout20,
+  entries: [{binding: 45, resource: sampler5}],
+});
+let commandEncoder223 = device0.createCommandEncoder({});
+let texture215 = device0.createTexture({
+  size: [2, 2, 12],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture216 = device0.createTexture({
+  size: [2, 2, 12],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder59 = commandEncoder223.beginRenderPass({
+  label: '\u{1ff1e}\u6ad7\u068e',
+  colorAttachments: [{
+  view: textureView104,
+  clearValue: { r: 864.1, g: -885.8, b: 148.9, a: 691.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture20 = device0.importExternalTexture({source: video3});
+try {
+computePassEncoder155.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer63, 1_560);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer71, 300);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let imageData34 = new ImageData(64, 92);
+let texture217 = device0.createTexture({
+  size: {width: 600, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture218 = device0.createTexture({
+  size: [75],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler130 = device0.createSampler({
+  label: '\u{1fa9c}\u0eec\uf2ff\u{1fac6}\u8f22\u0578\u3d78\ua271\u{1fd06}\u4c5d\uf77b',
+  addressModeW: 'repeat',
+  lodMaxClamp: 96.49,
+  compare: 'always',
+});
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup90);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup16, new Uint32Array(1994), 671, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle0, renderBundle20, renderBundle9, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder8.draw(152, 275, 1_167_470_686, 391_645_419);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer53, 884);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer119, 4_480);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 407,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let buffer139 = device0.createBuffer({
+  size: 21690,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder224 = device0.createCommandEncoder({});
+let textureView186 = texture215.createView({dimension: 'cube'});
+let renderPassEncoder60 = commandEncoder224.beginRenderPass({
+  colorAttachments: [{view: textureView183, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 78580474,
+});
+let sampler131 = device0.createSampler({minFilter: 'nearest', mipmapFilter: 'nearest', lodMinClamp: 10.23, lodMaxClamp: 54.51});
+try {
+renderPassEncoder8.draw(50, 378, 270_312_128, 241_147_291);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer21, 920);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer26, 1_668);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let sampler132 = device0.createSampler({
+  label: '\ua2ca\u{1f7a6}',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.43,
+  lodMaxClamp: 78.25,
+});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup64, []);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup73, new Uint32Array(241), 14, 0);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 599.3, g: 542.9, b: -418.7, a: 26.79, });
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer52, 568);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData35 = new ImageData(36, 20);
+let textureView187 = texture196.createView({dimension: '2d-array'});
+let sampler133 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.27,
+  lodMaxClamp: 96.49,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup3, new Uint32Array(193), 93, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(27, 162, 1, 325_640_327, 534_505_130);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer134, 'uint32', 5_044, 1_014);
+} catch {}
+try {
+computePassEncoder71.popDebugGroup();
+} catch {}
+let textureView188 = texture215.createView({dimension: 'cube'});
+try {
+computePassEncoder141.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(3, bindGroup60, new Uint32Array(1311), 88, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(64, 237, 63, 21_125_892, 152_740_264);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 164, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData32,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 15, resource: {buffer: buffer68, offset: 0, size: 148}},
+    {binding: 0, resource: textureView6},
+  ],
+});
+let buffer140 = device0.createBuffer({
+  size: 15368,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(2, bindGroup68, new Uint32Array(298), 10, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle27, renderBundle6, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer135, 396);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(7, buffer133, 0, 1_165);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup123 = device0.createBindGroup({
+  label: '\u949b\ud2b1\u0c6b\u923a',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 0, resource: textureView179},
+    {binding: 15, resource: {buffer: buffer107, offset: 768, size: 536}},
+  ],
+});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 285});
+let textureView189 = texture199.createView({});
+try {
+computePassEncoder160.setBindGroup(0, bindGroup79, new Uint32Array(517), 35, 0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup51, new Uint32Array(164), 3, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(9, 205, 984_056_123, 365_501_589);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer27, 'uint32', 40, 467);
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\ua469\u768c\u{1f8eb}\u823a\u41f2\u041f\uacea\u{1f8ec}',
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView190 = texture4.createView({dimension: '2d-array'});
+let textureView191 = texture41.createView({label: '\u{1f765}\u0068\u0e69\u1160\ud89d\u{1f753}\u{1fa3c}\u5620\u0a3c\u39b2', mipLevelCount: 1});
+try {
+renderPassEncoder30.setBlendConstant({ r: 475.2, g: -241.8, b: -741.0, a: -208.7, });
+} catch {}
+try {
+renderPassEncoder0.draw(0, 235, 0, 1_690_877_110);
+} catch {}
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 532});
+try {
+renderPassEncoder8.draw(245, 46, 149_419_039, 525_062);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(1, 180, 3, 294_112_629, 843_484_933);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline14);
+} catch {}
+let bindGroup124 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 67, resource: textureView109}]});
+let pipelineLayout26 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture219 = device0.createTexture({
+  size: [329, 24, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup63, new Uint32Array(775), 258, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup0, new Uint32Array(2309), 98, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer51, 1_736);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer101, 'uint16', 4_110, 4_447);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 180, new Float32Array(6553));
+} catch {}
+let bindGroup125 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 589, resource: {buffer: buffer78, offset: 2560}},
+    {binding: 19, resource: textureView43},
+    {binding: 168, resource: sampler84},
+  ],
+});
+let sampler134 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.09,
+});
+try {
+renderPassEncoder5.drawIndexed(3, 3, 0, -1_281_372_453, 2_009_930_378);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer27, 92);
+} catch {}
+let texture220 = device0.createTexture({
+  size: {width: 659, height: 48, depthOrArrayLayers: 86},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder150.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+computePassEncoder103.setBindGroup(1, bindGroup122, new Uint32Array(3269), 21, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(146, 27, 618_375_066, 194_176_574);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(122, 7, 10, -1_704_152_451, 70_846_513);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline5);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let commandEncoder225 = device0.createCommandEncoder({});
+let computePassEncoder162 = commandEncoder225.beginComputePass({});
+let sampler135 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 67.77,
+  lodMaxClamp: 95.07,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup11, new Uint32Array(2100), 758, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder7.draw(72, 38, 525_968_141, 804_601_658);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(3, 33, 2, 612_421_247, 475_305_516);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer132, 'uint32', 676, 1_330);
+} catch {}
+await gc();
+let buffer141 = device0.createBuffer({size: 4105, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer48, 668); };
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle22]);
+} catch {}
+let bindGroup126 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 67, resource: textureView123}]});
+let texture221 = device0.createTexture({
+  size: {width: 75, height: 12, depthOrArrayLayers: 77},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup64, new Uint32Array(1212), 3, 0);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder7.draw(274, 892, 852_444_722, 592_068_823);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(86, 54, 6, -1_937_195_723, 880_386_236);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer66, 916);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer99, 1_572);
+} catch {}
+let bindGroup127 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 92, resource: textureView165}, {binding: 73, resource: textureView108}],
+});
+let querySet36 = device0.createQuerySet({label: '\u2737\ud7b4\u6f14\u{1fe07}\u0190\ub686\u8e87\u09e7\u2493', type: 'occlusion', count: 2692});
+let texture222 = device0.createTexture({
+  size: [150, 24, 1],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView192 = texture182.createView({dimension: 'cube', baseArrayLayer: 1});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup91, []);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup78, new Uint32Array(528), 39, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(43, 63, 550_448_178, 696_393_958);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(32, 9, 42, -1_950_104_650, 257_911_543);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer129, 7_764);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer68, 'uint32', 820, 207);
+} catch {}
+let promise23 = shaderModule10.getCompilationInfo();
+let pipelineLayout27 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer142 = device0.createBuffer({
+  size: 4712,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture223 = device0.createTexture({size: [164, 12, 1], format: 'depth16unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup115, new Uint32Array(131), 8, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup60, new Uint32Array(163), 23, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder0.draw(0, 143, 0, 1_121_607_503);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer105, 1_304);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer111, 'uint16', 16, 13);
+} catch {}
+try {
+buffer74.unmap();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture224 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 12},
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16sint'],
+});
+let sampler136 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.53,
+  compare: 'less',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup113, new Uint32Array(725), 17, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup90, []);
+} catch {}
+try {
+renderPassEncoder53.beginOcclusionQuery(526);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer107, 276);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 0, new Float32Array(41720), 13369, 1824);
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 565,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder226 = device0.createCommandEncoder({});
+let textureView193 = texture165.createView({});
+let texture225 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 12},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView194 = texture124.createView({format: 'rgba32float', mipLevelCount: 1});
+let renderPassEncoder61 = commandEncoder226.beginRenderPass({
+  label: '\u1228\uc1e3\u0e4c\u{1f877}\uf426\uaf0f\u{1f9b0}\u3567\ueb08\u05c9\u1038',
+  colorAttachments: [{view: textureView132, depthSlice: 179, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView110,
+    depthClearValue: 6.179156427145426,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 11115,
+  },
+  maxDrawCount: 235957195,
+});
+let sampler137 = device0.createSampler({
+  label: '\u0326\ub324\ud619\uedee',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.20,
+  lodMaxClamp: 34.73,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder48.setBindGroup(3, bindGroup52, new Uint32Array(307), 74, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 9, 8, 18_508_629, 339_907_229);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer68, 132);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let bindGroupLayout31 = pipeline12.getBindGroupLayout(0);
+let texture226 = device0.createTexture({
+  size: {width: 720},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup80, new Uint32Array(3741), 189, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 51, 3, 384_740_597, 772_500_729);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer78, 48);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 48, depthOrArrayLayers: 3}
+*/
+{
+  source: imageData18,
+  origin: { x: 10, y: 8 },
+  flipY: false,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+let buffer143 = device0.createBuffer({
+  size: 20230,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder227 = device0.createCommandEncoder({});
+let textureView195 = texture226.createView({label: '\u0cc3\uda85', arrayLayerCount: 1});
+let computePassEncoder163 = commandEncoder227.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup89);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle0, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder5.draw(25, 21, 257_113_700, 43_907_512);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer19, 248);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(17).fill(246), /* required buffer size: 17 */
+{offset: 17}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder45.setBindGroup(2, bindGroup31, new Uint32Array(714), 192, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer107, 304);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let videoFrame31 = new VideoFrame(videoFrame30, {timestamp: 0});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(89, 167, 1_227_763_916, 257_220_882);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer66, 2_844);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup128 = device0.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 565, resource: textureView195}]});
+let commandEncoder228 = device0.createCommandEncoder({});
+let computePassEncoder164 = commandEncoder228.beginComputePass({});
+try {
+computePassEncoder164.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder7.draw(17, 91, 559_293_544, 788_850_716);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(48, 60, 10, 659_897_105, 1_410_157_662);
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'unspecified', transfer: 'bt1361ExtendedColourGamut'} });
+let texture227 = device0.createTexture({
+  size: [2, 2, 12],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder3.drawIndexed(73, 29, 16, 253_307_538, 698_728_789);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer38, 196);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer68, 0);
+} catch {}
+try {
+renderPassEncoder51.pushDebugGroup('\u{1f8f2}');
+} catch {}
+try {
+renderPassEncoder51.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let commandEncoder229 = device0.createCommandEncoder({});
+let texture228 = device0.createTexture({
+  size: {width: 659, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup31, new Uint32Array(4), 0, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(5, 498, 1_387_456_494, 279_463_224);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(52, 43, 16, -1_010_776_839, 199_451_386);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer53, 944);
+} catch {}
+try {
+commandEncoder229.copyBufferToBuffer(buffer21, 56, buffer99, 248, 64);
+} catch {}
+try {
+commandEncoder229.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1088 */
+  offset: 1088,
+  buffer: buffer1,
+}, {
+  texture: texture184,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let buffer144 = device0.createBuffer({
+  size: 17836,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture229 = device0.createTexture({
+  size: [360, 1, 1],
+  mipLevelCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler138 = device0.createSampler({
+  label: '\u0b9d\u0c83\u{1fdd0}\u9a1a',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup48, new Uint32Array(1864), 133, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(99, 839, 175, 305_536_364, 471_567_222);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer68, 168);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer144, 0, 2_264);
+} catch {}
+try {
+commandEncoder229.copyTextureToTexture({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 9, y: 8, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer145 = device0.createBuffer({
+  label: '\u8f50\u085b\u1908\u0af5\u7ed6\u{1fd09}\u6ba3\u15b5\u9bc4\uf26d\u0933',
+  size: 1525,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder230 = device0.createCommandEncoder({});
+let texture230 = device0.createTexture({
+  size: {width: 75},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler139 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 88.63,
+});
+try {
+renderPassEncoder23.executeBundles([renderBundle2, renderBundle20, renderBundle9, renderBundle2, renderBundle20, renderBundle2, renderBundle9, renderBundle3, renderBundle21, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder7.draw(31, 15, 315_067_544, 1_856_035_131);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder230.copyTextureToTexture({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 29, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 234, resource: sampler105},
+    {binding: 15, resource: textureView20},
+    {binding: 49, resource: textureView5},
+    {binding: 374, resource: textureView35},
+  ],
+});
+let textureView196 = texture21.createView({dimension: '2d-array', format: 'rgb10a2unorm'});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame15, colorSpace: 'display-p3'});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup70, new Uint32Array(2128), 50, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer108, 1_060);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer124, 'uint32', 2_484, 3_419);
+} catch {}
+document.body.append(img4);
+let shaderModule18 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+/* target size: 8 max align: 8 */
+struct T0 {
+  @size(8) f0: atomic<i32>,
+}
+/* target size: 73 max align: 1 */
+struct T1 {
+  @align(1) @size(73) f0: atomic<i32>,
+}
+/* target size: 12 max align: 4 */
+struct T2 {
+  @align(1) @size(8) f0: atomic<u32>,
+  f1: array<atomic<u32>, 1>,
+}
+@group(0) @binding(67) var st38: texture_storage_2d<rgba8snorm, read>;
+struct VertexOutput19 {
+  @builtin(position) f64: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput19 {
+  var out: VertexOutput19;
+  return out;
+}
+struct VertexOutput20 {
+  @location(11) @interpolate(flat, centroid) f65: vec3i,
+  @builtin(position) f66: vec4f,
+  @location(3) @interpolate(perspective, sample) f67: f32,
+  @location(12) @interpolate(flat) f68: vec4h
+}
+
+@vertex
+fn vertex1() -> VertexOutput20 {
+  var out: VertexOutput20;
+  out.f66 %= vec4f(0.02570, 0.4283, 0.07145, 0.09166);
+  return out;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0() {
+}`,
+  hints: {},
+});
+let bindGroup130 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [
+    {binding: 390, resource: {buffer: buffer129, offset: 6656, size: 1252}},
+    {binding: 55, resource: {buffer: buffer102, offset: 2816}},
+  ],
+});
+let commandEncoder231 = device0.createCommandEncoder({label: '\u0a02\u027d\u2b40\u2551\u51bc\u0c4a\uf55f'});
+let textureView197 = texture143.createView({dimension: '2d-array', format: 'rgba32float', baseArrayLayer: 0});
+let sampler140 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 22.04,
+  lodMaxClamp: 23.18,
+});
+try {
+renderPassEncoder53.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(174, 195, 34, 275_278_920, 24_693_580);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(2, buffer133, 0, 110);
+} catch {}
+try {
+commandEncoder229.copyBufferToBuffer(buffer53, 160, buffer58, 1928, 556);
+} catch {}
+try {
+commandEncoder230.copyBufferToTexture({
+  /* bytesInLastRow: 1200 widthInBlocks: 600 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 732 */
+  offset: 732,
+  buffer: buffer120,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 600, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder231.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+videoFrame0.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame28.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### c4a3d3b51a46f30c0e200e436d1af427f6ba9554
<pre>
[WebGPU] Debug assertion in RenderBundleEncoder::currentRenderCommand() fails when RenderBundle has zero commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=279693">https://bugs.webkit.org/show_bug.cgi?id=279693</a>
radar://135708146

Reviewed by Tadeu Zagallo.

When commandCount is zero, we would replay the first recorded operation
when that was not needed, triggering the debug assertion in currentRenderCommand()

* LayoutTests/fast/webgpu/nocrash/fuzz-279693-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-279693.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::endCurrentICB):

Canonical link: <a href="https://commits.webkit.org/284539@main">https://commits.webkit.org/284539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1eca31e260a4b98b2b7fc06dd420fd0dc52db96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20870 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55388 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13847 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41439 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17568 "16 flakes 2 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17164 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63065 "Found 3 new test failures: imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_under_load.https.optional.html?mouse imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_under_load.https.optional.html?pen imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62985 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15491 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4600 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44916 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->