### PR TITLE
[iOS] Many layout tests are failing after some changes in UIKit (rdar://133635866)

### DIFF
--- a/LayoutTests/editing/input/cocoa/do-not-allow-inline-predictions-if-text-changes.html
+++ b/LayoutTests/editing/input/cocoa/do-not-allow-inline-predictions-if-text-changes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/editing/input/cocoa/writing-suggestions-in-anonymous-renderer-expected.html
+++ b/LayoutTests/editing/input/cocoa/writing-suggestions-in-anonymous-renderer-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/editing/input/cocoa/writing-suggestions-in-anonymous-renderer.html
+++ b/LayoutTests/editing/input/cocoa/writing-suggestions-in-anonymous-renderer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html
+++ b/LayoutTests/editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/activating-button-should-not-scroll-page.html
+++ b/LayoutTests/fast/events/ios/activating-button-should-not-scroll-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/events/ios/activating-checkbox-should-not-scroll-page.html
+++ b/LayoutTests/fast/events/ios/activating-checkbox-should-not-scroll-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/events/ios/activating-radio-button-should-not-scroll-page.html
+++ b/LayoutTests/fast/events/ios/activating-radio-button-should-not-scroll-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/events/ios/activating-reset-button-should-not-scroll-page.html
+++ b/LayoutTests/fast/events/ios/activating-reset-button-should-not-scroll-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/events/ios/activating-submit-button-should-not-scroll-page.html
+++ b/LayoutTests/fast/events/ios/activating-submit-button-should-not-scroll-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/events/ios/keydown-keyup-keypress-keys-in-non-editable-using-chinese-keyboard.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-keypress-keys-in-non-editable-using-chinese-keyboard.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/keypress-keys-in-non-editable-element.html
+++ b/LayoutTests/fast/events/ios/keypress-keys-in-non-editable-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta charset="utf8">

--- a/LayoutTests/fast/events/ios/tab-into-text-field-inside-iframe.html
+++ b/LayoutTests/fast/events/ios/tab-into-text-field-inside-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/events/touch/ios/touch-event-stall-after-navigating-with-pending-asynchronous-touch-start.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-stall-after-navigating-with-pending-asynchronous-touch-start.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true useHardwareKeyboardMode=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 <head>

--- a/LayoutTests/fast/forms/caps-lock-indicator-width.html
+++ b/LayoutTests/fast/forms/caps-lock-indicator-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/fast/forms/ios/focus-radio.html
+++ b/LayoutTests/fast/forms/ios/focus-radio.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/forms/ios/focus-reset-button.html
+++ b/LayoutTests/fast/forms/ios/focus-reset-button.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/forms/ios/focus-ring-size.html
+++ b/LayoutTests/fast/forms/ios/focus-ring-size.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/forms/ios/focus-search-field.html
+++ b/LayoutTests/fast/forms/ios/focus-search-field.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/forms/ios/focus-submit-button.html
+++ b/LayoutTests/fast/forms/ios/focus-submit-button.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/forms/ios/focus-text-field.html
+++ b/LayoutTests/fast/forms/ios/focus-text-field.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/forms/ios/ipad/open-picker-using-keyboard.html
+++ b/LayoutTests/fast/forms/ios/ipad/open-picker-using-keyboard.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=800">

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ showsScrollIndicators=false ] -->
+<!-- webkit-test-runner [ showsScrollIndicators=false useHardwareKeyboardMode=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ showsScrollIndicators=false ] -->
+<!-- webkit-test-runner [ showsScrollIndicators=false useHardwareKeyboardMode=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html
+++ b/LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
 
 <html>
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -78,6 +78,8 @@ ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]
 # Individually failing tests should be marked in separate expectations.
 imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase [ Pass ]
 
+# Caps lock indicator is disabled on iOS, as it is provided by the OS (through caret decoration UI).
+fast/forms/caps-lock-indicator-width.html [ Skip ]
 
 # --- imported from ios-wk2 ---
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -363,6 +363,8 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void setKeyboardInputModeIdentifier(const String&);
     UIKeyboardInputMode *overriddenKeyboardInputMode() const { return m_overriddenKeyboardInputMode.get(); }
