### PR TITLE
Port WebExtension Page and Content Security Properties to C++

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -38,6 +38,16 @@ static constexpr auto versionManifestKey = "version"_s;
 static constexpr auto versionNameManifestKey = "version_name"_s;
 static constexpr auto descriptionManifestKey = "description"_s;
 
+static constexpr auto contentSecurityPolicyManifestKey = "content_security_policy"_s;
+static constexpr auto contentSecurityPolicyExtensionPagesManifestKey = "extension_pages"_s;
+
+static constexpr auto optionsUIManifestKey = "options_ui"_s;
+static constexpr auto optionsUIPageManifestKey = "page"_s;
+static constexpr auto optionsPageManifestKey = "options_page"_s;
+static constexpr auto chromeURLOverridesManifestKey = "chrome_url_overrides"_s;
+static constexpr auto browserURLOverridesManifestKey = "browser_url_overrides"_s;
+static constexpr auto newTabManifestKey = "newtab"_s;
+
 bool WebExtension::manifestParsedSuccessfully()
 {
     if (m_parsedManifest)
@@ -131,6 +141,103 @@ void WebExtension::populateDisplayStringsIfNeeded()
     m_displayDescription = manifestObject->getString(descriptionManifestKey);
     if (m_displayDescription.isEmpty())
         recordError(createError(Error::InvalidDescription));
+}
+
+const String& WebExtension::contentSecurityPolicy()
+{
+    populateContentSecurityPolicyStringsIfNeeded();
+    return m_contentSecurityPolicy;
+}
+
+void WebExtension::populateContentSecurityPolicyStringsIfNeeded()
+{
+    if (m_parsedManifestContentSecurityPolicyStrings)
+        return;
+
+    m_parsedManifestContentSecurityPolicyStrings = true;
+
+    RefPtr manifestObject = this->manifestObject();
+    if (!manifestObject)
+        return;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy
+
+    if (supportsManifestVersion(3)) {
+        if (RefPtr policyObject = manifestObject->getObject(contentSecurityPolicyManifestKey)) {
+            m_contentSecurityPolicy = policyObject->getString(contentSecurityPolicyExtensionPagesManifestKey);
+            if (!m_contentSecurityPolicy && (!policyObject->size() || policyObject->getValue(contentSecurityPolicyExtensionPagesManifestKey)))
+                recordError(createError(Error::InvalidContentSecurityPolicy));
+        }
+    } else {
+        m_contentSecurityPolicy = manifestObject->getString(contentSecurityPolicyManifestKey);
+        if (!m_contentSecurityPolicy && manifestObject->getValue(contentSecurityPolicyManifestKey))
+            recordError(createError(Error::InvalidContentSecurityPolicy));
+    }
+
+    if (!m_contentSecurityPolicy)
+        m_contentSecurityPolicy = "script-src 'self'"_s;
+}
+
+bool WebExtension::hasOptionsPage()
+{
+    populatePagePropertiesIfNeeded();
+    return !m_optionsPagePath.isEmpty();
+}
+
+bool WebExtension::hasOverrideNewTabPage()
+{
+    populatePagePropertiesIfNeeded();
+    return !m_overrideNewTabPagePath.isEmpty();
+}
+
+const String& WebExtension::optionsPagePath()
+{
+    populatePagePropertiesIfNeeded();
+    return m_optionsPagePath;
+}
+
+const String& WebExtension::overrideNewTabPagePath()
+{
+    populatePagePropertiesIfNeeded();
+    return m_overrideNewTabPagePath;
+}
+
+void WebExtension::populatePagePropertiesIfNeeded()
+{
+    if (m_parsedManifestPageProperties)
+        return;
+
+    m_parsedManifestPageProperties = true;
+
+    RefPtr manifestObject = this->manifestObject();
+    if (!manifestObject)
+        return;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides
+
+    RefPtr optionsObject = manifestObject->getObject(optionsUIManifestKey);
+    if (optionsObject) {
+        m_optionsPagePath = optionsObject->getString(optionsUIPageManifestKey);
+        if (m_optionsPagePath.isEmpty())
+            recordError(createError(Error::InvalidOptionsPage));
+    } else {
+        m_optionsPagePath = manifestObject->getString(optionsPageManifestKey);
+        if (m_optionsPagePath.isEmpty() && manifestObject->getValue(optionsPageManifestKey))
+            recordError(createError(Error::InvalidOptionsPage));
+    }
+
+    RefPtr overridesObject = manifestObject->getObject(browserURLOverridesManifestKey);
+    if (!overridesObject)
+        overridesObject = manifestObject->getObject(chromeURLOverridesManifestKey);
+
+    if (overridesObject && overridesObject->size()) {
+        m_overrideNewTabPagePath = overridesObject->getString(newTabManifestKey);
+        if (m_overrideNewTabPagePath.isEmpty() && overridesObject->getValue(newTabManifestKey))
+            recordError(createError(Error::InvalidURLOverrides, WEB_UI_STRING("Empty or invalid `newtab` manifest entry.", "WKWebExtensionErrorInvalidManifestEntry description for invalid new tab entry")));
+    } else if (overridesObject)
+        recordError(createError(Error::InvalidURLOverrides));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -230,7 +230,7 @@ public:
     const String& displayDescription();
     const String& version();
 
-    NSString *contentSecurityPolicy();
+    const String& contentSecurityPolicy();
 
     CocoaImage *icon(CGSize idealSize);
 
@@ -277,8 +277,8 @@ public:
     bool hasOptionsPage();
     bool hasOverrideNewTabPage();
 
-    NSString *optionsPagePath();
-    NSString *overrideNewTabPagePath();
+    const String& optionsPagePath();
+    const String& overrideNewTabPagePath();
 
     const CommandsVector& commands();
     bool hasCommands();
@@ -310,7 +310,7 @@ public:
     // Combined pattern set that includes permission patterns and injected content patterns from the manifest.
     MatchPatternSet allRequestedMatchPatterns();
 
-    NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
+    NSError *createError(Error, String customLocalizedDescription = { }, NSError *underlyingError = nil);
     void recordErrorIfNeeded(NSError *error) { if (error) recordError(error); }
     void recordError(NSError *);
 
@@ -390,7 +390,7 @@ private:
     RetainPtr<NSString> m_sidebarTitle;
 #endif
 
-    RetainPtr<NSString> m_contentSecurityPolicy;
+    String m_contentSecurityPolicy;
 
     RetainPtr<NSArray> m_backgroundScriptPaths;
     RetainPtr<NSString> m_backgroundPagePath;
@@ -400,8 +400,8 @@ private:
 
     RetainPtr<NSString> m_inspectorBackgroundPagePath;
 
-    RetainPtr<NSString> m_optionsPagePath;
-    RetainPtr<NSString> m_overrideNewTabPagePath;
+    String m_optionsPagePath;
+    String m_overrideNewTabPagePath;
 
     bool m_backgroundContentIsPersistent : 1 { false };
     bool m_backgroundContentUsesModules : 1 { false };


### PR DESCRIPTION
#### ea61e1921e0f26dfcba16ccc16e239229dda259d
<pre>
Port WebExtension Page and Content Security Properties to C++
<a href="https://webkit.org/b/279719">https://webkit.org/b/279719</a>

Reviewed by Timothy Hatcher.

Ports the Page and Content Security strings including Options and Overrides to C++.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseManifest):
(WebKit::WebExtension::createError):
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded):
(WebKit::WebExtension::contentSecurityPolicy): Deleted.
(WebKit::WebExtension::populateContentSecurityPolicyStringsIfNeeded): Deleted.
(WebKit::WebExtension::hasOptionsPage): Deleted.
(WebKit::WebExtension::hasOverrideNewTabPage): Deleted.
(WebKit::WebExtension::optionsPagePath): Deleted.
(WebKit::WebExtension::overrideNewTabPagePath): Deleted.
(WebKit::WebExtension::populatePagePropertiesIfNeeded): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::contentSecurityPolicy):
(WebKit::WebExtension::populateContentSecurityPolicyStringsIfNeeded):
(WebKit::WebExtension::hasOptionsPage):
(WebKit::WebExtension::hasOverrideNewTabPage):
(WebKit::WebExtension::optionsPagePath):
(WebKit::WebExtension::overrideNewTabPagePath):
(WebKit::WebExtension::populatePagePropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::createError):

Canonical link: <a href="https://commits.webkit.org/283676@main">https://commits.webkit.org/283676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e80fa7e1c096c50e085242e6d00aeaf4edc64f66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18157 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53756 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39347 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16511 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72760 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61301 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2626 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10170 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42206 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->