### PR TITLE
[LegacySVG] Adding 'id's of pending SVG "resource" references does not work for non-resources

### DIFF
--- a/LayoutTests/svg/text/adding-id-on-pending-path-expected.html
+++ b/LayoutTests/svg/text/adding-id-on-pending-path-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<svg>
+  <path id="path" d="M0,20h100" fill="none"/>
+  <text><textPath xlink:href="#path">PASS</textPath></text>
+</svg>

--- a/LayoutTests/svg/text/adding-id-on-pending-path.html
+++ b/LayoutTests/svg/text/adding-id-on-pending-path.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<svg>
+  <path d="M0,20h100" fill="none"/>
+  <text><textPath xlink:href="#path">PASS</textPath></text>
+</svg>
+<script>
+function runAfterLayoutAndPaint(callback, autoNotifyDone) {
+    if (!window.testRunner) {
+        // For manual test. Delay 500ms to allow us to see the visual change
+        // caused by the callback.
+        setTimeout(callback, 500);
+        return;
+    }
+
+    if (autoNotifyDone)
+        testRunner.waitUntilDone();
+
+    // We do requestAnimationFrame and setTimeout to ensure a frame has started
+    // and layout and paint have run. The requestAnimationFrame fires after the
+    // frame has started but before layout and paint. The setTimeout fires
+    // at the beginning of the next frame, meaning that the previous frame has
+    // completed layout and paint.
+    // See http://crrev.com/c/1395193/10/third_party/blink/web_tests/http/tests/resources/run-after-layout-and-paint.js
+    // for more discussions.
+    requestAnimationFrame(function() {
+        setTimeout(function() {
+            callback();
+            if (autoNotifyDone)
+                testRunner.notifyDone();
+        }, 1);
+    });
+}
+</script>
+<script>
+runAfterLayoutAndPaint(function() {
+  document.querySelector('path').id = 'path';
+}, true);
+</script>

--- a/LayoutTests/svg/text/removing-id-on-path-expected.html
+++ b/LayoutTests/svg/text/removing-id-on-path-expected.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/LayoutTests/svg/text/removing-id-on-path.html
+++ b/LayoutTests/svg/text/removing-id-on-path.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<svg>
+  <path id="path" d="M0,20h100" fill="none"/>
+  <text><textPath xlink:href="#path">FAIL</textPath></text>
+</svg>
+<script>
+function runAfterLayoutAndPaint(callback, autoNotifyDone) {
+    if (!window.testRunner) {
+        // For manual test. Delay 500ms to allow us to see the visual change
+        // caused by the callback.
+        setTimeout(callback, 500);
+        return;
+    }
+
+    if (autoNotifyDone)
+        testRunner.waitUntilDone();
+
+    // We do requestAnimationFrame and setTimeout to ensure a frame has started
+    // and layout and paint have run. The requestAnimationFrame fires after the
+    // frame has started but before layout and paint. The setTimeout fires
+    // at the beginning of the next frame, meaning that the previous frame has
+    // completed layout and paint.
+    // See http://crrev.com/c/1395193/10/third_party/blink/web_tests/http/tests/resources/run-after-layout-and-paint.js
+    // for more discussions.
+    requestAnimationFrame(function() {
+        setTimeout(function() {
+            callback();
+            if (autoNotifyDone)
+                testRunner.notifyDone();
+        }, 1);
+    });
+}
+</script>
+<script>
+runAfterLayoutAndPaint(function() {
+  document.querySelector('path').id = '';
+}, true);
+</script>

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2010 Rob Buis <rwlbuis@gmail.com>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -161,6 +162,12 @@ void SVGTextPathElement::buildPendingResource()
         }
     } else if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(*target.element))
         pathElement->addReferencingElement(*this);
+
+    CheckedPtr renderer = this->renderer();
+    if (!renderer)
+        return;
+
+    LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(*renderer);
 }
 
 Node::InsertedIntoAncestorResult SVGTextPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)


### PR DESCRIPTION
#### 1303a49bf2d3d814eca190822c033a43eab7992d
<pre>
[LegacySVG] Adding &apos;id&apos;s of pending SVG &quot;resource&quot; references does not work for non-resources

<a href="https://bugs.webkit.org/show_bug.cgi?id=279323">https://bugs.webkit.org/show_bug.cgi?id=279323</a>
<a href="https://rdar.apple.com/problem/135509733">rdar://problem/135509733</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/6a5978f382eca334bfab56ab7409a71e45a51bca">https://chromium.googlesource.com/chromium/src.git/+/6a5978f382eca334bfab56ab7409a71e45a51bca</a>

When add &apos;id&apos; on pending resource(&lt;path&gt;), it does no apply to
non-resources(&lt;textPath&gt;). Because if need to build pending resource,
re-layout non-resources.

* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::buildPendingResource):
* LayoutTests/svg/text/adding-id-on-pending-path.html:
* LayoutTests/svg/text/adding-id-on-pending-path-expected.html:
* LayoutTests/svg/text/removing-id-on-path.html:
* LayoutTests/svg/text/removing-id-on-path-expected.html:

Canonical link: <a href="https://commits.webkit.org/283675@main">https://commits.webkit.org/283675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17f7f9520912058f6c418dcef592c1709b506eb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18133 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53739 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72736 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61204 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14807 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2603 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42182 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->