### PR TITLE
[JSC] Implement Math.sumPrecise()

### DIFF
--- a/JSTests/stress/math-sum-precise.js
+++ b/JSTests/stress/math-sum-precise.js
@@ -1,0 +1,54 @@
+//@ requireOptions("--useMathSumPreciseMethod=1")
+
+// Copyright (C) 2024 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the https://github.com/tc39/test262/blob/main/LICENSE file.
+
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+for (var i = 0; i < 1e4; i++) {
+    shouldBe(Math.sumPrecise([1, 2, 3]), 6);
+    shouldBe(Math.sumPrecise([1e308]), 1e308);
+    shouldBe(Math.sumPrecise([1e308, -1e308]), 0);
+    shouldBe(Math.sumPrecise([0.1]), 0.1);
+    shouldBe(Math.sumPrecise([0.1, 0.1]), 0.2);
+    shouldBe(Math.sumPrecise([0.1, -0.1]), 0);
+    shouldBe(Math.sumPrecise([1e308, 1e308, 0.1, 0.1, 1e30, 0.1, -1e30, -1e308, -1e308]), 0.30000000000000004);
+    shouldBe(Math.sumPrecise([1e30, 0.1, -1e30]), 0.1);
+
+    // These cases are chosen for having exercised bugs in real implementations.
+    // There is no other logic behind choice of constants.
+    shouldBe(Math.sumPrecise([8.98846567431158e+307, 8.988465674311579e+307, -1.7976931348623157e+308]), 9.9792015476736e+291);
+    shouldBe(Math.sumPrecise([-5.630637621603525e+255, 9.565271205476345e+307, 2.9937604643020797e+292]), 9.565271205476347e+307);
+    shouldBe(Math.sumPrecise([6.739986666787661e+66, 2, -1.2689709186578243e-116, 1.7046015739467354e+308, -9.979201547673601e+291, 6.160926733208294e+307, -3.179557053031852e+234, -7.027282978772846e+307, -0.7500000000000001]), 1.61796594939028e+308);
+    shouldBe(Math.sumPrecise([0.31150493246968836, -8.988465674311582e+307, 1.8315037361673755e-270, -15.999999999999996, 2.9999999999999996, 7.345200721499384e+164, -2.033582473639399, -8.98846567431158e+307, -3.5737295155405993e+292, 4.13894772383715e-124, -3.6111186457260667e-35, 2.387234887098013e+180, 7.645295562778372e-298, 3.395189016861822e-103, -2.6331611115768973e-149]), -Infinity);
+    shouldBe(Math.sumPrecise([-1.1442589134409902e+308, 9.593842098384855e+138, 4.494232837155791e+307, -1.3482698511467367e+308, 4.494232837155792e+307]), -1.5936821971565685e+308);
+    shouldBe(Math.sumPrecise([-1.1442589134409902e+308, 4.494232837155791e+307, -1.3482698511467367e+308, 4.494232837155792e+307]), -1.5936821971565687e+308);
+    shouldBe(Math.sumPrecise([9.593842098384855e+138, -6.948356297254111e+307, -1.3482698511467367e+308, 4.494232837155792e+307]), -1.5936821971565685e+308);
+    shouldBe(Math.sumPrecise([-2.534858246857893e+115, 8.988465674311579e+307, 8.98846567431158e+307]), 1.7976931348623157e+308);
+    shouldBe(Math.sumPrecise([1.3588124894186193e+308, 1.4803986201152006e+223, 6.741349255733684e+307]), Infinity);
+    shouldBe(Math.sumPrecise([6.741349255733684e+307, 1.7976931348623155e+308, -7.388327292663961e+41]), Infinity);
+    shouldBe(Math.sumPrecise([-1.9807040628566093e+28, 1.7976931348623157e+308, 9.9792015476736e+291]), 1.7976931348623157e+308);
+    shouldBe(Math.sumPrecise([-1.0214557991173964e+61, 1.7976931348623157e+308, 8.98846567431158e+307, -8.988465674311579e+307]), 1.7976931348623157e+308);
+    shouldBe(Math.sumPrecise([1.7976931348623157e+308, 7.999999999999999, -1.908963895403937e-230, 1.6445950082320264e+292, 2.0734856707605806e+205]), Infinity);
+    shouldBe(Math.sumPrecise([6.197409167220438e-223, -9.979201547673601e+291, -1.7976931348623157e+308]), -Infinity);
+    shouldBe(Math.sumPrecise([4.49423283715579e+307, 8.944251746776101e+307, -0.0002441406250000001, 1.1752060710043817e+308, 4.940846717201632e+292, -1.6836699406454528e+308]), 8.353845887521184e+307);
+    shouldBe(Math.sumPrecise([8.988465674311579e+307, 7.999999999999998, 7.029158107234023e-308, -2.2303483759420562e-172, -1.7976931348623157e+308, -8.98846567431158e+307]), -1.7976931348623157e+308);
+    shouldBe(Math.sumPrecise([8.98846567431158e+307, 8.98846567431158e+307]), Infinity);
+
+    shouldBe(Math.sumPrecise([NaN]), NaN);
+    shouldBe(Math.sumPrecise([Infinity, -Infinity]), NaN);
+    shouldBe(Math.sumPrecise([-Infinity, Infinity]), NaN);
+
+    shouldBe(Math.sumPrecise([Infinity]), Infinity);
+    shouldBe(Math.sumPrecise([Infinity, Infinity]), Infinity);
+    shouldBe(Math.sumPrecise([-Infinity]), -Infinity);
+    shouldBe(Math.sumPrecise([-Infinity, -Infinity]), -Infinity);
+
+    shouldBe(Math.sumPrecise([]), -0);
+    shouldBe(Math.sumPrecise([-0]), -0);
+    shouldBe(Math.sumPrecise([-0, -0]), -0);
+    shouldBe(Math.sumPrecise([-0, 0]), 0);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -18,7 +18,6 @@ skip:
     - regexp-modifiers
     - source-phase-imports
     - Atomics.pause
-    - Math.sumPrecise
   paths:
     - test/built-ins/Temporal/Calendar
     - test/built-ins/Temporal/Instant/prototype/toZonedDateTime

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -25,6 +25,7 @@
 #include "MathCommon.h"
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
+#include <wtf/PreciseSum.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -64,6 +65,7 @@ static JSC_DECLARE_HOST_FUNCTION(mathProtoFuncTanh);
 static JSC_DECLARE_HOST_FUNCTION(mathProtoFuncTrunc);
 static JSC_DECLARE_HOST_FUNCTION(mathProtoFuncIMul);
 static JSC_DECLARE_HOST_FUNCTION(mathProtoFuncF16Round);
+static JSC_DECLARE_HOST_FUNCTION(mathProtoFuncSumPrecise);
 
 const ClassInfo MathObject::s_info = { "Math"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(MathObject) };
 
@@ -123,6 +125,9 @@ void MathObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "trunc"_s), 1, mathProtoFuncTrunc, ImplementationVisibility::Public, TruncIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "imul"_s), 2, mathProtoFuncIMul, ImplementationVisibility::Public, IMulIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "f16round"_s), 1, mathProtoFuncF16Round, ImplementationVisibility::Public, F16RoundIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::useMathSumPreciseMethod())
+        putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sumPrecise"_s), 1, mathProtoFuncSumPrecise, ImplementationVisibility::Public, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 // ------------------------------ Functions --------------------------------
@@ -395,6 +400,31 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncTrunc, (JSGlobalObject* globalObject, Call
 JSC_DEFINE_HOST_FUNCTION(mathProtoFuncF16Round, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(jsDoubleNumber(Float16 { callFrame->argument(0).toNumber(globalObject) }));
+}
+
+JSC_DEFINE_HOST_FUNCTION(mathProtoFuncSumPrecise, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue iterable = callFrame->argument(0);
+    if (iterable.isUndefinedOrNull())
+        return throwVMTypeError(globalObject, scope, "Math.sumPrecise requires first argument not be null or undefined"_s);
+
+    PreciseSum sum;
+
+    scope.release();
+    forEachInIterable(globalObject, iterable, [&sum](VM& vm, JSGlobalObject* globalObject, JSValue value) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        if (!value.isNumber()) {
+            throwTypeError(globalObject, scope, "Math.sumPrecise was passed a non-number"_s);
+            return;
+        }
+
+        sum.add(value.asNumber());
+    });
+
+    return JSValue::encode(jsNumber(sum.compute()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -584,6 +584,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
     v(Bool, useIteratorHelpers, false, Normal, "Expose the Iterator Helpers."_s) \
+    v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -129,6 +129,8 @@
 		7B8A1DC82A336B9000A4CE4E /* SequenceLocked.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
+		8AB05DFB2C99482E00738BDD /* PreciseSum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8AB05DF92C99482E00738BDD /* PreciseSum.cpp */; };
+		8AB05DFC2C99482E00738BDD /* PreciseSum.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB05DFA2C99482E00738BDD /* PreciseSum.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93934BD318A1E8C300D0D6A1 /* StringViewCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93934BD218A1E8C300D0D6A1 /* StringViewCocoa.mm */; };
 		93934BD518A1F16900D0D6A1 /* StringViewCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93934BD418A1F16900D0D6A1 /* StringViewCF.cpp */; };
