### PR TITLE
Remove excessive indirection with sending remote drawing commands (part 1)

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -451,9 +451,8 @@ void DrawLine::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("point-2", point2());
 }
 
-DrawLinesForText::DrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle style)
-    : m_blockLocation(blockLocation)
-    , m_localAnchor(localAnchor)
+DrawLinesForText::DrawLinesForText(const FloatPoint& point, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle style)
+    : m_point(point)
     , m_widths(widths)
     , m_thickness(thickness)
     , m_printing(printing)
@@ -464,13 +463,11 @@ DrawLinesForText::DrawLinesForText(const FloatPoint& blockLocation, const FloatS
 
 void DrawLinesForText::apply(GraphicsContext& context) const
 {
-    context.drawLinesForText(point(), m_thickness, m_widths, m_printing, m_doubleLines, m_style);
+    context.drawLinesForText(m_point, m_thickness, m_widths, m_printing, m_doubleLines, m_style);
 }
 
 void DrawLinesForText::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 {
-    ts.dumpProperty("block-location", blockLocation());
-    ts.dumpProperty("local-anchor", localAnchor());
     ts.dumpProperty("point", point());
     ts.dumpProperty("thickness", thickness());
     ts.dumpProperty("double", doubleLines());

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -758,12 +758,9 @@ class DrawLinesForText {
 public:
     static constexpr char name[] = "draw-lines-for-text";
 
-    WEBCORE_EXPORT DrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle);
+    WEBCORE_EXPORT DrawLinesForText(const FloatPoint&, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle);
 
-    void setBlockLocation(const FloatPoint& blockLocation) { m_blockLocation = blockLocation; }
-    const FloatPoint& blockLocation() const { return m_blockLocation; }
-    const FloatSize& localAnchor() const { return m_localAnchor; }
-    FloatPoint point() const { return m_blockLocation + m_localAnchor; }
+    FloatPoint point() const { return m_point; }
     float thickness() const { return m_thickness; }
     const DashArray& widths() const { return m_widths; }
     bool isPrinting() const { return m_printing; }
@@ -774,8 +771,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    FloatPoint m_blockLocation;
-    FloatSize m_localAnchor;
+    FloatPoint m_point;
     DashArray m_widths;
     float m_thickness;
     bool m_printing;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -71,29 +71,11 @@ public:
 protected:
     WEBCORE_EXPORT Recorder(IsDeferred, const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode);
 
-    virtual void recordSave() = 0;
-    virtual void recordRestore() = 0;
-    virtual void recordTranslate(float x, float y) = 0;
-    virtual void recordRotate(float angle) = 0;
-    virtual void recordScale(const FloatSize&) = 0;
-    virtual void recordSetCTM(const AffineTransform&) = 0;
-    virtual void recordConcatenateCTM(const AffineTransform&) = 0;
     virtual void recordSetInlineFillColor(PackedColor::RGBA) = 0;
     virtual void recordSetInlineStroke(SetInlineStroke&&) = 0;
     virtual void recordSetState(const GraphicsContextState&) = 0;
-    virtual void recordSetLineCap(LineCap) = 0;
-    virtual void recordSetLineDash(const DashArray&, float dashOffset) = 0;
-    virtual void recordSetLineJoin(LineJoin) = 0;
-    virtual void recordSetMiterLimit(float) = 0;
     virtual void recordClearDropShadow() = 0;
-    virtual void recordResetClip() = 0;
-    virtual void recordClip(const FloatRect&) = 0;
-    virtual void recordClipRoundedRect(const FloatRoundedRect&) = 0;
-    virtual void recordClipOut(const FloatRect&) = 0;
-    virtual void recordClipOutRoundedRect(const FloatRoundedRect&) = 0;
     virtual void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) = 0;
-    virtual void recordClipOutToPath(const Path&) = 0;
-    virtual void recordClipPath(const Path&, WindRule) = 0;
     virtual void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) = 0;
     virtual void recordDrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) = 0;
     virtual void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) = 0;
@@ -101,24 +83,6 @@ protected:
     virtual void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
     virtual void recordDrawSystemImage(SystemImage&, const FloatRect&) = 0;
     virtual void recordDrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) = 0;
-    virtual void recordBeginTransparencyLayer(float) = 0;
-    virtual void recordBeginTransparencyLayer(CompositeOperator, BlendMode) = 0;
-    virtual void recordEndTransparencyLayer() = 0;
-    virtual void recordDrawRect(const FloatRect&, float) = 0;
-    virtual void recordDrawLine(const FloatPoint& point1, const FloatPoint& point2) = 0;
-    virtual void recordDrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) = 0;
-    virtual void recordDrawDotsForDocumentMarker(const FloatRect&, const DocumentMarkerLineStyle&) = 0;
-    virtual void recordDrawEllipse(const FloatRect&) = 0;
-    virtual void recordDrawPath(const Path&) = 0;
-    virtual void recordDrawFocusRingPath(const Path&, float outlineWidth, const Color&) = 0;
-    virtual void recordDrawFocusRingRects(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) = 0;
-    virtual void recordFillRect(const FloatRect&, RequiresClipToRect) = 0;
-    virtual void recordFillRectWithColor(const FloatRect&, const Color&) = 0;
-    virtual void recordFillRectWithGradient(const FloatRect&, Gradient&) = 0;
-    virtual void recordFillRectWithGradientAndSpaceTransform(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) = 0;
-    virtual void recordFillCompositedRect(const FloatRect&, const Color&, CompositeOperator, BlendMode) = 0;
-    virtual void recordFillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode) = 0;
-    virtual void recordFillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) = 0;
 #if ENABLE(INLINE_PATH_DATA)
     virtual void recordFillLine(const PathDataLine&) = 0;
     virtual void recordFillArc(const PathArc&) = 0;
