### PR TITLE
Deploy more smart pointers in WebInspectorUIProxy.cpp

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
@@ -42,7 +42,7 @@ WKTypeID WKInspectorGetTypeID()
 
 WKPageRef WKInspectorGetPage(WKInspectorRef inspectorRef)
 {
-    return toAPI(toImpl(inspectorRef)->inspectedPage().get());
+    return toAPI(toImpl(inspectorRef)->protectedInspectedPage().get());
 }
 
 bool WKInspectorIsConnected(WKInspectorRef inspectorRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -101,7 +101,7 @@ private:
 
 - (WKWebView *)webView
 {
-    auto page = _inspector->inspectedPage();
+    RefPtr page = _inspector->protectedInspectedPage();
     return page ? page->cocoaView().autorelease() : nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
@@ -47,7 +47,7 @@ static NSString *JavaScriptSnippetToFetchURL(NSURL *url)
 
 - (WKWebView *)inspectorWebView
 {
-    auto page = _inspector->inspectorPage();
+    RefPtr page = _inspector->protectedInspectorPage();
     return page ? page->cocoaView().autorelease() : nil;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2037,7 +2037,7 @@ RefPtr<WebExtensionTab> WebExtensionContext::getCurrentTab(WebPageProxyIdentifie
 
     // Search open inspectors.
     for (auto [inspector, tab] : openInspectors()) {
-        if (inspector->inspectorPage()->identifier() == webPageProxyIdentifier) {
+        if (Ref { inspector }->protectedInspectorPage()->identifier() == webPageProxyIdentifier) {
             if (includeExtensionViews == IncludeExtensionViews::No)
                 return nullptr;
 
@@ -3162,7 +3162,7 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorP
         auto tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-        result.append({ inspector->inspectorPage()->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
+        result.append({ inspector->protectedInspectorPage()->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
     }
 
     return result;
@@ -3869,7 +3869,7 @@ RefPtr<API::InspectorExtension> WebExtensionContext::inspectorExtension(WebPageP
 
     if (!foundInspector) {
         for (auto [inspector, tab] : openInspectors()) {
-            if (inspector->inspectorPage()->identifier() == webPageProxyIdentifier)
+            if (Ref { inspector }->protectedInspectorPage()->identifier() == webPageProxyIdentifier)
                 foundInspector = inspector.ptr();
         }
     }
@@ -3942,7 +3942,7 @@ void WebExtensionContext::loadInspectorBackgroundPagesDuringLoad()
         return;
 
     for (auto [inspector, tab] : openInspectors())
-        loadInspectorBackgroundPage(inspector, *tab);
+        loadInspectorBackgroundPage(Ref { inspector }, *tab);
 }
 
 void WebExtensionContext::unloadInspectorBackgroundPages()
@@ -4037,7 +4037,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
             return;
         }
 
-        auto *inspectorWebView = inspector->inspectorPage()->cocoaView().get();
+        auto *inspectorWebView = inspector->protectedInspectorPage()->cocoaView().get();
         auto *inspectorWebViewConfiguration = inspectorWebView.configuration;
 
         auto *configuration = webViewConfiguration(WebViewPurpose::Inspector);
@@ -4069,7 +4069,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         RefPtr window = tab->window();
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-        auto appearance = inspector->inspectorPage()->useDarkAppearance() ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
+        auto appearance = inspector->protectedInspectorPage()->useDarkAppearance() ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
 
         Ref process = webView._page->legacyMainFrameProcess();
         ASSERT(inspectorWebView._page->legacyMainFrameProcess() == process);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -113,8 +113,8 @@ public:
     void setInspectorClient(std::unique_ptr<API::InspectorClient>&&);
 
     // Public APIs
-    RefPtr<WebPageProxy> inspectedPage() const { return m_inspectedPage.get(); }
-    RefPtr<WebPageProxy> inspectorPage() const { return m_inspectorPage.get(); }
+    RefPtr<WebPageProxy> protectedInspectedPage() const { return m_inspectedPage.get(); }
+    RefPtr<WebPageProxy> protectedInspectorPage() const { return m_inspectorPage.get(); }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WebInspectorUIExtensionControllerProxy* extensionController() const { return m_extensionController.get(); }
@@ -294,6 +294,7 @@ private:
     unsigned inspectionLevel() const;
 
     WebPreferences& inspectorPagePreferences() const;
+    Ref<WebPreferences> protectedInspectorPagePreferences() const;
 
 #if PLATFORM(MAC)
     void applyForcedAppearance();

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -139,7 +139,7 @@ static void decidePolicyForNavigationAction(WKPageRef pageRef, WKNavigationActio
     toImpl(listenerRef)->ignore();
 
     // And instead load it in the inspected page.
-    inspector->inspectedPage()->loadRequest(WTFMove(request));
+    inspector->protectedInspectedPage()->loadRequest(WTFMove(request));
 }
 
 static void getContextMenuFromProposedMenu(WKPageRef pageRef, WKArrayRef proposedMenuRef, WKArrayRef* newMenuRef, WKHitTestResultRef, WKTypeRef, const void*)
@@ -180,8 +180,7 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
 {
     ASSERT(inspectedPage());
     ASSERT(!m_inspectorView);
-
-    auto preferences = WebPreferences::create(String(), "WebKit2."_s, "WebKit2."_s);
+    Ref preferences = WebPreferences::create(String(), "WebKit2."_s, "WebKit2."_s);
 #if ENABLE(DEVELOPER_MODE)
     // Allow developers to inspect the Web Inspector in debug builds without changing settings.
     preferences->setDeveloperExtrasEnabled(true);
@@ -192,11 +191,11 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     });
     if (m_underTest)
         preferences->setHiddenPageDOMTimerThrottlingEnabled(false);
-    const auto& inspectedPagePreferences = inspectedPage()->preferences();
-    preferences->setAcceleratedCompositingEnabled(inspectedPagePreferences.acceleratedCompositingEnabled());
-    preferences->setForceCompositingMode(inspectedPagePreferences.forceCompositingMode());
-    preferences->setThreadedScrollingEnabled(inspectedPagePreferences.threadedScrollingEnabled());
-    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage().get()));
+    Ref inspectedPagePreferences = protectedInspectedPage()->protectedPreferences();
+    preferences->setAcceleratedCompositingEnabled(inspectedPagePreferences->acceleratedCompositingEnabled());
+    preferences->setForceCompositingMode(inspectedPagePreferences->forceCompositingMode());
+    preferences->setThreadedScrollingEnabled(inspectedPagePreferences->threadedScrollingEnabled());
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protectedInspectedPage().get()));
     auto websiteDataStore = inspectorWebsiteDataStore();
     auto& processPool = WebKit::defaultInspectorProcessPool(inspectionLevel());
 
@@ -445,11 +444,11 @@ void WebInspectorUIProxy::platformAttach()
     static const unsigned minimumAttachedHeight = 250;
 
     if (m_attachmentSide == AttachmentSide::Bottom) {
-        unsigned inspectedWindowHeight = gtk_widget_get_allocated_height(inspectedPage()->viewWidget());
+        unsigned inspectedWindowHeight = gtk_widget_get_allocated_height(protectedInspectedPage()->viewWidget());
         unsigned maximumAttachedHeight = inspectedWindowHeight * 3 / 4;
         platformSetAttachedWindowHeight(std::max(minimumAttachedHeight, std::min(defaultAttachedSize, maximumAttachedHeight)));
     } else {
-        unsigned inspectedWindowWidth = gtk_widget_get_allocated_width(inspectedPage()->viewWidget());
+        unsigned inspectedWindowWidth = gtk_widget_get_allocated_width(protectedInspectedPage()->viewWidget());
         unsigned maximumAttachedWidth = inspectedWindowWidth * 3 / 4;
         platformSetAttachedWindowWidth(std::max(minimumAttachedWidth, std::min(defaultAttachedSize, maximumAttachedWidth)));
     }
@@ -457,13 +456,13 @@ void WebInspectorUIProxy::platformAttach()
     if (m_client && m_client->attach(*this))
         return;
 
-    webkitWebViewBaseAddWebInspector(WEBKIT_WEB_VIEW_BASE(inspectedPage()->viewWidget()), m_inspectorView.get(), m_attachmentSide);
+    webkitWebViewBaseAddWebInspector(WEBKIT_WEB_VIEW_BASE(protectedInspectedPage()->viewWidget()), m_inspectorView.get(), m_attachmentSide);
     gtk_widget_show(m_inspectorView.get());
 }
 
 void WebInspectorUIProxy::platformDetach()
 {
-    if (!inspectedPage()->hasRunningProcess())
+    if (!protectedInspectedPage()->hasRunningProcess())
         return;
 
     GRefPtr<GtkWidget> inspectorView = m_inspectorView.get();
@@ -495,7 +494,7 @@ void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
 
     if (m_client)
         m_client->didChangeAttachedHeight(*this, height);
-    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(inspectedPage()->viewWidget()), height);
+    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(protectedInspectedPage()->viewWidget()), height);
 }
 
 void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
@@ -505,7 +504,7 @@ void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
 
     if (m_client)
         m_client->didChangeAttachedWidth(*this, width);
-    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(inspectedPage()->viewWidget()), width);
+    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(protectedInspectedPage()->viewWidget()), width);
 }
 
 void WebInspectorUIProxy::platformSetSheetRect(const WebCore::FloatRect&)