@@ -1309,6 +1311,8 @@
 		83FBA93119DF459700F30ADB /* TypeCasts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCasts.h; sourceTree = "<group>"; };
 		862A8D32278DE74A0014120C /* SignedPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SignedPtr.h; sourceTree = "<group>"; };
 		86F46F5F1A2840EE00CCBF22 /* RefCounter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefCounter.h; sourceTree = "<group>"; };
+		8AB05DF92C99482E00738BDD /* PreciseSum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PreciseSum.cpp; sourceTree = "<group>"; };
+		8AB05DFA2C99482E00738BDD /* PreciseSum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreciseSum.h; sourceTree = "<group>"; };
 		93156C8D262C982200EAE27B /* SortedArrayMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SortedArrayMap.h; sourceTree = "<group>"; };
 		93241657243BC2E50032FAAE /* VectorCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VectorCocoa.h; sourceTree = "<group>"; };
 		933D63191FCB6AB90032ECD6 /* StringHasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringHasher.h; sourceTree = "<group>"; };
@@ -2338,6 +2342,8 @@
 				7CFAF3C923D0AF1500D21BDD /* PlatformUse.h */,
 				0FF860941BCCBD740045127F /* PointerComparison.h */,
 				FEB6B035201BE0B600B958C1 /* PointerPreparations.h */,