@@ -128,11 +92,6 @@ protected:
 #endif
     virtual void recordFillPathSegment(const PathSegment&) = 0;
     virtual void recordFillPath(const Path&) = 0;
-    virtual void recordFillEllipse(const FloatRect&) = 0;
-#if ENABLE(VIDEO)
-    virtual void recordDrawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) = 0;
-#endif
-    virtual void recordStrokeRect(const FloatRect&, float) = 0;
 #if ENABLE(INLINE_PATH_DATA)
     virtual void recordStrokeLine(const PathDataLine&) = 0;
     virtual void recordStrokeLineWithColorAndThickness(const PathDataLine&, SetInlineStroke&&) = 0;
@@ -143,18 +102,7 @@ protected:
 #endif
     virtual void recordStrokePathSegment(const PathSegment&) = 0;
     virtual void recordStrokePath(const Path&) = 0;
-    virtual void recordStrokeEllipse(const FloatRect&) = 0;
-    virtual void recordClearRect(const FloatRect&) = 0;
-
-    virtual void recordDrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) = 0;
-
     virtual void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) = 0;
-
-#if USE(CG)
-    virtual void recordApplyStrokePattern() = 0;
-    virtual void recordApplyFillPattern() = 0;
-#endif
-    virtual void recordApplyDeviceScaleFactor(float) = 0;
 
     virtual bool recordResourceUse(NativeImage&) = 0;
     virtual bool recordResourceUse(ImageBuffer&) = 0;
@@ -191,6 +139,28 @@ protected:
     const ContextState& currentState() const;
     ContextState& currentState();
 
+protected:
+    WEBCORE_EXPORT void updateStateForSave(GraphicsContextState::Purpose);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForRestore(GraphicsContextState::Purpose);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForTranslate(float x, float y);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForRotate(float angleInRadians);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForScale(const FloatSize&);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForConcatCTM(const AffineTransform&);
+    WEBCORE_EXPORT void updateStateForSetCTM(const AffineTransform&);
+    WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(float opacity);
+    WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(CompositeOperator, BlendMode);
+    WEBCORE_EXPORT void updateStateForEndTransparencyLayer();
+    WEBCORE_EXPORT void updateStateForResetClip();
+    WEBCORE_EXPORT void updateStateForClip(const FloatRect&);
+    WEBCORE_EXPORT void updateStateForClipRoundedRect(const FloatRoundedRect&);
+    WEBCORE_EXPORT void updateStateForClipPath(const Path&);
+    WEBCORE_EXPORT void updateStateForClipOut(const FloatRect&);
+    WEBCORE_EXPORT void updateStateForClipOut(const Path&);
+    WEBCORE_EXPORT void updateStateForClipOutRoundedRect(const FloatRoundedRect&);
+    WEBCORE_EXPORT void updateStateForApplyDeviceScaleFactor(float);
+    WEBCORE_EXPORT void appendStateChangeItemIfNecessary();
+    FloatRect initialClip() const { return m_initialClip; }
+
 private:
     bool hasPlatformContext() const final { return false; }
     PlatformGraphicsContext* platformContext() const final { ASSERT_NOT_REACHED(); return nullptr; }
@@ -206,93 +176,23 @@ private:
     WEBCORE_EXPORT const GraphicsContextState& state() const final;
 
     WEBCORE_EXPORT void didUpdateState(GraphicsContextState&) final;
-
-    WEBCORE_EXPORT void setLineCap(LineCap) final;
-    WEBCORE_EXPORT void setLineDash(const DashArray&, float dashOffset) final;
-    WEBCORE_EXPORT void setLineJoin(LineJoin) final;
-    WEBCORE_EXPORT void setMiterLimit(float) final;
-
-    WEBCORE_EXPORT void fillRect(const FloatRect&, RequiresClipToRect) final;
-    WEBCORE_EXPORT void fillRect(const FloatRect&, const Color&) final;
-    WEBCORE_EXPORT void fillRect(const FloatRect&, Gradient&) final;
-    WEBCORE_EXPORT void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final;
-    WEBCORE_EXPORT void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode) final;
-    WEBCORE_EXPORT void fillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode) final;
-    WEBCORE_EXPORT void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect& roundedHoleRect, const Color&) final;
     WEBCORE_EXPORT void fillPath(const Path&) final;
-    WEBCORE_EXPORT void fillEllipse(const FloatRect&) final;
-    WEBCORE_EXPORT void strokeRect(const FloatRect&, float lineWidth) final;
     WEBCORE_EXPORT void strokePath(const Path&) final;
-    WEBCORE_EXPORT void strokeEllipse(const FloatRect&) final;
-    WEBCORE_EXPORT void clearRect(const FloatRect&) final;
-
-#if USE(CG)
-    WEBCORE_EXPORT void applyStrokePattern() final;
-    WEBCORE_EXPORT void applyFillPattern() final;
-#endif
-
-    WEBCORE_EXPORT void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
-
     WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
-
     WEBCORE_EXPORT void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
     WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
-
     WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, ControlFactory&, const FloatPoint& destination) final;
-
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawSystemImage(SystemImage&, const FloatRect&) final;
     WEBCORE_EXPORT void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
