### PR TITLE
[scroll-animations] update `ComputedEffectTiming` to use `CSSNumberish`

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -694,6 +694,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/AnimationFrameRatePreset.h
     animation/AnimationTimeline.h
     animation/AnimationTimelinesController.h
+    animation/CSSNumberishTime.h
     animation/CSSPropertyBlendingClient.h
     animation/CustomAnimationOptions.h
     animation/CompositeOperation.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -590,6 +590,7 @@ animation/AnimationTimeline.cpp
 animation/BlendingKeyframes.cpp
 animation/CSSAnimation.cpp
 animation/CSSAnimationEvent.cpp
+animation/CSSNumberishTime.cpp
 animation/CSSPropertyAnimation.cpp
 animation/CSSTransition.cpp
 animation/CSSTransitionEvent.cpp

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSNumberishTime.h"
+
+#include "CSSNumericFactory.h"
+#include "CSSUnitValue.h"
+#include "CSSUnits.h"
+
+namespace WebCore {
+
+CSSNumberishTime::CSSNumberishTime(double value)
+    : m_type(Type::Time)
+    , m_source(Source::Literal)
+    , m_value(value / 1000)
+{
+}
+
+CSSNumberishTime::CSSNumberishTime(Type type, Source source, double value)
+    : m_type(type)
+    , m_source(source)
+    , m_value(value)
+{
+}
+
+CSSNumberishTime::CSSNumberishTime(CSSNumberish value)
+{
+    if (auto* doubleValue = std::get_if<double>(&value)) {
+        m_type = Type::Time;
+        m_source = Source::Literal;
+        m_value = *doubleValue / 1000;
+        return;
+    }
+
+    ASSERT(std::holds_alternative<RefPtr<CSSNumericValue>>(value));
+    auto numericValue = std::get<RefPtr<CSSNumericValue>>(value);
+    if (auto* unitValue = dynamicDowncast<CSSUnitValue>(numericValue.get())) {
+        if (unitValue->unitEnum() == CSSUnitType::CSS_NUMBER) {
+            m_type = Type::Time;
+            m_source = Source::Number;
+            m_value = unitValue->value() / 1000;
+        } else if (auto milliseconds = unitValue->convertTo(CSSUnitType::CSS_MS)) {
+            m_type = Type::Time;
+            m_source = Source::Milliseconds;
+            m_value = milliseconds->value() / 1000;
+        } else if (auto seconds = unitValue->convertTo(CSSUnitType::CSS_S)) {
+            m_type = Type::Time;
+            m_source = Source::Seconds;
+            m_value = seconds->value();
+        } else if (auto percentage = unitValue->convertTo(CSSUnitType::CSS_PERCENTAGE)) {
+            m_type = Type::Percentage;
+            m_source = Source::Percentage;
+            m_value = percentage->value();
+        }
+    }
+}
+
+std::optional<Seconds> CSSNumberishTime::time() const
+{
+    if (m_type == Type::Time)
+        return Seconds { m_value };
+    return std::nullopt;
+}
+
+std::optional<double> CSSNumberishTime::percentage() const
+{
+    if (m_type == Type::Percentage)
+        return m_value;
+    return std::nullopt;
+}
+
+bool CSSNumberishTime::isValid() const
+{
+    return m_type != Type::Unknown;
+}
+
+CSSNumberishTime CSSNumberishTime::operator+(CSSNumberishTime other) const
+{
+    ASSERT(m_type == other.m_type);
+    return { m_type, m_source, m_value + other.m_value };
+}
+
+CSSNumberishTime CSSNumberishTime::operator-(CSSNumberishTime other) const
+{
+    ASSERT(m_type == other.m_type);
+    return { m_type, m_source, m_value - other.m_value };
+}
+
+bool CSSNumberishTime::operator<(CSSNumberishTime other) const
+{
+    ASSERT(m_type == other.m_type);
+    return m_value < other.m_value;
+}
+
+bool CSSNumberishTime::operator<=(CSSNumberishTime other) const
+{
+    ASSERT(m_type == other.m_type);
+    return m_value <= other.m_value;
+}
+
+bool CSSNumberishTime::operator>(CSSNumberishTime other) const
+{
+    ASSERT(m_type == other.m_type);
+    return m_value > other.m_value;
+}
+
+bool CSSNumberishTime::operator>=(CSSNumberishTime other) const
+{
+    ASSERT(m_type == other.m_type);
+    return m_value >= other.m_value;
+}
+
+CSSNumberishTime::operator CSSNumberish() const
+{
+    switch (m_source) {
+    case Source::Literal:
+        ASSERT(m_type == Type::Time);
+        return m_value * 1000;
+    case Source::Number:
+        ASSERT(m_type == Type::Time);
+        return CSSNumericFactory::number(m_value * 1000);
+    case Source::Milliseconds:
+        ASSERT(m_type == Type::Time);
+        return CSSNumericFactory::ms(m_value * 1000);
+    case Source::Seconds:
+        ASSERT(m_type == Type::Time);
+        return CSSNumericFactory::s(m_value);
+    case Source::Percentage:
+        ASSERT(m_type == Type::Percentage);
+        return CSSNumericFactory::percent(m_value);
+    }
+
+    ASSERT_NOT_REACHED();
+    return m_value;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSNumericValue.h"
+#include <wtf/Seconds.h>
+
+namespace WebCore {
+
+class CSSNumberishTime {
+public:
+    CSSNumberishTime() = default;
+
+    CSSNumberishTime(double);
+    CSSNumberishTime(CSSNumberish);
+
+    std::optional<Seconds> time() const;
+    std::optional<double> percentage() const;
+
+    bool isValid() const;
+
+    CSSNumberishTime operator+(CSSNumberishTime) const;
+    CSSNumberishTime operator-(CSSNumberishTime) const;
+    bool operator<(CSSNumberishTime) const;
+    bool operator<=(CSSNumberishTime) const;
+    bool operator>(CSSNumberishTime) const;
+    bool operator>=(CSSNumberishTime) const;
+
+    operator CSSNumberish() const;
+
+private:
+    enum class Type : uint8_t { Unknown, Time, Percentage };
+    enum class Source : uint8_t { Literal, Number, Milliseconds, Seconds, Percentage };
+
+    CSSNumberishTime(Type, Source, double);
+
+    Type m_type { Type::Unknown };
+    Source m_source { Source::Literal };
+    double m_value { 0 };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/animation/ComputedEffectTiming.h
+++ b/Source/WebCore/animation/ComputedEffectTiming.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AnimationEffectPhase.h"
+#include "CSSNumericValue.h"
 #include "EffectTiming.h"
 #include "TimingFunction.h"
 #include "WebAnimationTypes.h"
@@ -34,12 +35,12 @@ namespace WebCore {
 
 struct ComputedEffectTiming : EffectTiming {
     AnimationEffectPhase phase { AnimationEffectPhase::Idle };
-    MarkableDouble localTime;
+    std::optional<CSSNumberishTime> localTime;
     MarkableDouble simpleIterationProgress;
     MarkableDouble progress;
     MarkableDouble currentIteration;
-    double endTime;
-    double activeDuration;
+    CSSNumberishTime endTime;
+    CSSNumberishTime activeDuration;
     TimingFunction::Before before { TimingFunction::Before::No };
 };
 

--- a/Source/WebCore/animation/ComputedEffectTiming.idl
+++ b/Source/WebCore/animation/ComputedEffectTiming.idl
@@ -23,12 +23,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (double or CSSNumericValue) CSSNumberish;
+
 [
     JSGenerateToJSObject
 ] dictionary ComputedEffectTiming : EffectTiming {
-    unrestricted double  endTime;
-    unrestricted double  activeDuration;
-    double?              localTime = null;
+    CSSNumberish         endTime;
+    CSSNumberish         activeDuration;
+    CSSNumberish?        localTime = null;
     double?              progress = null;
     unrestricted double? currentIteration = null;
 };

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -30,6 +30,7 @@
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSScrollValue.h"
 #include "CSSValuePool.h"
+#include "Document.h"
 #include "Element.h"
 
 namespace WebCore {

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -295,8 +295,9 @@ void StyleOriginatedAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEv
         if (auto computedIteration = timing.currentIteration)
             iteration = *computedIteration;
         currentPhase = timing.phase;
-        intervalStart = std::max(0_s, Seconds::fromMilliseconds(std::min(-timing.delay, timing.activeDuration)));
-        intervalEnd = std::max(0_s, Seconds::fromMilliseconds(std::min(timing.endTime - timing.delay, timing.activeDuration)));
+        auto activeDuration = timing.activeDuration.time()->milliseconds();
+        intervalStart = std::max(0_s, Seconds::fromMilliseconds(std::min(-timing.delay, activeDuration)));
+        intervalEnd = std::max(0_s, Seconds::fromMilliseconds(std::min(timing.endTime.time()->milliseconds() - timing.delay, activeDuration)));
     } else {
         iteration = 0;
         currentPhase = phaseWithoutEffect();

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -33,6 +33,7 @@
 #include "CSSUnits.h"
 #include "CSSValuePool.h"
 #include "CSSViewValue.h"
+#include "Document.h"
 #include "Element.h"
 #include "StyleBuilderConverter.h"
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -314,16 +314,8 @@ ExceptionOr<std::optional<Seconds>> WebAnimation::validateCSSNumberishValue(cons
     if (!optionalCSSNumberish)
         return { std::nullopt };
 
-    if (std::holds_alternative<double>(*optionalCSSNumberish))
-        return { Seconds::fromMilliseconds(std::get<double>(*optionalCSSNumberish)) };
-
-    auto numericValue = std::get<RefPtr<CSSNumericValue>>(*optionalCSSNumberish);
-    if (auto* unitValue = dynamicDowncast<CSSUnitValue>(numericValue.get())) {
-        if (unitValue->unitEnum() == CSSUnitType::CSS_NUMBER)
-            return { Seconds::fromMilliseconds(unitValue->value()) };
-        if (auto milliseconds = unitValue->convertTo(CSSUnitType::CSS_MS))
-            return { Seconds::fromMilliseconds(milliseconds->value()) };
-    }
+    if (auto seconds = CSSNumberishTime { *optionalCSSNumberish }.time())
+        return { *seconds };
 
     return Exception { ExceptionCode::TypeError };
 }

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSNumberishTime.h"
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
 #include "EventTarget.h"


### PR DESCRIPTION
#### cf5ac861157f59865809da65be40f10b33014cbe
<pre>
[scroll-animations] update `ComputedEffectTiming` to use `CSSNumberish`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279727">https://bugs.webkit.org/show_bug.cgi?id=279727</a>
<a href="https://rdar.apple.com/136031059">rdar://136031059</a>

Reviewed by Chris Dumez and Tim Nguyen.

To accommodate progress-based timelines (such as `ScrollTimeline` and `ViewTimeline`),
the following properties of `ComputedEffectTiming` have been updated to be `CSSNumberish`
(aka `double or CSSNumericValue`) to return `%` values: `localTime`, `endTime` and
`activeDuration`.

Before we do the work to actually compute such values, we update the IDL files for these
properties and back them with a new type called `CSSNumberishTime` which can automatically
convert from and to `CSSNumberish`. The benefit of `CSSNumberishTime` are twofold.

First, it removes the need to deal with `std::variant` switches and then the various units
which `CSSNumericValue` can represent with either &quot;time&quot; or &quot;percentage&quot; semantics and methods
to access such values.

Second, it supports various math operators to directly add, subtract and compare the time
or percentage values held by `CSSNumberishTime`. This will be critical when we adopt `CSSNumberish`
through more of the Web Animations API, especially with the `Animation` APIs which are used
throughout the Web Animations codebase currently as `Seconds`. This should make the move to
`CSSNumberishTime` mostly transparent for most of our code.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSNumberishTime.cpp: Added.
(WebCore::CSSNumberishTime::CSSNumberishTime):
(WebCore::CSSNumberishTime::time const):
(WebCore::CSSNumberishTime::percentage const):
(WebCore::CSSNumberishTime::isValid const):
(WebCore::CSSNumberishTime::operator+ const):
(WebCore::CSSNumberishTime::operator- const):
(WebCore::CSSNumberishTime::operator&lt; const):
(WebCore::CSSNumberishTime::operator&lt;= const):
(WebCore::CSSNumberishTime::operator&gt; const):
(WebCore::CSSNumberishTime::operator&gt;= const):
(WebCore::CSSNumberishTime::operator CSSNumberish const):
* Source/WebCore/animation/CSSNumberishTime.h: Added.
* Source/WebCore/animation/ComputedEffectTiming.h:
* Source/WebCore/animation/ComputedEffectTiming.idl:
* Source/WebCore/animation/ScrollTimeline.cpp: Fix missing header revealed by the addition of `CSSNumberishTime`.
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::invalidateDOMEvents):
* Source/WebCore/animation/ViewTimeline.cpp: Fix missing header revealed by the addition of `CSSNumberishTime`.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::validateCSSNumberishValue const): Remove code dealing with `CSSNumericValue` since all of
it is performed by the `CSSNumberishTime` constructor.
* Source/WebCore/animation/WebAnimationTypes.h: Add `CSSNumberishTime.h` so that the Web Animations code automatically
gets access to `CSSNumberishTime.h` via this oft-included file.

Canonical link: <a href="https://commits.webkit.org/283689@main">https://commits.webkit.org/283689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fbca49131fa37376e0c1c5513daf8dbe3cc6a1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53772 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12238 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61241 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61317 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2652 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10175 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42232 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->