@@ -567,7 +566,7 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
     GRefPtr<GFile> file = adoptGRef(gtk_file_chooser_get_file(chooser));
     GUniquePtr<char> path(g_file_get_path(file.get()));
     g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
-        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, inspectorPage().get());
+        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, protectedInspectorPage().get());
 }
 
 void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -82,7 +82,7 @@ public:
         listener->ignore();
 
         // Try to load the request in the inspected page.
-        if (RefPtr page = m_proxy.inspectedPage()) {
+        if (RefPtr page = m_proxy.protectedInspectedPage()) {
             auto request = navigationAction->request();
             page->loadRequest(WTFMove(request));
         }
@@ -104,7 +104,7 @@ static Ref<WebsiteDataStore> inspectorWebsiteDataStore()
 
 WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
 {
-    auto* inspectedWPEView = inspectedPage()->wpeView();
+    auto* inspectedWPEView = m_inspectedPage->wpeView();
     if (!inspectedWPEView)
         return nullptr;
 


### PR DESCRIPTION
#### 27e48df5e1512b899f6e49419b9528af42d3b260
<pre>
Deploy more smart pointers in WebInspectorUIProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=279781">https://bugs.webkit.org/show_bug.cgi?id=279781</a>

Reviewed by Devin Rousso.

Deploy more smart pointers in WebInspectorUIProxy.cpp per clang static analyzers.

* Source/WebKit/UIProcess/API/C/WKInspector.cpp:
(WKInspectorGetPage):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector webView]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm:
(-[_WKInspector inspectorWebView]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::inspectorExtension const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesDuringLoad):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::inspectionLevel const):
(WebKit::WebInspectorUIProxy::inspectorPagePreferences const):
(WebKit::WebInspectorUIProxy::protectedInspectorPagePreferences const):
(WebKit::WebInspectorUIProxy::sendMessageToFrontend):
(WebKit::WebInspectorUIProxy::connect):
(WebKit::WebInspectorUIProxy::close):
(WebKit::WebInspectorUIProxy::resetState):
(WebKit::WebInspectorUIProxy::reset):
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
(WebKit::WebInspectorUIProxy::setFrontendConnection):
(WebKit::WebInspectorUIProxy::showConsole):
(WebKit::WebInspectorUIProxy::showResources):
(WebKit::WebInspectorUIProxy::showMainResourceForFrame):
(WebKit::WebInspectorUIProxy::attach):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::setAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::setAttachedWindowWidth):
(WebKit::WebInspectorUIProxy::togglePageProfiling):
(WebKit::WebInspectorUIProxy::toggleElementSelection):
(WebKit::WebInspectorUIProxy::createFrontendPage):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::open):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::sendMessageToBackend):
(WebKit::WebInspectorUIProxy::frontendLoaded):
(WebKit::WebInspectorUIProxy::attachAvailabilityChanged):
(WebKit::WebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled):
(WebKit::WebInspectorUIProxy::setDeveloperPreferenceOverride):
(WebKit::WebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::WebInspectorUIProxy::load):
(WebKit::WebInspectorUIProxy::pickColorFromScreen):
(WebKit::WebInspectorUIProxy::evaluateInFrontendForTesting):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::protectedInspectedPage const):
(WebKit::WebInspectorUIProxy::protectedInspectorPage const):
(WebKit::WebInspectorUIProxy::inspectedPage const): Deleted.
(WebKit::WebInspectorUIProxy::inspectorPage const): Deleted.
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::decidePolicyForNavigationAction):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowWidth):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
(WebKit::WebInspectorUIProxy::platformResetState):
(WebKit::WebInspectorUIProxy::platformBringToFront):
(WebKit::WebInspectorUIProxy::platformBringInspectedPageToFront):
(WebKit::WebInspectorUIProxy::platformCanAttach):
(WebKit::WebInspectorUIProxy::windowFrameDidChange):
(WebKit::WebInspectorUIProxy::inspectedViewFrameDidChange):
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):

Canonical link: <a href="https://commits.webkit.org/283751@main">https://commits.webkit.org/283751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fc019ed4bf55ea06672ce3333dd38bf763a7c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19937 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42877 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39549 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16798 "Build is in progress. Recent messages:") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60420 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73050 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11264 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58286 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9225 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10211 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->