-
-    WEBCORE_EXPORT void drawRect(const FloatRect&, float borderThickness) final;
-    WEBCORE_EXPORT void drawLine(const FloatPoint&, const FloatPoint&) final;
-    WEBCORE_EXPORT void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
-    WEBCORE_EXPORT void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
-    WEBCORE_EXPORT void drawEllipse(const FloatRect&) final;
-
-    WEBCORE_EXPORT void drawPath(const Path&) final;
-
-    WEBCORE_EXPORT void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
-    WEBCORE_EXPORT void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;
-
-    WEBCORE_EXPORT void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
-    WEBCORE_EXPORT void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
-
-    WEBCORE_EXPORT void translate(float x, float y) final;
-    WEBCORE_EXPORT void rotate(float angleInRadians) final;
-    WEBCORE_EXPORT void scale(const FloatSize&) final;
-    WEBCORE_EXPORT void concatCTM(const AffineTransform&) final;
-    WEBCORE_EXPORT void setCTM(const AffineTransform&) final;
     WEBCORE_EXPORT AffineTransform getCTM(GraphicsContext::IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
-
-    WEBCORE_EXPORT void beginTransparencyLayer(float opacity) final;
-    WEBCORE_EXPORT void beginTransparencyLayer(CompositeOperator, BlendMode) final;
-    WEBCORE_EXPORT void endTransparencyLayer() final;
-
-    WEBCORE_EXPORT void resetClip() final;
-
-    WEBCORE_EXPORT void clip(const FloatRect&) final;
-    WEBCORE_EXPORT void clipRoundedRect(const FloatRoundedRect&) final;
-    WEBCORE_EXPORT void clipPath(const Path&, WindRule) final;
-
-    WEBCORE_EXPORT void clipOut(const FloatRect&) final;
-    WEBCORE_EXPORT void clipOut(const Path&) final;
-    WEBCORE_EXPORT void clipOutRoundedRect(const FloatRoundedRect&) final;
-
     WEBCORE_EXPORT IntRect clipBounds() const final;
     WEBCORE_EXPORT void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
 
-#if ENABLE(VIDEO)
-    WEBCORE_EXPORT void drawVideoFrame(VideoFrame&, const FloatRect&, ImageOrientation, bool shouldDiscardAlpha) final;
-#endif
-
-    WEBCORE_EXPORT void applyDeviceScaleFactor(float) final;
-
-    void appendStateChangeItemIfNecessary();
     void appendStateChangeItem(const GraphicsContextState&);
 
     SetInlineStroke buildSetInlineStroke(const GraphicsContextState&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -41,30 +41,62 @@ public:
 
     bool isEmpty() const { return m_displayList.isEmpty(); }
 
+    void save(GraphicsContextState::Purpose) final;
+    void restore(GraphicsContextState::Purpose) final;
+    void translate(float x, float y) final;
+    void rotate(float angle) final;
+    void scale(const FloatSize&) final;
+    void setCTM(const AffineTransform&) final;
+    void concatCTM(const AffineTransform&) final;
+    void setLineCap(LineCap) final;
+    void setLineDash(const DashArray&, float dashOffset) final;
+    void setLineJoin(LineJoin) final;
+    void setMiterLimit(float) final;
+    void resetClip() final;
+    void clip(const FloatRect&) final;
+    void clipRoundedRect(const FloatRoundedRect&) final;
+    void clipOut(const FloatRect&) final;
+    void clipOut(const Path&) final;
+    void clipOutRoundedRect(const FloatRoundedRect&) final;
+    void clipPath(const Path&, WindRule) final;
+    void beginTransparencyLayer(float) final;
+    void beginTransparencyLayer(CompositeOperator, BlendMode) final;
+    void endTransparencyLayer() final;
+    void drawRect(const FloatRect&, float) final;
+    void drawLine(const FloatPoint& point1, const FloatPoint& point2) final;
+    void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
+    void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
+    void drawEllipse(const FloatRect&) final;
+    void drawPath(const Path&) final;
+    void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
+    void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;
+    void fillEllipse(const FloatRect&) final;
+    void fillRect(const FloatRect&, RequiresClipToRect) final;
+    void fillRect(const FloatRect&, const Color&) final;
+    void fillRect(const FloatRect&, Gradient&) final;
+    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final;
+    void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode) final;
+    void fillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode) final;
+    void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final;
+#if ENABLE(VIDEO)
+    void drawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) final;
+#endif
+    void strokeRect(const FloatRect&, float) final;
+    void strokeEllipse(const FloatRect&) final;
+    void clearRect(const FloatRect&) final;
+    void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
+#if USE(CG)
+    void applyStrokePattern() final;
+    void applyFillPattern() final;
+#endif
+    void applyDeviceScaleFactor(float) final;
+
 private:
-    void recordSave() final;
-    void recordRestore() final;
-    void recordTranslate(float x, float y) final;
-    void recordRotate(float angle) final;
-    void recordScale(const FloatSize&) final;
-    void recordSetCTM(const AffineTransform&) final;
-    void recordConcatenateCTM(const AffineTransform&) final;
     void recordSetInlineFillColor(PackedColor::RGBA) final;
     void recordSetInlineStroke(SetInlineStroke&&) final;
     void recordSetState(const GraphicsContextState&) final;
-    void recordSetLineCap(LineCap) final;
-    void recordSetLineDash(const DashArray&, float dashOffset) final;
-    void recordSetLineJoin(LineJoin) final;
-    void recordSetMiterLimit(float) final;
     void recordClearDropShadow() final;
