### PR TITLE
Use async and await syntax for the Image decode() method tests

### DIFF
--- a/LayoutTests/fast/images/decode-animated-image.html
+++ b/LayoutTests/fast/images/decode-animated-image.html
@@ -8,24 +8,29 @@
     <p>This tests calling decode() multiple times for an animated image.</p>
     <canvas></canvas>
     <script>
+        function drawImageToCanvas(image, canvas) {
+            let context = canvas.getContext("2d");
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        }
+
         if (window.internals && window.testRunner) {
             internals.settings.setAnimatedImageDebugCanvasDrawingEnabled(true);
             internals.clearMemoryCache();
             testRunner.waitUntilDone();
         }
 
-        var image = new Image;
-        image.src = "resources/animated-red-green-blue-repeat-2.gif";
-        // First decode() will decode the red frame.
-        image.decode().then(() => {
-            // Second decode() will decode the green frame.
-            image.decode().then(() => {
-                let canvas = document.querySelector("canvas");
-                let context = canvas.getContext("2d");
-                context.drawImage(image, 0, 0, canvas.width, canvas.height);
-                if (window.testRunner)
-                    testRunner.notifyDone();
-            });
-        });
+        (async () => {
+            let image = new Image;
+            image.src = "resources/animated-red-green-blue-repeat-2.gif";
+
+            // Wait for the green frame.
+            await image.decode();
+            await image.decode();
+
+            drawImageToCanvas(image, document.querySelector("canvas"));
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        })();
     </script>
 </body>

--- a/LayoutTests/fast/images/decode-decoding-attribute-async-large-image.html
+++ b/LayoutTests/fast/images/decode-decoding-attribute-async-large-image.html
@@ -2,19 +2,20 @@
     <p>This test ensures if the src of an image with decoding="async" is set to the src of a decoded image, no further decoding will be requested.</p>
     <img decoding="async">
     <script>
