### PR TITLE
REGRESSION (283478@main): [ Sonoma arm64 wk2 Release ] 4x http/tests/webgpu/webgpu/* tests are flaky failing

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1633,7 +1633,10 @@ http/tests/webgpu/webgpu/api/validation/buffer/create.html [ Pass ]
 http/tests/webgpu/webgpu/api/validation/buffer/destroy.html [ Pass ]
 http/tests/webgpu/webgpu/api/validation/buffer/mapping.html [ Pass ]
 
+http/tests/webgpu/webgpu/api/validation/queue/submit.html [ Pass ]
 http/tests/webgpu/webgpu/api/validation/queue/destroyed [ Pass ]
+
+http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html [ Pass ]
 
 webkit.org/b/264266 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html [ ImageOnlyFailure ]
 
@@ -1854,9 +1857,3 @@ fast/scrolling/mac/scrollbars/scrollbar-state.html [ Failure ]
 
 # webkit.org/b/279477 REGRESSION (283102@main?): [macOS iOS wk2 Debug EWS ] ASSERTION FAILED: WebKit::WebPageProxy::startNetworkRequestsForPageLoadTiming(WebCore::FrameIdentifier) result of http/tests/site-isolation/window-open-with-name-cross-site.html to crash
 [ Debug ] http/tests/site-isolation/window-open-with-name-cross-site.html [ Skip ]
-
-# webkit.org/b/279769 REGRESSION (283478@main): [ Sonoma arm64 wk2 Release ] 4x http/tests/webgpu/webgpu/* tests are flaky failing. 
-[ Sonoma Release arm64 ] http/tests/webgpu/webgpu/api/validation/queue/destroyed/buffer.html [ Pass Failure ]
-[ Sonoma Release arm64 ] http/tests/webgpu/webgpu/api/validation/queue/destroyed/query_set.html [ Pass Failure ]
-[ Sonoma Release arm64 ] http/tests/webgpu/webgpu/api/validation/queue/submit.html [ Pass Failure ]
-[ Sonoma Release arm64 ] http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html [ Pass Failure ]

--- a/Source/WebGPU/WebGPU/XRSubImage.h
+++ b/Source/WebGPU/WebGPU/XRSubImage.h
@@ -70,7 +70,7 @@ private:
     HashMap<uint64_t, RefPtr<Texture>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_depthTextures;
     uint64_t m_currentTextureIndex { 0 };
 
-    Ref<Device> m_device;
+    ThreadSafeWeakPtr<Device> m_device;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRSubImage.mm
+++ b/Source/WebGPU/WebGPU/XRSubImage.mm
@@ -66,6 +66,10 @@ bool XRSubImage::isValid() const
 
 void XRSubImage::update(id<MTLTexture> colorTexture, id<MTLTexture> depthTexture, size_t currentTextureIndex, const std::pair<id<MTLSharedEvent>, uint64_t>& sharedEvent)
 {
+    RefPtr device = m_device.get();
+    if (!device)
+        return;
+
     m_currentTextureIndex = currentTextureIndex;
     auto* texture = this->colorTexture();
     if (!texture || texture->texture() != colorTexture) {
@@ -86,7 +90,7 @@ void XRSubImage::update(id<MTLTexture> colorTexture, id<MTLTexture> depthTexture
             .viewFormatCount = 1,
             .viewFormats = &colorFormat,
         };
-        auto newTexture = Texture::create(colorTexture, colorTextureDescriptor, { colorFormat }, m_device.get());
+        auto newTexture = Texture::create(colorTexture, colorTextureDescriptor, { colorFormat }, *device);
         newTexture->updateCompletionEvent(sharedEvent);
         m_colorTextures.set(currentTextureIndex, newTexture.ptr());
     } else
@@ -110,7 +114,7 @@ void XRSubImage::update(id<MTLTexture> colorTexture, id<MTLTexture> depthTexture
             .viewFormatCount = 1,
             .viewFormats = &depthFormat,
         };
-        m_depthTextures.set(currentTextureIndex, Texture::create(depthTexture, depthTextureDescriptor, { depthFormat }, m_device.get()));
+        m_depthTextures.set(currentTextureIndex, Texture::create(depthTexture, depthTextureDescriptor, { depthFormat }, *device));
     }
 }
 


### PR DESCRIPTION
#### 93be927de1ed6471954cb09a1f8d5669b2f8ee41
<pre>
REGRESSION (283478@main): [ Sonoma arm64 wk2 Release ] 4x http/tests/webgpu/webgpu/* tests are flaky failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=279769">https://bugs.webkit.org/show_bug.cgi?id=279769</a>
<a href="https://rdar.apple.com/136087702">rdar://136087702</a>

Reviewed by Cameron McCormack.

283478@main introduced a retain cycle between Device and XRSubImage.

Break the retain cycle similarly to what we do for Queue: use a WeakPtr
in the non-Device class.

* Source/WebGPU/WebGPU/XRSubImage.h:
* Source/WebGPU/WebGPU/XRSubImage.mm:
(WebGPU::XRSubImage::XRSubImage):
(WebGPU::XRSubImage::update):
Break retain cycle

* LayoutTests/platform/mac-wk2/TestExpectations
Undo skipped expectations.

Canonical link: <a href="https://commits.webkit.org/283746@main">https://commits.webkit.org/283746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f66c425a2d794457d7a9c4a939d907266c1c6ea7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71271 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53880 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16720 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11190 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15243 "Found 1 new test failure: media/video-replaces-poster.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61449 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2774 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->