### PR TITLE
Add isEmptyValue() to more HashTraits structures

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -214,6 +214,7 @@ inline bool is(const CheckedPtr<ArgType, ArgPtrTraits>& source)
 
 template<typename P> struct HashTraits<CheckedPtr<P>> : SimpleClassHashTraits<CheckedPtr<P>> {
     static P* emptyValue() { return nullptr; }
+    static bool isEmptyValue(const CheckedPtr<P>& value) { return !value; }
 
     typedef P* PeekType;
     static PeekType peek(const CheckedPtr<P>& value) { return value.get(); }

--- a/Source/WTF/wtf/GenericHashKey.h
+++ b/Source/WTF/wtf/GenericHashKey.h
@@ -85,6 +85,7 @@ private:
 
 template<typename K, typename H> struct HashTraits<GenericHashKey<K, H>> : GenericHashTraits<GenericHashKey<K, H>> {
     static GenericHashKey<K, H> emptyValue() { return GenericHashKey<K, H> { HashTableEmptyValue }; }
+    static bool isEmptyValue(const GenericHashKey<K, H>& value) { return value.isHashTableEmptyValue(); }
     static void constructDeletedValue(GenericHashKey<K, H>& slot) { slot = GenericHashKey<K, H> { HashTableDeletedValue }; }
     static bool isDeletedValue(const GenericHashKey<K, H>& value) { return value.isHashTableDeletedValue(); }
 };

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -156,6 +156,8 @@ public:
     bool isValid() const requires(supportsNullState == SupportsObjectIdentifierNullState::Yes) { return ObjectIdentifierGenericBase<RawValue>::isValidIdentifier(ObjectIdentifierGenericBase<RawValue>::toRawValue()); }
     explicit operator bool() const requires(supportsNullState == SupportsObjectIdentifierNullState::Yes) { return ObjectIdentifierGenericBase<RawValue>::toRawValue(); }
 
+    bool isHashTableEmptyValue() const { return !ObjectIdentifierGenericBase<RawValue>::toRawValue(); }
+
     ObjectIdentifierGeneric() requires (supportsNullState == SupportsObjectIdentifierNullState::Yes) = default;
 
     ObjectIdentifierGeneric(HashTableDeletedValueType) : ObjectIdentifierGenericBase<RawValue>(HashTableDeletedValue) { }
@@ -219,6 +221,7 @@ struct ObjectIdentifierGenericBaseHash<UUID> {
 
 template<typename T, typename U, typename V, SupportsObjectIdentifierNullState supportsNullState> struct HashTraits<ObjectIdentifierGeneric<T, U, V, supportsNullState>> : SimpleClassHashTraits<ObjectIdentifierGeneric<T, U, V, supportsNullState>> {
     static ObjectIdentifierGeneric<T, U, V, supportsNullState> emptyValue() { return ObjectIdentifierGeneric<T, U, V, supportsNullState>(ObjectIdentifierGeneric<T, U, V, supportsNullState>::InvalidIdValue); }
+    static bool isEmptyValue(const ObjectIdentifierGeneric<T, U, V, supportsNullState>& value) { return value.isHashTableEmptyValue(); }
 };
 
 template<typename T, typename U, typename V, SupportsObjectIdentifierNullState supportsNullState> struct DefaultHash<ObjectIdentifierGeneric<T, U, V, supportsNullState>> : ObjectIdentifierGenericBaseHash<V> { };

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -358,6 +358,8 @@ template<typename P> struct RetainPtrObjectHashTraits : SimpleClassHashTraits<Re
         static NeverDestroyed<RetainPtr<P>> null;
         return null;
     }
+
+    static bool isEmptyValue(const RetainPtr<P>& value) { return !value; }
 };
 
 template<typename P> struct RetainPtrObjectHash {

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -106,6 +106,7 @@ public:
     }
 
     constexpr bool isHashTableDeletedValue() const { return m_data == deletedValue; }
