### PR TITLE
[JSC] Don't search the FreeList when firing a watchpoint

### DIFF
--- a/Source/JavaScriptCore/bytecode/ChainedWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/ChainedWatchpoint.h
@@ -56,10 +56,8 @@ inline void ChainedWatchpoint::install(InlineWatchpointSet& fromWatchpoint, VM&)
 
 inline void ChainedWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
-    if (!m_owner->isLive())
-        return;
-
-    m_watchpointSet.fireAll(vm, StringFireDetail("chained watchpoint is fired."));
+    if (!m_owner->isPendingDestruction())
+        m_watchpointSet.fireAll(vm, StringFireDetail("chained watchpoint is fired."));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp
@@ -36,8 +36,8 @@ void CodeBlockJettisoningWatchpoint::fireInternal(VM&, const FireDetail& detail)
     ASSERT(!m_owner->wasDestructed());
     // If CodeBlock is no longer live, we do not fire it.
     // This works since CodeBlock is the owner of this watchpoint. When it gets destroyed, then this watchpoint also gets destroyed.
-    // Only problematic case is, (1) CodeBlock is dead, but (2) destructor is not called yet. In this case, isLive() check guards correctly.
-    if (!m_owner->isLive())
+    // Only problematic case is, (1) CodeBlock is dead, but (2) destructor is not called yet.
+    if (m_owner->isPendingDestruction())
         return;
 
     if (DFG::shouldDumpDisassembly())

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
@@ -70,7 +70,7 @@ void LLIntPrototypeLoadAdaptiveStructureWatchpoint::install(VM&)
 void LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
     ASSERT(!m_owner->wasDestructed());
