### PR TITLE
Smart pointer adoption in some IPC-adjacent code

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -131,7 +131,7 @@ public:
     class TimerBase {
         friend class RunLoop;
     public:
-        WTF_EXPORT_PRIVATE explicit TimerBase(RunLoop&);
+        WTF_EXPORT_PRIVATE explicit TimerBase(Ref<RunLoop>&&);
         WTF_EXPORT_PRIVATE virtual ~TimerBase();
 
         void startRepeating(Seconds interval) { start(std::max(interval, 0_s), true); }
@@ -180,13 +180,13 @@ public:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         template <typename TimerFiredClass>
-        Timer(RunLoop& runLoop, TimerFiredClass* o, void (TimerFiredClass::*f)())
-            : Timer(runLoop, std::bind(f, o))
+        Timer(Ref<RunLoop>&& runLoop, TimerFiredClass* o, void (TimerFiredClass::*f)())
+            : Timer(WTFMove(runLoop), std::bind(f, o))
         {
         }
 
-        Timer(RunLoop& runLoop, Function<void ()>&& function)
-            : TimerBase(runLoop)
+        Timer(Ref<RunLoop>&& runLoop, Function<void ()>&& function)
+            : TimerBase(WTFMove(runLoop))
             , m_function(WTFMove(function))
         {
         }

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -101,8 +101,8 @@ void RunLoop::dispatch(const SchedulePairHashSet& schedulePairs, Function<void()
 
 // RunLoop::Timer
 
-RunLoop::TimerBase::TimerBase(RunLoop& runLoop)
-    : m_runLoop(runLoop)
+RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
+    : m_runLoop(WTFMove(runLoop))
 {
 }
 

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -297,8 +297,8 @@ void RunLoop::unscheduleWithLock(TimerBase::ScheduledTask& task)
 
 // Since RunLoop does not own the registered TimerBase,
 // TimerBase and its owner should manage these lifetime.
-RunLoop::TimerBase::TimerBase(RunLoop& runLoop)
-    : m_runLoop(runLoop)
+RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
+    : m_runLoop(WTFMove(runLoop))
     , m_scheduledTask(ScheduledTask::create(*this))
 {
 }

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -157,8 +157,8 @@ void RunLoop::notify(RunLoop::Event event, const char* name)
     });
 }
 
-RunLoop::TimerBase::TimerBase(RunLoop& runLoop)
-    : m_runLoop(runLoop)
+RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
+    : m_runLoop(WTFMove(runLoop))
     , m_source(adoptGRef(g_source_new(&RunLoop::s_runLoopSourceFunctions, sizeof(RunLoopSource))))
 {
     auto& runLoopSource = *reinterpret_cast<RunLoopSource*>(m_source.get());

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -168,8 +168,8 @@ void RunLoop::TimerBase::timerFired()
     fired();
 }
 
-RunLoop::TimerBase::TimerBase(RunLoop& runLoop)
-    : m_runLoop(runLoop)
+RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
+    : m_runLoop(WTFMove(runLoop))
 {
 }
 

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -91,14 +91,6 @@ const DestinationColorSpace& DestinationColorSpace::DisplayP3()
 }
 #endif
 