+    constexpr bool isHashTableEmptyValue() const { return m_data == emptyValue; }
     WTF_EXPORT_PRIVATE String toString() const;
 
     constexpr operator bool() const { return !!m_data; }
@@ -143,6 +144,7 @@ struct UUIDHash {
 
 template<> struct HashTraits<UUID> : GenericHashTraits<UUID> {
     static UUID emptyValue() { return UUID { HashTableEmptyValue }; }
+    static bool isEmptyValue(const UUID& value) { return value.isHashTableEmptyValue(); }
     static void constructDeletedValue(UUID& slot) { slot = UUID { HashTableDeletedValue }; }
     static bool isDeletedValue(const UUID& value) { return value.isHashTableDeletedValue(); }
 };

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -90,6 +90,7 @@ public:
     std::unique_ptr<T> moveToUniquePtr() { return WTFMove(m_ref); }
 
     explicit UniqueRef(HashTableEmptyValueType) { }
+    bool isHashTableEmptyValue() const { return !m_ref; }
 
 private:
     template<class U, class... Args> friend UniqueRef<U> makeUniqueRefWithoutFastMallocCheck(Args&&...);

--- a/Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.h
@@ -76,6 +76,7 @@ template<> struct HashTraits<WebCore::IDBIndexInfo> : GenericHashTraits<WebCore:
     {
         return WebCore::IDBIndexInfo { { }, HashTraits<WebCore::IDBObjectStoreIdentifier>::emptyValue(), { }, { }, false, false };
     }
+    static bool isEmptyValue(const WebCore::IDBIndexInfo& value) { return value.objectStoreIdentifier().isHashTableEmptyValue(); }
 };
 
 } // namespace WTF

--- a/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.h
@@ -84,6 +84,7 @@ template<> struct HashTraits<WebCore::IDBObjectStoreInfo> : GenericHashTraits<We
     {
         return WebCore::IDBObjectStoreInfo { HashTraits<WebCore::IDBObjectStoreIdentifier>::emptyValue(), { }, { }, false };
     }
+    static bool isEmptyValue(const WebCore::IDBObjectStoreInfo& value) { return value.identifier().isHashTableEmptyValue(); }
 };
 
 } // namespace WTF

--- a/Source/WebCore/PAL/pal/SessionID.h
+++ b/Source/WebCore/PAL/pal/SessionID.h
@@ -68,6 +68,7 @@ public:
     bool isValid() const { return isValidSessionIDValue(m_identifier); }
     bool isEphemeral() const { return m_identifier & EphemeralSessionMask && m_identifier != HashTableDeletedValueID; }
     bool isHashTableDeletedValue() const { return m_identifier == HashTableDeletedValueID; }
+    bool isHashTableEmptyValue() const { return m_identifier == HashTableEmptyValueID; }
 
     uint64_t toUInt64() const { return m_identifier; }
     friend bool operator==(SessionID, SessionID) = default;