-        (function() {
-            if (window.internals && window.testRunner) {
-                internals.clearMemoryCache();
-                testRunner.waitUntilDone();
-            }
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            testRunner.waitUntilDone();
+        }
 
-            var image = new Image;
+        (async () => {
+            let image = new Image;
             image.src = "resources/green-400x400.png";
-            image.decode().then(() => {
-                document.querySelector("img").src = image.src;
-                if (window.testRunner)
-                    testRunner.notifyDone();
-            });
+
+            await image.decode();
+            document.querySelector("img").src = image.src;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
         })();
     </script>
 </body>

--- a/LayoutTests/fast/images/decode-non-bitmap-image-resolve.html
+++ b/LayoutTests/fast/images/decode-non-bitmap-image-resolve.html
@@ -1,5 +1,5 @@
 <head>
-    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/js-test.js"></script>
 </head>
 <body>
     <div></div>
@@ -7,21 +7,24 @@
         description("This tests resolving the decode() promise when decoding non bitmap images.");
         jsTestIsAsync = true;
 
-        var image = new Image;
-        image.src = "resources/green-100x100.svg";
-        image.decode()
-        .then(() => {
+        if (window.internals)
+            internals.clearMemoryCache();
+
+        (async () => {
+            let image = new Image;
+
+            image.src = "resources/green-100x100.svg";
+            await image.decode();
             debug("Promise for decoding an SVG image was resolved.");
+
             image.src = "data:image/svg+xml;utf8, \
                     <svg version='1.1' xmlns='http://www.w3.org/2000/svg' width='100' height='100'> \
                         <rect width='100%' height='100%' fill='green'/> \
                     </svg>";
-            return image.decode();
-        })
-        .then(() => {
+            await image.decode();
             debug("Promise for decoding an SVG data url image was resolved.");
+
             finishJSTest();
-        });
+        })();
     </script>
-    <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/images/decode-render-animated-image.html
+++ b/LayoutTests/fast/images/decode-render-animated-image.html
@@ -13,36 +13,39 @@
     <canvas id="canvas4"></canvas>
     <div></div>
     <script>
+        function drawImageToCanvas(image, canvas) {
+            let context = canvas.getContext("2d");
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        }
+
         if (window.internals && window.testRunner) {
             internals.clearMemoryCache();
             internals.settings.setAnimatedImageDebugCanvasDrawingEnabled(true);
             testRunner.waitUntilDone();
         }
 
-        var image = new Image;
-        var parent = document.querySelector("div");
-        parent.appendChild(image);
+        (async () => {
+            let image = new Image;
+            let parent = document.querySelector("div");
+            parent.appendChild(image);
 
-        function drawImageInCanvas(image, canvasId) {
-            var canvas = document.querySelector(canvasId);
-            var context = canvas.getContext("2d");
-            context.drawImage(image, 0, 0, canvas.width, canvas.height);
-        }
+            image.src = "resources/animated-red-green-blue-repeat-2.gif";
 
-        image.onload = (() => {
-            drawImageInCanvas(image, "#canvas1");
-            image.decode().then(() => {
-                drawImageInCanvas(image, "#canvas2");
-                return image.decode();
-            }).then(() => {
-                drawImageInCanvas(image, "#canvas3");
-                return image.decode();
-            }).then(() => {
-                drawImageInCanvas(image, "#canvas4");
-                parent.remove();
+            await image.decode();
+            drawImageToCanvas(image, canvas1);
+
+            await image.decode();
+            drawImageToCanvas(image, canvas2);
+
+            await image.decode();
+            drawImageToCanvas(image, canvas3);
+
+            await image.decode();
+            drawImageToCanvas(image, canvas4);
+
+            parent.remove();
+            if (window.testRunner)
                 testRunner.notifyDone();
-            });
-        });
-        image.src = "resources/animated-red-green-blue-repeat-2.gif";
+        })();
     </script>
 </body>

--- a/LayoutTests/fast/images/decode-resolve-reject-no-leak.html
+++ b/LayoutTests/fast/images/decode-resolve-reject-no-leak.html
@@ -1,74 +1,53 @@
 <!DOCTYPE html>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <body>
     <script>
-        var image = new Image;
-
-        description('Test HTMLImageElement::decode() does not leak the pending promises after resolving or rejecting them.');
-        jsTestIsAsync = true;
-
-        function decodeMultiple(image, multipleCount) {
+        function decodeParallel(image, count) {
             var promises = [];
-            for (index = 0; index < multipleCount; ++index)
+            for (index = 0; index < count; ++index)
                 promises.push(image.decode());
             return promises;
         }
 
-        function resolveSingle(image, singleCount) {
-            if (!singleCount)
-                return Promise.resolve();
-            return image.decode().then(() => {
-                return resolveSingle(image, singleCount - 1);
-            });
+        async function decodeImage(image, count) {
+            await Promise.all(decodeParallel(image, count));
+
+            for (let index = 0; index < count; ++index)
+                await image.decode();
         }
 
-        function rejectSingle(image, singleCount) {
-            if (!singleCount)
-                return Promise.reject();
-            return image.decode().catch(() => {
-                return rejectSingle(image, singleCount - 1);
-            });
-        }
+        description('Test HTMLImageElement::decode() does not leak the pending promises after resolving or rejecting them.');
+        jsTestIsAsync = true;
 
-        function decodeBitmapImage(image, multipleCount, singleCount) {
-            debug("Decoding a bitmap image - promises will be resolved:");
+        if (window.internals)
+            internals.clearMemoryCache();
+
+        (async () => {
+            image = new Image;
+
+            debug("Decoding a bitmap image - promises will be resolved:");            
             image.src = "resources/red-400x400.png";
-            return Promise.all(decodeMultiple(image, multipleCount)).then(() => {
-                return resolveSingle(image, singleCount);
-            });
-        }
 
-        function decodeSVGImage(image, multipleCount, singleCount) {
+            await decodeImage(image, 10);
+            if (window.internals)
+                shouldBeZero("internals.imagePendingDecodePromisesCountForTesting(image)");
+
             debug("Decoding a SVG image - promises will be resolved:");
             image.src = "resources/green-100x100.svg";
-            return Promise.all(decodeMultiple(image, multipleCount)).then(() => {
-                return resolveSingle(image, singleCount);
-            });
-        }
 
-        function decodeBrokenImage(image, multipleCount, singleCount) {
+            await decodeImage(image, 10);
+            if (window.internals)
+                shouldBeZero("internals.imagePendingDecodePromisesCountForTesting(image)");
+
             debug("Decoding a broken image - promises will be rejected:");
             image.src = "";
-            return Promise.all(decodeMultiple(image, multipleCount)).catch(() => {
-                return rejectSingle(image, singleCount);
-            });
-        }
 
-        (function() {
-            decodeBitmapImage(image, 10, 10).then(() => {
+            await decodeImage(image, 10).catch(reason => {
                 if (window.internals)
                     shouldBeZero("internals.imagePendingDecodePromisesCountForTesting(image)");
-                return decodeSVGImage(image, 10, 10);
-            }).then(() => {
-                if (window.internals)
-                    shouldBeZero("internals.imagePendingDecodePromisesCountForTesting(image)");
-                return decodeBrokenImage(image, 10, 10);
-            }).catch(() => {
-                if (window.internals)
-                    shouldBeZero("internals.imagePendingDecodePromisesCountForTesting(image)");
-                finishJSTest();
             });
+
+            finishJSTest();
         })();
     </script>
-    <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/images/decode-static-image-reject.html
+++ b/LayoutTests/fast/images/decode-static-image-reject.html
@@ -1,5 +1,5 @@
 <head>
-    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/js-test.js"></script>
 </head>
 <body>
     <div></div>
@@ -7,27 +7,32 @@
         description("Test rejecting the decode() promise when loading the image fails.");
         jsTestIsAsync = true;
 
-        var image = new Image;
-        image.decode()
-        .catch(reason => {
-            debug("Failed to decode image with no source. Result is: " + reason);
+        if (window.internals)
+            internals.clearMemoryCache();
+
+        (async () => {
+            let image = new Image;
+
+            await image.decode().catch(reason => {
+                debug("Failed to decode image with no source. Result is: " + reason);
+            });
+
             image.src = "wrongname.png";
-            return image.decode();
-        })
-        .catch(reason => {
-            debug("Failed to decode image with non-existent source. Result is: " + reason);
+            await image.decode().catch(reason => {
+                debug("Failed to decode image with non-existent source. Result is: " + reason);
+            });
+
             image.src = "100x100-red.psd";
-            return image.decode();
-        })
-        .catch(reason => {
-            debug("Failed to decode image with unsupported image format. Result is: " + reason);
+            await image.decode().catch(reason => {
+                debug("Failed to decode image with unsupported image format. Result is: " + reason);
+            });
+
             image.src = "https://server:80a80/";
-            return image.decode();
-        })
-        .catch(reason => {
-            debug("Failed to decode image with invalid URL. Result is: " + reason);
+            await image.decode().catch(reason => {
+                debug("Failed to decode image with invalid URL. Result is: " + reason);
+            });
+
             finishJSTest();
-        });
+        })();
     </script>
-    <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/images/decode-static-image-resolve.html
+++ b/LayoutTests/fast/images/decode-static-image-resolve.html
@@ -9,16 +9,25 @@
     <p>This tests resolving the decode() promise when loading and decoding a static image succeeds.</p>
     <canvas></canvas>
     <script>
-        if (window.testRunner)
-            testRunner.waitUntilDone();
-        var image = new Image;
-        image.src = "resources/green-400x400.png";
-        image.decode().then(() => {
-            let canvas = document.querySelector("canvas");
+        function drawImageToCanvas(image, canvas) {
             let context = canvas.getContext("2d");
             context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        }
+
+        if (window.internals && window.testRunner) {
+            testRunner.waitUntilDone();
+            internals.clearMemoryCache();
+        }
+
+        (async () => {
+            let image = new Image;
+            image.src = "resources/green-400x400.png";
+
+            await image.decode();
+            drawImageToCanvas(image, document.querySelector("canvas"))
+
             if (window.testRunner)
                 testRunner.notifyDone();
-        });
+        })();
     </script>
 </body>

--- a/LayoutTests/fast/images/decode-static-svg-image-resolve.html
+++ b/LayoutTests/fast/images/decode-static-svg-image-resolve.html
@@ -12,26 +12,25 @@
     </svg>
     <canvas></canvas>
     <script>
-        function loadImage(href) {
-            return new Promise((resolve) => {
-                let image = document.querySelector('image');
-                image.setAttribute("href", href);
-                image.decode().then(() => {
-                    resolve();
-                });
-            });
+        function drawImageToCanvas(image, canvas) {
+            let context = canvas.getContext("2d");
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
         }
 
-        if (window.testRunner)
+        if (window.internals && window.testRunner) {
             testRunner.waitUntilDone();
+            internals.clearMemoryCache();
+        }
 
-        loadImage("resources/green-400x400.png").then(() => {
-            let canvas = document.querySelector("canvas");
-            let context = canvas.getContext("2d");
+        (async () => {
             let image = document.querySelector('image');
-            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+            image.setAttribute("href", "resources/green-400x400.png");
+
+            await image.decode();
+            drawImageToCanvas(image, document.querySelector("canvas"));
+
             if (window.testRunner)
                 testRunner.notifyDone();
-        });
+        })();
     </script>
 </body>


### PR DESCRIPTION
#### 0bcab78d5df122b8b80c8b5553f73be8849db16a
<pre>
Use async and await syntax for the Image decode() method tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=279720">https://bugs.webkit.org/show_bug.cgi?id=279720</a>
<a href="https://rdar.apple.com/136021019">rdar://136021019</a>

Reviewed by Kimmo Kinnunen.

This makes the order of execution clearer and makes the code more readable.

* LayoutTests/fast/images/decode-animated-image.html:
* LayoutTests/fast/images/decode-decoding-attribute-async-large-image.html:
* LayoutTests/fast/images/decode-non-bitmap-image-resolve.html:
* LayoutTests/fast/images/decode-render-animated-image.html:
* LayoutTests/fast/images/decode-resolve-reject-no-leak.html:
* LayoutTests/fast/images/decode-static-image-reject.html:
* LayoutTests/fast/images/decode-static-image-resolve.html:
* LayoutTests/fast/images/decode-static-svg-image-resolve.html:

Canonical link: <a href="https://commits.webkit.org/283696@main">https://commits.webkit.org/283696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08a78dc01ef6e1a4b390d76efd7c3f10a452b715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18183 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53773 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12237 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16537 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2651 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42233 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->