+				8AB05DF92C99482E00738BDD /* PreciseSum.cpp */,
+				8AB05DFA2C99482E00738BDD /* PreciseSum.h */,
 				0F9D335D165DBA73005AD387 /* PrintStream.cpp */,
 				0F9D335E165DBA73005AD387 /* PrintStream.h */,
 				53EC253C1E95AD30000831B9 /* PriorityQueue.h */,
@@ -3407,6 +3413,7 @@
 				DD3DC96F27A4BF8E007E5B61 /* PointerPreparations.h in Headers */,
 				FFE39CAC2B1D7472004972B0 /* policy.h in Headers */,
 				FFE39CB22B1D7472004972B0 /* policy_holder.h in Headers */,
+				8AB05DFC2C99482E00738BDD /* PreciseSum.h in Headers */,
 				DD3DC93227A4BF8E007E5B61 /* PrintStream.h in Headers */,
 				DD3DC95027A4BF8E007E5B61 /* PriorityQueue.h in Headers */,
 				DD3DC89927A4BF8E007E5B61 /* ProcessID.h in Headers */,
@@ -4067,6 +4074,7 @@
 				51F1752C1F3D486000C74950 /* PersistentDecoder.cpp in Sources */,
 				51F1752D1F3D486000C74950 /* PersistentEncoder.cpp in Sources */,
 				FE1E2C42224187C600F6B729 /* PlatformRegisters.cpp in Sources */,
