### PR TITLE
WebKit needs to link to MediaExperience for AVSystemController, which lives there now

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/CelestialSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/CelestialSPI.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
 
 #import <Foundation/Foundation.h>
 
@@ -31,7 +31,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-W#warnings"
-#import <Celestial/AVSystemController.h>
+#import <MediaExperience/AVSystemController.h>
 #pragma clang diagnostic pop
 
 #else
@@ -47,4 +47,4 @@
 
 #endif
 
-#endif // HAVE(CELESTIAL)
+#endif // HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -50,11 +50,11 @@ WEBCORE_EXPORT NSString *WebUIApplicationWillEnterForegroundNotification = @"Web
 WEBCORE_EXPORT NSString *WebUIApplicationDidBecomeActiveNotification = @"WebUIApplicationDidBecomeActiveNotification";
 WEBCORE_EXPORT NSString *WebUIApplicationDidEnterBackgroundNotification = @"WebUIApplicationDidEnterBackgroundNotification";
 
-#if HAVE(CELESTIAL)
-SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(Celestial)
-SOFT_LINK_CLASS_OPTIONAL(Celestial, AVSystemController)
-SOFT_LINK_CONSTANT_MAY_FAIL(Celestial, AVSystemController_PIDToInheritApplicationStateFrom, NSString *)
-SOFT_LINK_CONSTANT_MAY_FAIL(Celestial, AVSystemController_ServerConnectionDiedNotification, NSString *)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
+SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(MediaExperience)
+SOFT_LINK_CLASS_OPTIONAL(MediaExperience, AVSystemController)
+SOFT_LINK_CONSTANT_MAY_FAIL(MediaExperience, AVSystemController_PIDToInheritApplicationStateFrom, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL(MediaExperience, AVSystemController_ServerConnectionDiedNotification, NSString *)
 #endif
 
 using namespace WebCore;
@@ -91,7 +91,7 @@ public:
 
     void externalOutputDeviceAvailableDidChange();
     void updateCarPlayIsConnected();
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     void mediaServerConnectionDied();
 #endif
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST) && !PLATFORM(WATCHOS)
@@ -107,7 +107,7 @@ private:
     void stopMonitoringWirelessRoutesInternal() final;
 
     RetainPtr<WebMediaSessionHelper> m_objcObserver;
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     std::optional<int> m_presentedApplicationPID;
 #endif
 };
@@ -272,7 +272,7 @@ void MediaSessionHelperIOS::providePresentingApplicationPID(int pid, ShouldOverr
         return;
 #endif
 
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     if (m_presentedApplicationPID && (*m_presentedApplicationPID == pid || shouldOverride == ShouldOverride::No))
         return;
 
@@ -309,7 +309,7 @@ void MediaSessionHelperIOS::stopMonitoringWirelessRoutesInternal()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
 void MediaSessionHelperIOS::mediaServerConnectionDied()
 {
     if (m_presentedApplicationPID) {
@@ -319,7 +319,7 @@ void MediaSessionHelperIOS::mediaServerConnectionDied()
         });
     }
 }
-#endif // HAVE(CELESTIAL)
+#endif // HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
 
 void MediaSessionHelperIOS::updateCarPlayIsConnected()
 {
@@ -388,7 +388,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     [center addObserver:self selector:@selector(activeOutputDeviceDidChange:) name:PAL::get_AVFoundation_AVAudioSessionRouteChangeNotification() object:nil];
     [center addObserver:self selector:@selector(spatialPlaybackCapabilitiesChanged:) name:PAL::get_AVFoundation_AVAudioSessionSpatialPlaybackCapabilitiesChangedNotification() object:nil];
 
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     if (canLoadAVSystemController_ServerConnectionDiedNotification())
         [center addObserver:self selector:@selector(mediaServerConnectionDied:) name:getAVSystemController_ServerConnectionDiedNotification() object:nil];
 #endif
@@ -549,7 +549,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     });
 }
 
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
 - (void)mediaServerConnectionDied:(NSNotification *)notification
 {
     LOG(Media, "-[WebMediaSessionHelper mediaServerConnectionDied:]");
@@ -559,7 +559,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
             callback->mediaServerConnectionDied();
     });
 }