-DestinationColorSpace::DestinationColorSpace(PlatformColorSpace platformColorSpace)
-    : m_platformColorSpace { WTFMove(platformColorSpace) }
-{
-#if USE(CG) || USE(SKIA)
-    ASSERT(m_platformColorSpace);
-#endif
-}
-
 bool operator==(const DestinationColorSpace& a, const DestinationColorSpace& b)
 {
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -39,7 +39,13 @@ public:
     WEBCORE_EXPORT static const DestinationColorSpace& DisplayP3();
 #endif
 
-    WEBCORE_EXPORT explicit DestinationColorSpace(PlatformColorSpace);
+    explicit DestinationColorSpace(PlatformColorSpace platformColorSpace)
+        : m_platformColorSpace { WTFMove(platformColorSpace) }
+    {
+#if USE(CG) || USE(SKIA)
+        ASSERT(m_platformColorSpace);
+#endif
+    }
 
 #if USE(SKIA)
     PlatformColorSpaceValue platformColorSpace() const { return m_platformColorSpace; }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -138,7 +138,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::statsFont()
 MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
     : RealtimeVideoCaptureSource(CaptureDevice { WTFMove(deviceID), CaptureDevice::DeviceType::Camera, WTFMove(name) }, WTFMove(hashSalts), pageIdentifier)
     , m_runLoop(RunLoop::create("WebKit::MockRealtimeVideoSource generateFrame runloop"_s))
-    , m_emitFrameTimer(m_runLoop, [protectedThis = Ref { *this }] { protectedThis->generateFrame(); })
+    , m_emitFrameTimer(m_runLoop.get(), [protectedThis = Ref { *this }] { protectedThis->generateFrame(); })
     , m_deviceOrientation { VideoFrameRotation::None }
 {
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
@@ -53,12 +53,12 @@ RemoteFaceDetector::~RemoteFaceDetector() = default;
 
 const SharedPreferencesForWebProcess& RemoteFaceDetector::sharedPreferencesForWebProcess() const
 {
-    return m_backend->sharedPreferencesForWebProcess();
+    return protectedBackend()->sharedPreferencesForWebProcess();
 }
 
 void RemoteFaceDetector::detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
-    auto sourceImage = m_backend->imageBuffer(renderingResourceIdentifier);
+    auto sourceImage = protectedBackend()->imageBuffer(renderingResourceIdentifier);
     if (!sourceImage) {
         completionHandler({ });
         return;

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -73,6 +73,7 @@ private:
     RemoteFaceDetector& operator=(RemoteFaceDetector&&) = delete;
 
     WebCore::ShapeDetection::FaceDetector& backing() { return m_backing; }
+    Ref<RemoteRenderingBackend> protectedBackend() const { return m_backend.get(); }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -56,14 +56,15 @@ RemoteImageBufferSet::RemoteImageBufferSet(RemoteImageBufferSetIdentifier identi
 
 RemoteImageBufferSet::~RemoteImageBufferSet()
 {
+    RefPtr frontBuffer = m_frontBuffer;
     // Volatile image buffers do not have contexts.
-    if (!m_frontBuffer || m_frontBuffer->volatilityState() == WebCore::VolatilityState::Volatile)
+    if (!frontBuffer || frontBuffer->volatilityState() == WebCore::VolatilityState::Volatile)
         return;
-    if (!m_frontBuffer->hasBackend())
+    if (!frontBuffer->hasBackend())
         return;
     // Unwind the context's state stack before destruction, since calls to restore may not have
     // been flushed yet, or the web process may have terminated.
-    auto& context = m_frontBuffer->context();
+    auto& context = frontBuffer->context();
     while (context.stackSize())
         context.restore();
 }
@@ -126,9 +127,9 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
 {
     assertIsCurrent(workQueue());
     LOG_WITH_STREAM(RemoteLayerBuffers, stream << "GPU Process: ::ensureFrontBufferForDisplay " << " - front "
-        << m_frontBuffer << " (in-use " << (m_frontBuffer && m_frontBuffer->isInUse()) << ") "
-        << m_backBuffer << " (in-use " << (m_backBuffer && m_backBuffer->isInUse()) << ") "
-        << m_secondaryBackBuffer << " (in-use " << (m_secondaryBackBuffer && m_secondaryBackBuffer->isInUse()) << ") ");
+        << m_frontBuffer << " (in-use " << (m_frontBuffer && protectedFrontBuffer()->isInUse()) << ") "
+        << m_backBuffer << " (in-use " << (m_backBuffer && protectedBackBuffer()->isInUse()) << ") "
+        << m_secondaryBackBuffer << " (in-use " << (m_secondaryBackBuffer && protectedSecondaryBackBuffer()->isInUse()) << ") ");
 
     displayRequirement = swapBuffersForDisplay(inputData.hasEmptyDirtyRegion, inputData.supportsPartialRepaint && !isSmallLayerBacking({ m_logicalSize, m_resolutionScale, m_colorSpace, m_pixelFormat, WebCore::RenderingPurpose::LayerBacking }));
     if (displayRequirement == SwapBuffersDisplayRequirement::NeedsFullDisplay) {

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -37,6 +37,7 @@
 #include "RemoteImageBufferSetIdentifier.h"
 #include "RemoteResourceCache.h"
 #include "RemoteSerializedImageBufferIdentifier.h"
+#include "RemoteSharedResourceCache.h"
 #include "RenderingBackendIdentifier.h"
 #include "RenderingUpdateID.h"
 #include "ScopedActiveMessageReceiveQueue.h"
@@ -77,7 +78,6 @@ class GPUConnectionToWebProcess;
 class RemoteDisplayListRecorder;
 class RemoteImageBuffer;
 class RemoteImageBufferSet;
-class RemoteSharedResourceCache;
 struct BufferIdentifierSet;
 struct ImageBufferSetPrepareBufferForDisplayInputData;
 struct ImageBufferSetPrepareBufferForDisplayOutputData;
@@ -98,6 +98,7 @@ public:
 
     RemoteResourceCache& remoteResourceCache() { return m_remoteResourceCache; }
     RemoteSharedResourceCache& sharedResourceCache() { return m_sharedResourceCache; }
+    Ref<RemoteSharedResourceCache> protectedSharedResourceCache() { return m_sharedResourceCache; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -59,9 +59,9 @@ public:
     static std::unique_ptr<RemoteMediaRecorder> create(GPUConnectionToWebProcess&, MediaRecorderIdentifier, bool recordAudio, bool recordVideo, const WebCore::MediaRecorderPrivateOptions&);
     ~RemoteMediaRecorder();
 
-    String mimeType() const { return m_writer->mimeType(); }
-    unsigned audioBitRate() const { return m_writer->audioBitRate(); }
-    unsigned videoBitRate() const { return m_writer->videoBitRate(); }
+    String mimeType() const { return protectedWriter()->mimeType(); }
+    unsigned audioBitRate() const { return protectedWriter()->audioBitRate(); }
+    unsigned videoBitRate() const { return protectedWriter()->videoBitRate(); }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
@@ -70,6 +70,8 @@ private:
     RemoteMediaRecorder(GPUConnectionToWebProcess&, MediaRecorderIdentifier, Ref<WebCore::MediaRecorderPrivateWriter>&&, bool recordAudio);
 
     RefPtr<IPC::Connection> connection() const;
+
+    Ref<WebCore::MediaRecorderPrivateWriter> protectedWriter() const { return m_writer; }
 
     // IPC::MessageReceiver
     void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -59,6 +59,11 @@ RemoteSampleBufferDisplayLayer::RemoteSampleBufferDisplayLayer(GPUConnectionToWe
     ASSERT(m_sampleBufferDisplayLayer);
 }
 
+RefPtr<WebCore::LocalSampleBufferDisplayLayer> RemoteSampleBufferDisplayLayer::protectedSampleBufferDisplayLayer() const
+{
+    return m_sampleBufferDisplayLayer;
+}
+
 void RemoteSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size, bool shouldMaintainAspectRatio, bool canShowWhileLocked, LayerInitializationCallback&& callback)
 {
     LayerHostingContextOptions contextOptions;
@@ -90,7 +95,7 @@ RemoteSampleBufferDisplayLayer::~RemoteSampleBufferDisplayLayer()
 
 CGRect RemoteSampleBufferDisplayLayer::bounds() const
 {
-    return m_sampleBufferDisplayLayer->bounds();
+    return protectedSampleBufferDisplayLayer()->bounds();
 }
 
 void RemoteSampleBufferDisplayLayer::updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)
@@ -144,7 +149,7 @@ IPC::Connection* RemoteSampleBufferDisplayLayer::messageSenderConnection() const
 
 void RemoteSampleBufferDisplayLayer::sampleBufferDisplayLayerStatusDidFail()
 {
-    send(Messages::SampleBufferDisplayLayer::SetDidFail { m_sampleBufferDisplayLayer->didFail() });
+    send(Messages::SampleBufferDisplayLayer::SetDidFail { protectedSampleBufferDisplayLayer()->didFail() });
 }
 
 void RemoteSampleBufferDisplayLayer::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphore)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -73,6 +73,8 @@ public:
 private:
     RemoteSampleBufferDisplayLayer(GPUConnectionToWebProcess&, SampleBufferDisplayLayerIdentifier, Ref<IPC::Connection>&&);
 
+    RefPtr<WebCore::LocalSampleBufferDisplayLayer> protectedSampleBufferDisplayLayer() const;
+
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(String&&);
 #endif

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -53,8 +53,9 @@ void RemoteSampleBufferDisplayLayerManager::startListeningForIPC()
     auto connection = m_connectionToWebProcess.get();
     if (!connection)
         return;
-    connection->connection().addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName(), m_queue, *this);
-    connection->connection().addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName(), m_queue, *this);
+    Ref ipcConnection = connection->protectedConnection();
+    ipcConnection->addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName(), m_queue, *this);
+    ipcConnection->addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName(), m_queue, *this);
 }
 
 RemoteSampleBufferDisplayLayerManager::~RemoteSampleBufferDisplayLayerManager() = default;
