### PR TITLE
[scroll-animations] Implement ViewTimeline.startOffset and ViewTimeline.endOffset

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -1,11 +1,14 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View timeline with px based inset. Test timed out
-NOTRUN View timeline with percent based inset.
-NOTRUN view timeline with inset auto.
-NOTRUN view timeline with font relative inset.
-NOTRUN view timeline with viewport relative insets.
-NOTRUN view timeline inset as string
-NOTRUN view timeline with invalid inset
+FAIL View timeline with px based inset. assert_equals: Effect at the start of the active phase: 0px 0px expected "0.3" but got "1"
+FAIL View timeline with percent based inset. assert_equals: Effect at the start of the active phase: 0% 0% expected "0.3" but got "1"
+FAIL view timeline with inset auto. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL view timeline with font relative inset. assert_equals: Effect at the start of the active phase: 1em 2em expected "0.3" but got "1"
+FAIL view timeline with viewport relative insets. assert_equals: Effect at the start of the active phase: 10vw 20vw expected "0.3" but got "1"
+FAIL view timeline inset as string assert_equals: Effect at the start of the active phase: 10px expected "0.3" but got "1"
+FAIL view timeline with invalid inset assert_throws_js: function "() => {
+    new ViewTimeline({
+      subject: target,
+      inset: [ CSS.rad(1) ]
+    });
+  }" did not throw
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -78,8 +78,6 @@ Ref<ViewTimeline> ViewTimeline::createFromCSSValue(Style::BuilderState& builderS
 ViewTimeline::ViewTimeline(ViewTimelineOptions&& options)
     : ScrollTimeline(nullAtom(), options.axis)
     , m_subject(WTFMove(options.subject))
-    , m_startOffset(CSSNumericFactory::px(0))
-    , m_endOffset(CSSNumericFactory::px(0))
 {
     if (m_subject)
         m_subject->protectedDocument()->ensureTimelinesController().addTimeline(*this);
@@ -87,8 +85,6 @@ ViewTimeline::ViewTimeline(ViewTimelineOptions&& options)
 
 ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, ViewTimelineInsets&& insets)
     : ScrollTimeline(name, axis)
-    , m_startOffset(CSSNumericFactory::px(0))
-    , m_endOffset(CSSNumericFactory::px(0))
     , m_insets(WTFMove(insets))
 {
 }
@@ -201,6 +197,18 @@ ViewTimeline::Data ViewTimeline::computeViewTimelineData() const
     auto coverRangeEnd = coverRangeStart + subjectSize;
 
     return { scrollContainerSize, subjectOffset, currentScrollOffset, coverRangeEnd };
+}
+
+const CSSNumericValue& ViewTimeline::startOffset() const
+{
+    auto data = computeViewTimelineData();
+    return CSSNumericFactory::px(data.subjectOffset - data.scrollContainerSize);
+}
+
+const CSSNumericValue& ViewTimeline::endOffset() const
+{
+    auto data = computeViewTimelineData();
+    return CSSNumericFactory::px(data.subjectOffset + data.coverRangeEnd - data.scrollContainerSize);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -53,8 +53,8 @@ public:
     static Ref<ViewTimeline> createFromCSSValue(Style::BuilderState&, const CSSViewValue&);
 
     Element* subject() const { return m_subject.get(); }
-    const CSSNumericValue& startOffset() const { return m_startOffset.get(); }
-    const CSSNumericValue& endOffset() const { return m_endOffset.get(); }
+    const CSSNumericValue& startOffset() const;
+    const CSSNumericValue& endOffset() const;
     const ViewTimelineInsets& insets() const { return m_insets; }
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
     AnimationTimelinesController* controller() const override;
@@ -79,8 +79,6 @@ private:
     bool isViewTimeline() const final { return true; }
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
-    Ref<CSSNumericValue> m_startOffset;
-    Ref<CSSNumericValue> m_endOffset;
     ViewTimelineInsets m_insets;
 };
 


### PR DESCRIPTION
#### 96d15b96074ad433884dddc77485ecae09b734b5
<pre>
[scroll-animations] Implement ViewTimeline.startOffset and ViewTimeline.endOffset
<a href="https://bugs.webkit.org/show_bug.cgi?id=279700">https://bugs.webkit.org/show_bug.cgi?id=279700</a>
<a href="https://rdar.apple.com/135984017">rdar://135984017</a>

Reviewed by Antoine Quint.

Implement ViewTimeline.startOffset and ViewTimeline.endOffset.

* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::ViewTimeline):
(WebCore::ViewTimeline::sourceRenderer const):
(WebCore::ViewTimeline::computeViewTimelineData const):
(WebCore::ViewTimeline::startOffset const):
(WebCore::ViewTimeline::endOffset const):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/284241@main">https://commits.webkit.org/284241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00b8e4576d44dddfe60071d5e00ced5d6707a9df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13283 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16438 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62373 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10330 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3939 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10498 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44003 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->