### PR TITLE
Add environment variable to disable WebGL ownership attribution

### DIFF
--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -31,6 +31,17 @@
 
 namespace WebCore {
 
+bool isMemoryAttributionDisabled()
+{
+    static bool result = []() {
+        const char* value = getenv("WEBKIT_DISABLE_MEMORY_ATTRIBUTION");
+        if (!value)
+            return false;
+        return !strcmp(value, "1");
+    }();
+    return result;
+}
+
 SharedMemoryHandle::SharedMemoryHandle(SharedMemoryHandle::Type&& handle, size_t size)
     : m_handle(WTFMove(handle))
     , m_size(size)

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -54,6 +54,8 @@ class SharedBuffer;
 
 enum class MemoryLedger { None, Default, Network, Media, Graphics, Neural };
 
+WEBCORE_EXPORT bool isMemoryAttributionDisabled();
+
 class SharedMemoryHandle {
 public:
     using Type =

--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
@@ -66,6 +66,8 @@ static int toVMMemoryLedger(MemoryLedger memoryLedger)
 
 void SharedMemoryHandle::takeOwnershipOfMemory(MemoryLedger memoryLedger) const
 {
+    if (isMemoryAttributionDisabled())
+        return;
 #if HAVE(MACH_MEMORY_ENTRY)
     if (!m_handle)
         return;
@@ -80,7 +82,7 @@ void SharedMemoryHandle::takeOwnershipOfMemory(MemoryLedger memoryLedger) const
 void SharedMemoryHandle::setOwnershipOfMemory(const ProcessIdentity& processIdentity, MemoryLedger memoryLedger) const
 {
 #if HAVE(TASK_IDENTITY_TOKEN) && HAVE(MACH_MEMORY_ENTRY_OWNERSHIP_IDENTITY_TOKEN_SUPPORT)
-    if (!m_handle)
+    if (!m_handle || !processIdentity)
         return;
 
     kern_return_t kr = mach_memory_entry_ownership(m_handle.sendRight(), processIdentity.taskIdToken(), toVMMemoryLedger(memoryLedger), 0);

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -34,6 +34,7 @@
 #import "PlatformScreen.h"
 #import "ProcessCapabilities.h"
 #import "ProcessIdentity.h"
+#import "SharedMemory.h"
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/Assertions.h>
 #import <wtf/EnumTraits.h>
@@ -616,8 +617,14 @@ void IOSurface::setOwnershipIdentity(const ProcessIdentity& resourceOwner)
 void IOSurface::setOwnershipIdentity(IOSurfaceRef surface, const ProcessIdentity& resourceOwner)
 {
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    ASSERT(resourceOwner);
+#if ASSERT_ENABLED
     ASSERT(surface);
+    if (!isMemoryAttributionDisabled())
+        ASSERT(resourceOwner);
+#endif
+
+    if (!resourceOwner)
+        return;
     task_id_token_t ownerTaskIdToken = resourceOwner.taskIdToken();
     auto result = IOSurfaceSetOwnershipIdentity(surface, ownerTaskIdToken, kIOSurfaceMemoryLedgerTagGraphics, 0);
     if (result != kIOReturnSuccess)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -92,6 +92,7 @@
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SerializedCryptoKeyWrap.h>
+#include <WebCore/SharedMemory.h>
 #include <WebCore/SuddenTermination.h>
 #include <WebCore/WrappedCryptoKey.h>
 #include <optional>
@@ -1110,8 +1111,9 @@ void WebProcessProxy::getNetworkProcessConnection(CompletionHandler<void(Network
 void WebProcessProxy::createGPUProcessConnection(GPUProcessConnectionIdentifier identifier, IPC::Connection::Handle&& connectionHandle)
 {
     WebKit::GPUProcessConnectionParameters parameters;
-#if HAVE(TASK_IDENTITY_TOKEN)
-    ASSERT(m_processIdentity);
+#if ASSERT_ENABLED && HAVE(TASK_IDENTITY_TOKEN)
+    if (!WebCore::isMemoryAttributionDisabled())
+        ASSERT(m_processIdentity);
 #endif
     parameters.webProcessIdentity = m_processIdentity;
     parameters.sharedPreferencesForWebProcess = m_sharedPreferencesForWebProcess;


### PR DESCRIPTION
#### b5c69f396a00cff9563e3ab36b16651d491b6c2a
<pre>
Add environment variable to disable WebGL ownership attribution
<a href="https://rdar.apple.com/135995576">rdar://135995576</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279708">https://bugs.webkit.org/show_bug.cgi?id=279708</a>

Reviewed by Kimmo Kinnunen.

We&apos;ve been looking in to memory usage issues on some websites that make heavy use of graphics memory
allocated by GPUProcess but then attributed back to UIProcess. Unfortunately, using these
attribution APIs seems to cause MallocStackLogging, vmmap, and other tools to not behave as
expected. In particular, it looks like the tools don&apos;t calculate the residency state for the
associated VM regions correctly anymore (e.g. a surface created in one process and attributed to
another shows up as resident in neither process in vmmap).

While we wait for the OS and/or devtools to sort out this bug, let&apos;s add an environment variable to
disable ownership attribution so things like `malloc_history -callTree com.apple.WebKit.GPU` produce
reasonable output for these types of graphics allocations.

* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::isMemoryAttributionDisabled):
* Source/WebCore/platform/SharedMemory.h:
* Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm:
(WebCore::SharedMemoryHandle::takeOwnershipOfMemory const):
(WebCore::SharedMemoryHandle::setOwnershipOfMemory const):
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::setOwnershipIdentity):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::adjustProcessIdentityIfNeeded):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createGPUProcessConnection):

Canonical link: <a href="https://commits.webkit.org/283861@main">https://commits.webkit.org/283861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/273b5a86ba44f61409ba5f624ab52063e10ba541

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54043 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12429 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58307 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61481 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61540 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14989 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2910 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42589 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43666 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->