### PR TITLE
Deploy smart pointers in RemoteWebInspectorUIProxy.cpp and RemoteWebInspectorUIProxyMac.mm

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -72,7 +72,7 @@ void RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable(bool available)
 {
 #if ENABLE(INSPECTOR_TELEMETRY)
     if (RefPtr page = protectedInspectorPage())
-        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::SetDiagnosticLoggingAvailable(available), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::SetDiagnosticLoggingAvailable(available), page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(available);
 #endif
@@ -86,7 +86,7 @@ void RemoteWebInspectorUIProxy::initialize(Ref<API::DebuggableInfo>&& debuggable
     createFrontendPageAndWindow();
 
     auto inspectorPage = protectedInspectorPage();
-    inspectorPage->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::Initialize(m_debuggableInfo->debuggableInfoData(), backendCommandsURL), m_inspectorPage->webPageIDInMainFrameProcess());
+    inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::Initialize(m_debuggableInfo->debuggableInfoData(), backendCommandsURL), m_inspectorPage->webPageIDInMainFrameProcess());
     inspectorPage->loadRequest(URL { WebInspectorUIProxy::inspectorPageURL() });
 }
 
@@ -109,19 +109,19 @@ void RemoteWebInspectorUIProxy::show()
 void RemoteWebInspectorUIProxy::showConsole()
 {
     if (RefPtr page = protectedInspectorPage())
-        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::ShowConsole { }, page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::ShowConsole { }, page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::showResources()
 {
     if (RefPtr page = protectedInspectorPage())
-        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::ShowResources { }, page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::ShowResources { }, page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::sendMessageToFrontend(const String& message)
 {
     if (RefPtr page = protectedInspectorPage())
-        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::SendMessageToFrontend(message), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::SendMessageToFrontend(message), page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::frontendLoaded()
@@ -206,11 +206,11 @@ void RemoteWebInspectorUIProxy::showCertificate(const CertificateInfo& certifica
 
 void RemoteWebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled(bool enabled)
 {
-    auto inspectorPage = protectedInspectorPage();
+    RefPtr inspectorPage = m_inspectorPage.get();
     if (!inspectorPage)
         return;
 
-    inspectorPage->preferences().setDeveloperExtrasEnabled(enabled);
+    inspectorPage->protectedPreferences()->setDeveloperExtrasEnabled(enabled);
 }
 
 void RemoteWebInspectorUIProxy::sendMessageToBackend(const String& message)
@@ -229,7 +229,7 @@ void RemoteWebInspectorUIProxy::createFrontendPageAndWindow()
 
     trackInspectorPage(inspectorPage.get(), nullptr);
 
-    inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess(), *this);
+    inspectorPage->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess(), *this);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = WebInspectorUIExtensionControllerProxy::create(*inspectorPage);
@@ -242,7 +242,7 @@ void RemoteWebInspectorUIProxy::closeFrontendPageAndWindow()
     if (!inspectorPage)
         return;
 
-    inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess());
+    inspectorPage->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess());
 
     untrackInspectorPage(inspectorPage.get());
 


### PR DESCRIPTION
#### 0739f32991315ec15617f1fb14feff26fb0110db
<pre>
Deploy smart pointers in RemoteWebInspectorUIProxy.cpp and RemoteWebInspectorUIProxyMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=279774">https://bugs.webkit.org/show_bug.cgi?id=279774</a>

Reviewed by Devin Rousso.

Deployed more smart pointers as identified by clang static analyzers.

* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
(WebKit::RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::RemoteWebInspectorUIProxy::initialize):
(WebKit::RemoteWebInspectorUIProxy::showConsole):
(WebKit::RemoteWebInspectorUIProxy::showResources):
(WebKit::RemoteWebInspectorUIProxy::sendMessageToFrontend):
(WebKit::RemoteWebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled):
(WebKit::RemoteWebInspectorUIProxy::createFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::closeFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(-[WKRemoteWebInspectorUIProxyObjCAdapter protectedInspectorProxy]):
(-[WKRemoteWebInspectorUIProxyObjCAdapter inspectorWKWebViewDidBecomeActive:]):
(-[WKRemoteWebInspectorUIProxyObjCAdapter inspectorViewControllerInspectorDidCrash:]):
(-[WKRemoteWebInspectorUIProxyObjCAdapter inspectorViewControllerInspectorIsUnderTest:]):
(WebKit::RemoteWebInspectorUIProxy::didBecomeActive):

Canonical link: <a href="https://commits.webkit.org/283730@main">https://commits.webkit.org/283730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/644f0b391433a99bb3ccaac955f3d85b84508bce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18333 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/12327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58143 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/66712 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39500 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16687 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11159 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61423 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9161 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10197 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->