### PR TITLE
Pass `RTLD_FIRST | RTLD_NOW` when dlopening UIKit

### DIFF
--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -373,7 +373,7 @@ static void* lib##Library() \
     } \
     }
 
-#define SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, export) \
+#define SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS_AND_EXPORT(functionNamespace, framework, flags, export) \
     namespace functionNamespace { \
     export void* framework##Library(bool isOptional = false); \
     void* framework##Library(bool isOptional) \
@@ -381,7 +381,7 @@ static void* lib##Library() \
         static void* frameworkLibrary; \
         static dispatch_once_t once; \
         dispatch_once(&once, ^{ \
-            frameworkLibrary = dlopen("/System/Library/Frameworks/" #framework ".framework/" #framework, RTLD_NOW); \
+            frameworkLibrary = dlopen("/System/Library/Frameworks/" #framework ".framework/" #framework, flags); \
             if (!isOptional) \
                 RELEASE_ASSERT_WITH_MESSAGE(frameworkLibrary, "%s", dlerror()); \
         }); \
@@ -389,8 +389,14 @@ static void* lib##Library() \
     } \
     }
 
+#define SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, export) \
+    SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS_AND_EXPORT(functionNamespace, framework, RTLD_NOW, export)
+
+#define SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS(functionNamespace, framework, flags) \
+    SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS_AND_EXPORT(functionNamespace, framework, flags, )
+
 #define SOFT_LINK_FRAMEWORK_FOR_SOURCE(functionNamespace, framework) \
-    SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, )
+    SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS(functionNamespace, framework, RTLD_NOW)
 
 #define SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, export) \
     namespace functionNamespace { \

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
@@ -32,7 +32,7 @@
 
 @class CUICatalog;
 
-SOFT_LINK_FRAMEWORK_FOR_SOURCE(PAL, UIKit)
+SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS(PAL, UIKit, RTLD_FIRST | RTLD_NOW)
 
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIAccessibilityAnnouncementNotification, UIAccessibilityNotifications)
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIApplicationWillResignActiveNotification, NSNotificationName)


### PR DESCRIPTION
#### 703850c886c514b1c4fbeea55ee5a50ba5ee5552
<pre>
Pass `RTLD_FIRST | RTLD_NOW` when dlopening UIKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=279777">https://bugs.webkit.org/show_bug.cgi?id=279777</a>
<a href="https://rdar.apple.com/130524656">rdar://130524656</a>

Reviewed by Wenson Hsieh.

Pass `RTLD_FIRST | RTLD_NOW` when dlopening UIKit, instead of just `RTLD_NOW`.
This is a launch time optimization recommended by the performance team. search
for the symbol RTLD_FIRST will cause calls to exit on first finding the symbol,
making the calls faster.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm:

Canonical link: <a href="https://commits.webkit.org/283729@main">https://commits.webkit.org/283729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/380a4f971cf56c3e8e8bec883f7179d3da5e31dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18320 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18113 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12318 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34399 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16674 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60302 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72925 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66432 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15219 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61416 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9152 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88201 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10196 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15533 "Found 4 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->