@@ -64,8 +65,9 @@ void RemoteSampleBufferDisplayLayerManager::close()
     auto connection = m_connectionToWebProcess.get();
     if (!connection)
         return;
-    connection->connection().removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName());
-    connection->connection().removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName());
+    Ref ipcConnection = connection->protectedConnection();
+    ipcConnection->removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName());
+    ipcConnection->removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName());
     m_queue->dispatch([this, protectedThis = Ref { *this }] {
         Locker lock(m_layersLock);
         callOnMainRunLoop([layers = WTFMove(m_layers)] { });

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
@@ -113,11 +113,6 @@ void StreamConnectionWorkQueue::wakeUp()
     m_wakeUpSemaphore.signal();
 }
 
-IPC::Semaphore& StreamConnectionWorkQueue::wakeUpSemaphore()
-{
-    return m_wakeUpSemaphore;
-}
-
 void StreamConnectionWorkQueue::startProcessingThread()
 {
     auto task = [this]() mutable {

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -49,7 +49,7 @@ public:
     void removeStreamConnection(StreamServerConnection&);
     void stopAndWaitForCompletion(WTF::Function<void()>&& cleanupFunction = nullptr);
     void wakeUp();
-    Semaphore& wakeUpSemaphore();
+    Semaphore& wakeUpSemaphore() { return m_wakeUpSemaphore; }
 
     // SerialFunctionDispatcher
     void dispatch(WTF::Function<void()>&&) final;

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -110,7 +110,7 @@ struct PendingReply {
     if (!(self = [super init]))
         return nil;
 
-    _remoteObjectRegistry = makeUnique<WebKit::WebRemoteObjectRegistry>(self, page.get());
+    _remoteObjectRegistry = makeUnique<WebKit::WebRemoteObjectRegistry>(self, Ref { page.get() });
 
     return self;
 }
@@ -120,7 +120,7 @@ struct PendingReply {
     if (!(self = [super init]))
         return nil;
 
-    _remoteObjectRegistry = makeUnique<WebKit::UIRemoteObjectRegistry>(self, page.get());
+    _remoteObjectRegistry = makeUnique<WebKit::UIRemoteObjectRegistry>(self, Ref { page.get() });
 
     return self;
 }

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -60,8 +60,8 @@ IPCStreamTester::~IPCStreamTester() = default;
 
 void IPCStreamTester::initialize()
 {
-    workQueue().dispatch([this] {
-        m_streamConnection->open(workQueue());
+    protectedWorkQueue()->dispatch([this] {
+        m_streamConnection->open(protectedWorkQueue());
         m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
         m_streamConnection->send(Messages::IPCStreamTesterProxy::WasCreated(workQueue().wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()), m_identifier);
     });
@@ -69,11 +69,12 @@ void IPCStreamTester::initialize()
 
 void IPCStreamTester::stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnection)
 {
-    workQueue().dispatch([this] {
+    Ref workQueue = m_workQueue;
+    workQueue->dispatch([this] {
         m_streamConnection->stopReceivingMessages(Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
         m_streamConnection->invalidate();
     });
-    workQueue().stopAndWaitForCompletion();
+    workQueue->stopAndWaitForCompletion();
 }
 
 void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(std::optional<WebCore::SharedMemory::Handle>&&)>&& completionHandler)

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -56,6 +56,7 @@ private:
     ~IPCStreamTester();
     void initialize();
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
+    Ref<IPC::StreamConnectionWorkQueue> protectedWorkQueue() const { return m_workQueue; }
 
     // Messages.
     void syncMessage(uint32_t value, CompletionHandler<void(uint32_t)>&&);

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -52,7 +52,7 @@ typedef void (*WKMessageTestDriverFunc)(WKMessageTestSendMessageFunc sendMessage
 
 namespace {
 struct SendMessageContext {
-    IPC::Connection& connection;
+    Ref<IPC::Connection> connection;
     std::atomic<bool>& shouldStop;
 };
 
@@ -230,9 +230,9 @@ void IPCTester::asyncOptionalExceptionData(IPC::Connection&, bool sendEngaged, C
 
 void IPCTester::stopIfNeeded()
 {
-    if (m_testQueue) {
+    if (RefPtr testQueue = m_testQueue) {
         m_shouldStop = true;
-        m_testQueue->dispatchSync([] { });
+        testQueue->dispatchSync([] { });
         m_testQueue = nullptr;
     }
 }

--- a/Source/WebKit/Shared/graphics/ImageBufferSet.h
+++ b/Source/WebKit/Shared/graphics/ImageBufferSet.h
@@ -61,6 +61,10 @@ public:
 
     void clearBuffers();
 
+    RefPtr<WebCore::ImageBuffer> protectedFrontBuffer() { return m_frontBuffer; }
+    RefPtr<WebCore::ImageBuffer> protectedBackBuffer() { return m_backBuffer; }
+    RefPtr<WebCore::ImageBuffer> protectedSecondaryBackBuffer() { return m_secondaryBackBuffer; }
+
     RefPtr<WebCore::ImageBuffer> m_frontBuffer;
     RefPtr<WebCore::ImageBuffer> m_backBuffer;
     RefPtr<WebCore::ImageBuffer> m_secondaryBackBuffer;

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -36,7 +36,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(UIRemoteObjectRegistry);
 
 std::unique_ptr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
-    return protectedPage()->legacyMainFrameProcess().throttler().backgroundActivity(name).moveToUniquePtr();
+    return protectedPage()->legacyMainFrameProcess().protectedThrottler()->backgroundActivity(name).moveToUniquePtr();
 }
 
 UIRemoteObjectRegistry::UIRemoteObjectRegistry(_WKRemoteObjectRegistry *remoteObjectRegistry, WebPageProxy& page)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -172,8 +172,8 @@ void WebExtensionMenuItem::update(const WebExtensionMenuItemParameters& paramete
     if (parameters.parentIdentifier) {
         RefPtr updatedParentMenuItem = m_extensionContext->menuItem(parameters.parentIdentifier.value());
         if (updatedParentMenuItem.get() != m_parentMenuItem) {
-            if (m_parentMenuItem)
-                m_parentMenuItem->removeSubmenuItem(*this);
+            if (RefPtr parentMenuItem = m_parentMenuItem.get())
+                parentMenuItem->removeSubmenuItem(*this);
 
             if (updatedParentMenuItem)
                 updatedParentMenuItem->addSubmenuItem(*this);
@@ -367,13 +367,13 @@ CocoaImage *WebExtensionMenuItem::icon(CGSize idealSize) const
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_iconVariants) {
-        result = extensionContext()->extension().bestImageForIconVariants(m_iconVariants.get(), idealSize, [&](auto *error) {
+        result = extensionContext()->protectedExtension()->bestImageForIconVariants(m_iconVariants.get(), idealSize, [&](auto *error) {
             extensionContext()->recordError(error);
         });
     } else
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_icons) {
-        result = extensionContext()->extension().bestImageInIconsDictionary(m_icons.get(), idealSize, [&](auto *error) {
+        result = extensionContext()->protectedExtension()->bestImageInIconsDictionary(m_icons.get(), idealSize, [&](auto *error) {
             extensionContext()->recordError(error);
         });
     }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -91,8 +91,8 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
 WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses() const
 {
     WebProcessProxySet processes;
-    for (auto& page : m_pages)
-        processes.add(page.legacyMainFrameProcess());
+    for (Ref page : m_pages)
+        processes.add(page->legacyMainFrameProcess());
     return processes;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -270,9 +270,9 @@ private:
 template<typename T, typename RawValue>
 void WebExtensionController::sendToAllProcesses(const T& message, const ObjectIdentifierGenericBase<RawValue>& destinationID)
 {
-    for (auto& process : allProcesses()) {
-        if (process.canSendMessage())
-            process.send(T(message), destinationID);
+    for (Ref process : allProcesses()) {
+        if (process->canSendMessage())
+            process->send(T(message), destinationID);
     }
 }
 

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -42,8 +42,8 @@ public:
     }
     ~RemotePageVisitedLinkStoreRegistration()
     {
-        if (m_page)
-            m_process->removeVisitedLinkStoreUser(m_page->visitedLinkStore(), m_page->identifier());
+        if (RefPtr page = m_page.get())
+            m_process->removeVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());
     }
 private:
     WeakPtr<WebPageProxy> m_page;

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -94,9 +94,9 @@ void VisitedLinkStore::removeAll()
 {
     m_linkHashStore.clear();
 
-    for (auto& process : m_processes) {
-        ASSERT(process.processPool().processes().containsIf([&](auto& item) { return item.ptr() == &process; }));
-        process.send(Messages::VisitedLinkTableController::RemoveAllVisitedLinks(), identifier());
+    for (Ref process : m_processes) {
+        ASSERT(process->processPool().processes().containsIf([&](auto& item) { return item.ptr() == &process.get(); }));
+        process->send(Messages::VisitedLinkTableController::RemoveAllVisitedLinks(), identifier());
     }
 }
 
@@ -122,8 +122,8 @@ void VisitedLinkStore::sendStoreHandleToProcess(WebProcessProxy& process)
 
 void VisitedLinkStore::didInvalidateSharedMemory()
 {
-    for (auto& process : m_processes)
-        sendStoreHandleToProcess(process);
+    for (Ref process : m_processes)
+        sendStoreHandleToProcess(process.get());
 }
 
 void VisitedLinkStore::didUpdateSharedStringHashes(const Vector<WebCore::SharedStringHash>& addedHashes, const Vector<WebCore::SharedStringHash>& removedHashes)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2103,6 +2103,11 @@ API::HTTPCookieStore& WebsiteDataStore::cookieStore()
     return *m_cookieStore;
 }
 
+Ref<API::HTTPCookieStore> WebsiteDataStore::protectedCookieStore()
+{
+    return cookieStore();
+}
+
 void WebsiteDataStore::resetQuota(CompletionHandler<void()>&& completionHandler)
 {
     protectedNetworkProcess()->resetQuota(m_sessionID, WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -333,6 +333,7 @@ public:
     void setClient(UniqueRef<WebsiteDataStoreClient>&& client) { m_client = WTFMove(client); }
 
     API::HTTPCookieStore& cookieStore();
+    Ref<API::HTTPCookieStore> protectedCookieStore();
     WebCore::LocalWebLockRegistry& webLockRegistry() { return m_webLockRegistry.get(); }
     Ref<WebCore::LocalWebLockRegistry> protectedWebLockRegistry();
 

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -419,7 +419,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     bool geometryIsFlippedToRoot = layerGeometryFlippedToRoot(snapshotLayerParent);
 
     RetainPtr<CGColorRef> backgroundColor = CGColorGetConstantColor(kCGColorWhite);
-    if (ViewSnapshot* snapshot = targetItem->snapshot()) {
+    if (RefPtr<ViewSnapshot> snapshot = targetItem->snapshot()) {
         if (shouldUseSnapshotForSize(*snapshot, swipeArea.size(), topContentInset))
             [m_swipeSnapshotLayer setContents:snapshot->asLayerContents()];
 
@@ -446,7 +446,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
     [m_swipeLayer addSublayer:m_swipeSnapshotLayer.get()];
 
-    if (webPageProxy->preferences().viewGestureDebuggingEnabled())
+    if (webPageProxy->protectedPreferences()->viewGestureDebuggingEnabled())
         applyDebuggingPropertiesToSwipeViews();
 
     m_didCallEndSwipeGesture = false;
@@ -572,7 +572,7 @@ void ViewGestureController::didMoveSwipeSnapshotLayer()
     if (!m_didMoveSwipeSnapshotCallback)
         return;
 
-    m_didMoveSwipeSnapshotCallback(m_webPageProxy->boundsOfLayerInLayerBackedWindowCoordinates(m_swipeLayer.get()));
+    m_didMoveSwipeSnapshotCallback(protectedWebPageProxy()->boundsOfLayerInLayerBackedWindowCoordinates(m_swipeLayer.get()));
 }
 
 void ViewGestureController::removeSwipeSnapshot()
@@ -619,7 +619,7 @@ void ViewGestureController::resetState()
 
     m_currentSwipeLiveLayers.clear();
 
-    m_webPageProxy->navigationGestureSnapshotWasRemoved();
+    protectedWebPageProxy()->navigationGestureSnapshotWasRemoved();
 
     m_backgroundColorForCurrentSnapshot = Color();
 


### PR DESCRIPTION
#### a4d31ef91fcd38d963f59a8fda513693f4d14f94
<pre>
Smart pointer adoption in some IPC-adjacent code
<a href="https://bugs.webkit.org/show_bug.cgi?id=279696">https://bugs.webkit.org/show_bug.cgi?id=279696</a>
<a href="https://rdar.apple.com/135978755">rdar://135978755</a>

Reviewed by Timothy Hatcher.

Static analysis told me to.

* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::TimerBase::TimerBase):
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
(WTF::RunLoop::TimerBase::TimerBase):
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::TimerBase::TimerBase):
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::TimerBase::TimerBase):
* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::DestinationColorSpace): Deleted.
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
(WebCore::DestinationColorSpace::DestinationColorSpace):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp:
(WebKit::RemoteFaceDetector::sharedPreferencesForWebProcess const):
(WebKit::RemoteFaceDetector::detect):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h:
(WebKit::RemoteFaceDetector::protectedBackend const):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
(WebKit::RemoteImageBuffer::~RemoteImageBuffer):
(WebKit::RemoteImageBuffer::stopListeningForIPC):
(WebKit::RemoteImageBuffer::getPixelBuffer):
(WebKit::RemoteImageBuffer::getShareableBitmap):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::~RemoteImageBufferSet):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
(WebKit::RemoteImageBufferSet::prepareBufferForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
(WebKit::RemoteImageBufferSet::protectedFrontBuffer):
(WebKit::RemoteImageBufferSet::protectedPreviousFrontBuffer):
(WebKit::RemoteImageBufferSet::protectedBackBuffer):
(WebKit::RemoteImageBufferSet::protectedSecondaryBackBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
(WebKit::RemoteRenderingBackend::protectedSharedResourceCache):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h:
(WebKit::RemoteMediaRecorder::mimeType const):
(WebKit::RemoteMediaRecorder::audioBitRate const):
(WebKit::RemoteMediaRecorder::videoBitRate const):
(WebKit::RemoteMediaRecorder::protectedWriter const):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
(WebKit::RemoteSampleBufferDisplayLayer::protectedSampleBufferDisplayLayer const):
(WebKit::RemoteSampleBufferDisplayLayer::bounds const):
(WebKit::RemoteSampleBufferDisplayLayer::sampleBufferDisplayLayerStatusDidFail):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp:
(WebKit::RemoteSampleBufferDisplayLayerManager::startListeningForIPC):
(WebKit::RemoteSampleBufferDisplayLayerManager::close):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::wakeUpSemaphore): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _initWithWebPage:]):
(-[_WKRemoteObjectRegistry _initWithWebPageProxy:]):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::initialize):
(WebKit::IPCStreamTester::stopListeningForIPC):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::stopIfNeeded):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addPage):
(WebKit::WebExtensionController::removeProcessPool):
(WebKit::WebExtensionController::websiteDataStore const):
(WebKit::WebExtensionController::addWebsiteDataStore):
(WebKit::WebExtensionController::removeWebsiteDataStore):
(WebKit::WebExtensionController::isFeatureEnabled const):
(WebKit::WebExtensionController::handleContentRuleListNotification):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::update):
(WebKit::WebExtensionMenuItem::icon const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::allProcesses const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::sendToAllProcesses):
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h:
(WebKit::RemotePageVisitedLinkStoreRegistration::~RemotePageVisitedLinkStoreRegistration):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::canSwipeInDirection const):
(WebKit::ViewGestureController::startSwipeGesture):
(WebKit::ViewGestureController::willEndSwipeGesture):
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::removeAll):
(WebKit::VisitedLinkStore::didInvalidateSharedMemory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::protectedCookieStore):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::didMoveSwipeSnapshotLayer):
(WebKit::ViewGestureController::resetState):

Canonical link: <a href="https://commits.webkit.org/283732@main">https://commits.webkit.org/283732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc61e4ae9d113e48eede32d2166f02f3c7138792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19856 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70291 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15559 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/60339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15900 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66469 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11183 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/72962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58224 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14884 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/9177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88238 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/15542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->