### PR TITLE
[Script Telemetry] Add taintedness support for ScriptElement and CachedScript

### DIFF
--- a/Source/JavaScriptCore/parser/SourceTaintedOrigin.h
+++ b/Source/JavaScriptCore/parser/SourceTaintedOrigin.h
@@ -53,7 +53,7 @@ inline TriState taintednessToTriState(SourceTaintedOrigin origin)
 }
 
 
-JS_EXPORT_PRIVATE SourceTaintedOrigin sourceTaintedOriginFromStack(VM&, CallFrame*);
+JS_EXPORT_PRIVATE std::pair<SourceTaintedOrigin, URL> sourceTaintedOriginFromStack(VM&, CallFrame*);
 JS_EXPORT_PRIVATE SourceTaintedOrigin computeNewSourceTaintedOriginFromStack(VM&, CallFrame*);
 
 JS_EXPORT_PRIVATE String sourceTaintedOriginToString(SourceTaintedOrigin taintedness);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2847,7 +2847,7 @@ JSC_DEFINE_HOST_FUNCTION(functionVMTaintedState, (JSGlobalObject* globalObject, 
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
 
-    SourceTaintedOrigin sourceTaintedOrigin = sourceTaintedOriginFromStack(vm, callFrame);
+    auto sourceTaintedOrigin = sourceTaintedOriginFromStack(vm, callFrame).first;
     return JSValue::encode(jsString(vm, sourceTaintedOriginToString(sourceTaintedOrigin)));
 }
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1612,6 +1612,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/RenderingUpdateScheduler.h
     page/ScreenOrientationLockType.h
     page/ScreenOrientationType.h
+    page/ScriptTelemetryCategory.h
     page/ScrollBehavior.h
     page/ScrollIntoViewOptions.h
     page/ScrollLogicalPosition.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2103,6 +2103,7 @@ page/ResourceUsageOverlay.cpp
 page/ResourceUsageThread.cpp
 page/Screen.cpp
 page/ScreenOrientation.cpp
+page/ScriptTelemetryCategory.cpp
 page/ScrollBehavior.cpp
 page/SecurityOrigin.cpp
 page/SecurityOriginData.cpp

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -49,7 +49,7 @@ public:
 
 private:
     CachedScriptSourceProvider(CachedScript* cachedScript, JSC::SourceProviderSourceType sourceType, Ref<CachedScriptFetcher>&& scriptFetcher)
-        : SourceProvider(JSC::SourceOrigin { cachedScript->response().url(), WTFMove(scriptFetcher) }, String(cachedScript->response().url().string()), cachedScript->response().isRedirected() ? String(cachedScript->url().string()) : String(), JSC::SourceTaintedOrigin::Untainted, TextPosition(), sourceType)
+        : SourceProvider(JSC::SourceOrigin { cachedScript->response().url(), WTFMove(scriptFetcher) }, String(cachedScript->response().url().string()), cachedScript->response().isRedirected() ? String(cachedScript->url().string()) : String(), cachedScript->requiresTelemetry() ? JSC::SourceTaintedOrigin::KnownTainted : JSC::SourceTaintedOrigin::Untainted, TextPosition(), sourceType)
         , m_cachedScript(cachedScript)
     {
         m_cachedScript->addClient(*this);

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -872,7 +872,7 @@ void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigi
 
     const int javascriptSchemeLength = sizeof("javascript:") - 1;
     String decodedURL = PAL::decodeURLEscapeSequences(preNavigationCheckURLString);
-    // FIXME: This probably needs to figure out if the origin is considered tanited.
+    // FIXME: This probably needs to figure out if the origin is considered tainted.
     auto result = executeScriptIgnoringException(decodedURL.substring(javascriptSchemeLength), JSC::SourceTaintedOrigin::Untainted);
     RELEASE_ASSERT(&vm == &jsWindowProxy(mainThreadNormalWorld()).window()->vm());
 

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -125,6 +125,8 @@ private:
     bool requestModuleScript(const TextPosition& scriptStartPosition);
     bool requestImportMap(LocalFrame&, const String& sourceURL);
 
+    void updateTaintedOriginFromSourceURL();
+
     virtual String sourceAttributeValue() const = 0;
     virtual String charsetAttributeValue() const = 0;
     virtual String typeAttributeValue() const = 0;

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -90,6 +90,7 @@ class WebCoreOpaqueRoot;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class LoadedFromOpaqueSource : bool;
 enum class NoiseInjectionPolicy : uint8_t;
+enum class ScriptTelemetryCategory : uint8_t;
 enum class TaskSource : uint8_t;
 
 #if ENABLE(NOTIFICATIONS)
@@ -214,6 +215,8 @@ public:
     WEBCORE_EXPORT void deref();
     WEBCORE_EXPORT void refAllowingPartiallyDestroyed();
     WEBCORE_EXPORT void derefAllowingPartiallyDestroyed();
+
+    WEBCORE_EXPORT bool requiresScriptExecutionTelemetry(ScriptTelemetryCategory);
 
     class Task {
         WTF_MAKE_TZONE_ALLOCATED_INLINE(Task);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2611,7 +2611,7 @@ ResourceError DocumentLoader::handleContentFilterDidBlock(ContentFilterUnblockHa
     if (!unblockRequestDeniedScript.isEmpty() && frame()) {
         unblockHandler.wrapWithDecisionHandler([scriptController = WeakPtr { frame()->script() }, script = WTFMove(unblockRequestDeniedScript).isolatedCopy()](bool unblocked) {
             if (!unblocked && scriptController) {
-                // FIXME: This probably needs to figure out if the origin is considered tanited.
+                // FIXME: This probably needs to figure out if the origin is considered tainted.
                 scriptController->executeScriptIgnoringException(script, JSC::SourceTaintedOrigin::Untainted);
             }
         });

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -35,8 +35,9 @@
 
 namespace WebCore {
 
-CachedScript::CachedScript(CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar* cookieJar)
+CachedScript::CachedScript(CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar* cookieJar, ScriptRequiresTelemetry requiresTelemetry)
     : CachedResource(WTFMove(request), Type::Script, sessionID, cookieJar)
+    , m_requiresTelemetry(requiresTelemetry == ScriptRequiresTelemetry::Yes)
     , m_decoder(TextResourceDecoder::create("text/javascript"_s, request.charset()))
 {
 }

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -31,14 +31,18 @@ namespace WebCore {
 
 class TextResourceDecoder;
 
+enum class ScriptRequiresTelemetry : bool { No, Yes };
+
 class CachedScript final : public CachedResource {
 public:
-    CachedScript(CachedResourceRequest&&, PAL::SessionID, const CookieJar*);
+    CachedScript(CachedResourceRequest&&, PAL::SessionID, const CookieJar*, ScriptRequiresTelemetry);
     virtual ~CachedScript();
 
     enum class ShouldDecodeAsUTF8Only : bool { No, Yes };
     WEBCORE_EXPORT StringView script(ShouldDecodeAsUTF8Only = ShouldDecodeAsUTF8Only::No);
     WEBCORE_EXPORT unsigned scriptHash(ShouldDecodeAsUTF8Only = ShouldDecodeAsUTF8Only::No);
+
+    bool requiresTelemetry() const { return m_requiresTelemetry; }
 
 private:
     bool mayTryReplaceEncodedData() const final { return true; }
@@ -58,6 +62,7 @@ private:
     String m_script;
     unsigned m_scriptHash { 0 };
     bool m_wasForceDecodedAsUTF8 { false };
+    bool m_requiresTelemetry { false };
 
     enum DecodingState { NeverDecoded, DataAndDecodedStringHaveSameBytes, DataAndDecodedStringHaveDifferentBytes };
     DecodingState m_decodingState { NeverDecoded };

--- a/Source/WebCore/page/ScriptTelemetryCategory.cpp
+++ b/Source/WebCore/page/ScriptTelemetryCategory.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScriptTelemetryCategory.h"
+
+namespace WebCore {
+
+ASCIILiteral description(ScriptTelemetryCategory category)
+{
+    switch (category) {
+    case ScriptTelemetryCategory::Unspecified:
+        ASSERT_NOT_REACHED();
+        return "Unspecified"_s;
+    case ScriptTelemetryCategory::Audio:
+        return "Audio"_s;
+    case ScriptTelemetryCategory::Canvas:
+        return "Canvas"_s;
+    case ScriptTelemetryCategory::Cookies:
+        return "Cookies"_s;
+    case ScriptTelemetryCategory::Gamepads:
+        return "Gamepads"_s;
+    case ScriptTelemetryCategory::HardwareConcurrency:
+        return "HardwareConcurrency"_s;
+    case ScriptTelemetryCategory::LocalStorage:
+        return "LocalStorage"_s;
+    case ScriptTelemetryCategory::MediaDevices:
+        return "MediaDevices"_s;
+    case ScriptTelemetryCategory::Notifications:
+        return "Notifications"_s;
+    case ScriptTelemetryCategory::Payments:
+        return "Payments"_s;
+    case ScriptTelemetryCategory::Permissions:
+        return "Permissions"_s;
+    case ScriptTelemetryCategory::QueryParameters:
+        return "QueryParameters"_s;
+    case ScriptTelemetryCategory::Referrer:
+        return "Referrer"_s;
+    case ScriptTelemetryCategory::ScreenOrViewport:
+        return "ScreenOrViewport"_s;
+    case ScriptTelemetryCategory::Speech:
+        return "Speech"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/ScriptTelemetryCategory.h
+++ b/Source/WebCore/page/ScriptTelemetryCategory.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashTraits.h>
+#include <wtf/text/ASCIILiteral.h>
+
+namespace WebCore {
+
+enum class ScriptTelemetryCategory : uint8_t {
+    Unspecified = 0,
+    Audio,
+    Canvas,
+    Cookies,
+    Gamepads,
+    HardwareConcurrency,
+    LocalStorage,
+    MediaDevices,
+    Notifications,
+    Payments,
+    QueryParameters,
+    Permissions,
+    Referrer,
+    ScreenOrViewport,
+    Speech,
+};
+
+ASCIILiteral description(ScriptTelemetryCategory);
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<typename T> struct DefaultHash;
+template<> struct DefaultHash<WebCore::ScriptTelemetryCategory> : public IntHash<WebCore::ScriptTelemetryCategory> { };
+
+template<typename T> struct HashTraits;
+template<> struct HashTraits<WebCore::ScriptTelemetryCategory> : public StrongEnumHashTraits<WebCore::ScriptTelemetryCategory> { };
+
+} // namespace WTF


### PR DESCRIPTION
#### 88d0219cb26e8e55dda7d3f3cfa8c94bce1d20c5
<pre>
[Script Telemetry] Add taintedness support for ScriptElement and CachedScript
<a href="https://bugs.webkit.org/show_bug.cgi?id=279601">https://bugs.webkit.org/show_bug.cgi?id=279601</a>

Reviewed by Abrar Rahman Protyasha, Charlie Wolfe, and Keith Miller.

Leverage JSC&apos;s taintedness tracking mechanism to propagate script telemetry state. See below for
more details.

* Source/JavaScriptCore/parser/SourceTaintedOrigin.cpp:
(JSC::sourceTaintedOriginFromStack):

Make this function return the closest tainted source URL along with the taintedness state, for use
in WebCore.

* Source/JavaScriptCore/parser/SourceTaintedOrigin.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
(WebCore::CachedScriptSourceProvider::CachedScriptSourceProvider):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::updateTaintedOriginFromSourceURL):

Teach `ScriptElement` to initialize `m_taintedOrigin` based on the source URL, immediately before
executing the script.

* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::requiresScriptExecutionTelemetry):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::handleContentFilterDidBlock):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::scriptRequiresTelemetry):
(WebCore::createResource):
(WebCore::CachedResourceLoader::updateCachedResourceWithCurrentRequest):
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::revalidateResource):
(WebCore::CachedResourceLoader::loadResource):
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::CachedScript):
* Source/WebCore/loader/cache/CachedScript.h:

Add plumbing to set a tainted bit on `CachedScript` after it&apos;s done loading, so that we create the
corresponding `SourceOrigin` with the correct tainted bit set when evaluating it.

* Source/WebCore/page/ScriptTelemetryCategory.cpp: Added.
(WebCore::description):
* Source/WebCore/page/ScriptTelemetryCategory.h: Added.

Canonical link: <a href="https://commits.webkit.org/283713@main">https://commits.webkit.org/283713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/396b39a06ee09b652da2e1299048f3f822ede2b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18045 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53831 "Found 4 new test failures: fast/images/animated-jpegxl-loop-count.html fast/images/jpegxl-as-image.html fast/images/jpegxl-with-color-profile.html http/tests/images/repaint-garbled.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12288 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16606 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60234 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72857 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66364 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61302 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61380 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9108 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2714 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42303 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15522 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->