### PR TITLE
[SVG] Reject hit-test queries when the element has a singular transform

### DIFF
--- a/LayoutTests/fast/svg/foreign-object-offset-position.html
+++ b/LayoutTests/fast/svg/foreign-object-offset-position.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body style="margin: 0;">
-  <script src="../../resources/js-test-pre.js"></script>
+  <script src="../../resources/js-test.js"></script>
   <script src="../../resources/ui-helper.js"></script>
   <script type="text/javascript">
     function runTest() {
@@ -30,6 +30,5 @@
       </script>
     </foreignObject>
   </svg>
-  <script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/glib/svg/custom/foreignObject-crash-on-hover-expected.txt
+++ b/LayoutTests/platform/glib/svg/custom/foreignObject-crash-on-hover-expected.txt
@@ -13,4 +13,4 @@ layer at (0,0) size 800x600
           text run at (0,18) width 246: "<path d=\"M50,80 L250,80 150,280 z\""
           text run at (0,36) width 187: "style=\"fill:red; stroke:blue;\"/>"
       RenderSVGPath {path} at (99,129) size 202x203 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#FF0000]}] [data="M 50 80 L 250 80 L 150 280 Z"]
-caret: position 66 of child 3 {#text} of child 5 {foreignObject} of child 3 {g} of child 1 {svg} of document
+caret: position 12 of child 3 {#text} of child 5 {foreignObject} of child 3 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/glib/svg/text/foreignObject-repaint-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/foreignObject-repaint-expected.txt
@@ -8,4 +8,4 @@ layer at (0,0) size 800x600
           text run at (0,1) width 495: "Select this text using"
           text run at (0,62) width 482: "the mouse, it should"
           text run at (0,123) width 342: "not disappear!"
-caret: position 34 of child 0 {#text} of child 1 {div} of child 1 {foreignObject} of child 0 {svg} of document
+caret: position 7 of child 0 {#text} of child 1 {div} of child 1 {foreignObject} of child 0 {svg} of document

--- a/LayoutTests/platform/mac/svg/custom/foreignObject-crash-on-hover-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/foreignObject-crash-on-hover-expected.txt
@@ -13,4 +13,4 @@ layer at (0,0) size 800x600
           text run at (0,18) width 246: "<path d=\"M50,80 L250,80 150,280 z\""
           text run at (0,36) width 193: "style=\"fill:red; stroke:blue;\"/>"
       RenderSVGPath {path} at (99,129) size 202x203 [stroke={[type=SOLID] [color=#0000FF]}] [fill={[type=SOLID] [color=#FF0000]}] [data="M 50 80 L 250 80 L 150 280 Z"]
-caret: position 66 of child 3 {#text} of child 5 {foreignObject} of child 3 {g} of child 1 {svg} of document
+caret: position 12 of child 3 {#text} of child 5 {foreignObject} of child 3 {g} of child 1 {svg} of document

--- a/LayoutTests/platform/mac/svg/text/foreignObject-repaint-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/foreignObject-repaint-expected.txt
@@ -8,4 +8,4 @@ layer at (0,0) size 800x600
           text run at (0,0) width 490: "Select this text using"
           text run at (0,61) width 478: "the mouse, it should"
           text run at (0,122) width 339: "not disappear!"
-caret: position 34 of child 0 {#text} of child 1 {div} of child 1 {foreignObject} of child 0 {svg} of document
+caret: position 7 of child 0 {#text} of child 1 {div} of child 1 {foreignObject} of child 0 {svg} of document

--- a/LayoutTests/svg/hittest/singular-transform-1-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-1-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVG hover transform test: .a element remains non-selectable under .p:hover
+

--- a/LayoutTests/svg/hittest/singular-transform-1.html
+++ b/LayoutTests/svg/hittest/singular-transform-1.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>SVG hover transform test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+    .p .a {
+    transform: scaleX(0);
+    }
+    .p:hover .a {
+    transform: scaleX(1);
+    fill: red;
+    }
+</style>
+<svg width="400" height="100">
+    <g class="p">
+        <rect class="a" width="200" height="100" fill="blue"/>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+        // eventSender must be available to simulate hover.
+        assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+        eventSender.mouseMoveTo(150, 50);
+    
+        // Verify that .p:hover .a is not in the DOM despite hover.
+        assert_equals(
+        document.querySelector('.p:hover .a'),
+        null,
+        "document.querySelector('.p:hover .a') should be null"
+      );
+    }, "SVG hover transform test: .a element remains non-selectable under .p:hover");
+</script>

--- a/LayoutTests/svg/hittest/singular-transform-2-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVG nested hover transform test: nested .a element remains non-selectable under .p:hover
+

--- a/LayoutTests/svg/hittest/singular-transform-2.html
+++ b/LayoutTests/svg/hittest/singular-transform-2.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>SVG nested hover transform test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+    .p .a {
+    transform: scaleX(0);
+    }
+    .p:hover .a {
+    transform: scaleX(1);
+    fill: red;
+    }
+</style>
+<svg width="400" height="100">
+    <g class="p">
+        <g class="a">
+            <rect class="a" width="200" height="100" fill="blue"/>
+        </g>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+      // eventSender must be available to simulate hover.
+      assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+      eventSender.mouseMoveTo(150, 50);
+    
+      // Verify that .p:hover .a is not selectable in nested structure.
+      assert_equals(
+        document.querySelector('.p:hover .a'),
+        null,
+        "document.querySelector('.p:hover .a') should be null"
+      );
+    }, "SVG nested hover transform test: nested .a element remains non-selectable under .p:hover");
+</script>

--- a/LayoutTests/svg/hittest/singular-transform-3-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-3-expected.txt
@@ -1,0 +1,4 @@
+XX
+
+PASS SVG hover transform text test: <text> element remains non-selectable under .p:hover
+

--- a/LayoutTests/svg/hittest/singular-transform-3.html
+++ b/LayoutTests/svg/hittest/singular-transform-3.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>SVG hover transform text test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+    .p .a {
+    transform: scaleX(0);
+    }
+    .p:hover .a {
+    transform: scaleX(1);
+    fill: red;
+    }
+</style>
+<svg width="400" height="100">
+    <g class="p">
+        <text class="a" y="80" font-size="100" font-family="Ahem">XX</text>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+      // eventSender must be available to simulate hover.
+      assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+      eventSender.mouseMoveTo(150, 50);
+    
+      // Verify that .p:hover .a is not selectable for <text> element.
+      assert_equals(
+        document.querySelector('.p:hover .a'),
+        null,
+        "document.querySelector('.p:hover .a') should be null"
+      );
+    }, "SVG hover transform text test: <text> element remains non-selectable under .p:hover");
+</script>

--- a/LayoutTests/svg/hittest/singular-transform-4-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-4-expected.txt
@@ -1,0 +1,4 @@
+XX
+
+PASS SVG hover transform text test: <text> element remains non-selectable under .p:hover
+

--- a/LayoutTests/svg/hittest/singular-transform-4.html
+++ b/LayoutTests/svg/hittest/singular-transform-4.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>SVG hover transform text test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+    .p .a {
+    transform: scaleX(0);
+    }
+    .p:hover .a {
+    transform: scaleX(1);
+    fill: red;
+    }
+</style>
+<svg width="400" height="100">
+    <g class="p">
+        <text class="a" y="80" font-size="100" font-family="Ahem">XX</text>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+      // eventSender must be available to simulate hover.
+      assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+      eventSender.mouseMoveTo(150, 50);
+    
+      // Verify that .p:hover .a is not selectable for <text> element.
+      assert_equals(
+        document.querySelector('.p:hover .a'),
+        null,
+        "document.querySelector('.p:hover .a') should be null"
+      );
+    }, "SVG hover transform text test: <text> element remains non-selectable under .p:hover");
+</script>

--- a/LayoutTests/svg/hittest/singular-transform-5-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-5-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVG hover transform image test: <image> element remains non-selectable under .p:hover
+

--- a/LayoutTests/svg/hittest/singular-transform-5.html
+++ b/LayoutTests/svg/hittest/singular-transform-5.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>SVG hover transform image test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+    .p .a {
+    transform: scaleX(0);
+    }
+    .p:hover .a {
+    transform: scaleX(1);
+    fill: red;
+    }
+</style>
+<svg width="400" height="100">
+    <g class="p">
+        <image class="a" width="200" height="100" preserveAspectRatio="none"
+            xlink:href="../custom/resources/red-checker.png"></image>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+      // eventSender must be available to simulate hover.
+      assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+      eventSender.mouseMoveTo(150, 50);
+    
+      // Verify that .p:hover .a is not selectable for <image> element.
+      assert_equals(
+        document.querySelector('.p:hover .a'),
+        null,
+        "document.querySelector('.p:hover .a') should be null"
+      );
+    }, "SVG hover transform image test: <image> element remains non-selectable under .p:hover");
+</script>

--- a/LayoutTests/svg/hittest/singular-transform-6-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-6-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVG hover transform viewBox test: <rect> element becomes selectable under .p:hover with zero viewBox
+

--- a/LayoutTests/svg/hittest/singular-transform-6.html
+++ b/LayoutTests/svg/hittest/singular-transform-6.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>SVG hover transform viewBox test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+</style>
+<svg width="400" height="100" viewBox="0 0 0 0">
+    <g class="p">
+        <rect class="a" width="200" height="100"/>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+      // eventSender must be available to simulate hover.
+      assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+      eventSender.mouseMoveTo(150, 50);
+    
+      // Verify that .p:hover .a is selectable when viewBox is zero-sized.
+      const elem = document.querySelector('.p:hover .a');
+      assert_not_equals(
+        elem,
+        null,
+        "document.querySelector('.p:hover .a') should not be null"
+      );
+      assert_true(
+        elem instanceof SVGRectElement,
+        "Selected element should be an SVGRectElement"
+      );
+    }, "SVG hover transform viewBox test: <rect> element becomes selectable under .p:hover with zero viewBox");
+</script>