-    void recordResetClip() final;
-    void recordClip(const FloatRect&) final;
-    void recordClipRoundedRect(const FloatRoundedRect&) final;
-    void recordClipOut(const FloatRect&) final;
-    void recordClipOutRoundedRect(const FloatRoundedRect&) final;
     void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) final;
-    void recordClipOutToPath(const Path&) final;
-    void recordClipPath(const Path&, WindRule) final;
     void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) final;
     void recordDrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) final;
@@ -72,24 +104,6 @@ private:
     void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     void recordDrawSystemImage(SystemImage&, const FloatRect&) final;
     void recordDrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
-    void recordBeginTransparencyLayer(float) final;
-    void recordBeginTransparencyLayer(CompositeOperator, BlendMode) final;
-    void recordEndTransparencyLayer() final;
-    void recordDrawRect(const FloatRect&, float) final;
-    void recordDrawLine(const FloatPoint& point1, const FloatPoint& point2) final;
-    void recordDrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
-    void recordDrawDotsForDocumentMarker(const FloatRect&, const DocumentMarkerLineStyle&) final;
-    void recordDrawEllipse(const FloatRect&) final;
-    void recordDrawPath(const Path&) final;
-    void recordDrawFocusRingPath(const Path&, float outlineWidth, const Color&) final;
-    void recordDrawFocusRingRects(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;
-    void recordFillRect(const FloatRect&, RequiresClipToRect) final;
-    void recordFillRectWithColor(const FloatRect&, const Color&) final;
-    void recordFillRectWithGradient(const FloatRect&, Gradient&) final;
-    void recordFillRectWithGradientAndSpaceTransform(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final;
-    void recordFillCompositedRect(const FloatRect&, const Color&, CompositeOperator, BlendMode) final;
-    void recordFillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode) final;
-    void recordFillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordFillLine(const PathDataLine&) final;
     void recordFillArc(const PathArc&) final;
@@ -99,11 +113,6 @@ private:
 #endif
     void recordFillPathSegment(const PathSegment&) final;
     void recordFillPath(const Path&) final;
-    void recordFillEllipse(const FloatRect&) final;
-#if ENABLE(VIDEO)
-    void recordDrawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) final;
-#endif
-    void recordStrokeRect(const FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const PathDataLine&) final;
     void recordStrokeLineWithColorAndThickness(const PathDataLine&, SetInlineStroke&&) final;
@@ -114,15 +123,7 @@ private:
 #endif
     void recordStrokePathSegment(const PathSegment&) final;
     void recordStrokePath(const Path&) final;
-    void recordStrokeEllipse(const FloatRect&) final;
-    void recordClearRect(const FloatRect&) final;
-    void recordDrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
     void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) final;
-#if USE(CG)
-    void recordApplyStrokePattern() final;
-    void recordApplyFillPattern() final;
-#endif
-    void recordApplyDeviceScaleFactor(float) final;
 
     bool recordResourceUse(NativeImage&) final;
     bool recordResourceUse(ImageBuffer&) final;

