### PR TITLE
[scroll-animations] com.apple.WebKit.WebContent.CaptivePortal use-after-free crash at WebCore::DocumentTimeline::detachFromDocument

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -85,7 +85,6 @@ std::optional<double> AnimationTimeline::bindingsCurrentTime()
 
 void AnimationTimeline::detachFromDocument()
 {
-    Ref<AnimationTimeline> protectedThis(*this);
     if (CheckedPtr controller = this->controller())
         controller->removeTimeline(*this);
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -74,8 +74,8 @@ void AnimationTimelinesController::detachFromDocument()
     m_currentTimeClearingTaskCancellationGroup.cancel();
 
     while (!m_timelines.isEmptyIgnoringNullReferences()) {
-        auto& timeline = *m_timelines.begin();
-        timeline.detachFromDocument();
+        Ref timeline = *m_timelines.begin();
+        timeline->detachFromDocument();
     }
 }
 


### PR DESCRIPTION
#### 64a427a3f3793bc8c57cd9f26c2f47c7a0ecc869
<pre>
[scroll-animations] com.apple.WebKit.WebContent.CaptivePortal use-after-free crash at WebCore::DocumentTimeline::detachFromDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=279772">https://bugs.webkit.org/show_bug.cgi?id=279772</a>
<a href="https://rdar.apple.com/136077432">rdar://136077432</a>

Reviewed by Charlie Wolfe, Tim Nguyen, and Antoine Quint.

Protect current DocumentTimeline being detatched to prevent use after free.

* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::detachFromDocument):

Canonical link: <a href="https://commits.webkit.org/284052@main">https://commits.webkit.org/284052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e0a0e1644f0058e3d3c58cd580fee384c3a5558

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54563 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16436 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74097 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62038 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3575 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10391 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43531 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44605 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->