### PR TITLE
[CSS] @property initial-value descriptor can't contain var(--foo)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-expected.txt
@@ -36,7 +36,7 @@ PASS Attribute 'initial-value' returns expected value for [red]
 PASS Attribute 'initial-value' returns expected value for [foo]
 PASS Attribute 'initial-value' returns expected value for [if(){}]
 PASS Attribute 'initial-value' makes the @property rule invalid for [3em]
-FAIL Attribute 'initial-value' makes the @property rule invalid for [var(--x)] assert_true: expected true got false
+PASS Attribute 'initial-value' makes the @property rule invalid for [var(--x)]
 PASS Attribute 'inherits' returns expected value for [true]
 PASS Attribute 'inherits' returns expected value for [false]
 PASS Attribute 'inherits' makes the @property rule invalid for [none]

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1309,8 +1309,12 @@ RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange
     auto initialValueIsValid = [&] {
         auto tokenRange = descriptor.initialValue->tokenRange();
         auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, tokenRange, strictCSSParserContext());
-        return dependencies.isComputationallyIndependent();
-        // FIXME: We should also check values like "var(--foo)"
+        if (!dependencies.isComputationallyIndependent())
+            return false;
+        auto containsVariable = CSSVariableParser::containsValidVariableReferences(descriptor.initialValue->tokenRange(), m_context);
+        if (containsVariable)
+            return false;
+        return true;
     };
     if (descriptor.initialValue && !initialValueIsValid())
         return nullptr;


### PR DESCRIPTION
#### 68367bc72477ba3ee3596b1fa5a0c963563d1d98
<pre>
[CSS] @property initial-value descriptor can&apos;t contain var(--foo)
<a href="https://bugs.webkit.org/show_bug.cgi?id=279751">https://bugs.webkit.org/show_bug.cgi?id=279751</a>
<a href="https://rdar.apple.com/134317319">rdar://134317319</a>

Reviewed by Antti Koivisto.

<a href="https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor">https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor</a>

<a href="https://drafts.css-houdini.org/css-properties-values-api/#computationally-independent">https://drafts.css-houdini.org/css-properties-values-api/#computationally-independent</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumePropertyRule):

Canonical link: <a href="https://commits.webkit.org/283701@main">https://commits.webkit.org/283701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87fd411898b274a5b769f10b522801b2f9fd3eac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53796 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12257 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34315 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15434 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15132 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61272 "Found 1 new test failure: webanimations/accelerated-animation-opacity-animation-begin-time-after-scale-animation-ends.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9078 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2676 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42265 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->