--- a/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
@@ -188,8 +188,7 @@ headers: <WebCore/DisplayListItems.h>
 };
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawLinesForText {
-    WebCore::FloatPoint blockLocation();
-    WebCore::FloatSize localAnchor();
+    WebCore::FloatPoint point();
     WebCore::DashArray widths();
     float thickness();
     bool isPrinting();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -64,29 +64,62 @@ private:
 
     WebCore::RenderingMode renderingMode() const final;
 
-    void recordSave() final;
-    void recordRestore() final;
-    void recordTranslate(float x, float y) final;
-    void recordRotate(float angle) final;
-    void recordScale(const WebCore::FloatSize&) final;
-    void recordSetCTM(const WebCore::AffineTransform&) final;
-    void recordConcatenateCTM(const WebCore::AffineTransform&) final;
+    void save(WebCore::GraphicsContextState::Purpose) final;
+    void restore(WebCore::GraphicsContextState::Purpose) final;
+    void translate(float x, float y) final;
+    void rotate(float angle) final;
+    void scale(const WebCore::FloatSize&) final;
+    void setCTM(const WebCore::AffineTransform&) final;
+    void concatCTM(const WebCore::AffineTransform&) final;
+    void setLineCap(WebCore::LineCap) final;
+    void setLineDash(const WebCore::DashArray&, float dashOffset) final;
+    void setLineJoin(WebCore::LineJoin) final;
+    void setMiterLimit(float) final;
+    void clip(const WebCore::FloatRect&) final;
+    void clipRoundedRect(const WebCore::FloatRoundedRect&) final;
+    void clipOut(const WebCore::FloatRect&) final;
+    void clipOut(const WebCore::Path&) final;
+    void clipOutRoundedRect(const WebCore::FloatRoundedRect&) final;
+    void clipPath(const WebCore::Path&, WebCore::WindRule) final;
+    void resetClip() final;
+    void beginTransparencyLayer(float) final;
+    void beginTransparencyLayer(WebCore::CompositeOperator, WebCore::BlendMode) final;
+    void endTransparencyLayer() final;
+    void drawRect(const WebCore::FloatRect&, float) final;
+    void drawLine(const WebCore::FloatPoint& point1, const WebCore::FloatPoint& point2) final;
+    void drawLinesForText(const WebCore::FloatPoint&, float thickness, const WebCore::DashArray& widths, bool printing, bool doubleLines, WebCore::StrokeStyle) final;
+    void drawDotsForDocumentMarker(const WebCore::FloatRect&, WebCore::DocumentMarkerLineStyle) final;
+    void drawEllipse(const WebCore::FloatRect&) final;
+    void drawPath(const WebCore::Path&) final;
+    void drawFocusRing(const WebCore::Path&, float outlineWidth, const WebCore::Color&) final;
+    void drawFocusRing(const Vector<WebCore::FloatRect>&, float outlineOffset, float outlineWidth, const WebCore::Color&) final;
+    void fillRect(const WebCore::FloatRect&, RequiresClipToRect) final;
+    void fillRect(const WebCore::FloatRect&, const WebCore::Color&) final;
+    void fillRect(const WebCore::FloatRect&, WebCore::Gradient&) final;
+    void fillRect(const WebCore::FloatRect&, WebCore::Gradient&, const WebCore::AffineTransform&, RequiresClipToRect) final;
+    void fillRect(const WebCore::FloatRect&, const WebCore::Color&, WebCore::CompositeOperator, WebCore::BlendMode) final;
+    void fillRoundedRect(const WebCore::FloatRoundedRect&, const WebCore::Color&, WebCore::BlendMode) final;
+    void fillRectWithRoundedHole(const WebCore::FloatRect&, const WebCore::FloatRoundedRect&, const WebCore::Color&) final;
+    void fillEllipse(const WebCore::FloatRect&) final;
+#if ENABLE(VIDEO)
+    void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& distination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
+#endif
+    void strokeRect(const WebCore::FloatRect&, float) final;
+    void strokeEllipse(const WebCore::FloatRect&) final;
+    void clearRect(const WebCore::FloatRect&) final;
+    void drawControlPart(WebCore::ControlPart&, const WebCore::FloatRoundedRect& borderRect, float deviceScaleFactor, const WebCore::ControlStyle&) final;
+#if USE(CG)
+    void applyStrokePattern() final;
+    void applyFillPattern() final;
+#endif
+    void applyDeviceScaleFactor(float) final;
+
+private:
     void recordSetInlineFillColor(WebCore::PackedColor::RGBA) final;
     void recordSetInlineStroke(WebCore::DisplayList::SetInlineStroke&&) final;
     void recordSetState(const WebCore::GraphicsContextState&) final;
-    void recordSetLineCap(WebCore::LineCap) final;
-    void recordSetLineDash(const WebCore::DashArray&, float dashOffset) final;
-    void recordSetLineJoin(WebCore::LineJoin) final;
-    void recordSetMiterLimit(float) final;
     void recordClearDropShadow() final;
-    void recordClip(const WebCore::FloatRect&) final;
-    void recordClipRoundedRect(const WebCore::FloatRoundedRect&) final;
-    void recordClipOut(const WebCore::FloatRect&) final;
-    void recordClipOutRoundedRect(const WebCore::FloatRoundedRect&) final;
     void recordClipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destinationRect) final;
-    void recordClipOutToPath(const WebCore::Path&) final;
-    void recordClipPath(const WebCore::Path&, WebCore::WindRule) final;
-    void recordResetClip() final;
     void recordDrawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
     void recordDrawGlyphs(const WebCore::Font&, const WebCore::GlyphBufferGlyph*, const WebCore::GlyphBufferAdvance*, unsigned count, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) final;
@@ -95,24 +128,6 @@ private:
     void recordDrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawSystemImage(WebCore::SystemImage&, const WebCore::FloatRect&);
     void recordDrawPattern(WebCore::RenderingResourceIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& tileRect, const WebCore::AffineTransform&, const WebCore::FloatPoint& phase, const WebCore::FloatSize& spacing, WebCore::ImagePaintingOptions = { }) final;
-    void recordBeginTransparencyLayer(float) final;
-    void recordBeginTransparencyLayer(WebCore::CompositeOperator, WebCore::BlendMode) final;
-    void recordEndTransparencyLayer() final;
-    void recordDrawRect(const WebCore::FloatRect&, float) final;
-    void recordDrawLine(const WebCore::FloatPoint& point1, const WebCore::FloatPoint& point2) final;
-    void recordDrawLinesForText(const WebCore::FloatPoint& blockLocation, const WebCore::FloatSize& localAnchor, float thickness, const WebCore::DashArray& widths, bool printing, bool doubleLines, WebCore::StrokeStyle) final;
-    void recordDrawDotsForDocumentMarker(const WebCore::FloatRect&, const WebCore::DocumentMarkerLineStyle&) final;
-    void recordDrawEllipse(const WebCore::FloatRect&) final;
-    void recordDrawPath(const WebCore::Path&) final;
-    void recordDrawFocusRingPath(const WebCore::Path&, float outlineWidth, const WebCore::Color&) final;
-    void recordDrawFocusRingRects(const Vector<WebCore::FloatRect>&, float outlineOffset, float outlineWidth, const WebCore::Color&) final;
-    void recordFillRect(const WebCore::FloatRect&, RequiresClipToRect) final;
-    void recordFillRectWithColor(const WebCore::FloatRect&, const WebCore::Color&) final;
-    void recordFillRectWithGradient(const WebCore::FloatRect&, WebCore::Gradient&) final;
-    void recordFillRectWithGradientAndSpaceTransform(const WebCore::FloatRect&, WebCore::Gradient&, const WebCore::AffineTransform&, RequiresClipToRect) final;
-    void recordFillCompositedRect(const WebCore::FloatRect&, const WebCore::Color&, WebCore::CompositeOperator, WebCore::BlendMode) final;
-    void recordFillRoundedRect(const WebCore::FloatRoundedRect&, const WebCore::Color&, WebCore::BlendMode) final;
-    void recordFillRectWithRoundedHole(const WebCore::FloatRect&, const WebCore::FloatRoundedRect&, const WebCore::Color&) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordFillLine(const WebCore::PathDataLine&) final;
     void recordFillArc(const WebCore::PathArc&) final;
