### PR TITLE
[scroll-animations] update `AnimationPlaybackEvent` to use `CSSNumberish`

### DIFF
--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -35,39 +35,38 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AnimationPlaybackEvent);
 
 AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, const AnimationPlaybackEventInit& initializer, IsTrusted isTrusted)
     : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, initializer, isTrusted)
+    , m_timelineTime(initializer.timelineTime)
+    , m_currentTime(initializer.currentTime)
 {
-    if (initializer.currentTime)
-        m_currentTime = Seconds::fromMilliseconds(*initializer.currentTime);
-    else
-        m_currentTime = std::nullopt;
-
-    if (initializer.timelineTime)
-        m_timelineTime = Seconds::fromMilliseconds(*initializer.timelineTime);
-    else
-        m_timelineTime = std::nullopt;
 }
 
 AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime)
     : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, animation, scheduledTime)
-    , m_timelineTime(timelineTime)
-    , m_currentTime(currentTime)
 {
+    if (timelineTime)
+        m_timelineTime = timelineTime->milliseconds();
+    if (currentTime)
+        m_currentTime = currentTime->milliseconds();
 }
 
 AnimationPlaybackEvent::~AnimationPlaybackEvent() = default;
 
-std::optional<double> AnimationPlaybackEvent::bindingsCurrentTime() const
+std::optional<CSSNumberishTime> AnimationPlaybackEvent::bindingsCurrentTime() const
 {
-    if (!m_currentTime)
-        return std::nullopt;
-    return secondsToWebAnimationsAPITime(m_currentTime.value());
+    if (m_currentTime) {
+        ASSERT(m_currentTime->time());
+        return secondsToWebAnimationsAPITime(*m_currentTime->time());
+    }
+    return std::nullopt;
 }
 
-std::optional<double> AnimationPlaybackEvent::bindingsTimelineTime() const
+std::optional<CSSNumberishTime> AnimationPlaybackEvent::bindingsTimelineTime() const
 {
-    if (!m_timelineTime)
-        return std::nullopt;
-    return secondsToWebAnimationsAPITime(m_timelineTime.value());
+    if (m_timelineTime) {
+        ASSERT(m_timelineTime->time());
+        return secondsToWebAnimationsAPITime(*m_timelineTime->time());
+    }
+    return std::nullopt;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -27,6 +27,7 @@
 
 #include "AnimationEventBase.h"
 #include "AnimationPlaybackEventInit.h"
+#include "WebAnimationTypes.h"
 #include <wtf/Markable.h>
 
 namespace WebCore {
@@ -48,18 +49,18 @@ public:
 
     bool isAnimationPlaybackEvent() const final { return true; }
 
-    std::optional<Seconds> timelineTime() const { return m_timelineTime; }
-    std::optional<double> bindingsTimelineTime() const;
+    std::optional<CSSNumberishTime> timelineTime() const { return m_timelineTime; }
+    std::optional<CSSNumberishTime> bindingsTimelineTime() const;
 
-    std::optional<double> bindingsCurrentTime() const;
-    std::optional<Seconds> currentTime() const { return m_currentTime; }
+    std::optional<CSSNumberishTime> bindingsCurrentTime() const;
+    std::optional<CSSNumberishTime> currentTime() const { return m_currentTime; }
 
 private:
     AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime);
     AnimationPlaybackEvent(const AtomString&, const AnimationPlaybackEventInit&, IsTrusted);
 
-    Markable<Seconds, Seconds::MarkableTraits> m_timelineTime;
-    Markable<Seconds, Seconds::MarkableTraits> m_currentTime;
+    std::optional<CSSNumberishTime> m_timelineTime;
+    std::optional<CSSNumberishTime> m_currentTime;
 };
 
 }

--- a/Source/WebCore/animation/AnimationPlaybackEvent.idl
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.idl
@@ -23,11 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (double or CSSNumericValue) CSSNumberish;
+
 [
     Exposed=Window
 ] interface AnimationPlaybackEvent : Event {
     constructor([AtomString] DOMString type, optional AnimationPlaybackEventInit eventInitDict);
 
-    [ImplementedAs=bindingsCurrentTime] readonly attribute double? currentTime;
-    [ImplementedAs=bindingsTimelineTime] readonly attribute double? timelineTime;
+    [ImplementedAs=bindingsCurrentTime] readonly attribute CSSNumberish? currentTime;
+    [ImplementedAs=bindingsTimelineTime] readonly attribute CSSNumberish? timelineTime;
 };

--- a/Source/WebCore/animation/AnimationPlaybackEventInit.h
+++ b/Source/WebCore/animation/AnimationPlaybackEventInit.h
@@ -31,8 +31,8 @@
 namespace WebCore {
 
 struct AnimationPlaybackEventInit : EventInit {
-    MarkableDouble currentTime;
-    MarkableDouble timelineTime;
+    std::optional<CSSNumberishTime> currentTime;
+    std::optional<CSSNumberishTime> timelineTime;
 };
 
 }

--- a/Source/WebCore/animation/AnimationPlaybackEventInit.idl
+++ b/Source/WebCore/animation/AnimationPlaybackEventInit.idl
@@ -23,7 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (double or CSSNumericValue) CSSNumberish;
+
 dictionary AnimationPlaybackEventInit : EventInit {
-    double? currentTime = null;
-    double? timelineTime = null;
+    CSSNumberish? currentTime = null;
+    CSSNumberish? timelineTime = null;
 };


### PR DESCRIPTION
#### a4d0166e64f247eb1f80a1a3d2d076009ac4b9a3
<pre>
[scroll-animations] update `AnimationPlaybackEvent` to use `CSSNumberish`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279731">https://bugs.webkit.org/show_bug.cgi?id=279731</a>
<a href="https://rdar.apple.com/136031174">rdar://136031174</a>

Reviewed by Dean Jackson.

Adopt `CSSNumberishTime` introduced in 283689@main to represent `CSSNumberish`
time values for the `AnimationPlaybackEvent` class and the `AnimationPlaybackEventInit`
dictionary.

* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
(WebCore::AnimationPlaybackEvent::bindingsCurrentTime const):
(WebCore::AnimationPlaybackEvent::bindingsTimelineTime const):
* Source/WebCore/animation/AnimationPlaybackEvent.h:
* Source/WebCore/animation/AnimationPlaybackEvent.idl:
* Source/WebCore/animation/AnimationPlaybackEventInit.h:
* Source/WebCore/animation/AnimationPlaybackEventInit.idl:

Canonical link: <a href="https://commits.webkit.org/283770@main">https://commits.webkit.org/283770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebabf09e9376b0815d4da0af677b495f2e067b41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53803 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12259 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16572 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15136 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61271 "Found 23 new test failures: imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-animated-001.html imported/w3c/web-platform-tests/css/css-values/vh-interpolate-pct.html imported/w3c/web-platform-tests/css/css-view-transitions/block-with-overflowing-text.html imported/w3c/web-platform-tests/css/css-view-transitions/break-inside-avoid-child.html imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child-translated.html imported/w3c/web-platform-tests/css/css-view-transitions/exit-transition-with-anonymous-layout-object.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-old-main.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-with-name-on-iframe.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61348 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2685 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10218 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42269 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->