### PR TITLE
[Buildstream SDK] Add libspiel

### DIFF
--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -32,6 +32,7 @@ depends:
 - sdk/libmanette.bst
 - sdk/libportal.bst
 - sdk/libsecret.bst
+- sdk/libspiel.bst
 - sdk/libusrsctp.bst
 - sdk/libwpe.bst
 - sdk/mold.bst

--- a/Tools/buildstream/elements/sdk/libspiel.bst
+++ b/Tools/buildstream/elements/sdk/libspiel.bst
@@ -1,0 +1,26 @@
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+- freedesktop-sdk.bst:components/gstreamer-plugins-base.bst
+
+variables:
+  meson-local: >-
+    -Dtests=false
+    -Ddocs=false
+    -Dlibspeechprovider:docs=false
+    -Dlibspeechprovider:introspection=false
+
+sources:
+- kind: git_repo
+  url: github_com:project-spiel/libspiel.git
+  track: main
+  ref: SPIEL_1_0_1-31-gac56d0dd19b2b2ecd9e81a3c436cc9f9e7299e9d
+- kind: git_repo
+  url: github_com:project-spiel/libspeechprovider.git
+  track: main
+  ref: SPEECHPROVIDER_1_0_1-11-g3de6db3b18b8da26f2d60c35c330ff68be96e992
+  directory: subprojects/libspeechprovider


### PR DESCRIPTION
#### b23773bba83e86597275db8972a45094ac614825
<pre>
[Buildstream SDK] Add libspiel
<a href="https://bugs.webkit.org/show_bug.cgi?id=279737">https://bugs.webkit.org/show_bug.cgi?id=279737</a>

Reviewed by Adrian Perez de Castro.

Spiel is a nicer alternative to Festival for speech synthesys because its API is directly inspired
from WebSpeech. A future patch will rewrite our speech synthesys backend using Spiel, but we first
need it in the SDK. The host is responsible for installing voice providers using Flatpak, so this
part is not included in this patch.

* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/libspiel.bst: Added.

Canonical link: <a href="https://commits.webkit.org/283692@main">https://commits.webkit.org/283692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4beef40f154058d9d422f29b093304bb2458817d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18013 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/12263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70156 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/15447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16576 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/15788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11048 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/72826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11081 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/58112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/9086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10176 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->