### PR TITLE
Deploy more smart pointers in WebAutomationSession.cpp

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -949,6 +949,11 @@ LocalDOMWindow* LocalFrame::window() const
     return document() ? document()->domWindow() : nullptr;
 }
 
+RefPtr<LocalDOMWindow> LocalFrame::protectedWindow() const
+{
+    return window();
+}
+
 DOMWindow* LocalFrame::virtualWindow() const
 {
     return window();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -139,6 +139,7 @@ public:
     WEBCORE_EXPORT ~LocalFrame();
 
     WEBCORE_EXPORT LocalDOMWindow* window() const;
+    WEBCORE_EXPORT RefPtr<LocalDOMWindow> protectedWindow() const;
 
     void addDestructionObserver(FrameDestructionObserver&);
     void removeDestructionObserver(FrameDestructionObserver&);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -900,7 +900,7 @@ public:
     SocketProvider& socketProvider() { return m_socketProvider; }
     MediaRecorderProvider& mediaRecorderProvider() { return m_mediaRecorderProvider; }
     CookieJar& cookieJar() { return m_cookieJar.get(); }
-    Ref<CookieJar> protectedCookieJar() const;
+    WEBCORE_EXPORT Ref<CookieJar> protectedCookieJar() const;
 
     StorageNamespaceProvider& storageNamespaceProvider() { return m_storageNamespaceProvider.get(); }
     WEBCORE_EXPORT Ref<StorageNamespaceProvider> protectedStorageNamespaceProvider() const;

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -61,12 +61,12 @@ void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Aut
 
     // Don't bring the inspector to front since this may be done automatically.
     // We just want it loaded so it can pause if a breakpoint is hit during a command.
-    if (page->inspector()) {
-        page->inspector()->show();
+    if (RefPtr inspector = page->inspector()) {
+        inspector->show();
 
         // Start collecting profile information immediately so the entire session is captured.
         if (enableAutoCapturing && *enableAutoCapturing)
-            page->inspector()->togglePageProfiling();
+            inspector->togglePageProfiling();
     }
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -156,11 +156,6 @@ void WebFrameProxy::webProcessWillShutDown()
         m_navigateCallback({ }, { });
 }
 
-bool WebFrameProxy::isMainFrame() const
-{
-    return m_isMainFrame == IsMainFrame::Yes;
-}
-
 WebProcessProxy& WebFrameProxy::process() const
 {
     return m_frameProcess->process();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -100,7 +100,7 @@ public:
 
     void webProcessWillShutDown();
 
-    bool isMainFrame() const;
+    bool isMainFrame() const { return m_isMainFrame == IsMainFrame::Yes; }
 
     FrameLoadState& frameLoadState() { return m_frameLoadState; }
 


### PR DESCRIPTION
#### f80aefb615c137b257c27421f138d87ceed671e1
<pre>
Deploy more smart pointers in WebAutomationSession.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279631">https://bugs.webkit.org/show_bug.cgi?id=279631</a>

Reviewed by Chris Dumez.

Deploy more smart pointers in WebAutomationSession.cpp as warned by the clang static analyzer.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::protectedWindow const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::findPageForFrameID):
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::navigationOccurredForFrame):
(WebKit::WebAutomationSession::handleRunOpenPanel):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::addSingleCookie):
(WebKit::WebAutomationSession::removeVirtualAuthenticator):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::inspectBrowsingContext):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::isMainFrame const): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::isMainFrame const):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::ensureObserverForFrame):
(WebKit::WebAutomationSessionProxy::willDestroyGlobalObjectForFrame):
(WebKit::WebAutomationSessionProxy::evaluateJavaScriptFunction):
(WebKit::WebAutomationSessionProxy::didEvaluateJavaScriptFunction):
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithOrdinal):
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithNodeHandle):
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithName):
(WebKit::containerElementForElement):
(WebKit::WebAutomationSessionProxy::computeElementLayout):
(WebKit::WebAutomationSessionProxy::selectOptionElement):
(WebKit::WebAutomationSessionProxy::setFilesForInputFileUpload):
(WebKit::WebAutomationSessionProxy::takeScreenshot):
(WebKit::WebAutomationSessionProxy::snapshotRectForScreenshot):
(WebKit::WebAutomationSessionProxy::getCookiesForFrame):
(WebKit::WebAutomationSessionProxy::deleteCookie):

Canonical link: <a href="https://commits.webkit.org/283717@main">https://commits.webkit.org/283717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13baad728aa2aa6ac1d78ca32828b07b9fe42ab6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71186 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18284 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18077 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15195 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9132 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->