+    void setIsInHardwareKeyboardMode(bool value) { m_isInHardwareKeyboardMode = value; }
+    bool isInHardwareKeyboardMode() const { return m_isInHardwareKeyboardMode; }
 #endif
 
     void setAllowedMenuActions(const Vector<String>&);
@@ -670,6 +672,8 @@ private:
     RetainPtr<UIPasteboardConsistencyEnforcer> m_pasteboardConsistencyEnforcer;
     RetainPtr<UIKeyboardInputMode> m_overriddenKeyboardInputMode;
     Vector<std::unique_ptr<InstanceMethodSwizzler>> m_presentPopoverSwizzlers;
+    std::unique_ptr<ClassMethodSwizzler> m_hardwareKeyboardModeSwizzler;
+    bool m_isInHardwareKeyboardMode { false };
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -205,6 +205,7 @@ const TestFeatures& TestOptions::defaults()
             { "longPressActionsEnabled", true },
             { "enhancedWindowingEnabled", false },
             { "textExtractionEnabled", false },
+            { "useHardwareKeyboardMode", false },
         };
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },
@@ -276,6 +277,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "longPressActionsEnabled", TestHeaderKeyType::BoolTestRunner },
         { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
         { "textExtractionEnabled", TestHeaderKeyType::BoolTestRunner },
+        { "useHardwareKeyboardMode", TestHeaderKeyType::BoolTestRunner },
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "obscuredInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "horizontalSystemMinimumLayoutMargin", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -84,6 +84,7 @@ public:
     bool longPressActionsEnabled() const { return boolTestRunnerFeatureValue("longPressActionsEnabled"); }
     bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
     bool textExtractionEnabled() const { return boolTestRunnerFeatureValue("textExtractionEnabled"); }
+    bool useHardwareKeyboardMode() const { return boolTestRunnerFeatureValue("useHardwareKeyboardMode"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }
     double horizontalSystemMinimumLayoutMargin() const { return doubleTestRunnerFeatureValue("horizontalSystemMinimumLayoutMargin"); }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -75,16 +75,6 @@ static bool isHiddenOrHasHiddenAncestor(UIView *view)
 
 #endif // HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
 
-static BOOL returnYes()
-{
-    return YES;
-}
-
-static BOOL returnNo()
-{
-    return NO;
-}
-
 static NSDictionary *toNSDictionary(CGRect rect)
 {
     return @{
@@ -1463,7 +1453,7 @@ JSObjectRef UIScriptControllerIOS::calendarType() const
 void UIScriptControllerIOS::setHardwareKeyboardAttached(bool attached)
 {
     GSEventSetHardwareKeyboardAttached(attached, 0);
-    method_setImplementation(class_getClassMethod([UIKeyboard class], @selector(isInHardwareKeyboardMode)), reinterpret_cast<IMP>(attached ? returnYes : returnNo));
+    TestController::singleton().setIsInHardwareKeyboardMode(attached);
 }
 
 void UIScriptControllerIOS::setAllowsViewportShrinkToFit(bool allows)


### PR DESCRIPTION
#### 7af7faec853a98f9d17e7cb3a76e2ae9fa837d22
<pre>
[iOS] Many layout tests are failing after some changes in UIKit (<a href="https://rdar.apple.com/133635866">rdar://133635866</a>)
<a href="https://bugs.webkit.org/show_bug.cgi?id=279794">https://bugs.webkit.org/show_bug.cgi?id=279794</a>
<a href="https://rdar.apple.com/136090040">rdar://136090040</a>

Reviewed by Abrar Rahman Protyasha.

Several layout tests that rely on the ability to dispatch events via the hardware keyboard are
failing after the UIKit changes in <a href="https://rdar.apple.com/133635866">rdar://133635866</a>, because WebKitTestRunnerApp swizzles out the
SPI method (`+[UIKeyboard isInHardwareKeyboardMode]`) that UIKit now uses to determine whether
WebKit&apos;s content view should receive key events.

This SPI method has historically been swizzled out in order to ensure that various tests in
`editing/` and `fast/forms/` aren&apos;t flaky, due to the input view appearing on iOS. At the same time,
we also run tests with a connected hardware keyboard using `GSEventSetHardwareKeyboardAttached`, to
ensure that tests which rely on receiving key events without focusing an editable element also run
as expected. While this state is inherently contradictory, it Just Works™ on shipping iOS, only
because UIKit used `-[UIKeyboardImpl hardwareKeyboardAttached]` to determine whether or not it
should send hardware key events to the web view.

Now that UIKit uses `+isInHardwareKeyboardMode`, this new logic now collides with the way in which
WebKitTestRunnerApp swizzles out `+isInHardwareKeyboardMode` to prevent input sessions from starting
by default. To fix this, we add a new test option — `useHardwareKeyboardMode` — and deploy it in a
handful of tests that require hardware keyboard support, to ensure that `+isInHardwareKeyboardMode`
returns `YES` for the tests that require it.

* LayoutTests/editing/input/cocoa/do-not-allow-inline-predictions-if-text-changes.html:
* LayoutTests/editing/input/cocoa/writing-suggestions-in-anonymous-renderer-expected.html:
* LayoutTests/editing/input/cocoa/writing-suggestions-in-anonymous-renderer.html:
* LayoutTests/editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html:
* LayoutTests/fast/events/ios/activating-button-should-not-scroll-page.html:
* LayoutTests/fast/events/ios/activating-checkbox-should-not-scroll-page.html:
* LayoutTests/fast/events/ios/activating-radio-button-should-not-scroll-page.html:
* LayoutTests/fast/events/ios/activating-reset-button-should-not-scroll-page.html:
* LayoutTests/fast/events/ios/activating-submit-button-should-not-scroll-page.html:
* LayoutTests/fast/events/ios/keydown-keyup-keypress-keys-in-non-editable-using-chinese-keyboard.html:
* LayoutTests/fast/events/ios/keypress-keys-in-non-editable-element.html:
* LayoutTests/fast/events/ios/tab-into-text-field-inside-iframe.html:
* LayoutTests/fast/events/touch/ios/touch-event-stall-after-navigating-with-pending-asynchronous-touch-start.html:
* LayoutTests/fast/forms/caps-lock-indicator-width.html:
* LayoutTests/fast/forms/ios/focus-radio.html:
* LayoutTests/fast/forms/ios/focus-reset-button.html:
* LayoutTests/fast/forms/ios/focus-ring-size.html:
* LayoutTests/fast/forms/ios/focus-search-field.html:
* LayoutTests/fast/forms/ios/focus-submit-button.html:
* LayoutTests/fast/forms/ios/focus-text-field.html:
* LayoutTests/fast/forms/ios/ipad/open-picker-using-keyboard.html:
* LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html:
* LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html:
* LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html:
* LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html:

Deploy the new test option, `useHardwareKeyboardMode`, in several failing layout tests that
currently assume that the hardware keyboard is connected.

* LayoutTests/platform/ios/TestExpectations:

Skip a test that&apos;s no longer relevant on iOS 17+, since we no longer show the caps lock indicator
inside of the text field. Instead, the caps lock indicator is shown underneath the text cursor.

* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::setIsInHardwareKeyboardMode):
(WTR::TestController::isInHardwareKeyboardMode const):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::useHardwareKeyboardMode const):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(overrideIsInHardwareKeyboardMode):
(WTR::TestController::platformInitialize):
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setHardwareKeyboardAttached):

Consolidate logic to override `+isInHardwareKeyboard` into a common helper method on
`TestController`, and call into it from `UIScriptController` to avoid duplicating code.

(WTR::returnYes): Deleted.
(WTR::returnNo): Deleted.

Canonical link: <a href="https://commits.webkit.org/283793@main">https://commits.webkit.org/283793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4328b8fb9360ff110a6fe0aa7256de1e2a325bef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20026 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18322 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12419 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70461 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42952 "Exiting early after 10 failures. 44 tests run. 9 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58297 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39624 "Exiting early after 10 failures. 44 tests run. 9 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15697 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73141 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15365 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58362 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14927 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2900 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43655 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->