@@ -122,11 +137,6 @@ private:
 #endif
     void recordFillPathSegment(const WebCore::PathSegment&) final;
     void recordFillPath(const WebCore::Path&) final;
-    void recordFillEllipse(const WebCore::FloatRect&) final;
-#if ENABLE(VIDEO)
-    void recordDrawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& distination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
-#endif
-    void recordStrokeRect(const WebCore::FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const WebCore::PathDataLine&) final;
     void recordStrokeLineWithColorAndThickness(const WebCore::PathDataLine&, WebCore::DisplayList::SetInlineStroke&&) final;
@@ -137,14 +147,6 @@ private:
 #endif
     void recordStrokePathSegment(const WebCore::PathSegment&) final;
     void recordStrokePath(const WebCore::Path&) final;
-    void recordStrokeEllipse(const WebCore::FloatRect&) final;
-    void recordClearRect(const WebCore::FloatRect&) final;
-    void recordDrawControlPart(WebCore::ControlPart&, const WebCore::FloatRoundedRect& borderRect, float deviceScaleFactor, const WebCore::ControlStyle&) final;
-#if USE(CG)
-    void recordApplyStrokePattern() final;
-    void recordApplyFillPattern() final;
-#endif
-    void recordApplyDeviceScaleFactor(float) final;
 
     bool recordResourceUse(WebCore::NativeImage&) final;
     bool recordResourceUse(WebCore::ImageBuffer&) final;


