### PR TITLE
Deploy more smart pointers in WebUserContentControllerProxy.cpp

### DIFF
--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
@@ -46,4 +46,9 @@ WebScriptMessageHandler::~WebScriptMessageHandler()
 {
 }
 
+Ref<API::ContentWorld> WebScriptMessageHandler::protectedWorld()
+{
+    return m_world;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
@@ -65,6 +65,7 @@ public:
     String name() const { return m_name; }
 
     API::ContentWorld& world() { return m_world.get(); }
+    Ref<API::ContentWorld> protectedWorld();
 
     Client& client() const { return *m_client; }
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -136,6 +136,8 @@ public:
     bool operator==(const WebUserContentControllerProxy& other) const { return (this == &other); }
 
 private:
+    Ref<API::Array> protectedUserScripts() const;
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 


### PR DESCRIPTION
#### 1ab93f000cd812500b2c9cb73346a6f91166bcd5
<pre>
Deploy more smart pointers in WebUserContentControllerProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279771">https://bugs.webkit.org/show_bug.cgi?id=279771</a>

Reviewed by Chris Dumez.

Deployed more smart pointers as warned by the clang static analyzer.

* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::protectedNetworkProcess):
(WebKit::WebSharedWorkerServerConnection::session):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp:
(WebKit::WebScriptMessageHandler::protectedWorld):
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::~WebUserContentControllerProxy):
(WebKit::WebUserContentControllerProxy::protectedUserScripts const):
(WebKit::WebUserContentControllerProxy::parameters const):
(WebKit::WebUserContentControllerProxy::addContentWorld):
(WebKit::WebUserContentControllerProxy::addUserScriptMessageHandler):
(WebKit::WebUserContentControllerProxy::removeUserMessageHandlerForName):
(WebKit::WebUserContentControllerProxy::didPostMessage):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:

Canonical link: <a href="https://commits.webkit.org/283734@main">https://commits.webkit.org/283734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9e532e487bbef15512ccd69d1a28e8ee1b7a8ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18301 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53857 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12313 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42801 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58121 "1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34392 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39473 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16655 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61439 "Found 7 new API test failures: TestWebKitAPI.InAppBrowserPrivacy.NonAppBoundUserStyleSheetForAllWebViewsFails, TestWebKitAPI.WKUserContentController.UserStyleSheetAffectingAllFrames, TestWebKitAPI.WKUserContentController.UserStyleSheetAffectingOnlyMainFrame, TestWebKitAPI.InAppBrowserPrivacy.NonAppBoundUserStyleSheetAffectingAllFramesFails, TestWebKitAPI.WKUserContentController.AddUserStyleSheetBeforeCreatingView, TestWebKitAPI.WKUserContentController.UserStyleSheetSpecificityLevelAuthor, TestWebKitAPI.WKAttachmentTests.UserDragNonePreventsDragOnAttachmentElement (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72906 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61425 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2747 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10198 "") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->