### PR TITLE
Adopt more smart pointers in RemoteCDMInstanceProxy and RemoteVideoFrameObjectHeap

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -78,7 +78,7 @@ void RemoteCDMInstanceProxy::unrequestedInitializationDataReceived(const String&
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstance::UnrequestedInitializationDataReceived(type, WTFMove(initData)), m_identifier);
+    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstance::UnrequestedInitializationDataReceived(type, WTFMove(initData)), m_identifier);
 }
 
 void RemoteCDMInstanceProxy::initializeWithConfiguration(const WebCore::CDMKeySystemConfiguration& configuration, AllowDistinctiveIdentifiers allowDistinctiveIdentifiers, AllowPersistentState allowPersistentState, CompletionHandler<void(SuccessValue)>&& completion)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -47,7 +47,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static WorkQueue& remoteVideoFrameObjectHeapQueue()
+static WorkQueue& remoteVideoFrameObjectHeapQueueSingleton()
 {
     static NeverDestroyed queue = WorkQueue::create("org.webkit.RemoteVideoFrameObjectHeap"_s, WorkQueue::QOS::UserInteractive);
     return queue.get();
@@ -56,7 +56,7 @@ static WorkQueue& remoteVideoFrameObjectHeapQueue()
 Ref<RemoteVideoFrameObjectHeap> RemoteVideoFrameObjectHeap::create(Ref<IPC::Connection>&& connection)
 {
     auto heap = adoptRef(*new RemoteVideoFrameObjectHeap(WTFMove(connection)));
-    heap->m_connection->addWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeap::messageReceiverName(), remoteVideoFrameObjectHeapQueue(), heap);
+    heap->m_connection->addWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeap::messageReceiverName(), remoteVideoFrameObjectHeapQueueSingleton(), heap);
     return heap;
 }
 
@@ -102,14 +102,14 @@ RemoteVideoFrameProxy::Properties RemoteVideoFrameObjectHeap::add(Ref<WebCore::V
 
 void RemoteVideoFrameObjectHeap::releaseVideoFrame(RemoteVideoFrameWriteReference&& write)
 {
-    assertIsCurrent(remoteVideoFrameObjectHeapQueue());
+    assertIsCurrent(remoteVideoFrameObjectHeapQueueSingleton());
     m_heap.remove(WTFMove(write));
 }
 
 #if PLATFORM(COCOA)
 void RemoteVideoFrameObjectHeap::getVideoFrameBuffer(RemoteVideoFrameReadReference&& read, bool canSendIOSurface)
 {
-    assertIsCurrent(remoteVideoFrameObjectHeapQueue());
+    assertIsCurrent(remoteVideoFrameObjectHeapQueueSingleton());
 
     auto identifier = read.identifier();
     auto videoFrame = get(WTFMove(read));
@@ -127,7 +127,7 @@ void RemoteVideoFrameObjectHeap::getVideoFrameBuffer(RemoteVideoFrameReadReferen
 
 void RemoteVideoFrameObjectHeap::pixelBuffer(RemoteVideoFrameReadReference&& read, CompletionHandler<void(RetainPtr<CVPixelBufferRef>)>&& completionHandler)
 {
-    assertIsCurrent(remoteVideoFrameObjectHeapQueue());
+    assertIsCurrent(remoteVideoFrameObjectHeapQueueSingleton());
 
     auto videoFrame = get(WTFMove(read));
     if (!videoFrame) {

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
@@ -42,7 +42,7 @@ class GPUProcessConnection;
 class RemoteVideoFrameProxy;
 #endif
 
-// Wrapper around RemoteVideoFrameObjectHeapProxyProcessor that will always be destroeyd on main thread.
+// Wrapper around RemoteVideoFrameObjectHeapProxyProcessor that will always be destroyed on main thread.
 class RemoteVideoFrameObjectHeapProxy : public ThreadSafeRefCounted<RemoteVideoFrameObjectHeapProxy, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<RemoteVideoFrameObjectHeapProxy> create(GPUProcessConnection& connection) { return adoptRef(*new RemoteVideoFrameObjectHeapProxy(connection)); }


### PR DESCRIPTION
#### b5c6650e0ec320d8cb4ce92e14d45266cc65ca87
<pre>
Adopt more smart pointers in RemoteCDMInstanceProxy and RemoteVideoFrameObjectHeap
<a href="https://bugs.webkit.org/show_bug.cgi?id=279785">https://bugs.webkit.org/show_bug.cgi?id=279785</a>
<a href="https://rdar.apple.com/136103868">rdar://136103868</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::unrequestedInitializationDataReceived):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::remoteVideoFrameObjectHeapQueueSingleton):
(WebKit::RemoteVideoFrameObjectHeap::create):
(WebKit::RemoteVideoFrameObjectHeap::releaseVideoFrame):
(WebKit::RemoteVideoFrameObjectHeap::getVideoFrameBuffer):
(WebKit::RemoteVideoFrameObjectHeap::pixelBuffer):
(WebKit::remoteVideoFrameObjectHeapQueue): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidClose):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):

Canonical link: <a href="https://commits.webkit.org/283775@main">https://commits.webkit.org/283775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c643120542f2b84c9ea7f99ad2133f4c4ece72a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67225 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19857 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71276 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18358 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53882 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12333 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34416 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39510 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72963 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61358 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61437 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2772 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10222 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42409 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->