### PR TITLE
[Static Analyzer CI] Add tool to improve smart pointer development workflow

### DIFF
--- a/Tools/Scripts/smart-pointer-tool
+++ b/Tools/Scripts/smart-pointer-tool
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import argparse
+
+EXPECTATIONS_PATH = '../../Source/{project}/SmartPointerExpectations/{checker_type}Expectations'
+CHECKERS = ['NoUncountedMemberChecker', 'RefCntblBaseVirtualDtor', 'UncountedCallArgsChecker', 'UncountedLocalVarsChecker']
+PROJECTS = ['WebCore', 'WebKit']
+
+
+def parser():
+    parser = argparse.ArgumentParser(description='Various tools for working on smart pointers')
+    parser.add_argument(
+        '--update-expectations', '-u',
+        dest='unexpected_results',
+        default=None,
+        help='Path to unexpected results file following this naming scheme: "[WebKit/WebCore]-unexpected-[passes/failures]". Removes unexpected passes and adds unexpected failures to the expectations files in SmartPointerExpectations.'
+    )
+    parser.add_argument(
+        '--find-expectations', '-f',
+        dest='expected_file',
+        default=None,
+        help='Check if the given file has expected failures'
+    )
+    return parser.parse_args()
+
+
+def modify_expectations_for_checker(checker_type, unexpected_contents, project, type):
+    path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker_type))
+    with open(path_to_expectations) as expectations_file:
+        expectations = expectations_file.readlines()
+        prev_len = len(expectations)
+    for line in unexpected_contents:
+        if '=>' in line:
+            new_checker_type = line.split()[-1]
+            modify_expectations_for_checker(new_checker_type, unexpected_contents, project, type)
+        elif line.strip():
+            if type == 'passes':
+                expectations.remove(line)
+            elif line not in expectations:
+                expectations.append(line)
+            else:
+                print(f'{line.strip()} already in {checker_type}Expectations!\n')
+    with open(path_to_expectations, 'w') as expectations_file:
+        expectations_file.writelines(sorted(expectations))
+    print(f'Updated expectations for {checker_type}!')
+    if type == 'passes':
+        print(f'Removed {prev_len - len(expectations)} fixed files.\n')
+    else:
+        print(f'Added {len(expectations) - prev_len} files with issues.\n')
+
+
+def update_expectations(unexpected_results):
+    filename = unexpected_results.split('/')[-1]
+    project, type = filename.split('-')[0], filename.split('-')[-1].removesuffix('.txt')
+    print(f'Modifying unexpected {type} for {project}...\n')
+    with open(unexpected_results, 'r') as unexpected_contents:
+        for line in unexpected_contents:
+            if '=>' in line:
+                checker_type = line.split()[-1]
+                modify_expectations_for_checker(checker_type, unexpected_contents, project, type)
+
+
+'''
+This currently checks against the files in your local checkout at SmartPointerExpectations.
+Ensure that it is up-to-date before using this script.
+'''
+def is_expected_file(expected_file):
+    print('This checks against local expectations. Ensure your checkout is up-to-date.')
+    line = f'{expected_file}\n'
+    issues = False
+    for project in PROJECTS:
+        for checker in CHECKERS:
+            path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker))
+            with open(path_to_expectations, 'r') as f:
+                expectations = f.read()
+                if line in expectations:
+                    if not issues:
+                        print(f'{expected_file} has smart pointer issues:')
+                    issues = True
+                    print(f'- {project} {checker}')
+    if not issues:
+        print(f'{expected_file} has no known smart pointer issues!')
+
+
+def main():
+    args = parser()
+    if args.unexpected_results:
+        update_expectations(args.unexpected_results)
+    if args.expected_file:
+        is_expected_file(args.expected_file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### 9692577c30fd125a0ea9bb930f00f2d1313682e4
<pre>
[Static Analyzer CI] Add tool to improve smart pointer development workflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=279793">https://bugs.webkit.org/show_bug.cgi?id=279793</a>
<a href="https://rdar.apple.com/136109601">rdar://136109601</a>

Reviewed by Ryosuke Niwa.

This script automates certain tasks in the smart pointer workflow.
- Run `smart-pointer-tool --update-expectations {unexpected result file}` to automatically
add or delete files from the expectation lists.
- Run `smart-pointer-tool --find-expectations {file}` to check if there are smart pointer bugs
for that file.

* Tools/Scripts/smart-pointer-tool: Added.
(parser):
(modify_expectations_for_checker):
(update_expectations):
(is_expected_file):
(main):

Canonical link: <a href="https://commits.webkit.org/283735@main">https://commits.webkit.org/283735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c7d87796320887a837ecc8eaa01d6e3a092d834

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19870 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69356 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/54415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70305 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/54415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/54415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/15570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/54415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/15911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/11197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/72983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/11230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58235 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/72983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10200 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/43240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->