### PR TITLE
REGRESSION (282580@main): 4.5MB binary size increase

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -560,3 +560,11 @@
 #if !defined(TLS_MODEL_INITIAL_EXEC)
 #define TLS_MODEL_INITIAL_EXEC
 #endif
+
+/* UNREACHABLE */
+
+#if COMPILER(MSVC)
+#define WTF_UNREACHABLE(...) __assume(0)
+#else
+#define WTF_UNREACHABLE(...) __builtin_unreachable();
+#endif


### PR DESCRIPTION
#### 6aa472c27a8ade5cad6dffe3f8a809688d9d559f
<pre>
REGRESSION (282580@main): 4.5MB binary size increase
<a href="https://bugs.webkit.org/show_bug.cgi?id=279498">https://bugs.webkit.org/show_bug.cgi?id=279498</a>

Reviewed by Darin Adler.

The implementation of std::visit in some standard library implementations,
including the current libc++, can cause excessive code generation size.

This works around it for the case of a visit with a single variant, the
most common use case in WebKit and the one used by WTF::switchOn, by
using a switch-based implementation.

Measured locally, this is a ~10% code size improvement for WebCore.framework:

    FILE SIZE        VM SIZE
 --------------  --------------
  +0.8% +5.41Ki  +0.8% +5.41Ki    __TEXT,__const
  +105% +5.31Ki  +105% +5.31Ki    [__TEXT]
  +0.0%      +2  +0.0%      +2    __TEXT,__objc_methname
  -0.3%      -8  -0.3%      -8    __TEXT,__eh_frame
  -0.0%     -44  -0.0%     -44    __TEXT,__gcc_except_tab
  -0.0%    -198  -0.0%    -198    __TEXT,__cstring
  -0.3%    -216  -0.3%    -216    __TEXT,__unwind_info
  [ = ]       0  -0.4% -4.00Ki    [__LINKEDIT]
  -2.8% -6.79Ki  -2.8% -6.79Ki    Function Start Addresses
 -70.8% -6.98Ki -70.8% -6.98Ki    [__DATA_CONST]
  -2.1% -57.0Ki  -2.1% -57.0Ki    __DATA_CONST,__const
 -10.0% -91.6Ki -10.0% -91.6Ki    Code Signature
  -0.4%  -154Ki  -0.4%  -154Ki    __TEXT,__text
  -3.6%  -502Ki  -3.6%  -502Ki    Symbol Table
 -20.0% -10.8Mi -20.0% -10.8Mi    String Table
 -10.2% -11.5Mi -10.2% -11.5Mi    TOTAL

* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/StdLibExtras.h:

Canonical link: <a href="https://commits.webkit.org/283806@main">https://commits.webkit.org/283806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7aaa5fdb8ba18f84e6fa1d90446e15c9b688648

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67360 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54020 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15671 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16855 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60475 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73107 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66605 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61459 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61516 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14938 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9271 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2875 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42544 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15595 "Found 3 new JSC stress test failures: wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-collect-continuously, wasm.yaml/wasm/stress/tail-call-js-inline.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43621 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->