### PR TITLE
Adopt `createRemoteContext(description: String)` for web view context retrieval

### DIFF
--- a/Source/WebKit/WebKitSwift/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/WebKitSwift/TextExtraction/WKWebView+TextExtraction.swift
@@ -72,7 +72,12 @@ extension WKWebView {
     }
 
     open override func _intelligenceCollectContent(in visibleRect: CGRect, collector: UIIntelligenceElementCollector) {
-        collector.collect(.remote(collector.context.createRemoteContext()))
+#if canImport(UIIntelligenceSupport, _version: 8208)
+        let context = collector.context.createRemoteContext("WKWebView")
+#else
+        let context = collector.context.createRemoteContext()
+#endif
+        collector.collect(.remote(context))
     }
 
     open override func _intelligenceCollectRemoteContent(in visibleRect: CGRect, remoteContextWrapper: UIIntelligenceCollectionRemoteContextWrapper) {


### PR DESCRIPTION
#### 41e732e085fc3db05a00e24428e98b6d4e5931bb
<pre>
Adopt `createRemoteContext(description: String)` for web view context retrieval
<a href="https://bugs.webkit.org/show_bug.cgi?id=279762">https://bugs.webkit.org/show_bug.cgi?id=279762</a>
<a href="https://rdar.apple.com/136018111">rdar://136018111</a>

Reviewed by Richard Robinson.

Adopt a new version of this function for creating a remote context item that represents the web
view&apos;s content. This new function takes a description string, which is used only for debugging
purposes and logging.

* Source/WebKit/WebKitSwift/TextExtraction/WKWebView+TextExtraction.swift:
(WKWebView._intelligenceCollectContent(in:collector:)):

Canonical link: <a href="https://commits.webkit.org/284472@main">https://commits.webkit.org/284472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7abdc221cfe79e8226e37a2071f2d465b4a8f79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54775 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13205 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35239 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40624 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74484 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62284 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3859 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43914 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->