### PR TITLE
[Site Isolation] Iframes with multiple ascendants in different processes cannot be navigated back or forward

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -781,7 +781,7 @@ Ref<HistoryItem> HistoryController::createItemTree(HistoryItemClient& client, Lo
             item->setDocumentSequenceNumber(previousItem->documentSequenceNumber());
         }
 
-        for (RefPtr child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling())
+        for (RefPtr child = m_frame->tree().firstLocalDescendant(); child; child = child->tree().nextLocalSibling())
             item->addChildItem(child->checkedHistory()->createItemTree(client, targetFrame, clipAtTarget));
     }
     // FIXME: Eliminate the isTargetItem flag in favor of itemSequenceNumber.
@@ -811,7 +811,7 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
         if (!fromChildItem)
             continue;
 
-        if (RefPtr childFrame = m_frame->tree().childByFrameID(*frameID))
+        if (RefPtr childFrame = m_frame->tree().descendantByFrameID(*frameID))
             childFrame->checkedHistory()->recursiveSetProvisionalItem(childItem, fromChildItem.get());
     }
 }
@@ -836,7 +836,7 @@ void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromIt
         if (!fromChildItem)
             continue;
 
-        if (RefPtr childFrame = m_frame->tree().childByFrameID(*frameID))
+        if (RefPtr childFrame = m_frame->tree().descendantByFrameID(*frameID))
             childFrame->checkedHistory()->recursiveGoToItem(childItem, fromChildItem.get(), type, shouldTreatAsContinuingLoad);
     }
 }

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -213,9 +213,9 @@ Frame* FrameTree::child(unsigned index) const
     return result;
 }
 
-Frame* FrameTree::childByFrameID(FrameIdentifier frameID) const
+Frame* FrameTree::descendantByFrameID(FrameIdentifier frameID) const
 {
-    for (auto* child = firstChild(); child; child = child->tree().nextSibling()) {
+    for (auto* child = firstChild(); child; child = child->tree().traverseNext()) {
         if (child->frameID() == frameID)
             return child;
     }
@@ -402,6 +402,24 @@ Frame* FrameTree::nextRenderedSibling() const
             return sibling;
     }
     
+    return nullptr;
+}
+
+LocalFrame* FrameTree::firstLocalDescendant() const
+{
+    for (auto* child = firstChild(); child; child = child->tree().traverseNext()) {
+        if (auto* localChild = dynamicDowncast<LocalFrame>(child))
+            return localChild;
+    }
+    return nullptr;
+}
+
+LocalFrame* FrameTree::nextLocalSibling() const
+{
+    for (auto* sibling = nextSibling(); sibling; sibling = sibling->tree().nextSibling()) {
+        if (auto* localSibling = dynamicDowncast<LocalFrame>(sibling))
+            return localSibling;
+    }
     return nullptr;
 }
 

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -56,6 +56,9 @@ public:
     Frame* firstRenderedChild() const;
     Frame* nextRenderedSibling() const;
 
+    LocalFrame* firstLocalDescendant() const;
+    LocalFrame* nextLocalSibling() const;
+
     WEBCORE_EXPORT bool isDescendantOf(const Frame* ancestor) const;
     
     WEBCORE_EXPORT Frame* traverseNext(const Frame* stayWithin = nullptr) const;
@@ -73,7 +76,7 @@ public:
 
     Frame* child(unsigned index) const;
     Frame* childBySpecifiedName(const AtomString& name) const;
-    Frame* childByFrameID(FrameIdentifier) const;
+    Frame* descendantByFrameID(FrameIdentifier) const;
     WEBCORE_EXPORT Frame* findByUniqueName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT Frame* findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT unsigned childCount() const;


### PR DESCRIPTION
#### 599ebf193f70af81c0b0c9cf6ce78a658d78a7f4
<pre>
[Site Isolation] Iframes with multiple ascendants in different processes cannot be navigated back or forward
<a href="https://bugs.webkit.org/show_bug.cgi?id=279752">https://bugs.webkit.org/show_bug.cgi?id=279752</a>
<a href="https://rdar.apple.com/136059631">rdar://136059631</a>

Reviewed by Alex Christensen.

When a history item tree is created in a web process, we initialize history items only for local frames.
Including empty history items for remote frames breaks the history tree traversal during back or forward
navigation, so we should just exclude them.

`FrameTree::childByFrameID()` now needs to search beyond immediate children, as there may be several
remote child frames above a local frame that were not included in the history tree.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::createItemTree):
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::recursiveGoToItem):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::descendantByFrameID const):
(WebCore::FrameTree::firstLocalChild const):
(WebCore::FrameTree::nextLocalSibling const):
(WebCore::FrameTree::childByFrameID const): Deleted.
* Source/WebCore/page/FrameTree.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigateNestedRootFramesBackForward)):

Canonical link: <a href="https://commits.webkit.org/283733@main">https://commits.webkit.org/283733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e59118f00bfbfcfd32165a1d66ecaed4701de80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18119 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58142 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11152 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61421 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9159 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10199 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43454 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->