### PR TITLE
Implement sidebarAction/sidePanel open/close/toggle API methods.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -312,7 +312,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 - (BOOL)_hasSidebar
 {
-    return _webExtension->hasSidebar();
+    return _webExtension->hasAnySidebar();
 }
 #else // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 - (BOOL)_hasSidebar

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1009,9 +1009,19 @@ void WebExtension::populateActionPropertiesIfNeeded()
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-bool WebExtension::hasSidebar()
+bool WebExtension::hasSidebarAction()
 {
-    return objectForKey<NSDictionary>(m_manifest, sidebarActionManifestKey) || hasRequestedPermission(WKWebExtensionPermissionSidePanel);
+    return objectForKey<NSDictionary>(m_manifest, sidebarActionManifestKey);
+}
+
+bool WebExtension::hasSidePanel()
+{
+    return hasRequestedPermission(WKWebExtensionPermissionSidePanel);
+}
+
+bool WebExtension::hasAnySidebar()
+{
+    return hasSidebarAction() || hasSidePanel();
 }
 
 CocoaImage *WebExtension::sidebarIcon(CGSize idealSize)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2755,7 +2755,7 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getSidebar(WebExten
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(WebExtensionWindow& window)
 {
-    if (!extension().hasSidebar())
+    if (!extension().hasAnySidebar())
         return std::nullopt;
 
     return m_sidebarWindowMap.ensure(window, [&] {
@@ -2765,7 +2765,7 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(WebExtensionTab& tab)
 {
-    if (!extension().hasSidebar())
+    if (!extension().hasAnySidebar())
         return std::nullopt;
 
     return m_sidebarTabMap.ensure(tab, [&] {
@@ -2775,7 +2775,7 @@ std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(
 
 RefPtr<WebExtensionSidebar> WebExtensionContext::getOrCreateSidebar(RefPtr<WebExtensionTab> tab)
 {
-    if (!extension().hasSidebar())
+    if (!extension().hasAnySidebar())
         return nil;
     if (!tab)
         return &defaultSidebar();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
@@ -373,32 +373,6 @@ void WebExtensionSidebar::setEnabled(bool enabled)
     propertiesDidChange();
 }
 
-bool WebExtensionSidebar::canProgrammaticallyOpenSidebar() const
-{
-    return extensionContext().transform([](auto const& context) -> bool { return !!context.get().extensionController(); })
-        .value_or(false);
-
-    // FIXME: <https://webkit.org/b/277575> also check that the controller delegate responds to whatever selector we use for this
-}
-
-void WebExtensionSidebar::openSidebarWhenReady()
-{
-    // FIXME: <https://webkit.org/b/277575> implement openSidebarWhenReady
-}
-
-bool WebExtensionSidebar::canProgrammaticallyCloseSidebar() const
-{
-    return extensionContext().transform([](auto const& context) -> bool { return !!context.get().extensionController(); })
-        .value_or(false);
-
-    // FIXME: <https://webkit.org/b/277575> also check that the controller delegate responds to whatever selector we use for this
-}
-
-void WebExtensionSidebar::closeSidebarWhenReady()
-{
-    // FIXME: <https://webkit.org/b/277575> implement closeSidebarWhenReady
-}
-
 String WebExtensionSidebar::sidebarPath() const
 {
     return m_sidebarPathOverride

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -243,7 +243,9 @@ public:
     bool hasPageAction();
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-    bool hasSidebar();
+    bool hasSidebarAction();
+    bool hasSidePanel();
+    bool hasAnySidebar();
     CocoaImage *sidebarIcon(CGSize idealSize);
     NSString *sidebarDocumentPath();
     NSString *sidebarTitle();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -458,8 +458,10 @@ public:
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionWindow&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionTab&);
     RefPtr<WebExtensionSidebar> getOrCreateSidebar(RefPtr<WebExtensionTab>);
-    void openSidebarForTab(WebExtensionTab&);
-    void closeSidebarForTab(WebExtensionTab&);
+    void openSidebar(WebExtensionSidebar&);
+    void closeSidebar(WebExtensionSidebar&);
+    bool canProgrammaticallyOpenSidebar();
+    bool canProgrammaticallyCloseSidebar();
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     const CommandsVector& commands();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -94,11 +94,6 @@ public:
 
     bool isOpen() const { return m_isOpen; }
     bool opensSidebar() { return !sidebarPath().isEmpty(); };
-    bool canProgrammaticallyOpenSidebar() const;
-    void openSidebarWhenReady();
-
-    bool canProgrammaticallyCloseSidebar() const;
-    void closeSidebarWhenReady();
 
     /// `sidebarPath()` will return the overriden path of this sidebar, or the path of the first parent sidebar in which the path is set
     String sidebarPath() const;
@@ -146,8 +141,6 @@ private:
     const std::optional<WeakPtr<WebExtensionWindow>> m_window;
 
     bool m_isOpen { false };
-    bool m_opensSidebarWhenReady { false };
-    bool m_sidebarOpened { false };
     const IsDefault m_isDefault { IsDefault::No };
 
     RetainPtr<WKWebView> m_webView;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -105,6 +105,11 @@ static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<Web
 
 void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callback , NSString **outExceptionString)
 {
+    if (!WebCore::UserGestureIndicator::processingUserGesture()) {
+        *outExceptionString = toErrorString(nil, nil, @"it must be called during a user gesture");
+        return;
+    }
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarOpen(std::nullopt, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
@@ -117,6 +122,11 @@ void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callb
 
 void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
+    if (!WebCore::UserGestureIndicator::processingUserGesture()) {
+        *outExceptionString = toErrorString(nil, nil, @"it must be called during a user gesture");
+        return;
+    }
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarClose(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
@@ -129,6 +139,11 @@ void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& call
 
 void WebExtensionAPISidebarAction::toggle(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
+    if (!WebCore::UserGestureIndicator::processingUserGesture()) {
+        *outExceptionString = toErrorString(nil, nil, @"it must be called during a user gesture");
+        return;
+    }
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarToggle(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
@@ -149,7 +164,7 @@ void WebExtensionAPISidebarAction::isOpen(NSDictionary *details, Ref<WebExtensio
     }
 
     std::optional<WebExtensionWindowIdentifier> windowId = maybeWindowId ? toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue) : std::nullopt;
-    if (!isValid(windowId)) {
+    if (windowId && !isValid(windowId)) {
         *outExceptionString = toErrorString(nil, @"details", @"'windowId' is invalid");
         return;
     }

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -42,7 +42,7 @@
 #import <WebKit/WKWebExtensionWindowConfiguration.h>
 #import <WebKit/WebKit.h>
 
-@interface TestWebExtensionsDelegate : NSObject <WKWebExtensionControllerDelegate>
+@interface TestWebExtensionsDelegate : NSObject <WKWebExtensionControllerDelegate, WKWebExtensionControllerDelegatePrivate>
 
 @property (nonatomic, copy) NSArray<id <WKWebExtensionWindow>> *(^openWindows)(WKWebExtensionContext *);
 @property (nonatomic, copy) id <WKWebExtensionWindow> (^focusedWindow)(WKWebExtensionContext *);
@@ -62,6 +62,12 @@
 @property (nonatomic, copy) void (^connectUsingMessagePort)(WKWebExtensionMessagePort *);
 
 @property (nonatomic, copy) void (^presentPopupForAction)(WKWebExtensionAction *);
+
+@property (nonatomic, copy) void (^presentSidebar)(_WKWebExtensionSidebar *);
+
+@property (nonatomic, copy) void (^closeSidebar)(_WKWebExtensionSidebar *);
+
+@property (nonatomic, copy) void (^didUpdateSidebar)(_WKWebExtensionSidebar *);
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -140,6 +140,30 @@
         completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"action.showPopup() not implemented" }]);
 }
 
+- (void)_webExtensionController:(WKWebExtensionController *)controller presentSidebar:(_WKWebExtensionSidebar *)sidebar forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    if (_presentSidebar) {
+        _presentSidebar(sidebar);
+        completionHandler(nil);
+    } else
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"sidebarAction.open() / sidePanel.open() not implemented" }]);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller closeSidebar:(_WKWebExtensionSidebar *)sidebar forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    if (_closeSidebar) {
+        _closeSidebar(sidebar);
+        completionHandler(nil);
+    } else
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"sidebarAction.close() not implemented" }]);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller didUpdateSidebar:(_WKWebExtensionSidebar *)sidebar forExtensionContext:(WKWebExtensionContext *)context
+{
+    if (_didUpdateSidebar)
+        _didUpdateSidebar(sidebar);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### be5aff9f77c6050e47b364c7d2db9fa73d197df4
<pre>
Implement sidebarAction/sidePanel open/close/toggle API methods.
<a href="https://webkit.org/b/279684">https://webkit.org/b/279684</a>
<a href="https://rdar.apple.com/135894111">rdar://135894111</a>

Reviewed by Timothy Hatcher.

This PR fills in the implementation of the `sidebarAction.open()`,
`sidebarAction.close()`, `sidebarAction.toggle()`, and
`sidePanel.open()` APIs. It also fixes a bug in the implementation
of `sidebarAction.isOpen`. Finally, this PR also adds a reasonably
comprehensive set of unit tests that exercise the behavior of these
API methods.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension _hasSidebar]): Replace WebExtension::hasSidebar with
WebExtension::hasAnySidebar
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::toExpected): Replace call to toWebExtensionError with
makeUnexpected
(WebKit::getSidebarWithIdentifiers): Replace calls to
toWebExtensionError with makeUnexpected
(WebKit::getOrCreateSidebarWithIdentifiers): Replace calls to
toWebExtensionError with makeUnexpected
(WebKit::scopedAPINameFor): Add helper method to create full API name
for methods which service both sidebarAction and sidePanel
(WebKit::WebExtensionContext::openSidebar): Replaced openSidebarForTab
with openSidebar (allows for less-convoluted code in other locations).
Removed call to fireActionClickEventIfNeeded, added call to delegate to
actually open sidebar.
(WebKit::WebExtensionContext::closeSidebar): Replaced closeSidebarForTab
with closeSidebar, added call to delegate to actually close sidebar.
(WebKit::WebExtensionContext::canProgrammaticallyOpenSidebar): Moved
this method to WebExtensionContext rather than WebExtensionSidebar,
added implementation.
(WebKit::WebExtensionContext::canProgrammaticallyCloseSidebar): Moved
this method to WebExtensionContext rather than WebExtensionSidebar,
added implementation.
(WebKit::WebExtensionContext::sidebarOpen): Simplified implementation
based on other changes in this PR, added condition that relevant tab
must have active user gesture to programmatically open sidebar.
(WebKit::WebExtensionContext::sidebarClose): Cleaned up implementation,
added condition that relevant tab must have active user gesture to
programmatically close sidebar.
(WebKit::WebExtensionContext::sidebarIsOpen): Removed code which checks
if window-specific sidebar is open (window-specific objects should never
directly be open).
(WebKit::WebExtensionContext::sidebarToggle): Fixed minor issues in
implementation, cleaned up implementation.
(WebKit::WebExtensionContext::sidebarGetTitle): Add API name to error
message
(WebKit::WebExtensionContext::sidebarSetTitle): Add API name to error
message
(WebKit::WebExtensionContext::sidebarGetOptions): Add API name to error
message
(WebKit::WebExtensionContext::sidebarSetOptions): Add API name to error
message
(WebKit::WebExtensionContext::openSidebarForTab): Deleted (renamed to
openSidebar).
(WebKit::WebExtensionContext::closeSidebarForTab): Deleted (renamed to
closeSidebar).
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::hasSidebarAction): Helper method to check whether
this extension uses sidebarAction
(WebKit::WebExtension::hasSidePanel): Helper method to check whether
this extension uses sidePanel
(WebKit::WebExtension::hasAnySidebar): Helper method to check whether
this extension uses sidebarAction or sidePanel
(WebKit::WebExtension::hasSidebar): Deleted (replaced with
hasAnySidebar).
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getOrCreateSidebar): Replace calls to
WebExtension::hasSidebar with WebExtension::hasAnySidebar
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(WebKit::WebExtensionSidebar::canProgrammaticallyOpenSidebar const): Deleted
(moved to WebExtensionContext).
(WebKit::WebExtensionSidebar::openSidebarWhenReady): Deleted.
(WebKit::WebExtensionSidebar::canProgrammaticallyCloseSidebar const): Deleted
(moved to WebExtensionContext).
(WebKit::WebExtensionSidebar::closeSidebarWhenReady): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.h: Add declarations of
  hasSidebarAction, hasSidePanel, hasAnySidebar; remove declaration of
  hasSidebar
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Removed
  declarations of openSidebarForTab and closeSidebarForTab, added