--- a/LayoutTests/svg/hittest/singular-transform-7-expected.txt
+++ b/LayoutTests/svg/hittest/singular-transform-7-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVG hover transform foreignObject test: nested <rect> inside <foreignObject> remains non-selectable under .p:hover
+

--- a/LayoutTests/svg/hittest/singular-transform-7.html
+++ b/LayoutTests/svg/hittest/singular-transform-7.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>SVG hover transform foreignObject test</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    body { margin: 0; }
+    .p .a {
+    transform: scaleX(0);
+    }
+    .p:hover .a {
+    transform: scaleX(1);
+    fill: red;
+    }
+</style>
+<svg width="400" height="100">
+    <g class="p">
+        <foreignObject transform="scale(0)" width="200" height="100">
+            <svg>
+                <rect class="a" width="200" height="100"/>
+            </svg>
+        </foreignObject>
+        <rect class="b" width="100" height="100" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+      // eventSender must be available to simulate hover.
+      assert_true(
+        'eventSender' in window,
+        'eventSender should exist for hover simulation'
+      );
+      eventSender.mouseMoveTo(150, 50);
+    
+      // Verify that .p:hover .a is not selectable inside a scaled foreignObject.
+      assert_equals(
+        document.querySelector('.p:hover .a'),
+        null,
+        "document.querySelector('.p:hover .a') should be null"
+      );
+    }, "SVG hover transform foreignObject test: nested <rect> inside <foreignObject> remains non-selectable under .p:hover");
+</script>

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -668,8 +668,8 @@ bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResul
 
             SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-            FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