@@ -94,6 +95,7 @@ struct SessionIDHash {
 
 template<> struct HashTraits<PAL::SessionID> : GenericHashTraits<PAL::SessionID> {
     static PAL::SessionID emptyValue() { return PAL::SessionID(HashTableEmptyValue); }
+    static bool isEmptyValue(const PAL::SessionID& value) { return value.isHashTableEmptyValue(); }
     static void constructDeletedValue(PAL::SessionID& slot) { new (NotNull, &slot) PAL::SessionID(HashTableDeletedValue); }
     static bool isDeletedValue(const PAL::SessionID& slot) { return slot.isHashTableDeletedValue(); }
 };

--- a/Source/WebCore/dom/MessagePortIdentifier.h
+++ b/Source/WebCore/dom/MessagePortIdentifier.h
@@ -69,6 +69,7 @@ struct MessagePortIdentifierHash {
 
 template<> struct HashTraits<WebCore::MessagePortIdentifier> : GenericHashTraits<WebCore::MessagePortIdentifier> {
     static WebCore::MessagePortIdentifier emptyValue() { return { }; }
+    static bool isEmptyValue(const WebCore::MessagePortIdentifier& value) { return value.portIdentifier.isHashTableEmptyValue(); }
 
     static void constructDeletedValue(WebCore::MessagePortIdentifier& slot) { new (NotNull, &slot.processIdentifier) WebCore::ProcessIdentifier(WTF::HashTableDeletedValue); }
 

--- a/Source/WebCore/layout/LayoutUnits.h
+++ b/Source/WebCore/layout/LayoutUnits.h
@@ -202,7 +202,8 @@ struct SlotPositionHash {
     static const bool safeToCompareToEmptyOrDeleted = true;
 };
 template<> struct HashTraits<WebCore::Layout::SlotPosition> : GenericHashTraits<WebCore::Layout::SlotPosition> {
-    static WebCore::Layout::SlotPosition emptyValue() { return WebCore::Layout::SlotPosition(0, std::numeric_limits<size_t>::max()); }
+    static WebCore::Layout::SlotPosition emptyValue() { return WebCore::Layout::SlotPosition(std::numeric_limits<size_t>::max() - 1, std::numeric_limits<size_t>::max() - 1); }
+    static bool isEmptyValue(const WebCore::Layout::SlotPosition& value) { return value.column == (std::numeric_limits<size_t>::max() - 1); }
 
     static void constructDeletedValue(WebCore::Layout::SlotPosition& slot) { slot.column = std::numeric_limits<size_t>::max(); }
     static bool isDeletedValue(const WebCore::Layout::SlotPosition& slot) { return slot.column == std::numeric_limits<size_t>::max(); }

--- a/Source/WebCore/loader/PCMSites.h
+++ b/Source/WebCore/loader/PCMSites.h
@@ -116,6 +116,7 @@ template<typename T> struct DefaultHash;
 template<> struct DefaultHash<WebCore::PCM::SourceSite> : WebCore::PCM::SourceSiteHash { };
 template<> struct HashTraits<WebCore::PCM::SourceSite> : GenericHashTraits<WebCore::PCM::SourceSite> {
     static WebCore::PCM::SourceSite emptyValue() { return WebCore::PCM::SourceSite(WebCore::RegistrableDomain()); }
+    static bool isEmptyValue(const WebCore::PCM::SourceSite& value) { return value.registrableDomain.string().isNull(); }
     static void constructDeletedValue(WebCore::PCM::SourceSite& slot) { new (NotNull, &slot.registrableDomain) WebCore::RegistrableDomain(WTF::HashTableDeletedValue); }
     static bool isDeletedValue(const WebCore::PCM::SourceSite& slot) { return slot.registrableDomain.isHashTableDeletedValue(); }
 };
@@ -123,6 +124,7 @@ template<> struct HashTraits<WebCore::PCM::SourceSite> : GenericHashTraits<WebCo
 template<> struct DefaultHash<WebCore::PCM::AttributionDestinationSite> : WebCore::PCM::AttributionDestinationSiteHash { };
 template<> struct HashTraits<WebCore::PCM::AttributionDestinationSite> : GenericHashTraits<WebCore::PCM::AttributionDestinationSite> {
     static WebCore::PCM::AttributionDestinationSite emptyValue() { return { }; }
+    static bool isEmptyValue(const WebCore::PCM::AttributionDestinationSite& value) { return value.registrableDomain.string().isNull(); }
     static void constructDeletedValue(WebCore::PCM::AttributionDestinationSite& slot) { new (NotNull, &slot.registrableDomain) WebCore::RegistrableDomain(WTF::HashTableDeletedValue); }
     static bool isDeletedValue(const WebCore::PCM::AttributionDestinationSite& slot) { return slot.registrableDomain.isHashTableDeletedValue(); }
 };

--- a/Source/WebCore/loader/ResourceCryptographicDigest.h
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.h
@@ -105,6 +105,8 @@ template<> struct HashTraits<WebCore::ResourceCryptographicDigest> : GenericHash
         return { emptyAlgorithmValue, { } };
     }
 
+    static bool isEmptyValue(const WebCore::ResourceCryptographicDigest& value) { return value.algorithm == emptyAlgorithmValue; }
+
     static void constructDeletedValue(WebCore::ResourceCryptographicDigest& slot)
     {
         slot.algorithm = deletedAlgorithmValue;

--- a/Source/WebCore/page/GlobalWindowIdentifier.h
+++ b/Source/WebCore/page/GlobalWindowIdentifier.h
@@ -60,6 +60,7 @@ struct GlobalWindowIdentifierHash {
 
 template<> struct HashTraits<WebCore::GlobalWindowIdentifier> : GenericHashTraits<WebCore::GlobalWindowIdentifier> {
     static WebCore::GlobalWindowIdentifier emptyValue() { return { { }, HashTraits<WebCore::WindowIdentifier>::emptyValue() }; }
+    static bool isEmptyValue(const WebCore::GlobalWindowIdentifier& value) { return value.windowIdentifier.isHashTableEmptyValue(); }
 
     static void constructDeletedValue(WebCore::GlobalWindowIdentifier& slot)
     {

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -158,6 +158,7 @@ template<typename T> struct DefaultHash<WebCore::ProcessQualified<T>> {
 template<typename T> struct HashTraits<WebCore::ProcessQualified<T>> : SimpleClassHashTraits<WebCore::ProcessQualified<T>> {
     static constexpr bool emptyValueIsZero = HashTraits<T>::emptyValueIsZero;
     static WebCore::ProcessQualified<T> emptyValue() { return { HashTraits<T>::emptyValue(), { } }; }
+    static bool isEmptyValue(const WebCore::ProcessQualified<T>& value) { return value.object().isHashTableEmptyValue(); }
 };
 
 class ProcessQualifiedStringTypeAdapter {

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -95,6 +95,7 @@ public:
     explicit Color(WTF::HashTableEmptyValueType);
     explicit Color(WTF::HashTableDeletedValueType);
     bool isHashTableDeletedValue() const;
+    bool isHashTableEmptyValue() const;
 
     WEBCORE_EXPORT Color(const Color&);
     WEBCORE_EXPORT Color(Color&&);
@@ -391,6 +392,11 @@ inline Color::Color(WTF::HashTableDeletedValueType)
 inline bool Color::isHashTableDeletedValue() const
 {
     return flags().contains(FlagsIncludingPrivate::HashTableDeletedValue);
+}
+
+inline bool Color::isHashTableEmptyValue() const
+{
+    return flags().contains(FlagsIncludingPrivate::HashTableEmptyValue);
 }
 
 inline Color::~Color()

--- a/Source/WebCore/platform/graphics/ColorHash.h
+++ b/Source/WebCore/platform/graphics/ColorHash.h
@@ -41,6 +41,7 @@ template<> struct DefaultHash<WebCore::Color> : ColorHash { };
 template<> struct HashTraits<WebCore::Color> : GenericHashTraits<WebCore::Color> {
     static const bool emptyValueIsZero = false;
     static WebCore::Color emptyValue() { return WebCore::Color(HashTableEmptyValue); }
+    static bool isEmptyValue(const WebCore::Color& value) { return value.isHashTableEmptyValue(); }
 
     static void constructDeletedValue(WebCore::Color& slot) { new (NotNull, &slot) WebCore::Color(HashTableDeletedValue); }
     static bool isDeletedValue(const WebCore::Color& value) { return value.isHashTableDeletedValue(); }

--- a/Source/WebCore/platform/graphics/IntPointHash.h
+++ b/Source/WebCore/platform/graphics/IntPointHash.h
@@ -34,6 +34,7 @@ struct IntPointHash {
 };
 template<> struct HashTraits<WebCore::IntPoint> : GenericHashTraits<WebCore::IntPoint> {
     static WebCore::IntPoint emptyValue() { return WebCore::IntPoint(0, std::numeric_limits<int>::min()); }
+    static bool isEmptyValue(const WebCore::IntPoint& value) { return value.y() == std::numeric_limits<int>::min(); }
     
     static void constructDeletedValue(WebCore::IntPoint& slot) { slot.setX(std::numeric_limits<int>::min()); }
     static bool isDeletedValue(const WebCore::IntPoint& slot) { return slot.x() == std::numeric_limits<int>::min(); }

--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -56,6 +56,8 @@ public:
     {
     }
 
+    bool isHashTableEmptyValue() const { return std::holds_alternative<WTF::HashTableEmptyValueType>(m_address); }
+
     WEBCORE_EXPORT IPAddress isolatedCopy() const;
     WEBCORE_EXPORT unsigned matchingNetMaskLength(const IPAddress& other) const;
     WEBCORE_EXPORT static std::optional<IPAddress> fromString(const String&);
@@ -118,6 +120,7 @@ namespace WTF {
 
 template<> struct HashTraits<WebCore::IPAddress> : GenericHashTraits<WebCore::IPAddress> {
     static WebCore::IPAddress emptyValue() { return WebCore::IPAddress { WTF::HashTableEmptyValue }; }
+    static bool isEmptyValue(const WebCore::IPAddress& value) { return value.isHashTableEmptyValue(); }
 };
 
 } // namespace WTF

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -84,6 +84,7 @@ struct GlobalFrameIDHash {
 
 template<> struct HashTraits<WebKit::NetworkCache::GlobalFrameID> : GenericHashTraits<WebKit::NetworkCache::GlobalFrameID> {
     static WebKit::NetworkCache::GlobalFrameID emptyValue() { return { { }, HashTraits<WebCore::PageIdentifier>::emptyValue(), HashTraits<WebCore::FrameIdentifier>::emptyValue() }; }
+    static bool isEmptyValue(const WebKit::NetworkCache::GlobalFrameID& slot) { return slot.webPageID.isHashTableEmptyValue(); }
 
     static void constructDeletedValue(WebKit::NetworkCache::GlobalFrameID& slot) { new (NotNull, &slot.webPageID) WebCore::PageIdentifier(WTF::HashTableDeletedValue); }
 

--- a/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
@@ -259,6 +259,7 @@ template<typename P> struct DefaultHash<WKRetainPtr<P>> : PtrHash<WKRetainPtr<P>
 
 template<typename P> struct HashTraits<WKRetainPtr<P>> : SimpleClassHashTraits<WKRetainPtr<P>> {
     static P emptyValue() { return nullptr; }
+    static bool isEmptyValue(const WKRetainPtr<P>& value) { return !value; }
 
     typedef P PeekType;
     static PeekType peek(const WKRetainPtr<P>& value) { return value.get(); }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -77,6 +77,7 @@ struct TileForGridHash {
 template<> struct HashTraits<WebKit::TileForGrid> : GenericHashTraits<WebKit::TileForGrid> {
     static constexpr bool emptyValueIsZero = true;
     static WebKit::TileForGrid emptyValue() { return { HashTraits<WebCore::TileGridIdentifier>::emptyValue(), { 0, 0 } }; }
+    static bool isEmptyValue(const WebKit::TileForGrid& value) { return value.gridIdentifier.isHashTableEmptyValue(); }
     static void constructDeletedValue(WebKit::TileForGrid& tileForGrid) { HashTraits<WebCore::TileGridIdentifier>::constructDeletedValue(tileForGrid.gridIdentifier); }
     static bool isDeletedValue(const WebKit::TileForGrid& tileForGrid) { return tileForGrid.gridIdentifier.isHashTableDeletedValue(); }
 };


### PR DESCRIPTION
#### b2bb9e615f7815483f79522af70b42e7e8115276
<pre>
Add isEmptyValue() to more HashTraits structures
<a href="https://bugs.webkit.org/show_bug.cgi?id=279724">https://bugs.webkit.org/show_bug.cgi?id=279724</a>

Reviewed by Darin Adler.

Add isEmptyValue() to more HashTraits structures to avoid
constructing empty values in HashTable::checkKey().

* Source/WTF/wtf/CheckedPtr.h:
(WTF::HashTraits&lt;CheckedPtr&lt;P&gt;&gt;::isEmptyValue):
* Source/WTF/wtf/GenericHashKey.h:
* Source/WTF/wtf/HashTraits.h:
(WTF::HashTraits&lt;UniqueRef&lt;T&gt;&gt;::isEmptyValue):
(WTF::HashTraits&lt;ASCIILiteral&gt;::isEmptyValue):
(WTF::PairHashTraits::isEmptyValue):
(WTF::KeyValuePairHashTraits::isEmptyValue):
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifierGeneric::isHashTableEmptyValue const):
* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtrObjectHashTraits::isEmptyValue):
* Source/WTF/wtf/UUID.h:
(WTF::UUID::isHashTableEmptyValue const):
(WTF::HashTraits&lt;UUID&gt;::isEmptyValue):
* Source/WTF/wtf/UniqueRef.h:
(WTF::UniqueRef::isHashTableEmptyValue const):
* Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.h:
(WTF::HashTraits&lt;WebCore::IDBIndexInfo&gt;::isEmptyValue):
* Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.h:
(WTF::HashTraits&lt;WebCore::IDBObjectStoreInfo&gt;::isEmptyValue):
* Source/WebCore/PAL/pal/SessionID.h:
(PAL::SessionID::isHashTableEmptyValue const):
(WTF::HashTraits&lt;PAL::SessionID&gt;::isEmptyValue):
* Source/WebCore/dom/ElementRareData.h:
(WebCore::LayoutUnitMarkableTraits::isEmptyValue):
* Source/WebCore/dom/MessagePortIdentifier.h:
(WTF::HashTraits&lt;WebCore::MessagePortIdentifier&gt;::isEmptyValue):
* Source/WebCore/layout/LayoutUnits.h:
(WTF::HashTraits&lt;WebCore::Layout::SlotPosition&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::Layout::SlotPosition&gt;::isEmptyValue):
* Source/WebCore/loader/PCMSites.h:
(WTF::HashTraits&lt;WebCore::PCM::SourceSite&gt;::isEmptyValue):
(WTF::HashTraits&lt;WebCore::PCM::AttributionDestinationSite&gt;::isEmptyValue):
* Source/WebCore/loader/ResourceCryptographicDigest.h:
(WTF::HashTraits&lt;WebCore::ResourceCryptographicDigest&gt;::isEmptyValue):
* Source/WebCore/page/GlobalWindowIdentifier.h:
(WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;::isEmptyValue):
* Source/WebCore/platform/ProcessQualified.h:
(WTF::HashTraits&lt;WebCore::ProcessQualified&lt;T&gt;&gt;::isEmptyValue):
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::isHashTableEmptyValue const):
* Source/WebCore/platform/graphics/ColorHash.h:
(WTF::HashTraits&lt;WebCore::Color&gt;::isEmptyValue):
* Source/WebCore/platform/graphics/IntPointHash.h:
(WTF::HashTraits&lt;WebCore::IntPoint&gt;::isEmptyValue):
* Source/WebCore/platform/network/DNS.h:
(WebCore::IPAddress::isHashTableEmptyValue const):
(WTF::HashTraits&lt;WebCore::IPAddress&gt;::isEmptyValue):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
(WTF::HashTraits&lt;WebKit::NetworkCache::GlobalFrameID&gt;::isEmptyValue):
* Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h:
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::isEmptyValue):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::isEmptyValue):

Canonical link: <a href="https://commits.webkit.org/283699@main">https://commits.webkit.org/283699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d05b3f74265e930847b5ea2b4b1c00389aca4d6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53788 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12251 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34307 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16552 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60180 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72801 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66310 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15125 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61256 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-element-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-fill.html webanimations/accelerated-animation-slot-invalidation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61332 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2665 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88078 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10178 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42249 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15503 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->