### PR TITLE
Remove SVGLengthContext's viewport for performance

### DIFF
--- a/LayoutTests/platform/glib/svg/batik/text/textEffect3-expected.txt
+++ b/LayoutTests/platform/glib/svg/batik/text/textEffect3-expected.txt
@@ -99,7 +99,7 @@ layer at (0,0) size 450x500
           RenderSVGInlineText {#text} at (94,2) size 55x68
             chunk 1 (middle anchor) text run 1 at (151.00,340.00) startOffset 0 endOffset 1 width 36.00: "K"
         RenderSVGInlineText {#text} at (0,0) size 0x0
-          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (-45,-50) size 540x600
+          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (0,0) size 0x0
       RenderSVGText {text} at (263,292) size 149x79 contains 1 chunk(s)
         [filter="dropShadow"] RenderSVGResourceFilter {filter} at (248.18,284.10) size 177.90x94.80
         RenderSVGInlineText {#text} at (0,20) size 36x59
@@ -118,7 +118,7 @@ layer at (0,0) size 450x500
           RenderSVGInlineText {#text} at (94,2) size 55x68
             chunk 1 (middle anchor) text run 1 at (361.00,340.00) startOffset 0 endOffset 1 width 36.00: "K"
         RenderSVGInlineText {#text} at (0,0) size 0x0
-          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (-45,-50) size 540x600
+          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (0,0) size 0x0
       RenderSVGText {text} at (87,389) size 66x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 65x14
           chunk 1 (middle anchor) text run 1 at (87.50,400.00) startOffset 0 endOffset 13 width 65.00: "(System font)"

--- a/LayoutTests/platform/ios/svg/batik/text/textEffect3-expected.txt
+++ b/LayoutTests/platform/ios/svg/batik/text/textEffect3-expected.txt
@@ -99,7 +99,7 @@ layer at (0,0) size 450x500
           RenderSVGInlineText {#text} at (93,2) size 54x69
             chunk 1 (middle anchor) text run 1 at (150.74,340.00) startOffset 0 endOffset 1 width 35.57: "K"
         RenderSVGInlineText {#text} at (0,0) size 0x0
-          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (-45,-50) size 540x600
+          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (0,0) size 0x0
       RenderSVGText {text} at (263,291) size 148x81 contains 1 chunk(s)
         [filter="dropShadow"] RenderSVGResourceFilter {filter} at (249.09,283.50) size 176.25x96
         RenderSVGInlineText {#text} at (0,20) size 36x60
@@ -118,7 +118,7 @@ layer at (0,0) size 450x500
           RenderSVGInlineText {#text} at (92,2) size 54x69
             chunk 1 (middle anchor) text run 1 at (360.69,340.00) startOffset 0 endOffset 1 width 35.52: "K"
         RenderSVGInlineText {#text} at (0,0) size 0x0
-          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (-45,-50) size 540x600
+          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (0,0) size 0x0
       RenderSVGText {text} at (87,389) size 66x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 66x14
           chunk 1 (middle anchor) text run 1 at (87.17,400.00) startOffset 0 endOffset 13 width 65.66: "(System font)"

--- a/LayoutTests/platform/mac/svg/batik/text/textEffect3-expected.txt
+++ b/LayoutTests/platform/mac/svg/batik/text/textEffect3-expected.txt
@@ -99,7 +99,7 @@ layer at (0,0) size 450x500
           RenderSVGInlineText {#text} at (93,2) size 54x69
             chunk 1 (middle anchor) text run 1 at (150.74,340.00) startOffset 0 endOffset 1 width 35.57: "K"
         RenderSVGInlineText {#text} at (0,0) size 0x0
-          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (-45,-50) size 540x600
+          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (0,0) size 0x0
       RenderSVGText {text} at (263,291) size 148x81 contains 1 chunk(s)
         [filter="dropShadow"] RenderSVGResourceFilter {filter} at (249.10,283.76) size 176.16x95.46
         RenderSVGInlineText {#text} at (0,20) size 36x60
@@ -118,7 +118,7 @@ layer at (0,0) size 450x500
           RenderSVGInlineText {#text} at (93,2) size 54x69
             chunk 1 (middle anchor) text run 1 at (360.69,340.00) startOffset 0 endOffset 1 width 35.52: "K"
         RenderSVGInlineText {#text} at (0,0) size 0x0
-          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (-45,-50) size 540x600
+          [filter="dropShadow"] RenderSVGResourceFilter {filter} at (0,0) size 0x0
       RenderSVGText {text} at (87,389) size 66x14 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 66x14
           chunk 1 (middle anchor) text run 1 at (87.17,400.00) startOffset 0 endOffset 13 width 65.66: "(System font)"

--- a/LayoutTests/svg/filters/feMerge-wrong-input-expected.txt
+++ b/LayoutTests/svg/filters/feMerge-wrong-input-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
     RenderSVGHiddenContainer {defs} at (0,0) size 0x0
-      RenderSVGResourceFilter {filter} [id="filter"] [filterUnits=objectBoundingBox] [primitiveUnits=objectBoundingBox]
+      RenderSVGResourceFilter {filter} [id="filter"] [filterUnits=userSpaceOnUse] [primitiveUnits=objectBoundingBox]
         [feMerge mergeNodes="1"]
           [SourceGraphic]
     RenderSVGContainer {g} at (0,0) size 800x600

--- a/LayoutTests/svg/filters/feMerge-wrong-input.svg
+++ b/LayoutTests/svg/filters/feMerge-wrong-input.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg">
 <defs>
 <!-- check that WebKit doesn't crash, if an effect is not available in feMerge -->
-<filter id="filter" primitiveUnits="objectBoundingBox">
+<filter id="filter" filterUnits="userSpaceOnUse" primitiveUnits="objectBoundingBox">
 <feMerge>
 <feMergeNode in="does-not-exist"/>
 </feMerge>

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -40,7 +40,7 @@ public:
     template<typename T>
     static FloatRect resolveRectangle(const T* context, SVGUnitTypes::SVGUnitType type, const FloatRect& viewport)
     {
-        return SVGLengthContext::resolveRectangle(context, type, viewport, context->x(), context->y(), context->width(), context->height());
+        return resolveRectangle(context, type, viewport, context->x(), context->y(), context->width(), context->height());
     }
 
     static FloatRect resolveRectangle(const SVGElement*, SVGUnitTypes::SVGUnitType, const FloatRect& viewport, const SVGLengthValue& x, const SVGLengthValue& y, const SVGLengthValue& width, const SVGLengthValue& height);
@@ -54,10 +54,9 @@ public:
     std::optional<FloatSize> viewportSize() const;
 
 private:
-    SVGLengthContext(const SVGElement*, const FloatRect& viewport);
-
     ExceptionOr<float> convertValueFromUserUnitsToPercentage(float value, SVGLengthMode) const;
     ExceptionOr<float> convertValueFromPercentageToUserUnits(float value, SVGLengthMode) const;
+    static float convertValueFromPercentageToUserUnits(float value, SVGLengthMode, FloatSize);
 
     ExceptionOr<float> convertValueFromUserUnitsToEMS(float value) const;
     ExceptionOr<float> convertValueFromEMSToUserUnits(float value) const;
@@ -70,7 +69,6 @@ private:
     RefPtr<const SVGElement> protectedContext() const;
 
     WeakPtr<const SVGElement, WeakPtrImplWithEventTargetData> m_context;
-    FloatRect m_overriddenViewport; // Ideally this would be std::optional<FloatRect>, but some tests depend on the behavior of it being a zero rect.
     mutable std::optional<FloatSize> m_viewportSize;
 };
 


### PR DESCRIPTION
#### 5a9ffa94d048a37908ed8bbb6c0694b45feacda1
<pre>
Remove SVGLengthContext&apos;s viewport for performance

<a href="https://bugs.webkit.org/show_bug.cgi?id=279716">https://bugs.webkit.org/show_bug.cgi?id=279716</a>
<a href="https://rdar.apple.com/136009811">rdar://136009811</a>

Reviewed by Nikolas Zimmermann and Simon Fraser.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/cf8a467f2e89d9e9dd5924750b782dd3724935c0">https://chromium.googlesource.com/chromium/src.git/+/cf8a467f2e89d9e9dd5924750b782dd3724935c0</a>

This patch removes m_overriddenViewport from SVGLengthContext and
moves all code into the only user - SVGLengthContext::resolveRectangle.
This was possible because resolveRectangle was the only callsite to
use a viewport.

* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::resolveRectangle):
(WebCore::SVGLengthContext::convertValueToUserUnits const):
(WebCore::SVGLengthContext::convertValueFromPercentageToUserUnits const):
(WebCore::SVGLengthContext::convertValueFromPercentageToUserUnits):
(WebCore::SVGLengthContext::viewportSize const):
(WebCore::SVGLengthContext::computeViewportSize const):
* Source/WebCore/svg/SVGLengthContext.h:
* LayoutTests/platform/glib/svg/batik/text/textEffect3-expected.txt:
* LayoutTests/platform/ios/svg/batik/text/textEffect3-expected.txt:
* LayoutTests/platform/mac/svg/batik/text/textEffect3-expected.txt:
* LayoutTests/svg/filters/feMerge-wrong-input-expected.txt:
* LayoutTests/svg/filters/feMerge-wrong-input.svg:

Canonical link: <a href="https://commits.webkit.org/283877@main">https://commits.webkit.org/283877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/565168c19394c0afd6d2e223c58e7ea9d4810077

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53844 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12301 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72886 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61317 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61394 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/15032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2730 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42332 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->