### PR TITLE
Port WebExtension identifier types to ObjectIdentifier

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionContextIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct WebExtensionContextIdentifierType;
-using WebExtensionContextIdentifier = LegacyNullableObjectIdentifier<WebExtensionContextIdentifierType>;
+using WebExtensionContextIdentifier = ObjectIdentifier<WebExtensionContextIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -40,7 +40,7 @@
 namespace WebKit {
 
 struct WebExtensionFrameIdentifierType;
-using WebExtensionFrameIdentifier = LegacyNullableObjectIdentifier<WebExtensionFrameIdentifierType>;
+using WebExtensionFrameIdentifier = ObjectIdentifier<WebExtensionFrameIdentifierType>;
 
 namespace WebExtensionFrameConstants {
 
@@ -102,13 +102,13 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(std::optional<W
         ASSERT_NOT_REACHED();
         return WebExtensionFrameConstants::NoneIdentifier;
     }
-    WebExtensionFrameIdentifier result { frameIdentifier->object().toUInt64() };
-    if (!result.isValid()) {
+    auto identifierAsUInt64 = frameIdentifier->object().toUInt64();
+    if (!WebExtensionFrameIdentifier::isValidIdentifier(identifierAsUInt64)) {
         ASSERT_NOT_REACHED();
         return WebExtensionFrameConstants::NoneIdentifier;
     }
 
-    return result;
+    return WebExtensionFrameIdentifier { identifierAsUInt64 };
 }
 
 inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame& frame)
@@ -140,14 +140,14 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WKFrameInfo *fr
     // which needs to be just one number and probably should only be generated in the UI process
     // to prevent collisions with numbers generated in different web content processes, especially with site isolation.
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WebExtensionFrameIdentifier result { frameInfo._handle.frameID };
+    auto identifier = frameInfo._handle.frameID;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    if (!result.isValid()) {
+    if (!WebExtensionFrameIdentifier::isValidIdentifier(identifier)) {
         ASSERT_NOT_REACHED();
         return WebExtensionFrameConstants::NoneIdentifier;
     }
 
-    return result;
+    return WebExtensionFrameIdentifier { identifier };
 }
 #endif // __OBJC__
 
@@ -168,15 +168,17 @@ inline std::optional<WebExtensionFrameIdentifier> toWebExtensionFrameIdentifier(
         return std::nullopt;
     }
 
-    WebExtensionFrameIdentifier result { static_cast<uint64_t>(identifier) };
-    ASSERT(result.isValid());
-    return result;
+    auto identifierAsUInt64 = static_cast<uint64_t>(identifier);
+    if (!WebExtensionFrameIdentifier::isValidIdentifier(identifierAsUInt64)) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    return WebExtensionFrameIdentifier { identifierAsUInt64 };
 }
 
 inline double toWebAPI(const WebExtensionFrameIdentifier& identifier)
 {
-    ASSERT(identifier.isValid());
-
     if (isMainFrame(identifier))
         return WebExtensionFrameConstants::MainFrame;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionPortChannelIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPortChannelIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct WebExtensionPortChannelIdentifierType;
-using WebExtensionPortChannelIdentifier = LegacyNullableObjectIdentifier<WebExtensionPortChannelIdentifierType>;
+using WebExtensionPortChannelIdentifier = ObjectIdentifier<WebExtensionPortChannelIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebKit {
 
 struct WebExtensionTabIdentifierType;
-using WebExtensionTabIdentifier = LegacyNullableObjectIdentifier<WebExtensionTabIdentifierType>;
+using WebExtensionTabIdentifier = ObjectIdentifier<WebExtensionTabIdentifierType>;
 
 namespace WebExtensionTabConstants {
 
@@ -69,19 +69,17 @@ inline std::optional<WebExtensionTabIdentifier> toWebExtensionTabIdentifier(doub
         return std::nullopt;
     }
 
-    WebExtensionTabIdentifier result { static_cast<uint64_t>(identifier) };
-    if (!result.isValid()) {
+    auto identifierAsUint64 = static_cast<uint64_t>(identifier);
+    if (!WebExtensionTabIdentifier::isValidIdentifier(identifierAsUint64)) {
         ASSERT_NOT_REACHED();
         return WebExtensionTabConstants::NoneIdentifier;
     }
 
-    return result;
+    return WebExtensionTabIdentifier { identifierAsUint64 };
 }
 
 inline double toWebAPI(const WebExtensionTabIdentifier& identifier)
 {
-    ASSERT(identifier.isValid());
-
     if (isNone(identifier))
         return WebExtensionTabConstants::None;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
@@ -31,7 +31,7 @@
 namespace WebKit {
 
 struct WebExtensionWindowIdentifierType;
-using WebExtensionWindowIdentifier = LegacyNullableObjectIdentifier<WebExtensionWindowIdentifierType>;
+using WebExtensionWindowIdentifier = ObjectIdentifier<WebExtensionWindowIdentifierType>;
 
 namespace WebExtensionWindowConstants {
 
@@ -85,19 +85,17 @@ inline std::optional<WebExtensionWindowIdentifier> toWebExtensionWindowIdentifie
         return std::nullopt;
     }
 
-    WebExtensionWindowIdentifier result { static_cast<uint64_t>(identifier) };
-    if (!result.isValid()) {
+    auto identifierAsUInt64 = static_cast<uint64_t>(identifier);
+    if (!WebExtensionWindowIdentifier::isValidIdentifier(identifierAsUInt64)) {
         ASSERT_NOT_REACHED();
         return WebExtensionWindowConstants::NoneIdentifier;
     }
 
-    return result;
+    return WebExtensionWindowIdentifier { identifierAsUInt64 };
 }
 
 inline double toWebAPI(const WebExtensionWindowIdentifier& identifier)
 {
-    ASSERT(identifier.isValid());
-
     if (isNone(identifier))
         return WebExtensionWindowConstants::None;
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -122,11 +122,6 @@ template: struct WebKit::IPCStreamTesterIdentifierType
 template: struct WebKit::NetworkResourceLoadIdentifierType
 template: struct WebKit::RemoteAudioDestinationIdentifierType
 template: struct WebKit::RemoteImageBufferSetIdentifierType
-template: struct WebKit::WebExtensionContextIdentifierType
-template: struct WebKit::WebExtensionFrameIdentifierType
-template: struct WebKit::WebExtensionPortChannelIdentifierType
-template: struct WebKit::WebExtensionTabIdentifierType
-template: struct WebKit::WebExtensionWindowIdentifierType
 template: struct WebKit::WebPageProxyIdentifierType
 template: struct WebKit::WebTransportSessionIdentifierType
 template: struct WebKit::WebTransportStreamIdentifierType
@@ -161,6 +156,11 @@ template: struct WebKit::PageGroupIdentifierType
 template: struct WebKit::TapIdentifierType
 template: struct WebKit::TextCheckerRequestType
 template: struct WebKit::UserContentControllerIdentifierType
+template: struct WebKit::WebExtensionContextIdentifierType
+template: struct WebKit::WebExtensionFrameIdentifierType
+template: struct WebKit::WebExtensionPortChannelIdentifierType
+template: struct WebKit::WebExtensionTabIdentifierType
+template: struct WebKit::WebExtensionWindowIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -170,7 +170,7 @@ void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
     if (isDisconnected())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu disconnected in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu disconnected in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, (NSString *)toDebugString(contentWorldType()));
 
     m_disconnected = true;
 
@@ -182,7 +182,7 @@ void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
     if (!m_onDisconnect || m_onDisconnect->listeners().isEmpty())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Fired port disconnect event for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Fired port disconnect event for channel %{public}llu in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, (NSString *)toDebugString(contentWorldType()));
 
     for (auto& listener : m_onDisconnect->listeners()) {
         auto globalContext = listener->globalContext();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -50,7 +50,7 @@ public:
     static PortSet get(WebExtensionPortChannelIdentifier);
 
     WebExtensionContentWorldType targetContentWorldType() const { return m_targetContentWorldType; }
-    WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
+    WebExtensionPortChannelIdentifier channelIdentifier() const { return *m_channelIdentifier; }
     WebPageProxyIdentifier owningPageProxyIdentifier() const { return m_owningPageProxyIdentifier; }
     const std::optional<WebExtensionMessageSenderParameters>& senderParameters() const { return m_senderParameters; }
 
@@ -139,7 +139,7 @@ private:
 
     WebExtensionContentWorldType m_targetContentWorldType;
     WebPageProxyIdentifier m_owningPageProxyIdentifier;
-    WebExtensionPortChannelIdentifier m_channelIdentifier;
+    Markable<WebExtensionPortChannelIdentifier> m_channelIdentifier;
     bool m_disconnected { false };
 
     String m_name;


### PR DESCRIPTION
#### e40631b5ed038d0b39ce3331ebd51b9dd9363aa2
<pre>
Port WebExtension identifier types to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=279764">https://bugs.webkit.org/show_bug.cgi?id=279764</a>

Reviewed by Timothy Hatcher.

* Source/WebKit/Shared/Extensions/WebExtensionContextIdentifier.h:
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::toWebExtensionFrameIdentifier):
(WebKit::toWebAPI):
* Source/WebKit/Shared/Extensions/WebExtensionPortChannelIdentifier.h:
* Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h:
(WebKit::toWebExtensionTabIdentifier):
(WebKit::toWebAPI):
* Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h:
(WebKit::toWebExtensionWindowIdentifier):
(WebKit::toWebAPI):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
(WebKit::WebExtensionAPIPort::channelIdentifier const):

Canonical link: <a href="https://commits.webkit.org/283748@main">https://commits.webkit.org/283748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca039f57efe4553206ecc014c4aabfc1bcf0052e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19932 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18228 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70367 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39547 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15964 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11259 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/73045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58288 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/9224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2828 "Build is in progress. Recent messages:") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10209 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->