### PR DESCRIPTION
#### 5910db50c2cdffce5ef0fe0cd12f5925029d0ec0
<pre>
Remove excessive indirection with sending remote drawing commands (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=279759">https://bugs.webkit.org/show_bug.cgi?id=279759</a>
<a href="https://rdar.apple.com/136070541">rdar://136070541</a>

Reviewed by Simon Fraser.

DisplayList::Recorder interface would cause overly many virtual function
calls and would prevent backend-specific caching behavior.

Consider callgraph for `context-&gt;save()`:
Recorder::save() &lt;vfunc&gt;
 RemoteDisplayListRecorderProxy::recordSave() &lt;vfunc&gt;

Instead, fix it in this patch to be:
RemoteDisplayListRecorderProxy::recordSave() &lt;vfunc&gt;
  Recorder::updateStateForSave() &lt;normal func&gt;

In future patches, this allows useResource calls to record and return
backend command specific data without the need for this data to leak
into the WebCore. For example, current identifiers should not be defined
in WebCore at all, but they are, since useResource is there.

In this part 1, change the commands that are the most straight-forward.

* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawLinesForText::DrawLinesForText):
(WebCore::DisplayList::DrawLinesForText::apply const):
(WebCore::DisplayList::DrawLinesForText::dump const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::DrawLinesForText::point const):
(WebCore::DisplayList::DrawLinesForText::setBlockLocation): Deleted.
(WebCore::DisplayList::DrawLinesForText::blockLocation const): Deleted.
(WebCore::DisplayList::DrawLinesForText::localAnchor const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::updateStateForSave):
(WebCore::DisplayList::Recorder::updateStateForRestore):
(WebCore::DisplayList::Recorder::updateStateForTranslate):
(WebCore::DisplayList::Recorder::updateStateForRotate):
(WebCore::DisplayList::Recorder::updateStateForScale):
(WebCore::DisplayList::Recorder::updateStateForConcatCTM):
(WebCore::DisplayList::Recorder::updateStateForSetCTM):
(WebCore::DisplayList::Recorder::updateStateForBeginTransparencyLayer):
(WebCore::DisplayList::Recorder::updateStateForEndTransparencyLayer):
(WebCore::DisplayList::Recorder::updateStateForResetClip):
(WebCore::DisplayList::Recorder::updateStateForClip):
(WebCore::DisplayList::Recorder::updateStateForClipRoundedRect):
(WebCore::DisplayList::Recorder::updateStateForClipOut):
(WebCore::DisplayList::Recorder::updateStateForClipOutRoundedRect):
(WebCore::DisplayList::Recorder::updateStateForClipPath):
(WebCore::DisplayList::Recorder::updateStateForApplyDeviceScaleFactor):
(WebCore::DisplayList::Recorder::setLineCap): Deleted.
(WebCore::DisplayList::Recorder::setLineDash): Deleted.
(WebCore::DisplayList::Recorder::setLineJoin): Deleted.
(WebCore::DisplayList::Recorder::setMiterLimit): Deleted.
(WebCore::DisplayList::Recorder::save): Deleted.
(WebCore::DisplayList::Recorder::restore): Deleted.
(WebCore::DisplayList::Recorder::translate): Deleted.
(WebCore::DisplayList::Recorder::rotate): Deleted.
(WebCore::DisplayList::Recorder::scale): Deleted.
(WebCore::DisplayList::Recorder::concatCTM): Deleted.
(WebCore::DisplayList::Recorder::setCTM): Deleted.
(WebCore::DisplayList::Recorder::beginTransparencyLayer): Deleted.
(WebCore::DisplayList::Recorder::endTransparencyLayer): Deleted.
(WebCore::DisplayList::Recorder::drawRect): Deleted.
(WebCore::DisplayList::Recorder::drawLine): Deleted.
(WebCore::DisplayList::Recorder::drawLinesForText): Deleted.
(WebCore::DisplayList::Recorder::drawDotsForDocumentMarker): Deleted.
(WebCore::DisplayList::Recorder::drawEllipse): Deleted.
(WebCore::DisplayList::Recorder::drawPath): Deleted.
(WebCore::DisplayList::Recorder::drawFocusRing): Deleted.
(WebCore::DisplayList::Recorder::fillRect): Deleted.
(WebCore::DisplayList::Recorder::fillRoundedRect): Deleted.
(WebCore::DisplayList::Recorder::fillRectWithRoundedHole): Deleted.
(WebCore::DisplayList::Recorder::fillEllipse): Deleted.
(WebCore::DisplayList::Recorder::strokeRect): Deleted.
(WebCore::DisplayList::Recorder::strokeEllipse): Deleted.
(WebCore::DisplayList::Recorder::clearRect): Deleted.
(WebCore::DisplayList::Recorder::applyStrokePattern): Deleted.
(WebCore::DisplayList::Recorder::applyFillPattern): Deleted.
(WebCore::DisplayList::Recorder::drawControlPart): Deleted.
(WebCore::DisplayList::Recorder::resetClip): Deleted.
(WebCore::DisplayList::Recorder::clip): Deleted.
(WebCore::DisplayList::Recorder::clipRoundedRect): Deleted.
(WebCore::DisplayList::Recorder::clipOut): Deleted.
(WebCore::DisplayList::Recorder::clipOutRoundedRect): Deleted.
(WebCore::DisplayList::Recorder::clipPath): Deleted.
(WebCore::DisplayList::Recorder::drawVideoFrame): Deleted.
(WebCore::DisplayList::Recorder::applyDeviceScaleFactor): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::recordDrawPattern):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::save):
(WebCore::DisplayList::RecorderImpl::restore):
(WebCore::DisplayList::RecorderImpl::translate):
(WebCore::DisplayList::RecorderImpl::rotate):
(WebCore::DisplayList::RecorderImpl::scale):
(WebCore::DisplayList::RecorderImpl::setCTM):
(WebCore::DisplayList::RecorderImpl::concatCTM):
(WebCore::DisplayList::RecorderImpl::setLineCap):
(WebCore::DisplayList::RecorderImpl::setLineDash):
(WebCore::DisplayList::RecorderImpl::setLineJoin):
(WebCore::DisplayList::RecorderImpl::setMiterLimit):
(WebCore::DisplayList::RecorderImpl::resetClip):
(WebCore::DisplayList::RecorderImpl::clip):
(WebCore::DisplayList::RecorderImpl::clipRoundedRect):
(WebCore::DisplayList::RecorderImpl::clipOut):
(WebCore::DisplayList::RecorderImpl::clipOutRoundedRect):
(WebCore::DisplayList::RecorderImpl::clipPath):
(WebCore::DisplayList::RecorderImpl::beginTransparencyLayer):
(WebCore::DisplayList::RecorderImpl::endTransparencyLayer):
(WebCore::DisplayList::RecorderImpl::drawRect):
(WebCore::DisplayList::RecorderImpl::drawLine):
(WebCore::DisplayList::RecorderImpl::drawLinesForText):
(WebCore::DisplayList::RecorderImpl::drawDotsForDocumentMarker):
(WebCore::DisplayList::RecorderImpl::drawEllipse):
(WebCore::DisplayList::RecorderImpl::drawPath):
(WebCore::DisplayList::RecorderImpl::drawFocusRing):
(WebCore::DisplayList::RecorderImpl::fillRect):
(WebCore::DisplayList::RecorderImpl::fillRoundedRect):
(WebCore::DisplayList::RecorderImpl::fillRectWithRoundedHole):
(WebCore::DisplayList::RecorderImpl::fillEllipse):
(WebCore::DisplayList::RecorderImpl::drawVideoFrame):
(WebCore::DisplayList::RecorderImpl::strokeRect):
(WebCore::DisplayList::RecorderImpl::strokeEllipse):
(WebCore::DisplayList::RecorderImpl::clearRect):
(WebCore::DisplayList::RecorderImpl::drawControlPart):
(WebCore::DisplayList::RecorderImpl::applyStrokePattern):
(WebCore::DisplayList::RecorderImpl::applyFillPattern):
(WebCore::DisplayList::RecorderImpl::applyDeviceScaleFactor):
(WebCore::DisplayList::RecorderImpl::recordSave): Deleted.
(WebCore::DisplayList::RecorderImpl::recordRestore): Deleted.
(WebCore::DisplayList::RecorderImpl::recordTranslate): Deleted.
(WebCore::DisplayList::RecorderImpl::recordRotate): Deleted.
(WebCore::DisplayList::RecorderImpl::recordScale): Deleted.
(WebCore::DisplayList::RecorderImpl::recordSetCTM): Deleted.
(WebCore::DisplayList::RecorderImpl::recordConcatenateCTM): Deleted.
(WebCore::DisplayList::RecorderImpl::recordSetLineCap): Deleted.
(WebCore::DisplayList::RecorderImpl::recordSetLineDash): Deleted.
(WebCore::DisplayList::RecorderImpl::recordSetLineJoin): Deleted.
(WebCore::DisplayList::RecorderImpl::recordSetMiterLimit): Deleted.
(WebCore::DisplayList::RecorderImpl::recordResetClip): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClip): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClipRoundedRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClipOut): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClipOutRoundedRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClipOutToPath): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClipPath): Deleted.
(WebCore::DisplayList::RecorderImpl::recordBeginTransparencyLayer): Deleted.
(WebCore::DisplayList::RecorderImpl::recordEndTransparencyLayer): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawLine): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawLinesForText): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawDotsForDocumentMarker): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawEllipse): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawPath): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawFocusRingPath): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawFocusRingRects): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillRectWithColor): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillRectWithGradient): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillRectWithGradientAndSpaceTransform): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillCompositedRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillRoundedRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillRectWithRoundedHole): Deleted.
(WebCore::DisplayList::RecorderImpl::recordFillEllipse): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawVideoFrame): Deleted.
(WebCore::DisplayList::RecorderImpl::recordStrokeRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordStrokeEllipse): Deleted.
(WebCore::DisplayList::RecorderImpl::recordClearRect): Deleted.
(WebCore::DisplayList::RecorderImpl::recordDrawControlPart): Deleted.
(WebCore::DisplayList::RecorderImpl::recordApplyStrokePattern): Deleted.
(WebCore::DisplayList::RecorderImpl::recordApplyFillPattern): Deleted.
(WebCore::DisplayList::RecorderImpl::recordApplyDeviceScaleFactor): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
(WebCore::DisplayList::RecorderImpl::recordDrawPattern):
* Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::save):
(WebKit::RemoteDisplayListRecorderProxy::restore):
(WebKit::RemoteDisplayListRecorderProxy::translate):
(WebKit::RemoteDisplayListRecorderProxy::rotate):
(WebKit::RemoteDisplayListRecorderProxy::scale):
(WebKit::RemoteDisplayListRecorderProxy::setCTM):
(WebKit::RemoteDisplayListRecorderProxy::concatCTM):
(WebKit::RemoteDisplayListRecorderProxy::setLineCap):
(WebKit::RemoteDisplayListRecorderProxy::setLineDash):
(WebKit::RemoteDisplayListRecorderProxy::setLineJoin):
(WebKit::RemoteDisplayListRecorderProxy::setMiterLimit):
(WebKit::RemoteDisplayListRecorderProxy::clip):
(WebKit::RemoteDisplayListRecorderProxy::clipRoundedRect):
(WebKit::RemoteDisplayListRecorderProxy::clipOut):
(WebKit::RemoteDisplayListRecorderProxy::clipOutRoundedRect):
(WebKit::RemoteDisplayListRecorderProxy::clipPath):
(WebKit::RemoteDisplayListRecorderProxy::resetClip):
(WebKit::RemoteDisplayListRecorderProxy::beginTransparencyLayer):
(WebKit::RemoteDisplayListRecorderProxy::endTransparencyLayer):
(WebKit::RemoteDisplayListRecorderProxy::drawRect):
(WebKit::RemoteDisplayListRecorderProxy::drawLine):
(WebKit::RemoteDisplayListRecorderProxy::drawLinesForText):
(WebKit::RemoteDisplayListRecorderProxy::drawDotsForDocumentMarker):
(WebKit::RemoteDisplayListRecorderProxy::drawEllipse):
(WebKit::RemoteDisplayListRecorderProxy::drawPath):
(WebKit::RemoteDisplayListRecorderProxy::drawFocusRing):
(WebKit::RemoteDisplayListRecorderProxy::fillRect):
(WebKit::RemoteDisplayListRecorderProxy::fillRoundedRect):
(WebKit::RemoteDisplayListRecorderProxy::fillRectWithRoundedHole):
(WebKit::RemoteDisplayListRecorderProxy::fillEllipse):
(WebKit::RemoteDisplayListRecorderProxy::drawVideoFrame):
(WebKit::RemoteDisplayListRecorderProxy::strokeRect):
(WebKit::RemoteDisplayListRecorderProxy::strokeEllipse):
(WebKit::RemoteDisplayListRecorderProxy::clearRect):
(WebKit::RemoteDisplayListRecorderProxy::drawControlPart):
(WebKit::RemoteDisplayListRecorderProxy::applyStrokePattern):
(WebKit::RemoteDisplayListRecorderProxy::applyFillPattern):
(WebKit::RemoteDisplayListRecorderProxy::applyDeviceScaleFactor):
(WebKit::RemoteDisplayListRecorderProxy::recordSave): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordRestore): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordTranslate): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordRotate): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordScale): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordSetCTM): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordConcatenateCTM): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordSetLineCap): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordSetLineDash): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordSetLineJoin): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordSetMiterLimit): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClip): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClipRoundedRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClipOut): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClipOutRoundedRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClipOutToPath): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClipPath): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordResetClip): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordBeginTransparencyLayer): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordEndTransparencyLayer): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawLine): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawLinesForText): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawDotsForDocumentMarker): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawEllipse): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawPath): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawFocusRingPath): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawFocusRingRects): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillRectWithColor): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillRectWithGradient): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillRectWithGradientAndSpaceTransform): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillCompositedRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillRoundedRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillRectWithRoundedHole): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordFillEllipse): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawVideoFrame): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordStrokeRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordStrokeEllipse): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordClearRect): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordDrawControlPart): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordApplyStrokePattern): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordApplyFillPattern): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordApplyDeviceScaleFactor): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
(WebKit::RemoteDisplayListRecorderProxy::recordDrawPattern):

Canonical link: <a href="https://commits.webkit.org/284963@main">https://commits.webkit.org/284963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a06e405e630d45939804e9469b00fb6fa7ce7c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20749 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55322 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62984 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62901 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4543 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44795 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->