-#endif // HAVE(CELESTIAL)
+#endif // HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
 
 - (void)activeOutputDeviceDidChange:(NSNotification *)notification
 {

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -116,7 +116,7 @@ void MediaSessionManageriOS::configureWirelessTargetMonitoring()
 
 void MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary()
 {
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     if (m_havePresentedApplicationPID)
         return;
     m_havePresentedApplicationPID = true;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -164,15 +164,15 @@ SOFT_LINK_OPTIONAL(MediaToolbox, MTEnableCaption2015Behavior, Boolean, (), ())
 
 #if PLATFORM(IOS_FAMILY)
 
-#if HAVE(CELESTIAL)
-SOFT_LINK_PRIVATE_FRAMEWORK(Celestial)
-SOFT_LINK_CONSTANT(Celestial, AVController_RouteDescriptionKey_RouteCurrentlyPicked, NSString *)
-SOFT_LINK_CONSTANT(Celestial, AVController_RouteDescriptionKey_RouteName, NSString *)
-SOFT_LINK_CONSTANT(Celestial, AVController_RouteDescriptionKey_AVAudioRouteName, NSString *)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
+SOFT_LINK_PRIVATE_FRAMEWORK(MediaExperience)
+SOFT_LINK_CONSTANT(MediaExperience, AVController_RouteDescriptionKey_RouteCurrentlyPicked, NSString *)
+SOFT_LINK_CONSTANT(MediaExperience, AVController_RouteDescriptionKey_RouteName, NSString *)
+SOFT_LINK_CONSTANT(MediaExperience, AVController_RouteDescriptionKey_AVAudioRouteName, NSString *)
 #define AVController_RouteDescriptionKey_RouteCurrentlyPicked getAVController_RouteDescriptionKey_RouteCurrentlyPicked()
 #define AVController_RouteDescriptionKey_RouteName getAVController_RouteDescriptionKey_RouteName()
 #define AVController_RouteDescriptionKey_AVAudioRouteName getAVController_RouteDescriptionKey_AVAudioRouteName()
-#endif // HAVE(CELESTIAL)
+#endif // HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
 
 #endif // PLATFORM(IOS_FAMILY)
 
@@ -3340,7 +3340,7 @@ MediaPlayer::WirelessPlaybackTargetType MediaPlayerPrivateAVFoundationObjC::wire
 #if PLATFORM(IOS_FAMILY)
 static NSString *exernalDeviceDisplayNameForPlayer(AVPlayer *player)
 {
-#if HAVE(CELESTIAL)
+#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     if (!PAL::isAVFoundationFrameworkAvailable())
         return nil;
 


### PR DESCRIPTION
#### 31f3194b191e140da29bb8edd76807fc5046a745
<pre>
WebKit needs to link to MediaExperience for AVSystemController, which lives there now
<a href="https://rdar.apple.com/134522027">rdar://134522027</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279694">https://bugs.webkit.org/show_bug.cgi?id=279694</a>

Reviewed by Eric Carlson and Jer Noble.

Explanation of why this fixes the bug:

These SPIs have moved (more than two years ago) and will be removed from their old location.  The change is a search-replace of Celestial with MediaExperience (private framework name) and from HAVE(CELESTIAL) to HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER).

* Source/WebCore/PAL/pal/spi/ios/CelestialSPI.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelperIOS::providePresentingApplicationPID):
(-[WebMediaSessionHelper initWithCallback:]):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::exernalDeviceDisplayNameForPlayer):

Canonical link: <a href="https://commits.webkit.org/284313@main">https://commits.webkit.org/284313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2900ba6a10beed8070670682b3a71fcee944ed3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54947 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13400 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35421 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16997 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15321 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4076 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44204 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->