-    if (!m_owner->isLive())
+    if (m_owner->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
@@ -47,7 +47,7 @@ StructureStubInfoClearingWatchpoint::~StructureStubInfoClearingWatchpoint()
 void StructureStubInfoClearingWatchpoint::fireInternal(VM&, const FireDetail&)
 {
     ASSERT(!m_owner->wasDestructed());
-    if (!m_owner->isLive())
+    if (m_owner->isPendingDestruction())
         return;
 
     // This will implicitly cause my own demise: stub reset removes all watchpoints.

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
@@ -63,10 +63,10 @@ void AdaptiveInferredPropertyValueWatchpoint::handleFire(VM&, const FireDetail& 
 
 bool AdaptiveInferredPropertyValueWatchpoint::isValid() const
 {
-    return m_codeBlock->isLive();
+    ASSERT(!m_codeBlock->wasDestructed());
+    return !m_codeBlock->isPendingDestruction();
 }
 
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)
-

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
@@ -66,7 +66,7 @@ void AdaptiveStructureWatchpoint::install(VM&)
 void AdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail& detail)
 {
     ASSERT(!m_codeBlock->wasDestructed());
-    if (!m_codeBlock->isLive())
+    if (m_codeBlock->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -483,16 +483,6 @@ MarkedSpace& BlockDirectory::markedSpace() const
     return m_subspace->space();
 }
 
-bool BlockDirectory::isFreeListedCell(const void* target)
-{
-    bool result = false;
-    m_localAllocators.forEach(
-        [&] (LocalAllocator* allocator) {
-            result |= allocator->isFreeListedCell(target);
-        });
-    return result;
-}
-
 #if ASSERT_ENABLED
 void BlockDirectory::assertIsMutatorOrMutatorIsStopped() const
 {

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -79,8 +79,6 @@ public:
     DestructionMode destruction() const { return m_attributes.destruction; }
     HeapCell::Kind cellKind() const { return m_attributes.cellKind; }
 
-    bool isFreeListedCell(const void* target);
-
     inline void forEachBlock(const std::invocable<MarkedBlock::Handle*> auto&);
     inline void forEachNotEmptyBlock(const std::invocable<MarkedBlock::Handle*> auto&);
     

--- a/Source/JavaScriptCore/heap/FreeList.cpp
+++ b/Source/JavaScriptCore/heap/FreeList.cpp
@@ -58,24 +58,6 @@ void FreeList::initialize(FreeCell* start, uint64_t secret, unsigned bytes)
     m_originalSize = bytes;
 }
 
-bool FreeList::contains(HeapCell* target) const
-{
-    char* targetPtr = bitwise_cast<char*>(target);
-    if (m_intervalStart <= targetPtr && targetPtr < m_intervalEnd)
-        return true;
-
-    FreeCell* candidate = nextInterval();
-    while (!isSentinel(candidate)) {
-        char* start;
-        char* end;
-        FreeCell::advance(m_secret, candidate, start, end);
-        if (start <= targetPtr && targetPtr < end)
-            return true;
-    }
-
-    return false;
-}
-
 void FreeList::dump(PrintStream& out) const
 {
     out.print("{nextInterval = ", RawPointer(nextInterval()), ", secret = ", m_secret, ", intervalStart = ", RawPointer(m_intervalStart), ", intervalEnd = ", RawPointer(m_intervalEnd), ", originalSize = ", m_originalSize, "}");

--- a/Source/JavaScriptCore/heap/FreeList.h
+++ b/Source/JavaScriptCore/heap/FreeList.h
@@ -91,8 +91,6 @@ public:
     template<typename Func>
     HeapCell* allocateWithCellSize(const Func& slowPath, size_t cellSize);
     
-    bool contains(HeapCell*) const;
-    
     template<typename Func>
     void forEach(const Func&) const;
     

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -60,7 +60,9 @@ public:
     }
     bool isZapped() const { return !*bitwise_cast<const uint32_t*>(this); }
 
-    bool isLive();
+    // isPendingDestruction returns true iff the cell is no longer alive but has not yet
+    // been swept and therefore its destructor (if it has one) has not yet run.
+    bool isPendingDestruction();
 
     bool isPreciseAllocation() const;
     CellContainer cellContainer() const;

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -274,15 +274,5 @@ void LocalAllocator::doTestCollectionsIfNeeded(JSC::Heap& heap, GCDeferralContex
         allocationCount = 0;
 }
 
-bool LocalAllocator::isFreeListedCell(const void* target) const
-{
-    // This abomination exists to detect when an object is in the dead-but-not-destructed state.
-    // Therefore, it's not even clear that this needs to do anything beyond returning "false", since
-    // if we know that the block owning the object is free-listed, then it's impossible for any
-    // objects to be in the dead-but-not-destructed state.
-    // FIXME: Get rid of this abomination. https://bugs.webkit.org/show_bug.cgi?id=181655
-    return m_freeList.contains(bitwise_cast<HeapCell*>(target));
-}
-
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/LocalAllocator.h
+++ b/Source/JavaScriptCore/heap/LocalAllocator.h
@@ -54,8 +54,6 @@ public:
     
     static constexpr ptrdiff_t offsetOfFreeList();
     static constexpr ptrdiff_t offsetOfCellSize();
-    
-    bool isFreeListedCell(const void*) const;
 
     BlockDirectory& directory() const { return *m_directory; }
 

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -502,12 +502,6 @@ void MarkedBlock::Handle::sweep(FreeList* freeList)
     specializedSweep<false, IsEmpty, SweepOnly, BlockHasNoDestructors, DontScribble, HasNewlyAllocated, MarksStale>(freeList, emptyMode, sweepMode, BlockHasNoDestructors, scribbleMode, newlyAllocatedMode, marksMode, [] (VM&, JSCell*) { });
 }
 
-bool MarkedBlock::Handle::isFreeListedCell(const void* target) const
-{
-    ASSERT(isFreeListed());
-    return m_directory->isFreeListedCell(target);
-}
-
 } // namespace JSC
 
 namespace WTF {

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -184,8 +184,6 @@ public:
         bool isLive(const HeapCell*);
         bool isLiveCell(const void*);
 
-        bool isFreeListedCell(const void* target) const;
-
         template <typename Functor> IterationStatus forEachCell(const Functor&);
         template <typename Functor> inline IterationStatus forEachLiveCell(const Functor&);
         template <typename Functor> inline IterationStatus forEachDeadCell(const Functor&);

--- a/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp
@@ -49,7 +49,7 @@ void CachedSpecialPropertyAdaptiveStructureWatchpoint::install(VM&)
 
 void CachedSpecialPropertyAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
-    if (!m_structureRareData->isLive())
+    if (m_structureRareData->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
@@ -66,7 +66,7 @@ inline void ObjectAdaptiveStructureWatchpoint::install(VM&)
 
 inline void ObjectAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
-    if (!m_owner->isLive())
+    if (m_owner->isPendingDestruction())
         return;
 
     if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {

--- a/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
@@ -46,7 +46,7 @@ public:
 private:
     bool isValid() const final
     {
-        return m_owner->isLive();
+        return !m_owner->isPendingDestruction();
     }
 
     void handleFire(VM& vm, const FireDetail&) final

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -264,7 +264,7 @@ CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::CachedSpecialPrope
 
 bool CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::isValid() const
 {
-    return m_structureRareData->isLive();
+    return !m_structureRareData->isPendingDestruction();
 }
 
 void CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::handleFire(VM& vm, const FireDetail&)

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -179,9 +179,8 @@ inline void StructureChainInvalidationWatchpoint::install(StructureRareData* str
 
 inline void StructureChainInvalidationWatchpoint::fireInternal(VM&, const FireDetail&)
 {
-    if (!m_structureRareData->isLive())
-        return;
-    m_structureRareData->clearCachedPropertyNameEnumerator();
+    if (!m_structureRareData->isPendingDestruction())
+        m_structureRareData->clearCachedPropertyNameEnumerator();
 }
 
 inline bool StructureRareData::tryCachePropertyNameEnumeratorViaWatchpoint(VM&, Structure* baseStructure, StructureChain* chain)


### PR DESCRIPTION
#### 5ae437da2c04cd1be9827bf9a8a8863ef01c656a
<pre>
[JSC] Don&apos;t search the FreeList when firing a watchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=181655">https://bugs.webkit.org/show_bug.cgi?id=181655</a>
<a href="https://rdar.apple.com/135961786">rdar://135961786</a>

Reviewed by Yusuke Suzuki and Keith Miller.

Conceptually, a heap cell can be in one of three states:
(1) Live
(2) Pending destruction/sweeping
(3) Free

For MarkedBlocks that are freelisted, distinguishing between
states (1) &amp; (3) require searching the FreeList.

The watchpoint code was previously asking whether the watchpoint&apos;s
owner was (1) Live in order to know whether the watchdpoint should
still fire, and so the freelist was searched to filter out state (3).

Instead, we can ask the question: is the cell in state (2)? This
question can be answered without searching the FreeList since a
FreeListed block never contains cells of state (2). And this is
sufficient for determining whether the watchdpoint should fire.

This also makes the intent of the watchdpoint code clearer since
it is asking a more specific question.

Regardless of which question was asked, it has to be the responsibility
of the caller (i.e. watchdpoint/owner code) to manage the lifetime of
these objects properly, so we don&apos;t lose anything by reframing the
question. i.e. a caller (outside of the heap code) cannot be allowed to
pass in a cell in state (2) because it can&apos;t know whether the block
backing that cell has already been freed. The old isLive() check was
misleading in this regard.

* Source/JavaScriptCore/bytecode/ChainedWatchpoint.h:
(JSC::ChainedWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp:
(JSC::CodeBlockJettisoningWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp:
(JSC::LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
(JSC::StructureStubInfoClearingWatchpoint::fireInternal):
* Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp:
(JSC::DFG::AdaptiveInferredPropertyValueWatchpoint::isValid const):
* Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp:
(JSC::DFG::AdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::isFreeListedCell): Deleted.
* Source/JavaScriptCore/heap/BlockDirectory.h:
* Source/JavaScriptCore/heap/FreeList.cpp:
(JSC::FreeList::contains const): Deleted.
* Source/JavaScriptCore/heap/FreeList.h:
* Source/JavaScriptCore/heap/HeapCell.cpp:
(JSC::HeapCell::isPendingDestruction):
(JSC::HeapCell::isLive): Deleted.
* Source/JavaScriptCore/heap/HeapCell.h:
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::isFreeListedCell const): Deleted.
* Source/JavaScriptCore/heap/LocalAllocator.h:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::isFreeListedCell const): Deleted.
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp:
(JSC::CachedSpecialPropertyAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h:
(JSC::ObjectAdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h:
* Source/JavaScriptCore/runtime/StructureRareData.cpp:
(JSC::CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::isValid const):
* Source/JavaScriptCore/runtime/StructureRareDataInlines.h:
(JSC::StructureChainInvalidationWatchpoint::fireInternal):

Canonical link: <a href="https://commits.webkit.org/283772@main">https://commits.webkit.org/283772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41e5d5d37b3de72b39669b57c1793a2cf8dcc9b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18283 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18121 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58106 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16637 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60265 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72888 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66395 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61321 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61399 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14917 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2735 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88163 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42334 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15527 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->