-            if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
+            FloatPoint localPoint;
+            if (!SVGRenderSupport::transformToUserSpaceAndCheckClipping(*this, localToParentTransform(), pointInParent, localPoint))
                 return false;
 
             HitTestLocation hitTestLocation(LayoutPoint(flooredIntPoint(localPoint)));

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -470,6 +470,14 @@ bool SVGRenderSupport::pointInClippingArea(const RenderElement& renderer, const 
     return true;
 }
 
+bool SVGRenderSupport::transformToUserSpaceAndCheckClipping(RenderElement& object, const AffineTransform& localTransform, const FloatPoint& pointInParent, FloatPoint& localPoint)
+{
+    if (!localTransform.isInvertible())
+        return false;
+    localPoint = localTransform.inverse()->mapPoint(pointInParent);
+    return pointInClippingArea(object, localPoint);
+}
+
 void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const RenderStyle& style, const RenderElement& renderer)
 {
     auto element = dynamicDowncast<SVGElement>(renderer.protectedElement());

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -62,6 +62,11 @@ public:
     // Determines whether the passed point lies in a clipping area
     static bool pointInClippingArea(const RenderElement&, const FloatPoint&);
 
+    // Transform 'pointInParent' to object's user-space and check if it is
+    // within the clipping area. Returns false if the transform is singular or
+    // the point is outside the clipping area.
+    static bool transformToUserSpaceAndCheckClipping(RenderElement&, const AffineTransform& localTransform, const FloatPoint& pointInParent, FloatPoint& localPoint);
+
     struct ContainerBoundingBoxes {
         Markable<FloatRect> objectBoundingBox;
         FloatRect repaintBoundingBox;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -234,8 +234,8 @@ bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, H
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-    FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
-    if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
+    FloatPoint localPoint;
+    if (!SVGRenderSupport::transformToUserSpaceAndCheckClipping(*this, localToParentTransform(), pointInParent, localPoint))
         return false;
 
     for (RenderObject* child = lastChild(); child; child = child->previousSibling()) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -174,7 +174,9 @@ bool LegacyRenderSVGForeignObject::nodeAtFloatPoint(const HitTestRequest& reques
     if (hitTestAction != HitTestForeground)
         return false;
 
-    FloatPoint localPoint = valueOrDefault(localTransform().inverse()).mapPoint(pointInParent);
+    FloatPoint localPoint;
+    if (!SVGRenderSupport::transformToUserSpaceAndCheckClipping(*this, localToParentTransform(), pointInParent, localPoint))
+        return false;
 
     // Early exit if local point is not contained in clipped viewport area
     if (SVGRenderSupport::isOverflowHidden(*this) && !m_viewport.contains(localPoint))

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -250,8 +250,8 @@ bool LegacyRenderSVGImage::nodeAtFloatPoint(const HitTestRequest& request, HitTe
 
         SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-        FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
-        if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
+        FloatPoint localPoint;
+        if (!SVGRenderSupport::transformToUserSpaceAndCheckClipping(*this, localToParentTransform(), pointInParent, localPoint))
             return false;
 
         if (hitRules.canHitFill) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -331,7 +331,11 @@ bool LegacyRenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectB
         point = valueOrDefault(transform.inverse()).mapPoint(point);
     }
 
-    point = valueOrDefault(clipPathElement().animatedLocalTransform().inverse()).mapPoint(point);
+    AffineTransform animatedLocalTransform = clipPathElement().animatedLocalTransform();
+    if (!animatedLocalTransform.isInvertible())
+        return false;
+
+    point = animatedLocalTransform.inverse()->mapPoint(point);
 
     for (Node* childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
         RenderObject* renderer = childNode->renderer();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -513,7 +513,9 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
     // Test SVG content if the point is in our content box or it is inside the visualOverflowRect and the overflow is visible.
     // FIXME: This should be an intersection when rect-based hit tests are supported by nodeAtFloatPoint.
     if (contentBoxRect().contains(pointInBorderBox) || (!shouldApplyViewportClip() && visualOverflowRect().contains(pointInParent))) {
-        FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(FloatPoint(pointInParent));
+        FloatPoint localPoint;
+        if (!SVGRenderSupport::transformToUserSpaceAndCheckClipping(*this, localToParentTransform(), pointInParent, localPoint))
+        return false;
 
         for (RenderObject* child = lastChild(); child; child = child->previousSibling()) {
             // FIXME: nodeAtFloatPoint() doesn't handle rect-based hit tests yet.

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -348,9 +348,8 @@ bool LegacyRenderSVGShape::nodeAtFloatPoint(const HitTestRequest& request, HitTe
     if (recursionTracking.isVisiting(*this))
         return false;
 
-    FloatPoint localPoint = valueOrDefault(m_localTransform.inverse()).mapPoint(pointInParent);
-
-    if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
+    FloatPoint localPoint;
+    if (!SVGRenderSupport::transformToUserSpaceAndCheckClipping(*this, localToParentTransform(), pointInParent, localPoint))
         return false;
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);


### PR DESCRIPTION
#### 13651f15a8d8df4391331086d5947dfabc17650a
<pre>
[SVG] Reject hit-test queries when the element has a singular transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=279706">https://bugs.webkit.org/show_bug.cgi?id=279706</a>
<a href="https://rdar.apple.com/135993456">rdar://135993456</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/99bd9dada6909a94a7e725bc42f7e6c98ce756dd">https://source.chromium.org/chromium/chromium/src/+/99bd9dada6909a94a7e725bc42f7e6c98ce756dd</a>

When an SVG element was affected by a transform that was singular,
AffineTransform::inverse() would return the identity transform, and the
query point would not actually be transformed to the local user-space.

Make sure all calls to said method is guarded by a check to
AffineTransform::isInvertible(), and fail the hit-test if it returns false.
Add a new SVGRenderSupport-helper that does the point-transformation and
checks against the clipping area, since this is a recurring pattern in
various implementations of RenderSVG*::nodeAtFloatPoint.

RenderSVGRoot has the logic added, but still does not reject queries. This
is due to special-case handling of empty viewBoxes in
SVGFitToViewBox::viewBoxToViewTransform.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::transformToUserSpaceAndCheckClipping):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::hitTestClipContent):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::nodeAtPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::nodeAtFloatPoint):
* LayoutTests/svg/hittest/singular-transform-1-expected.txt:
* LayoutTests/svg/hittest/singular-transform-1.html:
* LayoutTests/svg/hittest/singular-transform-2-expected.txt:
* LayoutTests/svg/hittest/singular-transform-2.html:
* LayoutTests/svg/hittest/singular-transform-3-expected.txt:
* LayoutTests/svg/hittest/singular-transform-3.html:
* LayoutTests/svg/hittest/singular-transform-4-expected.txt:
* LayoutTests/svg/hittest/singular-transform-4.html:
* LayoutTests/svg/hittest/singular-transform-5-expected.txt:
* LayoutTests/svg/hittest/singular-transform-5.html:
* LayoutTests/svg/hittest/singular-transform-6.html:
* LayoutTests/svg/hittest/singular-transform-6-expected.txt:
* LayoutTests/svg/hittest/singular-transform-7-expected.txt:
* LayoutTests/svg/hittest/singular-transform-7.html:
* LayoutTests/platform/glib/svg/text/foreignObject-repaint-expected.txt: Rebaselined
* LayoutTests/platform/mac/svg/text/foreignObject-repaint-expected.txt: Rebaselined
* LayoutTests/fast/svg/foreign-object-offset-position.html: Rebaselined
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13651f15a8d8df4391331086d5947dfabc17650a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38596 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83909 "Found 2 new test failures: fast/svg/foreign-object-offset-position.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113298 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24485 "Found 2 new test failures: fast/svg/foreign-object-offset-position.html svg/hittest/singular-transform-6.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64351 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23846 "Exiting early after 10 failures. 69 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17504 "Found 1 new test failure: fast/svg/foreign-object-offset-position.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93866 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17561 "Found 2 new test failures: fast/svg/foreign-object-offset-position.html imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119164 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37390 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27733 "Found 1 new test failure: fast/svg/foreign-object-offset-position.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92876 "Found 1 new test failure: fast/svg/foreign-object-offset-position.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37763 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95634 "Exiting early after 10 failures. 1410 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92699 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37700 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15431 "Found 1 new test failure: fast/svg/foreign-object-offset-position.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33301 "Hash 13651f15 for PR 33657 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42756 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->