### PR TITLE
[WIP][JSC] Don't search the FreeList when checking liveness

### DIFF
--- a/Source/JavaScriptCore/bytecode/ChainedWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/ChainedWatchpoint.h
@@ -56,10 +56,8 @@ inline void ChainedWatchpoint::install(InlineWatchpointSet& fromWatchpoint, VM&)
 
 inline void ChainedWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
-    if (!m_owner->isLive())
-        return;
-
-    m_watchpointSet.fireAll(vm, StringFireDetail("chained watchpoint is fired."));
+    if (!m_owner->isPendingDestruction())
+        m_watchpointSet.fireAll(vm, StringFireDetail("chained watchpoint is fired."));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp
@@ -36,8 +36,8 @@ void CodeBlockJettisoningWatchpoint::fireInternal(VM&, const FireDetail& detail)
     ASSERT(!m_owner->wasDestructed());
     // If CodeBlock is no longer live, we do not fire it.
     // This works since CodeBlock is the owner of this watchpoint. When it gets destroyed, then this watchpoint also gets destroyed.
-    // Only problematic case is, (1) CodeBlock is dead, but (2) destructor is not called yet. In this case, isLive() check guards correctly.
-    if (!m_owner->isLive())
+    // Only problematic case is, (1) CodeBlock is dead, but (2) destructor is not called yet.
+    if (m_owner->isPendingDestruction())
         return;
 
     if (DFG::shouldDumpDisassembly())

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
@@ -70,7 +70,7 @@ void LLIntPrototypeLoadAdaptiveStructureWatchpoint::install(VM&)
 void LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
     ASSERT(!m_owner->wasDestructed());
-    if (!m_owner->isLive())
+    if (m_owner->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
@@ -47,7 +47,7 @@ StructureStubInfoClearingWatchpoint::~StructureStubInfoClearingWatchpoint()
 void StructureStubInfoClearingWatchpoint::fireInternal(VM&, const FireDetail&)
 {
     ASSERT(!m_owner->wasDestructed());
-    if (!m_owner->isLive())
+    if (m_owner->isPendingDestruction())
         return;
 
     // This will implicitly cause my own demise: stub reset removes all watchpoints.

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
@@ -63,10 +63,10 @@ void AdaptiveInferredPropertyValueWatchpoint::handleFire(VM&, const FireDetail& 
 
 bool AdaptiveInferredPropertyValueWatchpoint::isValid() const
 {
-    return m_codeBlock->isLive();
+    ASSERT(!m_codeBlock->wasDestructed());
+    return !m_codeBlock->isPendingDestruction();
 }
 
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)
-

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
@@ -66,7 +66,7 @@ void AdaptiveStructureWatchpoint::install(VM&)
 void AdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail& detail)
 {
     ASSERT(!m_codeBlock->wasDestructed());
-    if (!m_codeBlock->isLive())
+    if (m_codeBlock->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -60,7 +60,7 @@ public:
     }
     bool isZapped() const { return !*bitwise_cast<const uint32_t*>(this); }
 
-    bool isLive();
+    bool isPendingDestruction();
 
     bool isPreciseAllocation() const;
     CellContainer cellContainer() const;

--- a/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp
@@ -49,7 +49,7 @@ void CachedSpecialPropertyAdaptiveStructureWatchpoint::install(VM&)
 
 void CachedSpecialPropertyAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
-    if (!m_structureRareData->isLive())
+    if (m_structureRareData->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
@@ -66,7 +66,7 @@ inline void ObjectAdaptiveStructureWatchpoint::install(VM&)
 
 inline void ObjectAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
-    if (!m_owner->isLive())
+    if (m_owner->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
@@ -46,7 +46,7 @@ public:
 private:
     bool isValid() const final
     {
-        return m_owner->isLive();
+        return !m_owner->isPendingDestruction();
     }
 
     void handleFire(VM& vm, const FireDetail&) final

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -264,7 +264,7 @@ CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::CachedSpecialPrope
 
 bool CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::isValid() const
 {
-    return m_structureRareData->isLive();
+    return !m_structureRareData->isPendingDestruction();
 }
 
 void CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::handleFire(VM& vm, const FireDetail&)

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -179,9 +179,8 @@ inline void StructureChainInvalidationWatchpoint::install(StructureRareData* str
 
 inline void StructureChainInvalidationWatchpoint::fireInternal(VM&, const FireDetail&)
 {
-    if (!m_structureRareData->isLive())
-        return;
-    m_structureRareData->clearCachedPropertyNameEnumerator();
+    if (!m_structureRareData->isPendingDestruction())
+        m_structureRareData->clearCachedPropertyNameEnumerator();
 }
 
 inline bool StructureRareData::tryCachePropertyNameEnumeratorViaWatchpoint(VM&, Structure* baseStructure, StructureChain* chain)


### PR DESCRIPTION
#### 15c390fa1567c3a2e7c27e274aad4b66f92f1d66
<pre>
[WIP][JSC] Don&apos;t search the FreeList when checking liveness
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/JavaScriptCore/bytecode/ChainedWatchpoint.h:
(JSC::ChainedWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp:
(JSC::CodeBlockJettisoningWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp:
(JSC::LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
(JSC::StructureStubInfoClearingWatchpoint::fireInternal):
* Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp:
(JSC::DFG::AdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/heap/HeapCell.cpp:
(JSC::HeapCell::isPendingDestruction):
(JSC::HeapCell::isLive): Deleted.
* Source/JavaScriptCore/heap/HeapCell.h:
* Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp:
(JSC::CachedSpecialPropertyAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h:
(JSC::ObjectAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/runtime/StructureRareDataInlines.h:
(JSC::StructureChainInvalidationWatchpoint::fireInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c390fa1567c3a2e7c27e274aad4b66f92f1d66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18122 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53728 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16476 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60103 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72725 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66234 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61195 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10978 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58016 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61270 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2595 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88002 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42171 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15489 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->