declarations of openSidebar, closeSidebar,
canProgrammaticallyOpenSidebar, and canProgrammaticallyCloseSidebar
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Removed
  declarations of canProgrammaticallyOpenSidebar, openSidebarWhenReady,
canProgrammaticallyCloseSidebar, and closeSidebarWhenReady.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::parseWindowIdentifier): Fix bug (accidentally typo&apos;d tabIdKey
rather than windowIdKey).
(WebKit::WebExtensionAPISidePanel::open): Add user gesture check
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::WebExtensionAPISidebarAction::open): Add user gesture check
(WebKit::WebExtensionAPISidebarAction::close): Add user gesture check
(WebKit::WebExtensionAPISidebarAction::toggle): Add user gesture check
(WebKit::WebExtensionAPISidebarAction::isOpen): Only return error for
invalid window ID if windowId has a value AND isValid(windowId) also
fails, rather than just if isValid(windowId) fails
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm: Add
  import for _WKWebExtensionSidebar.h, add default path to
sidePanelManifest global
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionClearTabPanel)): Renamed old test to fix typo
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenFailsWithoutUserGesture)):
Added test ensuring that sidebarAction.open() fails if the current tab
has no user gesture.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseFailsWithoutUserGesture)):
Added test ensuring that sidebarAction.close() fails if the current tab
has no user gesture.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionToggleFailsWithoutUserGesture)):
Added test ensuring that sidebarAction.toggle() fails if the current tab
has no user gesture.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)):
Added test ensuring that sidebarAction.open() succeeds if the current
tab has a user gesture. Also ensures that the relevant delegate method
is called correctly.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)):
Added test ensuring that sidebarAction.close() succeeds if the current
tab has a user gesture. Also ensures that the relevant delegate method
is called correctly.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionToggleSucceedsWithUserGesture)):
Added test ensuring that sidebarAction.toggle() succeeds if the current
tab has a user gesture. Also ensures that the relevant delegate method
is called correctly.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabFailsWithoutUserGesture)):
Added test ensuring that sidePanel.open({ tabId: ... }) fails if the
current tab has no user gesture.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowFailsWithoutUserGesture)):
Added test ensuring that sidePanel.open({ windowId: ... }) fails if the
current tab has no user gesture.
(TestWebKitAPI::TEST_F(WKWebExtnsionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)):
Added test ensuring that sidePanel.open({ tabId: ... }) succeeds if the
current tab has a user gesture. Also ensures that the relevant delegate
method is called correctly.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)):
Added test ensuring that sidePanel.open({ windowId: ... }) succeeds if
the current tab has a user gesture. Also ensures that the relevant
delegate method is called correctly, and that the sidebar is opened in
the correct window.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarAcionClearTabPanel)): Deleted (renamed to SidebarActionClearTabPanel).
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h: Added
  presentSidebar, closeSidebar, and didUpdateSidebar callback
properties.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:presentSidebar:forExtensionContext:completionHandler:]):
Added.
(-[TestWebExtensionsDelegate _webExtensionController:closeSidebar:forExtensionContext:completionHandler:]):
Added.
(-[TestWebExtensionsDelegate _webExtensionController:didUpdateSidebar:forExtensionContext:]):
Added.

Canonical link: <a href="https://commits.webkit.org/283934@main">https://commits.webkit.org/283934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b995be748702ecd4949a69726a8b3a1b060a279f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71697 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54159 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17142 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73395 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11606 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61655 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3090 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42828 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->