### PR TITLE
Fix test `overflow-repaint.html` to show repaint rects

### DIFF
--- a/LayoutTests/platform/ios/svg/in-html/overflow-repaint-expected.txt
+++ b/LayoutTests/platform/ios/svg/in-html/overflow-repaint-expected.txt
@@ -1,7 +1,7 @@
  (repaint rects
   (rect 8 108 100 100)
   (rect 8 8 100 200)
-  (rect 8 112 100 96)
+  (rect 8 113 100 95)
   (rect 8 8 100 200)
 )
 

--- a/LayoutTests/svg/in-html/overflow-repaint.html
+++ b/LayoutTests/svg/in-html/overflow-repaint.html
@@ -13,7 +13,7 @@
 		div + div { background: red; }
 	</style>
 </head>
-<body onload="runRepaintAndPixelTest()">
+<body onload="runRepaintTest()">
 	<div>
 		<svg id="svg" height="100" width="100" viewbox="0 0 100 100">
 			<rect y="100" width="100" height="100" fill="green"/>


### PR DESCRIPTION
#### c6f68efef7e9e39de77ddaa721a0b5fbd97414e2
<pre>
Fix test `overflow-repaint.html` to show repaint rects

<a href="https://bugs.webkit.org/show_bug.cgi?id=251224">https://bugs.webkit.org/show_bug.cgi?id=251224</a>
<a href="https://rdar.apple.com/104975685">rdar://104975685</a>

Reviewed by Alan Baradlay.

This patch fixes test which was relying on `runRepaintAndPixelTest`,
which is present in Blink / Chromium code only while not in WebKit.
These tests should have been modified to run in WebKit by leveraging
&apos;runRepaintTest&apos; and this patch does so, it enables us to generate
repaint rects in tests rather than do tree dumps.

* LayoutTests/svg/in-html/overflow-repaint-expected.txt:
* LayoutTests/svg/in-html/overflow-repaint.html:
* LayoutTests/platform/ios/svg/in-html/overflow-repaint-expected.txt: Platform Specific Expectation

Canonical link: <a href="https://commits.webkit.org/291860@main">https://commits.webkit.org/291860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc26b692f13fd845ab76a582e328c83ac14b3860

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44747 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71877 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29217 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85074 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52224 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44065 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101276 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80883 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80265 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14470 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->