+				8AB05DFB2C99482E00738BDD /* PreciseSum.cpp in Sources */,
 				0F9D3362165DBA73005AD387 /* PrintStream.cpp in Sources */,
 				7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */,
 				FE1E2C3B2240C06600F6B729 /* PtrTag.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -217,6 +217,7 @@ set(WTF_PUBLIC_HEADERS
     PlatformUse.h
     PointerComparison.h
     PointerPreparations.h
+    PreciseSum.h
     PrintStream.h
     PriorityQueue.h
     ProcessID.h
@@ -527,6 +528,7 @@ set(WTF_SOURCES
     ParallelHelperPool.cpp
     ParallelJobsGeneric.cpp
     ParkingLot.cpp
+    PreciseSum.cpp
     PrintStream.cpp
     ProcessPrivilege.cpp
     RAMSize.cpp

--- a/Source/WTF/wtf/PreciseSum.cpp
+++ b/Source/WTF/wtf/PreciseSum.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This is the Math.sumPrecise() polyfill by Kevin Gibbons, ported to C++. Original LICENSE is as follows:
+ *
+ * BSD 3-Clause License
+ * 
+ * Copyright (c) 2024 Kevin Gibbons
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ * and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/PreciseSum.h>
+
+#include <cmath>
+
+namespace WTF {
+
+static constexpr double MAX_DOUBLE = 1.79769313486231570815e+308;
+static constexpr double PENULTIMATE_DOUBLE = 1.79769313486231550856e+308;
+static constexpr double MAX_ULP = MAX_DOUBLE - PENULTIMATE_DOUBLE;
+static constexpr double TWO_POW_1023 = 8.98846567431158e+307;
+
+ALWAYS_INLINE std::pair<double, double> twosum(double x, double y)
+{
+    double hi = x + y;
+    double lo = y - (hi - x);
+    return std::make_pair(hi, lo);
+}
+
+void PreciseSum::add(double x)
+{
+    if (!(!x && std::signbit(x)))
+        m_everyValueIsNegativeZero = false;
+
+    unsigned actuallyUsedPartials = 0;
+
+    for (double y : m_partials) {
+        if (std::fabs(x) < std::fabs(y))
+            std::swap(x, y);
+
+        auto pair = twosum(x, y);
+        if (std::isinf(std::fabs(pair.first))) {
+            double sign = pair.first < 0 ? -1 : 1;
+            m_overflow += sign;
+
+            x = (x - sign * TWO_POW_1023) - sign * TWO_POW_1023;
+            if (std::fabs(x) < std::fabs(y))
+                std::swap(x, y);
+
+            pair = twosum(x, y);
+        }
+
+        if (auto lo = pair.second) {
+            m_partials[actuallyUsedPartials] = lo;
+            ++actuallyUsedPartials;
+        }
+
+        x = pair.first;
+    }
+
+    m_partials.shrink(actuallyUsedPartials);
+
+    if (x)
+        m_partials.append(x);
+}
+
+double PreciseSum::compute()
+{
+    if (m_everyValueIsNegativeZero)
+        return -0.0;
+
+    int32_t n = m_partials.size() - 1;
+    double hi = 0;
+    double lo = 0;
+
+    if (m_overflow) {
+        double next = n >= 0 ? m_partials[n] : 0;
+        --n;
+        if (std::fabs(m_overflow) > 1 || (m_overflow > 0 && next > 0) || (m_overflow < 0 && next < 0))
+            return m_overflow > 0 ? std::numeric_limits<double>::infinity() : -std::numeric_limits<double>::infinity();
+
+        auto pair = twosum(m_overflow * TWO_POW_1023, next / 2);
+        hi = pair.first;
+        lo = pair.second * 2;
+
+        if (std::isinf(std::fabs(hi * 2))) {
+            // silly edge case: rounding to the maximum value
+            // MAX_DOUBLE has a 1 in the last place of its significand, so if we subtract exactly half a ULP from 2**1024, the result rounds away from it (i.e. to infinity) under ties-to-even
+            // but if the next partial has the opposite sign of the current value, we need to round towards MAX_DOUBLE instead
+            // this is the same as the "handle rounding" case below, but there's only one potentially-finite case we need to worry about, so we just hardcode that one
+            if (hi > 0) {
+                if (hi == TWO_POW_1023 && lo == -(MAX_ULP / 2) && n >= 0 && m_partials[n] < 0)
+                    return MAX_DOUBLE;
+                return std::numeric_limits<double>::infinity();
+            }
+
+            if (hi == -TWO_POW_1023 && lo == (MAX_ULP / 2) && n >= 0 && m_partials[n] > 0)
+                return -MAX_DOUBLE;
+            return -std::numeric_limits<double>::infinity();
+        }
+
+        if (lo) {
+            m_partials[n + 1] = lo;
+            ++n;
+            lo = 0;
+        }
+
+        hi *= 2;
+    }
+
+    while (n >= 0) {
+        double x = hi;
+        double y = m_partials[n];
+        --n;
+
+        auto pair = twosum(x, y);
+        hi = pair.first;
+        lo = pair.second;
+
+        if (lo)
+            break;
+    }
+
+    // handle rounding
+    // when the roundoff error is exactly half of the ULP for the result, we need to check one more partial to know which way to round
+    if (n >= 0 && ((lo < 0 && m_partials[n] < 0) || (lo > 0 && m_partials[n] > 0))) {
+        double y = lo * 2;
+        double x = hi + y;
+        double yr = x - hi;
+        if (y == yr)
+            hi = x;
+    }
+
+    return hi;
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/PreciseSum.h
+++ b/Source/WTF/wtf/PreciseSum.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+class PreciseSum {
+public:
+    WTF_EXPORT_PRIVATE void add(double);
+    WTF_EXPORT_PRIVATE double compute();
+
+private:
+    bool m_everyValueIsNegativeZero { true };
+    Vector<double> m_partials;
+    double m_overflow { 0 };
+};
+
+} // namespace WTF
+
+using WTF::PreciseSum;


### PR DESCRIPTION
#### f49d6a41fb8d93f9c7e6758d87a06a9eea3e9698
<pre>
[JSC] Implement Math.sumPrecise()
<a href="https://bugs.webkit.org/show_bug.cgi?id=279768">https://bugs.webkit.org/show_bug.cgi?id=279768</a>
&lt;<a href="https://rdar.apple.com/131580043">rdar://131580043</a>&gt;

Reviewed by Yusuke Suzuki.

This patch implements Math.sumPrecise() proposal [1] behind a flag by importing its polyfill [2] and
rewriting it in C++, with a minor tweak of how negative zero edge case is handled (without extra loop)
and proper iterator closure.

radfordneal/xsum [3], mentioned in the proposal, didn&apos;t pass all the test262 tests.

[1]: <a href="https://github.com/tc39/proposal-math-sum">https://github.com/tc39/proposal-math-sum</a>
[2]: <a href="https://github.com/tc39/proposal-math-sum/blob/main/polyfill/polyfill.mjs">https://github.com/tc39/proposal-math-sum/blob/main/polyfill/polyfill.mjs</a>
[3]: <a href="https://gitlab.com/radfordneal/xsum">https://gitlab.com/radfordneal/xsum</a>

* JSTests/stress/math-sum-precise.js: Added.
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::MathObject::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/LICENSE-SumPrecise.txt: Added.
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/sum_precise/LICENSE.txt: Added.
* Source/WTF/wtf/sum_precise/SumPrecise.cpp: Added.
(WTF::SumPrecise::twosum):
(WTF::SumPrecise::add):
(WTF::SumPrecise::compute):
* Source/WTF/wtf/sum_precise/SumPrecise.h: Added.

Canonical link: <a href="https://commits.webkit.org/283774@main">https://commits.webkit.org/283774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04642d774ceb91ffdbe541168eaea936fabe0f15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18448 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53917 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12376 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34450 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15629 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16805 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60427 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73065 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66557 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61401 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61482 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2834 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88326 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10220 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15558 "Found 6 new JSC stress test failures: wasm.yaml/wasm/stress/cc-f32-kitchen-sink.js.wasm-eager, wasm.yaml/wasm/stress/f32-tuple-jsapi-exported.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit, wasm.yaml/wasm/stress/tail-call.js.wasm-bbq, wasm.yaml/wasm/stress/tail-call.js.wasm-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->