### PR TITLE
Create a standalone bundle for TestWebKitAPI resources

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIResources.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIResources.xcconfig
@@ -1,0 +1,31 @@
+//
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+CURRENT_PROJECT_VERSION = 1;
+MARKETING_VERSION = 1.0;
+GENERATE_INFOPLIST_FILE = YES;
+PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.TestWebKitAPIResources;
+PRODUCT_NAME = $(TARGET_NAME);
+SKIP_INSTALL = YES;

--- a/Tools/TestWebKitAPI/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/PlatformUtilities.h
@@ -34,6 +34,10 @@
 #include "Utilities.h"
 #include <string>
 
+#if PLATFORM(COCOA) && defined(__OBJC__)
+#import "TestNSBundleExtras.h"
+#endif
+
 #if USE(FOUNDATION)
 OBJC_CLASS NSString;
 OBJC_CLASS NSDictionary;

--- a/Tools/TestWebKitAPI/TestNSBundleExtras.h
+++ b/Tools/TestWebKitAPI/TestNSBundleExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,30 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
+#import <Foundation/Foundation.h>
 
-#import "PlatformUtilities.h"
-#import "TestWKWebView.h"
-#import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/WKWebViewPrivateForTesting.h>
-#import <wtf/RetainPtr.h>
+NS_ASSUME_NONNULL_BEGIN
 
-namespace TestWebKitAPI {
+@interface NSBundle (TestExtras)
 
-#if ENABLE(VIDEO_PRESENTATION_MODE)
++ (instancetype _Nullable)test_resourcesBundle;
 
-TEST(MediaDocument, WirelessPlaybackEnabled)
-{
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+@end
 
-    NSURL *videoURL = [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"];
-    [webView loadFileURL:videoURL allowingReadAccessToURL:videoURL];
-
-    while (![webView _wirelessVideoPlaybackDisabled])
-        Util::runFor(0.1_s);
-}
-
-#endif // ENABLE(VIDEO_PRESENTATION_MODE)
-
-}
+NS_ASSUME_NONNULL_END

--- a/Tools/TestWebKitAPI/TestNSBundleExtras.m
+++ b/Tools/TestWebKitAPI/TestNSBundleExtras.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,34 +24,17 @@
  */
 
 #import "config.h"
-#import <WebKit/WKFoundation.h>
+#import "TestNSBundleExtras.h"
 
-#import "PlatformUtilities.h"
-#import "Test.h"
-#import "TestNavigationDelegate.h"
-#import "UserContentWorldProtocol.h"
-#import "WKWebViewConfigurationExtras.h"
-#import <WebKit/WKProcessPoolPrivate.h>
-#import <WebKit/WKUserContentControllerPrivate.h>
-#import <WebKit/WKUserScriptPrivate.h>
-#import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/WebKit.h>
-#import <WebKit/_WKProcessPoolConfiguration.h>
-#import <WebKit/_WKRemoteObjectInterface.h>
-#import <WebKit/_WKRemoteObjectRegistry.h>
-#import <WebKit/_WKUserContentWorld.h>
-#import <WebKit/_WKUserStyleSheet.h>
-#import <wtf/RetainPtr.h>
+NS_ASSUME_NONNULL_BEGIN
 
-TEST(CancelLoading, CancelFontSubresource)
+@implementation NSBundle (TestExtras)
+
++ (instancetype _Nullable)test_resourcesBundle
 {
-    NSString * const testPlugInClassName = @"CancelFontSubresourcePlugIn";
-
-    RetainPtr<WKWebViewConfiguration> configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
-
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"webfont" withExtension:@"html"]];
-    [webView loadRequest:request];
-    [webView _test_waitForDidFinishNavigation];
+    return [NSBundle bundleWithURL:[NSBundle.mainBundle URLForResource:@"TestWebKitAPIResources" withExtension:@"bundle"]];
 }
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -49,181 +49,87 @@
 /* Begin PBXBuildFile section */
 		041A1E34216FFDBC00789E0A /* PublicSuffix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */; };
 		04DB2396235E43EC00328F17 /* BumpPointerAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */; };
-		0721D4592838296C00A95853 /* start-offset.ts in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0721D4582838295400A95853 /* start-offset.ts */; };
 		07492B3B1DF8B14C00633DE1 /* EnumerateMediaDevices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07492B3A1DF8AE2D00633DE1 /* EnumerateMediaDevices.cpp */; };
-		07492B3C1DF8B86600633DE1 /* enumerateMediaDevices.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07492B391DF8ADA400633DE1 /* enumerateMediaDevices.html */; };
-		07492B3C1DF8B86600633EQ1 /* playable-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07492B391DF8ADA400633DQ1 /* playable-audio.html */; };
-		074994421EA5034B000DA44D /* invalidDeviceIDHashSalts in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAB4 /* invalidDeviceIDHashSalts */; };
-		074994421EA5034B000DA44E /* getUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAB5 /* getUserMedia.html */; };
-		074994421EA5034B000DA44F /* ondevicechange.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAB6 /* ondevicechange.html */; };
-		074994421EA5034B000DA45E /* getUserMediaAudioVideoCapture.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAC5 /* getUserMediaAudioVideoCapture.html */; };
-		074994521EA5034B000DA44E /* getUserMedia2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 41BAF4E225AC9DB800D82F32 /* getUserMedia2.html */; };
-		074994521EA5034B000DA46E /* getUserMediaPermission.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4198524F27AD7B70005477B7 /* getUserMediaPermission.html */; };
 		075A9CF526177218006DFA3A /* MediaSessionCoordinatorTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 075A9CF426177217006DFA3A /* MediaSessionCoordinatorTest.mm */; };
 		076E507F1F4513D6006E9F5A /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 076E507E1F45031E006E9F5A /* Logging.cpp */; };
 		077A5AF3230638A600A7105C /* AccessibilityTestPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0746645822FF630500E3451A /* AccessibilityTestPlugin.mm */; };
-		0794742D25CB33FD00C597EB /* media-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EB /* media-remote.html */; };
-		0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EC /* webrtc-remote.html */; };
-		0794742D25CB33FD00C597ED /* webrtc-remote-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */; };
-		0794742D25CB33FD00C597EE /* camera-to-canvas.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EE /* camera-to-canvas.html */; };
-		0799C34B1EBA3301003B7532 /* disableGetUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */; };
 		079D45F22A2A6BBE003830C7 /* Viewport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D45F12A2A6BBE003830C7 /* Viewport.mm */; };
 		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
-		07E1F6A21FFC44FA0096C7EC /* getDisplayMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07E1F6A11FFC44F90096C7EC /* getDisplayMedia.html */; };
 		07E499911F9E56DF002F1EF3 /* GetUserMediaReprompt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */; };
-		07FC26E8267A735A002B1BEF /* audio-buffer-size.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1D5BE6AD2673EC5F00CB0B12 /* audio-buffer-size.html */; };
 		0DE559ED2A6B0AAF009AA320 /* WKWebViewResize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */; };
 		0E404A8C2166DE0A008271BA /* InjectedBundleNodeHandleIsSelectElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0E404A8A2166DDF8008271BA /* InjectedBundleNodeHandleIsSelectElement.mm */; };
-		0EBBCC661FFF9E0C00FA42AB /* pop-up-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0EBBCC651FFF9DCE00FA42AB /* pop-up-check.html */; };
 		0F139E771A423A5B00F590F5 /* WeakObjCPtr.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F139E751A423A5300F590F5 /* WeakObjCPtr.mm */; };
 		0F139E791A42457000F590F5 /* PlatformUtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F139E721A423A2B00F590F5 /* PlatformUtilitiesCocoa.mm */; };
-		0F16BED82304A1F300B4A167 /* composited.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F16BED72304A1D100B4A167 /* composited.html */; };
 		0F2C20B81DCD545000542D9E /* Time.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C20B71DCD544800542D9E /* Time.cpp */; };
 		0F30CB5C1FCE1796004B5323 /* ConcurrentPtrHashSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F30CB5B1FCE1792004B5323 /* ConcurrentPtrHashSet.cpp */; };
 		0F34077623037FDC0060A1A0 /* OverflowScrollViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F34077523037FDC0060A1A0 /* OverflowScrollViewTests.mm */; };
-		0F340779230382870060A1A0 /* overflow-scroll.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F340777230382540060A1A0 /* overflow-scroll.html */; };
 		0F4FFA9E1ED3AA8500F7111F /* SnapshotViaRenderInContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F4FFA9D1ED3AA8500F7111F /* SnapshotViaRenderInContext.mm */; };
 		0F5651F71FCE4DDC00310FBC /* NoHistoryItemScrollToFragment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F5651F61FCE4DDB00310FBC /* NoHistoryItemScrollToFragment.mm */; };
-		0F5651F91FCE513500310FBC /* scroll-to-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F5651F81FCE50E800310FBC /* scroll-to-anchor.html */; };
 		0F5EC8C32C7F76B900B8051B /* PathTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5EC8BB2C7F76B900B8051B /* PathTests.cpp */; };
 		0FEFAF64271FC2CD005704D7 /* ScrollingCoordinatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FEFAF63271FC2CD005704D7 /* ScrollingCoordinatorTests.mm */; };
 		0FF1134E22D68679009A81DA /* ScrollViewScrollabilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FF1134D22D68679009A81DA /* ScrollViewScrollabilityTests.mm */; };
-		0FF1F0CD2AE205F5006ECC4F /* scrollable-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0FF1F0C52AE204C0006ECC4F /* scrollable-page.html */; };
 		0FF332932A0EFCCF00C048D8 /* HysteresisActivityTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF3328B2A0EFCCF00C048D8 /* HysteresisActivityTests.cpp */; };
 		115EB3431EE0BA03003C2C0A /* ViewportSizeForViewportUnits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 115EB3421EE0B720003C2C0A /* ViewportSizeForViewportUnits.mm */; };
 		1171B24F219F49CD00CB897D /* FirstMeaningfulPaintMilestone_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD21219F46DD0069B27F /* FirstMeaningfulPaintMilestone_Bundle.cpp */; };
-		118153442208B7AC00B2CCD2 /* deferred-script-load.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 118153432208B7AC00B2CCD2 /* deferred-script-load.html */; };
-		118153462208B7E500B2CCD2 /* deferred-script.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = 118153452208B7E500B2CCD2 /* deferred-script.js */; };
 		11B7FD28219F47110069B27F /* FirstMeaningfulPaintMilestone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD22219F46DD0069B27F /* FirstMeaningfulPaintMilestone.cpp */; };
-		11C2598D21FA6324004C9E23 /* async-script-load.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 11C2598C21FA618D004C9E23 /* async-script-load.html */; };
 		143DDE9820C9018B007F76FA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
 		14CC42E624B8D8FA00E64F48 /* JSRunLoopTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 14CC42E524B8D8FA00E64F48 /* JSRunLoopTimer.mm */; };
 		155B87332BF55D7800D93968 /* TextBoundaries.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 155B872B2BF55D7800D93968 /* TextBoundaries.cpp */; };
-		1A02C870125D4CFD00E3F4BD /* find.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A02C84B125D4A5E00E3F4BD /* find.html */; };
 		1A3524AE1D63A4FB0031729B /* Scope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A3524AC1D63A4FB0031729B /* Scope.cpp */; };
 		1A4F81CF1BDFFD53004E672E /* RemoteObjectRegistryPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A4F81CD1BDFFD53004E672E /* RemoteObjectRegistryPlugIn.mm */; };
-		1A50AA201A2A51FC00F4C345 /* close-from-within-create-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A50AA1F1A2A4EA500F4C345 /* close-from-within-create-page.html */; };
-		1A63479F183D72A4005B1707 /* all-content-in-one-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93D3D19B17B1A7B000C7C415 /* all-content-in-one-iframe.html */; };
 		1A77BAA31D9AFFFC005FC568 /* OptionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE50D8C81C8665CE0072EA5A /* OptionSet.cpp */; };
-		1A7E8B3618120B2F00AEB74A /* FragmentNavigation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A7E8B351812093600AEB74A /* FragmentNavigation.html */; };
-		1A9E52C913E65EF4006917F5 /* 18-characters.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C045F9461385C2F800C0F3CD /* 18-characters.html */; };
 		1AD7343D28D2A78400797100 /* ScrollViewBouncesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AD7343C28D2A78400797100 /* ScrollViewBouncesTests.mm */; };
 		1ADAD1501D77A9F600212586 /* BlockPtr.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ADAD14E1D77A9F600212586 /* BlockPtr.mm */; };
-		1ADBEFE3130C6AA100D61D19 /* simple-accelerated-compositing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1ADBEFBC130C6A0100D61D19 /* simple-accelerated-compositing.html */; };
 		1AEDE22613E5E7E700E62FE8 /* InjectedBundleControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */; };
 		1AF7B21F1D6CD14D008C126C /* EnumTraits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7B21D1D6CD12E008C126C /* EnumTraits.cpp */; };
 		1C15499A2928475C001B9E5B /* WebExtensionUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C24DEED263001DE00450D07 /* TextStyleFontSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C24DEEC263001DE00450D07 /* TextStyleFontSize.mm */; };
 		1C2B81831C891F0900A5529F /* CancelFontSubresourcePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */; };
-		1C2B81861C89259D00A5529F /* webfont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C2B81841C8924A200A5529F /* webfont.html */; };
-		1C2B81871C8925A000A5529F /* Ahem.ttf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C2B81851C89252300A5529F /* Ahem.ttf */; };
 		1C4616A026BA5A2100F8C9F6 /* TextStreamCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C46169E26BA510700F8C9F6 /* TextStreamCocoa.mm */; };
 		1C4616A726BB172F00F8C9F6 /* TextStreamCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C4616A626BB172F00F8C9F6 /* TextStreamCocoa.cpp */; };
-		1C51534C261596D700FBC4FE /* UserInstalledAhem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */; };
 		1C7FEB20207C0F2E00D23278 /* BackgroundColor.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C7FEB1F207C0F2D00D23278 /* BackgroundColor.mm */; };
 		1C81802725FB09E200608B3E /* FontRegistrySandboxCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C81802625FB09E200608B3E /* FontRegistrySandboxCheck.mm */; };
 		1C8FA53A2685A6D500B7E49E /* StringWidth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C8FA5392685A6D500B7E49E /* StringWidth.mm */; };
 		1C90420C2326E03C00BEF91E /* SelectionByWord.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C90420B2326E03C00BEF91E /* SelectionByWord.mm */; };
-		1C9C7F512891238500C4649E /* ImmediateFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C9C7F4F2891234500C4649E /* ImmediateFont.html */; };
 		1C9DD9232697655B00274DB2 /* SVGImageCasts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C9DD9222697655B00274DB2 /* SVGImageCasts.cpp */; };
 		1C9EB8411E380DA1005C6442 /* ComplexTextController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C9EB8401E380DA1005C6442 /* ComplexTextController.cpp */; };
 		1CA6FBAD2A1D818D001D4402 /* ContextualizedNSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CA6FBAC2A1D818C001D4402 /* ContextualizedNSString.mm */; };
 		1CACADA1230620AE0007D54C /* WKWebViewOpaque.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CACADA0230620AD0007D54C /* WKWebViewOpaque.mm */; };
 		1CB2F27C24F88379000A5BC1 /* OrthogonalFlowAvailableSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CB2F27B24F88379000A5BC1 /* OrthogonalFlowAvailableSize.mm */; };
-		1CB2F27E24F88A52000A5BC1 /* orthogonal-flow-available-size.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CB2F27D24F883BE000A5BC1 /* orthogonal-flow-available-size.html */; };
-		1CC4C74D28890D3700A3B23D /* SVGFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CC4C74B28890C5400A3B23D /* SVGFont.html */; };
-		1CC4C74E28890D3700A3B23D /* Helvetica_light.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CC4C74C28890CE100A3B23D /* Helvetica_light.svg */; };
-		1CC80CEA2474F249004DC489 /* idempotent-mode-autosizing-only-honors-percentages.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CC80CE92474F1F7004DC489 /* idempotent-mode-autosizing-only-honors-percentages.html */; };
-		1CE6FAC32320267C00E48F6E /* rich-color-filtered.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CE6FAC12320264F00E48F6E /* rich-color-filtered.html */; };
 		1CF087D825ED7F73004148CB /* MobileAssetSandboxCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF087D725ED7F73004148CB /* MobileAssetSandboxCheck.mm */; };
 		1CF59AE221E68925006E37EC /* ForceLightAppearanceInBundle_Bundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF59AE021E68925006E37EC /* ForceLightAppearanceInBundle_Bundle.mm */; };
 		1CF59AE321E68932006E37EC /* ForceLightAppearanceInBundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF59ADF21E68925006E37EC /* ForceLightAppearanceInBundle.mm */; };
-		1CF59AE521E6977D006E37EC /* dark-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CF59AE421E696FB006E37EC /* dark-mode.html */; };
 		1CFD5D3F2851B62100A0E30B /* EnumeratedArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CFD5D3E2851B62100A0E30B /* EnumeratedArray.cpp */; };
 		1D67BFDC2433E0A7006B5047 /* PreemptVideoFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1D67BFDB2433E0A7006B5047 /* PreemptVideoFullscreen.mm */; };
-		1D67BFDD2433EE66006B5047 /* two-videos.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1D67BFD92433DFD8006B5047 /* two-videos.html */; };
-		1DAA52CC243BE805001A3159 /* one-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1DAA52CB243BE621001A3159 /* one-video.html */; };
-		1F0559E52890A11B002E279C /* image-with-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1F0559E42890A09D002E279C /* image-with-text.html */; };
-		26DF5A6315A2A27E003689C2 /* CancelLoadFromResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26DF5A6115A2A22B003689C2 /* CancelLoadFromResourceLoadDelegate.html */; };
-		26F52EAD1828827B0023D412 /* geolocationGetCurrentPosition.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EAC1828820E0023D412 /* geolocationGetCurrentPosition.html */; };
-		26F52EAF18288C230023D412 /* geolocationGetCurrentPositionWithHighAccuracy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EAE18288C040023D412 /* geolocationGetCurrentPositionWithHighAccuracy.html */; };
-		26F52EB218288F240023D412 /* geolocationWatchPosition.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EB018288F0F0023D412 /* geolocationWatchPosition.html */; };
-		26F52EB318288F240023D412 /* geolocationWatchPositionWithHighAccuracy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EB118288F0F0023D412 /* geolocationWatchPositionWithHighAccuracy.html */; };
 		272A691022F012DA000FDABB /* PageLoadState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 272A690F22F012C7000FDABB /* PageLoadState.cpp */; };
 		278E3E1923CD842F005A6B80 /* KeyedCoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 278E3E1823CD82FA005A6B80 /* KeyedCoding.cpp */; };
-		290A9BB91735F63800D71BBC /* OpenNewWindow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 290A9BB81735F42300D71BBC /* OpenNewWindow.html */; };
-		290F4275172A221C00939FF0 /* custom-protocol-sync-xhr.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 290F4274172A1FDE00939FF0 /* custom-protocol-sync-xhr.html */; };
 		297234B7173AFAC700983601 /* CustomProtocolsInvalidScheme_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 297234B5173AFAC700983601 /* CustomProtocolsInvalidScheme_Bundle.cpp */; };
 		29E06E5E266F3C0600F1A707 /* AccessibilityIncreaseContrast.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29E06E5D266F3C0600F1A707 /* AccessibilityIncreaseContrast.mm */; };
 		2D09CF0026A68297009C43C0 /* GraphicsContextCGTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D09CEFF26A68296009C43C0 /* GraphicsContextCGTests.mm */; };
 		2D1646E21D1862CD00015A1A /* DeferredViewInWindowStateChange.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D1646E11D1862CD00015A1A /* DeferredViewInWindowStateChange.mm */; };
-		2D2FE8DA231745C900B2E9C9 /* long-email-viewport.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2D2FE8D9231745AB00B2E9C9 /* long-email-viewport.html */; };
 		2D3CA3A8221DF4B40088E803 /* PageOverlayPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D3CA3A4221DF2390088E803 /* PageOverlayPlugin.mm */; };
 		2D4CF8BD1D8360CC0001CE8D /* WKThumbnailView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D4CF8BC1D8360CC0001CE8D /* WKThumbnailView.mm */; };
 		2D51A0C71C8BF00C00765C45 /* DOMHTMLVideoElementWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D51A0C51C8BF00400765C45 /* DOMHTMLVideoElementWrapper.mm */; };
 		2D70059921EDA4D0003463CB /* OffscreenWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D70059721EDA4D0003463CB /* OffscreenWindow.mm */; };
 		2D83D08B29194B0100C5C051 /* ArgumentCoderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2D83D08A29194B0100C5C051 /* ArgumentCoderTests.cpp */; };
 		2DC9451724D8AC0200430376 /* WebThreadLock.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DC9451624D8AC0200430376 /* WebThreadLock.mm */; };
-		2DD7D3AF178227B30026E1E3 /* lots-of-text-vertical-lr.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DD7D3AE178227AC0026E1E3 /* lots-of-text-vertical-lr.html */; };
 		2DD87145265F23B4005F997C /* BifurcatedGraphicsContextTestsCG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2DD87144265F23B4005F997C /* BifurcatedGraphicsContextTestsCG.cpp */; };
-		2DDD4DA4270B8B3500659A61 /* cube.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DDD4DA3270B8B3300659A61 /* cube.usdz */; };
-		2DE71B001D49C3ED00904094 /* blinking-div.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DE71AFF1D49C2F000904094 /* blinking-div.html */; };
-		2E131C181D83A98A001BA36C /* wide-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E131C171D83A97E001BA36C /* wide-autoplaying-video-with-audio.html */; };
-		2E14A5291D3FE96B0010F35B /* autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E14A5281D3FE8B80010F35B /* autoplaying-video-with-audio.html */; };
-		2E1B7B001D41ABA7007558B4 /* large-video-seek-after-ending.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1B7AFF1D41A95F007558B4 /* large-video-seek-after-ending.html */; };
-		2E1B7B021D41B1B9007558B4 /* large-video-hides-controls-after-seek-to-end.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1B7B011D41B1B3007558B4 /* large-video-hides-controls-after-seek-to-end.html */; };
-		2E1DFDED1D42A51100714A00 /* large-videos-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1DFDEC1D42A41C00714A00 /* large-videos-with-audio.html */; };
-		2E1DFDEF1D42A6F200714A00 /* large-videos-with-audio-autoplay.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1DFDEE1D42A6EB00714A00 /* large-videos-with-audio-autoplay.html */; };
-		2E1DFDF11D42E1E400714A00 /* large-video-seek-to-beginning-and-play-after-ending.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1DFDF01D42E14400714A00 /* large-video-seek-to-beginning-and-play-after-ending.html */; };
 		2E205BA41F527746005952DD /* AccessibilityTestsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E205BA31F527746005952DD /* AccessibilityTestsIOS.mm */; };
-		2E4838472169DF30002F4531 /* nested-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E4838462169DD42002F4531 /* nested-lists.html */; };
-		2E54F40D1D7BC84200921ADF /* large-video-mutes-onplaying.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E54F40C1D7BC83900921ADF /* large-video-mutes-onplaying.html */; };
-		2E691AEA1D78B53600129407 /* large-videos-paused-video-hides-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AE81D78B52B00129407 /* large-videos-paused-video-hides-controls.html */; };
-		2E691AEB1D78B53600129407 /* large-videos-playing-video-keeps-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AE91D78B52B00129407 /* large-videos-playing-video-keeps-controls.html */; };
-		2E691AED1D78B91000129407 /* large-videos-playing-muted-video-hides-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AEC1D78B90200129407 /* large-videos-playing-muted-video-hides-controls.html */; };
-		2E691AEF1D79DE8400129407 /* large-videos-autoplaying-click-to-pause.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AEE1D79DE6F00129407 /* large-videos-autoplaying-click-to-pause.html */; };
-		2E691AF11D79E51A00129407 /* large-videos-autoplaying-scroll-to-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AF01D79E51400129407 /* large-videos-autoplaying-scroll-to-video.html */; };
-		2E691AF31D79E75E00129407 /* large-video-playing-scroll-away.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AF21D79E75400129407 /* large-video-playing-scroll-away.html */; };
 		2E7765CD16C4D80A00BA2BB1 /* mainIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CC16C4D80A00BA2BB1 /* mainIOS.mm */; };
 		2E7765CF16C4D81100BA2BB1 /* mainMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CE16C4D81100BA2BB1 /* mainMac.mm */; };
-		2E92B8F7216490D4005B64F0 /* rich-text-attributes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E92B8F6216490C3005B64F0 /* rich-text-attributes.html */; };
-		2E9896151D8F093800739892 /* text-and-password-inputs.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E9896141D8F092B00739892 /* text-and-password-inputs.html */; };
-		2EB29D5E1F762DB90023A5F1 /* dump-datatransfer-types.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EB29D5D1F762DA50023A5F1 /* dump-datatransfer-types.html */; };
-		2EBD9D0A2134730D002DA758 /* video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07CD32F72065B72A0064A4BE /* video.html */; };
 		2EC7034A26AF5E88002B2D37 /* KeyboardEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7034926AF5E88002B2D37 /* KeyboardEventTests.mm */; };
-		2ED88823277125AB00DB7E99 /* WKInspectorExtensionEvaluateScriptOnPage.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2ED8882127711F1200DB7E99 /* WKInspectorExtensionEvaluateScriptOnPage.html */; };
-		2ED88824277125AB00DB7E99 /* WKInspectorExtensionEvaluateScriptOnPageInnerFrame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2ED888222771203A00DB7E99 /* WKInspectorExtensionEvaluateScriptOnPageInnerFrame.html */; };
-		2EFF06C31D88621E0004BB30 /* large-video-offscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06C21D8862120004BB30 /* large-video-offscreen.html */; };
-		2EFF06C51D8867760004BB30 /* change-video-source-on-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06C41D8867700004BB30 /* change-video-source-on-click.html */; };
-		2EFF06C71D886A580004BB30 /* change-video-source-on-end.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06C61D886A560004BB30 /* change-video-source-on-end.html */; };
-		2EFF06CD1D8A429A0004BB30 /* input-field-in-scrollable-document.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06CC1D8A42910004BB30 /* input-field-in-scrollable-document.html */; };
-		3128A81323763FAC00D90D40 /* link-with-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3128A81223763F0B00D90D40 /* link-with-image.html */; };
-		3128A8152376413300D90D40 /* image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3128A814237640FD00D90D40 /* image.html */; };
-		313C3A0221E567C300DBA86E /* SystemPreviewBlobNaming.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 313C3A0121E5677A00DBA86E /* SystemPreviewBlobNaming.html */; };
-		31727A5329F7518C00A7FB0F /* system-preview.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A4A29F7338C00A7FB0F /* system-preview.html */; };
-		31727A5429F7519400A7FB0F /* UnitBox.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5229F733D300A7FB0F /* UnitBox.usdz */; };
 		318210CE2C59AEFF00C334B4 /* CSSTokenizerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 318210CD2C59AEFF00C334B4 /* CSSTokenizerTests.cpp */; };
-		31903C912765077400363472 /* color-scheme.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31903C902764FE1400363472 /* color-scheme.html */; };
-		31B76E4523299BDC007FED2C /* system-preview-trigger.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31B76E4423299BA3007FED2C /* system-preview-trigger.html */; };
 		31E9BDA1247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BDA0247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm */; };
-		31E9BDA3247F5729002E51A2 /* webgl.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31E9BDA2247F4DD0002E51A2 /* webgl.html */; };
 		33976D8324DC479B00812304 /* IndexSparseSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33976D8224DC479B00812304 /* IndexSparseSet.cpp */; };
 		33BE5AF9137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33BE5AF8137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp */; };
 		33C2C9C12651F5B900E407F6 /* SmallSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33C2C9C02651F5B900E407F6 /* SmallSet.cpp */; };
-		33DC8912141955FE00747EF7 /* simple-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 33DC890E1419539300747EF7 /* simple-iframe.html */; };
 		33DC89141419579F00747EF7 /* LoadCanceledNoServerRedirectCallback_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33DC89131419579F00747EF7 /* LoadCanceledNoServerRedirectCallback_Bundle.cpp */; };
-		33E79E06137B5FD900E32D99 /* mouse-move-listener.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 33E79E05137B5FCE00E32D99 /* mouse-move-listener.html */; };
 		3545E58927E2AD1300F1910E /* WritingModeTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3545E58827E2AD1200F1910E /* WritingModeTests.cpp */; };
-		37137E4B21124D01002BEEA4 /* AttrStyle.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3760C4F221124BD000233ACC /* AttrStyle.html */; };
 		374B7A611DF371CF00ACCB6C /* BundleEditingDelegatePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 374B7A5F1DF36EEE00ACCB6C /* BundleEditingDelegatePlugIn.mm */; };
 		378E64771632655E00B6C676 /* InjectedBundleFrameHitTest_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378E64751632655D00B6C676 /* InjectedBundleFrameHitTest_Bundle.cpp */; };
-		378E64791632707400B6C676 /* link-with-title.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 378E647816326FDF00B6C676 /* link-with-title.html */; };
-		379028B914FAC24C007E6B43 /* acceptsFirstMouse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 379028B814FABE49007E6B43 /* acceptsFirstMouse.html */; };
 		37A709AF1E3EA97E00CA5969 /* BundleRangeHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37A709AA1E3EA79000CA5969 /* BundleRangeHandlePlugIn.mm */; };
 		37C7CC2D1EA4146B007BD956 /* WeakLinking.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37C7CC2B1EA4146B007BD956 /* WeakLinking.cpp */; };
-		37DC6791140D7D7600ABCCDB /* DOMRangeOfString.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 37DC678F140D7D3A00ABCCDB /* DOMRangeOfString.html */; };
-		37E1064C1697681800B78BD0 /* DOMHTMLTableCellElementCellAbove.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 37E1064B169767F700B78BD0 /* DOMHTMLTableCellElementCellAbove.html */; };
 		37E7DD671EA071F3009B396D /* AdditionalReadAccessAllowedURLsPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37E7DD661EA071F3009B396D /* AdditionalReadAccessAllowedURLsPlugin.mm */; };
 		37FB72971DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37FB72951DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm */; };
 		3A1337B328F9177600F29B73 /* UniqueRefVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A1337AB28F9177600F29B73 /* UniqueRefVector.cpp */; };
@@ -242,16 +148,12 @@
 		3A9C438828E3E057002F7294 /* ASTStringDumperTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A9C438028E3E057002F7294 /* ASTStringDumperTests.cpp */; };
 		3A9C438B28E3E240002F7294 /* TestWGSLAPI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A9C438928E3E240002F7294 /* TestWGSLAPI.cpp */; };
 		3ADD8988299F192F005DCE4E /* MetalGenerationTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3ADD897E299F1400005DCE4E /* MetalGenerationTests.cpp */; };
-		3FBD1B4A1D3D66AB00E6D6FA /* FullscreenLayoutConstraints.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */; };
-		3FCC4FE81EC4E8CA0076E37C /* PictureInPictureDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FCC4FE61EC4E87E0076E37C /* PictureInPictureDelegate.html */; };
 		4102EE1727845ED500D6BE74 /* ServiceWorkerRoutines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4102EE1627845ED500D6BE74 /* ServiceWorkerRoutines.cpp */; };
 		411223C726035FBF00B0A0B6 /* WebRTC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 411223C626035FBE00B0A0B6 /* WebRTC.mm */; };
 		41157237234B240C0050A1D1 /* GetUserMedia.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41157236234B24040050A1D1 /* GetUserMedia.mm */; };
 		4135FB842011FAA700332139 /* InjectInternals_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4135FB832011FAA300332139 /* InjectInternals_Bundle.cpp */; };
 		4135FB852011FABF00332139 /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4135FB862011FABF00332139 /* libWebCoreTestSupport.dylib */; };
-		41661C662355E85E00D33C27 /* getUserMedia-webaudio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 41661C652355D98B00D33C27 /* getUserMedia-webaudio.html */; };
 		4181C62D255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4181C62C255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp */; };
-		41848F4424891879000E2588 /* open-window-with-file-url-with-host.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 41848F4324891815000E2588 /* open-window-with-file-url-with-host.html */; };
 		41D2A21F27906F9F0088FCCE /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 144D40EC221B46A7004B474F /* UUID.cpp */; };
 		41E67A8525D16E83007B0A4C /* STUNMessageParsingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41E67A8425D16E83007B0A4C /* STUNMessageParsingTest.cpp */; };
 		41EBA9F228ABA06700953013 /* ImageRotationSessionVT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */; };
@@ -268,104 +170,44 @@
 		44CDE4D426EE6E4A009F6ACB /* TypeCastsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */; };
 		44CF31FD249941E8009CB6CB /* ContextMenuAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */; };
 		44D3F8402BE1A74200BE0218 /* XMLParsing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D3F8382BE1A6BE00BE0218 /* XMLParsing.mm */; };
-		44D3F8432BE1DB0000BE0218 /* test.xml in Copy Resources */ = {isa = PBXBuildFile; fileRef = 44D3F8422BE1DAD800BE0218 /* test.xml */; };
 		44D5008E26FE9ED6000EB12F /* RetainPtrARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D5008D26FE9ED6000EB12F /* RetainPtrARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		44FBAEFF2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44FBAEFD2C7A7FDB00AF51BC /* RetainPtrHashingCocoa.mm */; };
 		44FBAF002C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44FBAEFE2C7A7FDB00AF51BC /* RetainPtrHashingCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4628C8E92367ABD100B073F0 /* WKSecurityOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4628C8E82367ABBC00B073F0 /* WKSecurityOrigin.cpp */; };
-		462B4E8028E7B0E400653230 /* fragment-navigation-before-load-event.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 462B4E7828E7B0AF00653230 /* fragment-navigation-before-load-event.html */; };
 		46397B951DC2C850009A78AE /* DOMNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46397B941DC2C850009A78AE /* DOMNode.mm */; };
 		4647B1261EBA3B850041D7EF /* ProcessDidTerminate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4647B1251EBA3B730041D7EF /* ProcessDidTerminate.cpp */; };
-		464C764D230DF85C00AFB020 /* BadServiceWorkerRegistrations-4.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 464C764C230DF83200AFB020 /* BadServiceWorkerRegistrations-4.sqlite3 */; };
 		4657323A28BDB18F00972575 /* ProvisionalURLAfterWillSendRequestCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4657323828BDB18F00972575 /* ProvisionalURLAfterWillSendRequestCallback.cpp */; };
 		4657323C28BDB2E500972575 /* ProvisionalURLAfterWillSendRequestCallback_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4657323928BDB18F00972575 /* ProvisionalURLAfterWillSendRequestCallback_Bundle.cpp */; };
-		465C23AF2640C3FE00F2FC7F /* postMessage-regularly.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 465C23AE2640C3C500F2FC7F /* postMessage-regularly.html */; };
 		466AF38A26FE393600CE2EB8 /* ServiceWorkerPagePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 466AF38826FE393200CE2EB8 /* ServiceWorkerPagePlugIn.mm */; };
-		466C3843210637DE006A88DE /* notify-resourceLoadObserver.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 466C3842210637CE006A88DE /* notify-resourceLoadObserver.html */; };
-		467C565321B5ED130057516D /* GetSessionCookie.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 467C565121B5ECDF0057516D /* GetSessionCookie.html */; };
-		467C565421B5ED130057516D /* SetSessionCookie.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 467C565221B5ECDF0057516D /* SetSessionCookie.html */; };
-		468BC45522653A1000A36C96 /* open-window-then-write-to-it.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 468BC454226539C800A36C96 /* open-window-then-write-to-it.html */; };
-		468F2F942368DAF100F4B864 /* window-open-then-document-open.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 468F2F932368DAA700F4B864 /* window-open-then-document-open.html */; };
-		46A44A5425A7830300F61E16 /* webaudio-createMediaElementSource.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46A44A5325A782DD00F61E16 /* webaudio-createMediaElementSource.html */; };
 		46BBEA1B25F9835700D4987A /* WorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AA6A1511AAC0B31002B2ED3 /* WorkQueue.cpp */; };
-		46C1EA9825758820005E409E /* alert.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C1EA9725758805005E409E /* alert.html */; };
-		46C3AEB323D0E529001B0680 /* beforeunload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C3AEB223D0E50F001B0680 /* beforeunload.html */; };
-		46C519E61D3563FD00DAA51A /* LocalStorageNullEntries.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C519E21D35629600DAA51A /* LocalStorageNullEntries.html */; };
-		46C519E71D3563FD00DAA51A /* LocalStorageNullEntries.localstorage in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C519E31D35629600DAA51A /* LocalStorageNullEntries.localstorage */; };
-		46C519E81D3563FD00DAA51A /* LocalStorageNullEntries.localstorage-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C519E41D35629600DAA51A /* LocalStorageNullEntries.localstorage-shm */; };
 		46E45EE62863D3E200441B14 /* WKBackForwardListTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F83571A1D3FFB0E00E3967B /* WKBackForwardListTests.mm */; };
 		46E816F81E79E29C00375ADC /* RestoreStateAfterTermination.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46E816F71E79E29100375ADC /* RestoreStateAfterTermination.mm */; };
-		46F03C1C255B2D5A00AA51C5 /* audio-context-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46F03C1B255B2D3600AA51C5 /* audio-context-playing.html */; };
 		46FA2FEE23846CA5000CCB0C /* HTTPHeaderMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46FA2FED23846C9A000CCB0C /* HTTPHeaderMap.cpp */; };
-		46FACF7423E8842300A9EBC6 /* beforeunload-slow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46FACF7323E883EE00A9EBC6 /* beforeunload-slow.html */; };
-		46FD40382A6B3E6800A1B210 /* postMessage-various-types.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46FD40302A6B3E3500A1B210 /* postMessage-various-types.html */; };
 		48124A272925A0C100EED506 /* AnimationControl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 48124A262925A0C100EED506 /* AnimationControl.mm */; };
-		48354DD929F08047003E566D /* animated-red-green-blue-repeat-infinite.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48354DD129F08036003E566D /* animated-red-green-blue-repeat-infinite.gif */; };
-		48354DDB29F092D1003E566D /* img-animation-in-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48354DDA29F092B1003E566D /* img-animation-in-anchor.html */; };
-		48B288E929F7743300F00F78 /* img-animation-covered-by-link.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48B288E129F7741300F00F78 /* img-animation-covered-by-link.html */; };
 		4909EE3A2D09480C88982D56 /* Markable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC79F168BE454E579E417B05 /* Markable.cpp */; };
 		491AEEF82652E33500D530A8 /* AppPrivacyReportPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 491AEEF42652DDD000D530A8 /* AppPrivacyReportPlugIn.mm */; };
-		4952BE5F257816F800B0AEF1 /* try-text-select-with-disabled-text-interaction.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4952BE5C2578113900B0AEF1 /* try-text-select-with-disabled-text-interaction.html */; };
-		4971B1182451F29A0096994D /* incorrectCreateTableSchema.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4971B1172451F2780096994D /* incorrectCreateTableSchema.db */; };
-		4971B1202453A88C0096994D /* missingTopFrameUniqueRedirectSameSiteStrictTableSchema.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4971B11F2453A87F0096994D /* missingTopFrameUniqueRedirectSameSiteStrictTableSchema.db */; };
 		4971B12F24623A3B0096994D /* basicITPDatabase.db-shm in Resources */ = {isa = PBXBuildFile; fileRef = 4971B12D24623A3B0096994D /* basicITPDatabase.db-shm */; };
 		4971B13024623A3C0096994D /* basicITPDatabase.db-wal in Resources */ = {isa = PBXBuildFile; fileRef = 4971B12E24623A3B0096994D /* basicITPDatabase.db-wal */; };
-		4971B13124623A4F0096994D /* basicITPDatabase.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4971B12C246239D30096994D /* basicITPDatabase.db */; };
-		49897D6C241FE9E400ECF153 /* in-app-browser-privacy-local-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D7FBA7241FDDDA00AB67FA /* in-app-browser-privacy-local-file.html */; };
-		498D030A26376B34009CBFAD /* resourceLoadStatisticsMissingUniqueIndex.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 498D030926376B2C009CBFAD /* resourceLoadStatisticsMissingUniqueIndex.db */; };
-		4995A6F025E8772000E5F0A9 /* csp-document-uri-report.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4995A6EF25E876A300E5F0A9 /* csp-document-uri-report.html */; };
-		49C64FD728349C38005BF0C2 /* test.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49C64FD628349C19005BF0C2 /* test.pages */; };
-		49D2E5C22731E3BC00BCCAED /* file-with-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D2E5C12731E37400BCCAED /* file-with-iframe.html */; };
-		49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D902B228209B0500E2C3B8 /* emptyTable.html */; };
 		4BFDFFA71314776C0061F24B /* HitTestResultNodeHandle_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BFDFFA61314776C0061F24B /* HitTestResultNodeHandle_Bundle.cpp */; };
 		4C041C6C2C405622002218A4 /* FontCascade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C041C6B2C405622002218A4 /* FontCascade.cpp */; };
-		4C453A44294A469500D91D2B /* Ahem-10000A.ttf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4C453A43294A468200D91D2B /* Ahem-10000A.ttf */; };
-		4CC961EC294A36CE00483F06 /* LockdownModeFonts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4CC961E4294A36A000483F06 /* LockdownModeFonts.html */; };
-		510477721D298DDD009747EB /* IDBDeleteRecovery.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5104776F1D298D85009747EB /* IDBDeleteRecovery.sqlite3 */; };
-		510477731D298DDD009747EB /* IDBDeleteRecovery.sqlite3-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 510477701D298D85009747EB /* IDBDeleteRecovery.sqlite3-shm */; };
-		510477741D298DDD009747EB /* IDBDeleteRecovery.sqlite3-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 510477711D298D85009747EB /* IDBDeleteRecovery.sqlite3-wal */; };
-		510477771D298E72009747EB /* IDBDeleteRecovery.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 510477761D298E57009747EB /* IDBDeleteRecovery.html */; };
 		510A667B27D301AC00D22629 /* CoreMediaUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 510A667A27D2FC7A00D22629 /* CoreMediaUtilities.mm */; };
 		510A667C27D301C600D22629 /* AVFoundationSoftLinkTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0711DF51226A95FB003DD2F7 /* AVFoundationSoftLinkTest.mm */; };
 		510A91F824D3622100BFD89C /* SonyDualShock3.mm in Sources */ = {isa = PBXBuildFile; fileRef = 510A91F724D3621900BFD89C /* SonyDualShock3.mm */; };
 		510A920A24D5048900BFD89C /* LogitechF310.mm in Sources */ = {isa = PBXBuildFile; fileRef = 510A920924D5048300BFD89C /* LogitechF310.mm */; };
 		510A920C24D5275500BFD89C /* LogitechF710.mm in Sources */ = {isa = PBXBuildFile; fileRef = 510A920B24D5275100BFD89C /* LogitechF710.mm */; };
 		510A921424D615B400BFD89C /* GoogleStadia.mm in Sources */ = {isa = PBXBuildFile; fileRef = 510A921324D60A3E00BFD89C /* GoogleStadia.mm */; };
-		5110FCF11E01CD64006F8D0B /* IDBIndexUpgradeToV2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF01E01CD53006F8D0B /* IDBIndexUpgradeToV2.html */; };
-		5110FCF61E01CD83006F8D0B /* IndexUpgrade.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF31E01CD77006F8D0B /* IndexUpgrade.sqlite3 */; };
-		5110FCF91E01CD8A006F8D0B /* IndexUpgrade.blob in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF21E01CD77006F8D0B /* IndexUpgrade.blob */; };
-		5120C83E1E67678F0025B250 /* WebsiteDataStoreCustomPaths.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5120C83B1E674E350025B250 /* WebsiteDataStoreCustomPaths.html */; };
 		512C4C9E20EAA40D004945EA /* ResponsivenessTimerCrash.mm in Sources */ = {isa = PBXBuildFile; fileRef = 512C4C9D20EAA405004945EA /* ResponsivenessTimerCrash.mm */; };
 		512F29102BA1D03100F1C326 /* MIMESniffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 512F290F2BA1D03100F1C326 /* MIMESniffer.cpp */; };
 		51393E221523952D005F39C5 /* DOMWindowExtensionBasic_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51393E1D1523944A005F39C5 /* DOMWindowExtensionBasic_Bundle.cpp */; };
-		5142B2731517C8C800C32B19 /* ContextMenuCanCopyURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5142B2721517C89100C32B19 /* ContextMenuCanCopyURL.html */; };
 		514958BE1F7427AC00E87BAD /* WKWebViewAutofillTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 514958BD1F7427AC00E87BAD /* WKWebViewAutofillTests.mm */; };
 		5159F267260D43E300B2DA3C /* NowPlayingInfoTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */; };
-		515BE16F1D428BB100DD7C68 /* StoreBlobToBeDeleted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 515BE16E1D4288FF00DD7C68 /* StoreBlobToBeDeleted.html */; };
 		516281252325C18000BB7E42 /* TestPDFDocument.mm in Sources */ = {isa = PBXBuildFile; fileRef = 516281242325C17B00BB7E42 /* TestPDFDocument.mm */; };
 		516404382AB1D9BC0042B1C3 /* NativePromise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 516404372AB1D9BB0042B1C3 /* NativePromise.cpp */; };
-		51714EB41CF8C78C004723C4 /* WebProcessKillIDBCleanup-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51714EB21CF8C761004723C4 /* WebProcessKillIDBCleanup-1.html */; };
-		51714EB51CF8C78C004723C4 /* WebProcessKillIDBCleanup-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51714EB31CF8C761004723C4 /* WebProcessKillIDBCleanup-2.html */; };
 		5175C7A226F876230003AF5C /* BundlePageConsoleMessage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5175C7A126F876230003AF5C /* BundlePageConsoleMessage.mm */; };
-		517E7E04151119C100D0B008 /* MemoryCachePruneWithinResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 517E7E031511187500D0B008 /* MemoryCachePruneWithinResourceLoadDelegate.html */; };
 		51820A4D22F4EE7F00DF0A01 /* JavascriptURLNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51820A4C22F4EE7700DF0A01 /* JavascriptURLNavigation.mm */; };
 		518EE51920A78CE500E024F3 /* DoubleDefersLoadingPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 518EE51720A78CDF00E024F3 /* DoubleDefersLoadingPlugin.mm */; };
-		51A5877D1D1B49CD004BA9AF /* IndexedDBMultiProcess-3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51A5877C1D1B3D8D004BA9AF /* IndexedDBMultiProcess-3.html */; };
-		51A587851D2739E3004BA9AF /* IndexedDBDatabaseProcessKill-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51A587821D272EB5004BA9AF /* IndexedDBDatabaseProcessKill-1.html */; };
-		51B1EE961C80FAEF0064FB98 /* IndexedDBPersistence-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE941C80FADD0064FB98 /* IndexedDBPersistence-1.html */; };
-		51B1EE971C80FAEF0064FB98 /* IndexedDBPersistence-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE951C80FADD0064FB98 /* IndexedDBPersistence-2.html */; };
-		51BB6B86296E931F0059B107 /* test-mse.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BB6B7E296E8FFD0059B107 /* test-mse.webm */; };
-		51BCEE4E1C84F53B0042C82E /* IndexedDBMultiProcess-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4C1C84F52C0042C82E /* IndexedDBMultiProcess-1.html */; };
-		51BCEE4F1C84F53B0042C82E /* IndexedDBMultiProcess-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4D1C84F52C0042C82E /* IndexedDBMultiProcess-2.html */; };
-		51C234CF2970E13500E35C4B /* test-mse-audio.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C234C72970E11400E35C4B /* test-mse-audio.webm */; };
-		51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */; };
-		51CD1C721B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51CD1C711B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html */; };
 		51DB16CE1F085137001FA4C5 /* WebViewIconLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */; };
-		51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E1007129C6D891009CEE99 /* file-with-managedmse.html */; };
 		51E4810D2AAB93800069B158 /* libWebKitPlatform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */; };
-		51E5C7021919C3B200D8B3E1 /* simple2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780361919AFF8001829A2 /* simple2.html */; };
-		51E5C7031919C3B200D8B3E1 /* simple3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780371919AFF8001829A2 /* simple3.html */; };
-		51E6A8961D2F1CA700C004B6 /* LocalStorageClear.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E6A8951D2F1C7700C004B6 /* LocalStorageClear.html */; };
 		51EB125724C67257000CB030 /* VirtualGamepad.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51EB125624C66FE8000CB030 /* VirtualGamepad.mm */; };
 		51EB125924C68592000CB030 /* HIDGamepads.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51EB125824C68589000CB030 /* HIDGamepads.mm */; };
 		51EB126224CA6B66000CB030 /* MicrosoftXboxOne.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51EB126024CA6B5F000CB030 /* MicrosoftXboxOne.mm */; };
@@ -375,86 +217,32 @@
 		51EB126724CB8753000CB030 /* SunLightApplicationGenericNES.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51EB126624CB8493000CB030 /* SunLightApplicationGenericNES.mm */; };
 		51FA14312AF5BAE00003ACD1 /* IPCSerialization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51FA14302AF5BAE00003ACD1 /* IPCSerialization.mm */; };
 		520BCF4C141EB09E00937EA8 /* WebArchive_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 520BCF4A141EB09E00937EA8 /* WebArchive_Bundle.cpp */; };
-		521D1B7327713E80003900C5 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 521D1B7227713E80003900C5 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html */; };
 		5245178721B9F57B0082CB34 /* RenderingProgressPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52D5D6BE21B9F1B20046ABA6 /* RenderingProgressPlugIn.mm */; };
-		524BBC9E19DF72C0002F1AF1 /* file-with-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 524BBC9B19DF3714002F1AF1 /* file-with-video.html */; };
-		524BBCA119E30C77002F1AF1 /* test.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 524BBCA019E30C63002F1AF1 /* test.mp4 */; };
-		52B8CF9815868D9100281053 /* SetDocumentURI.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 52B8CF9415868CF000281053 /* SetDocumentURI.html */; };
-		52C8C1382706437C00BDF3B7 /* web-authentication-make-credential-hid-internal-uv.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 52C8C1372706437C00BDF3B7 /* web-authentication-make-credential-hid-internal-uv.html */; };
-		52C8C13A2706439000BDF3B7 /* web-authentication-get-assertion-hid-internal-uv.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 52C8C1392706439000BDF3B7 /* web-authentication-get-assertion-hid-internal-uv.html */; };
 		52D673EE1AFB127300FA19FE /* WKPageCopySessionStateWithFiltering.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D673EC1AFB126800FA19FE /* WKPageCopySessionStateWithFiltering.cpp */; };
 		52E5CE4914D21EAB003B2BD8 /* ParentFrame_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52E5CE4814D21EAB003B2BD8 /* ParentFrame_Bundle.cpp */; };
 		5311BD5E1EA9490E00525281 /* ThreadMessages.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD5D1EA9490D00525281 /* ThreadMessages.cpp */; };
 		531C1D8E1DF8EF72006E979F /* LEBDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 531C1D8D1DF8EF72006E979F /* LEBDecoder.cpp */; };
 		536770341CC8022800D425B1 /* WebScriptObjectDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 536770331CC8022800D425B1 /* WebScriptObjectDescription.mm */; };
-		536770361CC81B6100D425B1 /* WebScriptObjectDescription.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 536770351CC812F900D425B1 /* WebScriptObjectDescription.html */; };
 		53EC25411E96FD87000831B9 /* PriorityQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53EC253F1E96BC80000831B9 /* PriorityQueue.cpp */; };
 		53FCDE6B229EFFB900598ECF /* IsoHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FCDE6A229EFFB900598ECF /* IsoHeap.cpp */; };
-		55226A2F1EBA44B900C36AD0 /* large-red-square-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 55226A2E1EB969B600C36AD0 /* large-red-square-image.html */; };
 		5597F8361D9596C80066BC21 /* SynchronizedFixedQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5597F8341D9596C80066BC21 /* SynchronizedFixedQueue.cpp */; };
-		55A817FF2181021A0004A39A /* 100x100-red.tga in Copy Resources */ = {isa = PBXBuildFile; fileRef = 55A817FE218101DF0004A39A /* 100x100-red.tga */; };
-		55A81800218102210004A39A /* 400x400-green.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = 55A817FD218101DF0004A39A /* 400x400-green.png */; };
 		55F9D2E52205031800A9AB38 /* AdditionalSupportedImageTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55F9D2E42205031800A9AB38 /* AdditionalSupportedImageTypes.mm */; };
-		5703BB8D2463F88700475FB2 /* web-authentication-make-credential-la-no-attestation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5703BB8C2463F87200475FB2 /* web-authentication-make-credential-la-no-attestation.html */; };
-		570D26F423C3CA6A00D5CF67 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26F323C3CA5500D5CF67 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html */; };
-		570D26F623C3D33000D5CF67 /* web-authentication-make-credential-hid-pin.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26F523C3D32700D5CF67 /* web-authentication-make-credential-hid-pin.html */; };
-		570D26FA23C3F25100D5CF67 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26F923C3F24500D5CF67 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error.html */; };
-		570D26FC23C3F87000D5CF67 /* web-authentication-get-assertion-hid-pin.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26FB23C3F86500D5CF67 /* web-authentication-get-assertion-hid-pin.html */; };
-		5714ECB91CA8B5B000051AC8 /* DownloadRequestOriginalURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5714ECB81CA8B58800051AC8 /* DownloadRequestOriginalURL.html */; };
-		5714ECBB1CA8BFE400051AC8 /* DownloadRequestOriginalURLFrame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5714ECBA1CA8BFD100051AC8 /* DownloadRequestOriginalURLFrame.html */; };
-		5714ECBD1CA8C22A00051AC8 /* DownloadRequestOriginalURL2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5714ECBC1CA8C21800051AC8 /* DownloadRequestOriginalURL2.html */; };
 		57152B5E21CC2045000C37CA /* ApduTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57152B5D21CC2045000C37CA /* ApduTest.cpp */; };
 		57152B7821DD4E8D000C37CA /* U2fCommandConstructorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57D1D75E21DCB7A80093E86A /* U2fCommandConstructorTest.cpp */; };
-		571F7FD01F2961FB00946648 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 571F7FCF1F2961E100946648 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-wal */; };
 		572B403421769A88000AD43E /* CtapRequestTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 572B403321769A88000AD43E /* CtapRequestTest.cpp */; };
 		572B404421781B43000AD43E /* CtapResponseTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 572B404321781B42000AD43E /* CtapResponseTest.cpp */; };
-		572CEF71240F874700C412A2 /* web-authentication-get-assertion-la.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 572CEF70240F86AE00C412A2 /* web-authentication-get-assertion-la.html */; };
 		57303BC9200824D300355965 /* CBORValueTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57303BAC2006C56000355965 /* CBORValueTest.cpp */; };
 		57303BCA20082C0100355965 /* CBORWriterTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57303BAB2006C55400355965 /* CBORWriterTest.cpp */; };
 		57303BCB2008376500355965 /* CBORReaderTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57303BC220071E2200355965 /* CBORReaderTest.cpp */; };
-		573255A522139BC700396AE8 /* helloworld.webarchive in Copy Resources */ = {isa = PBXBuildFile; fileRef = 573255A422139B9000396AE8 /* helloworld.webarchive */; };
-		573255A622139BC700396AE8 /* load-web-archive-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 573255A222139B8F00396AE8 /* load-web-archive-1.html */; };
-		573255A722139BC700396AE8 /* load-web-archive-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 573255A322139B9000396AE8 /* load-web-archive-2.html */; };
-		574217882400AC25002B303D /* web-authentication-make-credential-la-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 574217872400ABFD002B303D /* web-authentication-make-credential-la-error.html */; };
-		5742178A2400AED8002B303D /* web-authentication-make-credential-la-duplicate-credential.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 574217892400AED0002B303D /* web-authentication-make-credential-la-duplicate-credential.html */; };
-		5742178E2400D2DF002B303D /* web-authentication-make-credential-la.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5742178D2400D26C002B303D /* web-authentication-make-credential-la.html */; };
 		574F55D2204D47F0002948C6 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
-		5751B28A249D5BC500664C2A /* web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5751B289249D5B9900664C2A /* web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry.html */; };
-		57537EE824BEA05F0048DBA5 /* web-authentication-get-assertion-nfc-pin-disconnect.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57537EE724BEA0190048DBA5 /* web-authentication-get-assertion-nfc-pin-disconnect.html */; };
 		5758597F23A2527A00C74572 /* CtapPinTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5758597E23A2527A00C74572 /* CtapPinTest.cpp */; };
-		5758598423C3C3A400C74572 /* web-authentication-make-credential-hid-pin-get-retries-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5758598323C3C36200C74572 /* web-authentication-make-credential-hid-pin-get-retries-error.html */; };
-		57599E271F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E241F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3 */; };
-		57599E281F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E261F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-shm */; };
-		57599E2A1F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityRead.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E251F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityRead.html */; };
-		57599E2B1F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityWrite.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E231F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityWrite.html */; };
-		57663DEA234EA66D00E85E09 /* web-authentication-get-assertion-nfc.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DE9234EA60B00E85E09 /* web-authentication-get-assertion-nfc.html */; };
-		57663DEC234F1F9300E85E09 /* web-authentication-get-assertion-hid.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DEB234F1F8000E85E09 /* web-authentication-get-assertion-hid.html */; };
-		57663DF32357E48900E85E09 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DF22357E45D00E85E09 /* web-authentication-get-assertion-hid-cancel.html */; };
 		5769C50B1D9B0002000847FB /* SerializedCryptoKeyWrap.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5769C50A1D9B0001000847FB /* SerializedCryptoKeyWrap.mm */; };
-		577454D02359B378008E1ED7 /* web-authentication-get-assertion-hid-no-credentials.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 577454CF2359B338008E1ED7 /* web-authentication-get-assertion-hid-no-credentials.html */; };
-		577454D22359BB01008E1ED7 /* web-authentication-get-assertion-u2f-no-credentials.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 577454D12359BAD5008E1ED7 /* web-authentication-get-assertion-u2f-no-credentials.html */; };
 		5778D05622110A2600899E3B /* LoadWebArchive.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5778D05522110A2600899E3B /* LoadWebArchive.mm */; };
 		578CBD67204FB2C80083B9F2 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 578CBD66204FB2C70083B9F2 /* LocalAuthentication.framework */; };
-		578DA44223ECC7A000246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44123ECC76B00246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error.html */; };
-		578DA44423ECCAE900246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44323ECC8A800246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry.html */; };
-		578DA44623ECCC0A00246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44523ECCBD000246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry.html */; };
-		578DA44823ECD09B00246010 /* web-authentication-make-credential-hid-pin-auth-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44723ECD01300246010 /* web-authentication-make-credential-hid-pin-auth-blocked-error.html */; };
-		578DA44A23ECD18600246010 /* web-authentication-make-credential-hid-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44923ECD15500246010 /* web-authentication-make-credential-hid-pin-invalid-error-retry.html */; };
-		578DA44C23ECD23000246010 /* web-authentication-get-assertion-hid-pin-auth-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44B23ECD20300246010 /* web-authentication-get-assertion-hid-pin-auth-blocked-error.html */; };
-		578DA44E23ECD28B00246010 /* web-authentication-get-assertion-hid-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44D23ECD26100246010 /* web-authentication-get-assertion-hid-pin-invalid-error-retry.html */; };
-		57901FB11CAF142D00ED64F9 /* LoadInvalidURLRequest.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57901FB01CAF141C00ED64F9 /* LoadInvalidURLRequest.html */; };
 		579651E7216BFDED006EBFE5 /* FidoHidMessageTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 579651E6216BFD53006EBFE5 /* FidoHidMessageTest.cpp */; };
 		5797FE311EB15A6800B2F4A0 /* NavigationClientDefaultCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5797FE2F1EB15A5F00B2F4A0 /* NavigationClientDefaultCrypto.cpp */; };
-		5797FE331EB15AB100B2F4A0 /* navigation-client-default-crypto.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5797FE321EB15A8900B2F4A0 /* navigation-client-default-crypto.html */; };
-		5798337E236019A4008E5547 /* web-authentication-make-credential-hid.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5798337D2360196D008E5547 /* web-authentication-make-credential-hid.html */; };
-		579833922368FA37008E5547 /* web-authentication-get-assertion-nfc-multiple-tags.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5798337B235EB65C008E5547 /* web-authentication-get-assertion-nfc-multiple-tags.html */; };
-		579F1C0123C93AF500C7D4B4 /* web-authentication-get-assertion-hid-multiple-accounts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 579F1BFF23C92FD300C7D4B4 /* web-authentication-get-assertion-hid-multiple-accounts.html */; };
 		57C3FA661F7C248F009D4B80 /* WeakPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CB9BC371A67482300FE5678 /* WeakPtr.cpp */; };
-		57C624502346C21E00383FE7 /* web-authentication-get-assertion.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57C6244F2346C1EC00383FE7 /* web-authentication-get-assertion.html */; };
-		57EDFC5C245A1A3F00959521 /* web-authentication-make-credential-la-no-mock.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57EDFC5B245A18F500959521 /* web-authentication-make-credential-la-no-mock.html */; };
-		57EDFC60245A299C00959521 /* web-authentication-get-assertion-la-no-mock.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57EDFC5F245A279900959521 /* web-authentication-get-assertion-la-no-mock.html */; };
 		57F1C91125DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */; };
-		57F56A5C1C7F8CC100F31D7E /* IsNavigationActionTrusted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57F56A5B1C7F8A4000F31D7E /* IsNavigationActionTrusted.html */; };
 		5C0BF88D1DD5964D00B00328 /* MemoryPressureHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C0BF88C1DD5957400B00328 /* MemoryPressureHandler.mm */; };
 		5C0BF8911DD599A900B00328 /* WebViewCanPasteZeroPng.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C0BF88F1DD5999B00B00328 /* WebViewCanPasteZeroPng.mm */; };
 		5C0BF8921DD599B600B00328 /* EarlyKVOCrash.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FB6CC1CA34BE500966124 /* EarlyKVOCrash.mm */; };
@@ -462,12 +250,10 @@
 		5C0BF8941DD599C900B00328 /* MenuTypesForMouseEvents.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A99D9931AD4A29D00373141 /* MenuTypesForMouseEvents.mm */; };
 		5C121E8D2410704900486F9B /* ContentWorldPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C121E8C2410703200486F9B /* ContentWorldPlugIn.mm */; };
 		5C24A00A294A75E300463E2B /* SkipDecidePolicyForResponsePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C24A002294A75DD00463E2B /* SkipDecidePolicyForResponsePlugIn.mm */; };
-		5C2936961D5C00ED00DEAB1E /* CookieMessage.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C2936941D5BFD1900DEAB1E /* CookieMessage.html */; };
 		5C2C01A82734883600F89D37 /* CrossThreadCopierTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 278DE64B22B8D611004E0E7A /* CrossThreadCopierTests.cpp */; };
 		5C4259462266A68A0039AA7A /* BasicProposedCredentialPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C42594422669E9B0039AA7A /* BasicProposedCredentialPlugIn.mm */; };
 		5C581D3227C8A01C006B3BC4 /* YouTubePluginReplacement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C581D3127C8A01C006B3BC4 /* YouTubePluginReplacement.cpp */; };
 		5C6E27A7224EEBEA00128736 /* URLExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C6E27A6224EEBEA00128736 /* URLExtras.mm */; };
-		5C7101C725DD98B600686200 /* test_print.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C7101C625DD988700686200 /* test_print.pdf */; };
 		5C75716122124C5200B9E5AC /* BundleRetainPagePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C75715F221249BD00B9E5AC /* BundleRetainPagePlugIn.mm */; };
 		5C7964101EB0278D0075D74C /* EventModifiers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C79640F1EB0269B0075D74C /* EventModifiers.cpp */; };
 		5C7C24FC237C975400599C91 /* HTTPServer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C7C24FA237C972300599C91 /* HTTPServer.mm */; };
@@ -484,10 +270,6 @@
 		5C9D923B22D7E2B0008E9266 /* UnifiedSource4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C9D923222D7E235008E9266 /* UnifiedSource4.cpp */; };
 		5C9D923C22D7E2B0008E9266 /* UnifiedSource5-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C9D923522D7E235008E9266 /* UnifiedSource5-mm.mm */; };
 		5C9D923D22D7E2B0008E9266 /* UnifiedSource5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C9D923322D7E235008E9266 /* UnifiedSource5.cpp */; };
-		5C9E56871DF914AE00C9EE33 /* contentBlockerCheck.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E56861DF9148E00C9EE33 /* contentBlockerCheck.html */; };
-		5C9E59411D3EB5AC00E3C62E /* ApplicationCache.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E593E1D3EB1DE00E3C62E /* ApplicationCache.db */; };
-		5C9E59421D3EB5AC00E3C62E /* ApplicationCache.db-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E593F1D3EB1DE00E3C62E /* ApplicationCache.db-shm */; };
-		5C9E59431D3EB5AC00E3C62E /* ApplicationCache.db-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E59401D3EB1DE00E3C62E /* ApplicationCache.db-wal */; };
 		5CA1DEC81F71F70100E71BD3 /* HTTPHeaderField.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CA1DEC71F71F40700E71BD3 /* HTTPHeaderField.cpp */; };
 		5CABDBBF2735C9BD00B88BCB /* UnifiedSource16-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB922735C9BA00B88BCB /* UnifiedSource16-mm.mm */; };
 		5CABDBC02735C9BD00B88BCB /* UnifiedSource50-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB932735C9BA00B88BCB /* UnifiedSource50-mm.mm */; };
@@ -542,8 +324,6 @@
 		5CF540E92257E67C00E6BC0E /* DownloadThread.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CF540E82257E64B00E6BC0E /* DownloadThread.mm */; };
 		634910E01E9D3FF300880309 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 634910DF1E9D3FF300880309 /* CoreLocation.framework */; };
 		6354F4D11F7C3AB500D89DF3 /* ApplicationManifestParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6354F4D01F7C3AB500D89DF3 /* ApplicationManifestParser.cpp */; };
-		636353A71E98665D0009F8AF /* GeolocationGetCurrentPositionResult.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 636353A61E9861940009F8AF /* GeolocationGetCurrentPositionResult.html */; };
-		63A61B8B1FAD251100F06885 /* display-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 63A61B8A1FAD204D00F06885 /* display-mode.html */; };
 		63CAD0572C478A56009CE119 /* GetMatchedCSSRules.mm in Sources */ = {isa = PBXBuildFile; fileRef = 63CAD04F2C478A55009CE119 /* GetMatchedCSSRules.mm */; };
 		6B0A07F721FA9C2B00D57391 /* PrivateClickMeasurement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */; };
 		6B306106218A372900F5A802 /* ClosingWebView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B306105218A372900F5A802 /* ClosingWebView.mm */; };
@@ -554,27 +334,16 @@
 		712E4BC125DDC52A0007201C /* AnimationFrameRate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */; };
 		7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */; };
 		71E88C4124B5299C00665160 /* ShareSheetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 71E88C4024B5299C00665160 /* ShareSheetTests.mm */; };
-		71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
-		725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
-		7283A9D222FB1E0600B21C7D /* exif-orientation-8-llo.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */; };
-		72F21E9828C9216B007BF315 /* 100x100-red.jp2 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 72F21E9728C9214C007BF315 /* 100x100-red.jp2 */; };
 		7498C3D72A94435F009A387E /* TestUTIUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7498C3CF2A94435F009A387E /* TestUTIUtilities.cpp */; };
 		74DEF2252A946FD800E034A3 /* TestUTIRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74DEF21D2A946FD700E034A3 /* TestUTIRegistry.cpp */; };
 		751B05D61F8EAC410028A09E /* DatabaseTrackerTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */; };
 		754CEC811F6722F200D0039A /* AutoFillAvailable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */; };
 		76E182DD1547569100F1FADD /* WillSendSubmitEvent_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 76E182DC1547569100F1FADD /* WillSendSubmitEvent_Bundle.cpp */; };
-		76E182DF154767E600F1FADD /* auto-submitting-form.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 76E182DE15475A8300F1FADD /* auto-submitting-form.html */; };
-		7772ECE122FE06C60009A799 /* many-same-origin-iframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7772ECE022FE05E10009A799 /* many-same-origin-iframes.html */; };
 		79C5D431209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm in Sources */ = {isa = PBXBuildFile; fileRef = 79C5D430209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm */; };
 		7A010BCB1D877C0500EDE72A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A010BCA1D877C0500EDE72A /* CoreGraphics.framework */; };
 		7A010BCD1D877C0D00EDE72A /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A010BCC1D877C0D00EDE72A /* QuartzCore.framework */; };
 		7A0509411FB9F06400B33FB8 /* JSONValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A0509401FB9F04400B33FB8 /* JSONValue.cpp */; };
-		7A1458FC1AD5C07000E06772 /* mouse-button-listener.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A1458FB1AD5C03500E06772 /* mouse-button-listener.html */; };
 		7A32D74A1F02151500162C44 /* FileMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A32D7491F02151500162C44 /* FileMonitor.cpp */; };
-		7A33FF3027C82F8100D7E03E /* LockdownModePDF.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A33FF2F27C82F0B00D7E03E /* LockdownModePDF.html */; };
-		7A33FF3427C8317D00D7E03E /* webkit-logo.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A33FF3227C8314D00D7E03E /* webkit-logo.pdf */; };
-		7A66BDB81EAF18D500CCC924 /* set-long-title.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A66BDB71EAF150100CCC924 /* set-long-title.html */; };
-		7A6A2C721DCCFB5200C0D085 /* LocalStorageQuirkEnabled.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A6A2C711DCCFB0200C0D085 /* LocalStorageQuirkEnabled.html */; };
 		7A7B0E7F1EAFE4C3006AB8AE /* LimitTitleSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A7B0E7E1EAFE454006AB8AE /* LimitTitleSize.mm */; };
 		7A89BB682331643A0042CB1E /* BundleFormDelegatePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A89BB662331635D0042CB1E /* BundleFormDelegatePlugIn.mm */; };
 		7A909A7D1D877480007E10F8 /* AffineTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A6F1D877475007E10F8 /* AffineTransform.cpp */; };
@@ -591,9 +360,7 @@
 		7AC7B57020D9BA5B002C09A0 /* CustomBundleObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AC7B56F20D9BA5B002C09A0 /* CustomBundleObject.mm */; };
 		7AC7B57120D9BA5B002C09A0 /* CustomBundleObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AC7B56F20D9BA5B002C09A0 /* CustomBundleObject.mm */; };
 		7AD3FE8E1D76131200B169A4 /* TransformationMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AD3FE8D1D75FB8D00B169A4 /* TransformationMatrix.cpp */; };
-		7AE9E5091AE5AE8B00CF874B /* test.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AE9E5081AE5AE8B00CF874B /* test.pdf */; };
 		7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */; };
-		7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
 		7B06F95F2A377E23000DFC95 /* SequenceLockedTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */; };
 		7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */; };
 		7B2739F32632AB640040F182 /* ThreadAssertionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */; };
@@ -629,7 +396,6 @@
 		7BE876032919457B00B15289 /* AudioStreamDescriptionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */; };
 		7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */; };
 		7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C3965051CDD74F90094DBB8 /* ColorTests.cpp */; };
-		7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C486BA01AA1254B003F6F9B /* bundle-file.html */; };
 		7C83DE991D0A590C00FEBCF3 /* AtomString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26F1B44215CA434F00D1E4BF /* AtomString.cpp */; };
 		7C83DE9C1D0A590C00FEBCF3 /* BloomFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E40019301ACE9B5C001B0A2A /* BloomFilter.cpp */; };
 		7C83DEA01D0A590C00FEBCF3 /* CheckedArithmeticOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A966DA140ECCC8005EF9B4 /* CheckedArithmeticOperations.cpp */; };
@@ -691,9 +457,7 @@
 		7C882E091C80C630006BF731 /* UserContentWorldPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C882E041C80C624006BF731 /* UserContentWorldPlugIn.mm */; };
 		7C89D2AC1A69B80D003A5FDE /* WKPageConfiguration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89D2AA1A69B80D003A5FDE /* WKPageConfiguration.cpp */; };
 		7C8BFF7123C0107A00C009B3 /* HexNumber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8BFF7023C0106700C009B3 /* HexNumber.cpp */; };
-		7C9ED98B17A19F4B00E4DC33 /* attributedStringStrikethrough.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C9ED98A17A19D0600E4DC33 /* attributedStringStrikethrough.html */; };
 		7CB184C61AA3F2100066EDFD /* ContentExtensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CB184C41AA3F2100066EDFD /* ContentExtensions.cpp */; };
-		7CCB99231D3B4A46003922F6 /* open-multiple-external-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7CCB99221D3B44E7003922F6 /* open-multiple-external-url.html */; };
 		7CCE7EA51A411A0800447C4C /* JavaScriptTestMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = C081224013FC172400DC39AE /* JavaScriptTestMac.mm */; };
 		7CCE7EA61A411A0F00447C4C /* PlatformUtilitiesMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC131884117114B600B69727 /* PlatformUtilitiesMac.mm */; };
 		7CCE7EA71A411A1300447C4C /* PlatformWebViewMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC90955C125548AA00083756 /* PlatformWebViewMac.mm */; };
@@ -815,171 +579,584 @@
 		7CFBCAE51743238F00B2BFCF /* WillLoad_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CFBCAE31743238E00B2BFCF /* WillLoad_Bundle.cpp */; };
 		83148B06202AC6A400BADE99 /* InjectedBundleDisableOverrideBuiltinsBehavior.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83148B05202AC68200BADE99 /* InjectedBundleDisableOverrideBuiltinsBehavior.cpp */; };
 		83148B07202AC6AD00BADE99 /* InjectedBundleDisableOverrideBuiltinsBehavior_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83148B04202AC68200BADE99 /* InjectedBundleDisableOverrideBuiltinsBehavior_Bundle.cpp */; };
-		83148B09202AC78D00BADE99 /* override-builtins-test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 83148B08202AC76800BADE99 /* override-builtins-test.html */; };
 		8349D3C21DB96DDE004A9F65 /* ContextMenuDownload.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8349D3C11DB96DDA004A9F65 /* ContextMenuDownload.mm */; };
-		8349D3C41DB9728E004A9F65 /* link-with-download-attribute.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8349D3C31DB9724F004A9F65 /* link-with-download-attribute.html */; };
-		8361F1781E610B4E00759B25 /* link-with-download-attribute-with-slashes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8361F1771E610B2100759B25 /* link-with-download-attribute-with-slashes.html */; };
-		837A35F11D9A1E7D00663C57 /* DownloadRequestBlobURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 837A35F01D9A1E6400663C57 /* DownloadRequestBlobURL.html */; };
-		839AA35F21A26B0300980DD6 /* client-side-redirect.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 839AA35E21A26ACD00980DD6 /* client-side-redirect.html */; };
 		83B6DE6F1EE75221001E792F /* RestoreSessionState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83B6DE6E1EE7520F001E792F /* RestoreSessionState.cpp */; };
 		83BC5AC020E6C0DF00F5879F /* StartLoadInDidFailProvisionalLoad.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83BC5ABF20E6C0D300F5879F /* StartLoadInDidFailProvisionalLoad.mm */; };
 		83DB79691EF63B3C00BFA5E5 /* Function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83DB79671EF63B3C00BFA5E5 /* Function.cpp */; };
 		83F22C6420B355F80034277E /* NoPolicyDelegateResponse.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83F22C6320B355EB0034277E /* NoPolicyDelegateResponse.mm */; };
-		8C10AF98206467920018FD90 /* localstorage-empty-string-value.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8C10AF97206467830018FD90 /* localstorage-empty-string-value.html */; };
 		8E4A85371E1D1AB200F53B0F /* GridPosition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */; };
 		919B50762C177055009FE7B0 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 919B506E2C177055009FE7B0 /* Base64.cpp */; };
-		930AD402150698D00067970F /* lots-of-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 930AD401150698B30067970F /* lots-of-text.html */; };
 		9310CD381EF708FB0050FFE0 /* Function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9310CD361EF708FB0050FFE0 /* Function.cpp */; };
-		931C281E22BC579A001D98C4 /* opendatabase-always-exists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 931C281B22BC5583001D98C4 /* opendatabase-always-exists.html */; };
 		9329AA291DE3F81E003ABD07 /* TextBreakIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9329AA281DE3F81E003ABD07 /* TextBreakIterator.cpp */; };
-		932AE53D1D371047005DFFAF /* focus-inputs.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93575C551D30366E000D604D /* focus-inputs.html */; };
 		9332EF942649BB68009F5D6D /* StringToIntegerConversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9332EF932649BB68009F5D6D /* StringToIntegerConversion.cpp */; };
 		933D631D1FCB76200032ECD6 /* Hasher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933D631B1FCB76180032ECD6 /* Hasher.cpp */; };
-		9341C95727CD507A0023C0F4 /* indexeddb-persistence-third-party.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9341C95627CD50680023C0F4 /* indexeddb-persistence-third-party.sqlite3 */; };
-		9342589E255B6A120059EEDD /* speechrecognition-user-permission-persistence.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9342589D255B66A00059EEDD /* speechrecognition-user-permission-persistence.html */; };
-		935786CC20F6A2700000CDFC /* IndexedDB.sqlite3-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 934FA5C520F69FED0040DC1B /* IndexedDB.sqlite3-wal */; };
-		935786CD20F6A2910000CDFC /* IndexedDB.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 934FA5C720F69FEE0040DC1B /* IndexedDB.sqlite3 */; };
-		935786CE20F6A2A10000CDFC /* IndexedDB.sqlite3-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 934FA5C620F69FED0040DC1B /* IndexedDB.sqlite3-shm */; };
-		9358C33C273ED07B00F3B38C /* file-system-access.salt in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9358C33B273ED06A00F3B38C /* file-system-access.salt */; };
-		9360270625A3CF7600367670 /* speechrecognition-basic.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9360270525A3B28E00367670 /* speechrecognition-basic.html */; };
-		9361002914DC95A70061379D /* lots-of-iframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9361002814DC957B0061379D /* lots-of-iframes.html */; };
-		93625D271CD9741C006DC1F1 /* large-video-without-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93625D261CD973AF006DC1F1 /* large-video-without-audio.html */; };
-		9368A25E229EFB4700A829CA /* local-storage-process-suspends-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9368A25D229EFB3A00A829CA /* local-storage-process-suspends-1.html */; };
-		9368A25F229EFB4700A829CA /* local-storage-process-suspends-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9368A25C229EFB3A00A829CA /* local-storage-process-suspends-2.html */; };
 		936E4AE42821BB6D00208654 /* SuspendableWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 936E4AE32821BB6D00208654 /* SuspendableWorkQueueTests.cpp */; };
-		936EC36627BA3B0D00AFA8AE /* general-storage-directory.salt in Copy Resources */ = {isa = PBXBuildFile; fileRef = 936EC36527BA3AF200AFA8AE /* general-storage-directory.salt */; };
-		936F72801CD7D9EC0068A0FB /* large-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 936F727E1CD7D9D00068A0FB /* large-video-with-audio.html */; };
-		936F72811CD7D9EC0068A0FB /* large-video-with-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 936F727F1CD7D9D00068A0FB /* large-video-with-audio.mp4 */; };
-		937A6C8A24357C1700C3A6B0 /* KillWebProcessWithOpenConnection-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 937A6C8824357BF300C3A6B0 /* KillWebProcessWithOpenConnection-1.html */; };
-		937A6C8B24357C1700C3A6B0 /* KillWebProcessWithOpenConnection-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 937A6C8924357BF300C3A6B0 /* KillWebProcessWithOpenConnection-2.html */; };
-		937B569E23CD23DB002AE640 /* IDBObjectStoreInfoUpgrade.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93BCBC8123CC6EF500CA2221 /* IDBObjectStoreInfoUpgrade.sqlite3 */; };
 		93915A1724DB66C70019FF43 /* DocumentOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93915A1624DB66C70019FF43 /* DocumentOrder.cpp */; };
-		9399BA052371114F008392BF /* IndexedDBInPageCache.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9399BA02237110BF008392BF /* IndexedDBInPageCache.html */; };
-		9399BA062371114F008392BF /* IndexedDBNotInPageCache.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9399BA03237110BF008392BF /* IndexedDBNotInPageCache.html */; };
-		93A2749D251EF90700A1B6D4 /* IDBIndexUpgradeToV2WithMultipleIndices.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A2749A251EF52A00A1B6D4 /* IDBIndexUpgradeToV2WithMultipleIndices.html */; };
-		93A274A2252163EE00A1B6D4 /* IndexUpgradeWithMultipleIndices.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A274A1252163D600A1B6D4 /* IndexUpgradeWithMultipleIndices.sqlite3 */; };
-		93A274A5252241DE00A1B6D4 /* IndexUpgradeWithMultipleIndicesHaveSameID.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A274A4252241D000A1B6D4 /* IndexUpgradeWithMultipleIndicesHaveSameID.sqlite3 */; };
-		93A9BF5F27BF3686000B44D3 /* general-storage-directory-localstorage.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A9BF5E27BF3678000B44D3 /* general-storage-directory-localstorage.sqlite3 */; };
-		93A9BF6127BF5AF0000B44D3 /* general-storage-directory.origin in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A9BF6027BF5AE4000B44D3 /* general-storage-directory.origin */; };
-		93A9BF6327BF6804000B44D3 /* general-storage-directory-indexeddb.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A9BF6227BF67F4000B44D3 /* general-storage-directory-indexeddb.sqlite3 */; };
 		93AF4ECE1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93AF4ECD1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp */; };
-		93AF4ED11506F130007FD57E /* lots-of-images.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93AF4ECF1506F123007FD57E /* lots-of-images.html */; };
-		93BCBC8423CC6F4400CA2221 /* IDBObjectStoreInfoUpgradeToV2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93BCBC8223CC6EF500CA2221 /* IDBObjectStoreInfoUpgradeToV2.html */; };
 		93C3647B2BDD8800006D8B55 /* UTF8Conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */; };
-		93CFA8671CEB9E38000565A8 /* autofocused-text-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93CFA8661CEB9DE1000565A8 /* autofocused-text-input.html */; };
-		93D119FC22C680F7009BE3C7 /* localstorage-open-window-private.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93D119FB22C57112009BE3C7 /* localstorage-open-window-private.html */; };
 		93E2C5551FD3204100E1DF6A /* LineEnding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93E2C5541FD3204100E1DF6A /* LineEnding.cpp */; };
-		93E2D2761ED7D53200FA76F6 /* offscreen-iframe-of-media-document.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93E2D2751ED7D51700FA76F6 /* offscreen-iframe-of-media-document.html */; };
 		93E6193B1F931B3A00AF245E /* TextCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93A258981F92FF15003E510C /* TextCodec.cpp */; };
 		93F1DB3414DA20870024C362 /* NewFirstVisuallyNonEmptyLayout_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F1DB3314DA20870024C362 /* NewFirstVisuallyNonEmptyLayout_Bundle.cpp */; };
 		93F1DB5714DB1B840024C362 /* NewFirstVisuallyNonEmptyLayoutFails_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F1DB5614DB1B840024C362 /* NewFirstVisuallyNonEmptyLayoutFails_Bundle.cpp */; };
 		93F56DA71E5F9174003EDE84 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0331D0A5F2700FEBCF3 /* libicucore.dylib */; };
-		93F79A5A28E64A06003E7CEB /* websql-database-tracker.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93F79A5928E649EC003E7CEB /* websql-database-tracker.db */; };
-		93F79A5B28E64A07003E7CEB /* websql-database.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93F79A5128E649EB003E7CEB /* websql-database.db */; };
 		93F7E86F14DC8E5C00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F7E86E14DC8E5B00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp */; };
 		93FCDB34263631560046DD7D /* SortedArrayMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93FCDB33263631560046DD7D /* SortedArrayMap.cpp */; };
 		946422142BC83114001B42B3 /* SerializedScriptValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */; };
-		95194CC028A5811F00343FDE /* red.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 95194CBF28A580E900343FDE /* red.html */; };
 		9528E5FD279A0341008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9528E5FC279A0338008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm */; };
-		952F7167270BD9CB00D00DCC /* CSSViewportUnits.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCC /* CSSViewportUnits.html */; };
-		952F7167270BD9CB00D00DCD /* CSSViewportUnits.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCD /* CSSViewportUnits.svg */; };
 		95C52729275F35E100DA7E40 /* FontShadowTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95C52728275F35E100DA7E40 /* FontShadowTests.cpp */; };
-		996EDCCB270E70D7006DF175 /* InspectorExtension-basic-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 996EDCCA270E70AB006DF175 /* InspectorExtension-basic-page.html */; };
-		9984FACE1CFFB090008D198C /* editable-body.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9984FACD1CFFB038008D198C /* editable-body.html */; };
-		99E2846626F93DB50003F1FA /* InspectorExtension-TabIcon-30x30.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = 99E2846526F93D760003F1FA /* InspectorExtension-TabIcon-30x30.png */; };
-		99E2846826F941540003F1FA /* InspectorExtension-basic-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 99E2846726F9413B0003F1FA /* InspectorExtension-basic-tab.html */; };
 		9B0786A51C5885C300D159E3 /* InjectedBundleMakeAllShadowRootsOpen_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B0786A41C5885C300D159E3 /* InjectedBundleMakeAllShadowRootsOpen_Bundle.cpp */; };
 		9B0C051924FDFB7D00F2FE31 /* CompactUniquePtrTuple.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B0C051824FDFB7000F2FE31 /* CompactUniquePtrTuple.cpp */; };
 		9B19CDA01F06DFE3000548DD /* NetworkProcessCrashWithPendingConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B19CD9E1F06DFE3000548DD /* NetworkProcessCrashWithPendingConnection.mm */; };
-		9B1F6F791F90559E00B55744 /* copy-html.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B1056421F9047CC00D5583F /* copy-html.html */; };
-		9B26FCCA159D16DE00CC3765 /* HTMLFormCollectionNamedItem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B26FCB4159D15E700CC3765 /* HTMLFormCollectionNamedItem.html */; };
-		9B270FEE1DDC2C0B002D53F3 /* closed-shadow-tree-test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B270FED1DDC25FD002D53F3 /* closed-shadow-tree-test.html */; };
 		9B4B5EA522DEBE19001E3D5A /* SelectionModifyByParagraphBoundary.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B5EA422DEBE19001E3D5A /* SelectionModifyByParagraphBoundary.mm */; };
-		9B4F8FA7159D52DD002D9F94 /* HTMLCollectionNamedItem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B4F8FA6159D52CA002D9F94 /* HTMLCollectionNamedItem.html */; };
-		9B59F12A2034086F009E63D5 /* mso-list-compat-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B59F12920340854009E63D5 /* mso-list-compat-mode.html */; };
-		9B62630C1F8C25C8007EE29B /* copy-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B62630B1F8C2510007EE29B /* copy-url.html */; };
-		9B7D740F1F8378770006C432 /* paste-rtfd.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B7D740E1F8377E60006C432 /* paste-rtfd.html */; };
-		9B9332CE2320C745002D50E8 /* cocoa-writer-markup-with-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B9332CD2320C73E002D50E8 /* cocoa-writer-markup-with-lists.html */; };
 		9BAD7F3E22690F2000F8DA66 /* DeallocWebViewInEventListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BAD7F3D22690F1400F8DA66 /* DeallocWebViewInEventListener.mm */; };
-		9BAE177B22E2BBFB00DF3098 /* cocoa-writer-markup-with-system-fonts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BAE177A22E2BB6B00DF3098 /* cocoa-writer-markup-with-system-fonts.html */; };
 		9BBCA4DF265ACA5B00DFE723 /* CheckedPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BBCA4DE265ACA5B00DFE723 /* CheckedPtr.cpp */; };
-		9BCD411A206DBCA3001D71BE /* mso-list-on-h4.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BCD4119206D5ED7001D71BE /* mso-list-on-h4.html */; };
 		9BD4239A1E04BD9800200395 /* AttributedSubstringForProposedRangeWithImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BD423991E04BD9800200395 /* AttributedSubstringForProposedRangeWithImage.mm */; };
-		9BD4239C1E04C01C00200395 /* chinese-character-with-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD4239B1E04BFD000200395 /* chinese-character-with-image.html */; };
 		9BD5111C1FE8E11600D2B630 /* AccessingPastedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BD5111B1FE8E11600D2B630 /* AccessingPastedImage.mm */; };
-		9BD6D3A21F7B218300BD4962 /* sunset-in-cupertino-100px.tiff in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D3A11F7B202100BD4962 /* sunset-in-cupertino-100px.tiff */; };
-		9BD6D3A31F7B218300BD4962 /* sunset-in-cupertino-200px.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D3A01F7B202000BD4962 /* sunset-in-cupertino-200px.png */; };
-		9BD6D3A41F7B218300BD4962 /* sunset-in-cupertino-400px.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D39F1F7B202000BD4962 /* sunset-in-cupertino-400px.gif */; };
-		9BD6D3A51F7B218300BD4962 /* sunset-in-cupertino-600px.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D39E1F7B201E00BD4962 /* sunset-in-cupertino-600px.jpg */; };
-		9BD6D3A71F7B21DC00BD4962 /* paste-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D3A61F7B21CC00BD4962 /* paste-image.html */; };
 		9BF00133267C4C5900DCFB3F /* CheckedRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BF00132267C4C5900DCFB3F /* CheckedRef.cpp */; };
-		9BF356CD202D458500F71160 /* mso-list.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BF356CC202D44F200F71160 /* mso-list.html */; };
 		A1146A8D1D2D7115000FE710 /* ContentFiltering.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1146A8A1D2D704F000FE710 /* ContentFiltering.mm */; };
-		A1183D482C6C8FC400233D8B /* fullscreen-lifecycle-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1183D402C6C8F8600233D8B /* fullscreen-lifecycle-audio.html */; };
-		A11E7DA024A169F900026745 /* link-with-hover-menu.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A11E7D9F24A169E200026745 /* link-with-hover-menu.html */; };
 		A11E7DA324A17D2500026745 /* ElementActionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A11E7DA224A17C7D00026745 /* ElementActionTests.mm */; };
-		A12DDC001E8373E700CF6CAE /* rendered-image-excluding-overflow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A12DDBFF1E8373C100CF6CAE /* rendered-image-excluding-overflow.html */; };
 		A12DDC021E837C2400CF6CAE /* RenderedImageWithOptionsPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A12DDBFC1E836FF100CF6CAE /* RenderedImageWithOptionsPlugIn.mm */; };
-		A13D1AD624AD468F003F92A8 /* context-menu-control-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A13D1AD524AD4677003F92A8 /* context-menu-control-click.html */; };
 		A13EBBAA1B87428D00097110 /* WebProcessPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A13EBBA91B87428D00097110 /* WebProcessPlugIn.mm */; };
 		A13EBBAB1B87434600097110 /* PlatformUtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F139E721A423A2B00F590F5 /* PlatformUtilitiesCocoa.mm */; };
 		A13EBBB01B87436F00097110 /* BundleParametersPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A13EBBAE1B87436F00097110 /* BundleParametersPlugIn.mm */; };
-		A1409AD91E7254D4004949D9 /* password-protected.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1409AD81E7254AC004949D9 /* password-protected.pages */; };
-		A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = A14AAB641E78DC3F00C1ADC2 /* encrypted.pdf */; };
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
-		A155022C1E050D0300A24C57 /* duplicate-completion-handler-calls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A155022B1E050BC500A24C57 /* duplicate-completion-handler-calls.html */; };
-		A16F66BA1C40EB4F00BD4D24 /* ContentFiltering.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A16F66B91C40EA2000BD4D24 /* ContentFiltering.html */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
-		A1798B872243449B000764BD /* apple-pay-availability.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1798B862243446B000764BD /* apple-pay-availability.html */; };
-		A1798B8922435E29000764BD /* apple-pay-availability-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1798B8822435D2E000764BD /* apple-pay-availability-in-iframe.html */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };
 		A179918B1E1CA24100A505ED /* SharedBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A17991891E1CA24100A505ED /* SharedBufferTest.cpp */; };
-		A17EAC55208305A00084B41B /* find.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = A17EAC542083056E0084B41B /* find.pdf */; };
+		A17C46592C98E4A80023F3C7 /* download.example.webarchive in Copy Resources */ = {isa = PBXBuildFile; fileRef = D20C03AE2B704A26004C414A /* download.example.webarchive */; };
+		A17C465A2C98E4BB0023F3C7 /* active-touch-events.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A7CE792662D83E00228685 /* active-touch-events.html */; };
+		A17C465B2C98E4BB0023F3C7 /* animated-red-green-blue-repeat-infinite.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48354DD129F08036003E566D /* animated-red-green-blue-repeat-infinite.gif */; };
+		A17C465C2C98E4BB0023F3C7 /* composited.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F16BED72304A1D100B4A167 /* composited.html */; };
+		A17C465D2C98E4BB0023F3C7 /* editable-region-composited-and-non-composited-overlap.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEDA12402437C9EA00C28A9E /* editable-region-composited-and-non-composited-overlap.html */; };
+		A17C465E2C98E4BB0023F3C7 /* img-animation-covered-by-link.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48B288E129F7741300F00F78 /* img-animation-covered-by-link.html */; };
+		A17C465F2C98E4BB0023F3C7 /* img-animation-in-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48354DDA29F092B1003E566D /* img-animation-in-anchor.html */; };
+		A17C46602C98E4BB0023F3C7 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
+		A17C46612C98E4BB0023F3C7 /* insert-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE6D0EE22426B8ED002AD901 /* insert-text.html */; };
+		A17C46622C98E4BB0023F3C7 /* link-with-hover-menu.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A11E7D9F24A169E200026745 /* link-with-hover-menu.html */; };
+		A17C46632C98E4BB0023F3C7 /* overflow-scroll.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F340777230382540060A1A0 /* overflow-scroll.html */; };
+		A17C46642C98E4BB0023F3C7 /* pages.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1C4FB721BACD1B7003742D0 /* pages.pages */; };
+		A17C46652C98E4BB0023F3C7 /* scrollable-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0FF1F0C52AE204C0006ECC4F /* scrollable-page.html */; };
+		A17C46662C98E4BB0023F3C7 /* set-timeout-function.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE6E81A320A933B800E2C80F /* set-timeout-function.html */; };
+		A17C46672C98E4D20023F3C7 /* acceptsFirstMouse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 379028B814FABE49007E6B43 /* acceptsFirstMouse.html */; };
+		A17C46682C98E4D20023F3C7 /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
+		A17C46692C98E4D20023F3C7 /* attributedStringCustomFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = B55F11B01517A2C400915916 /* attributedStringCustomFont.html */; };
+		A17C466A2C98E4D20023F3C7 /* attributedStringNewlineAtEndOfDocument.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42BD7D8245CC4E6001E207A /* attributedStringNewlineAtEndOfDocument.html */; };
+		A17C466B2C98E4D20023F3C7 /* attributedStringStrikethrough.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C9ED98A17A19D0600E4DC33 /* attributedStringStrikethrough.html */; };
+		A17C466C2C98E4D20023F3C7 /* CancelLoadFromResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26DF5A6115A2A22B003689C2 /* CancelLoadFromResourceLoadDelegate.html */; };
+		A17C466D2C98E4D20023F3C7 /* ContextMenuCanCopyURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5142B2721517C89100C32B19 /* ContextMenuCanCopyURL.html */; };
+		A17C466E2C98E4D20023F3C7 /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
+		A17C466F2C98E4D20023F3C7 /* devicePixelRatio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C07E6CB113FD738A0038B22B /* devicePixelRatio.html */; };
+		A17C46702C98E4D20023F3C7 /* DOMHTMLTableCellElementCellAbove.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 37E1064B169767F700B78BD0 /* DOMHTMLTableCellElementCellAbove.html */; };
+		A17C46712C98E4D20023F3C7 /* DOMRangeOfString.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 37DC678F140D7D3A00ABCCDB /* DOMRangeOfString.html */; };
+		A17C46722C98E4D20023F3C7 /* double-click-does-not-select-trailing-space.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FA91821E618566007B8C1D /* double-click-does-not-select-trailing-space.html */; };
+		A17C46732C98E4D20023F3C7 /* FragmentNavigation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A7E8B351812093600AEB74A /* FragmentNavigation.html */; };
+		A17C46742C98E4D20023F3C7 /* full-page-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47728981E4AE3AD007ABF6A /* full-page-contenteditable.html */; };
+		A17C46752C98E4D20023F3C7 /* FullscreenZoomInitialFrame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDBFCC421A9FF44800A7B691 /* FullscreenZoomInitialFrame.html */; };
+		A17C46762C98E4D20023F3C7 /* helloworld.webarchive in Copy Resources */ = {isa = PBXBuildFile; fileRef = 573255A422139B9000396AE8 /* helloworld.webarchive */; };
+		A17C46772C98E4D20023F3C7 /* HTMLCollectionNamedItem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B4F8FA6159D52CA002D9F94 /* HTMLCollectionNamedItem.html */; };
+		A17C46782C98E4D20023F3C7 /* HTMLFormCollectionNamedItem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B26FCB4159D15E700CC3765 /* HTMLFormCollectionNamedItem.html */; };
+		A17C46792C98E4D20023F3C7 /* IsNavigationActionTrusted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57F56A5B1C7F8A4000F31D7E /* IsNavigationActionTrusted.html */; };
+		A17C467A2C98E4D20023F3C7 /* JSContextBackForwardCache1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C2CF975816CEC69E0054E99D /* JSContextBackForwardCache1.html */; };
+		A17C467B2C98E4D20023F3C7 /* JSContextBackForwardCache2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C2CF975916CEC69E0054E99D /* JSContextBackForwardCache2.html */; };
+		A17C467C2C98E4D20023F3C7 /* large-input-field-focus-onload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42DA5151D8CEFDB00336F40 /* large-input-field-focus-onload.html */; };
+		A17C467D2C98E4D20023F3C7 /* load-web-archive-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 573255A222139B8F00396AE8 /* load-web-archive-1.html */; };
+		A17C467E2C98E4D20023F3C7 /* load-web-archive-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 573255A322139B9000396AE8 /* load-web-archive-2.html */; };
+		A17C467F2C98E4D20023F3C7 /* LoadInvalidURLRequest.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57901FB01CAF141C00ED64F9 /* LoadInvalidURLRequest.html */; };
+		A17C46802C98E4D20023F3C7 /* MediaPlaybackSleepAssertion.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDA315991ED540A5009F60D3 /* MediaPlaybackSleepAssertion.html */; };
+		A17C46812C98E4D20023F3C7 /* MemoryCacheDisableWithinResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E1220DC9155B287D0013E2FC /* MemoryCacheDisableWithinResourceLoadDelegate.html */; };
+		A17C46822C98E4D20023F3C7 /* MemoryCachePruneWithinResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 517E7E031511187500D0B008 /* MemoryCachePruneWithinResourceLoadDelegate.html */; };
+		A17C46832C98E4D20023F3C7 /* open-in-new-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A2E64E28455D230001FEEF /* open-in-new-tab.html */; };
+		A17C46842C98E4D20023F3C7 /* OpenNewWindow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 290A9BB81735F42300D71BBC /* OpenNewWindow.html */; };
+		A17C46852C98E4D20023F3C7 /* PageVisibilityStateWithWindowChanges.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A57A34F116AF69E200C2501F /* PageVisibilityStateWithWindowChanges.html */; };
+		A17C46862C98E4D20023F3C7 /* SetDocumentURI.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 52B8CF9415868CF000281053 /* SetDocumentURI.html */; };
+		A17C46872C98E4D20023F3C7 /* StopLoadingFromDidReceiveResponse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E194E1BC177E534A009C4D4E /* StopLoadingFromDidReceiveResponse.html */; };
+		A17C46882C98E4D20023F3C7 /* verboseMarkup.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C540F783152E5A7800A40C8C /* verboseMarkup.html */; };
+		A17C46892C98E4D20023F3C7 /* WebScriptObjectDescription.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 536770351CC812F900D425B1 /* WebScriptObjectDescription.html */; };
+		A17C468A2C98E4D20023F3C7 /* WillPerformClientRedirectToURLCrash.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE14F1A2181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html */; };
+		A17C468B2C98E4D20023F3C7 /* WindowlessWebViewWithMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A5E2027015B2180600C13E14 /* WindowlessWebViewWithMedia.html */; };
+		A17C468C2C98E54B0023F3C7 /* context-menu-control-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A13D1AD524AD4677003F92A8 /* context-menu-control-click.html */; };
+		A17C468D2C98E54B0023F3C7 /* ContextMenuImgWithVideo.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD0BD0A71F7997C2001AB2CF /* ContextMenuImgWithVideo.html */; };
+		A17C468E2C98E54B0023F3C7 /* dark-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CF59AE421E696FB006E37EC /* dark-mode.html */; };
+		A17C468F2C98E54B0023F3C7 /* 18-characters.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C045F9461385C2F800C0F3CD /* 18-characters.html */; };
+		A17C46902C98E54B0023F3C7 /* Ahem.ttf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C2B81851C89252300A5529F /* Ahem.ttf */; };
+		A17C46912C98E54B0023F3C7 /* all-content-in-one-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93D3D19B17B1A7B000C7C415 /* all-content-in-one-iframe.html */; };
+		A17C46922C98E54B0023F3C7 /* associate-form-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F6B7BE9617469B7E008A3445 /* associate-form-controls.html */; };
+		A17C46932C98E54B0023F3C7 /* async-script-load.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 11C2598C21FA618D004C9E23 /* async-script-load.html */; };
+		A17C46942C98E54B0023F3C7 /* audio-buffer-size.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1D5BE6AD2673EC5F00CB0B12 /* audio-buffer-size.html */; };
+		A17C46952C98E54B0023F3C7 /* audio-with-play-button.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9A91A21DED24D00FDE96E /* audio-with-play-button.html */; };
+		A17C46962C98E54B0023F3C7 /* auto-submitting-form.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 76E182DE15475A8300F1FADD /* auto-submitting-form.html */; };
+		A17C46972C98E54B0023F3C7 /* autoplay-check-frame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C60E631E53A9BA006DA181 /* autoplay-check-frame.html */; };
+		A17C46982C98E54B0023F3C7 /* autoplay-check-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C60E641E53A9BA006DA181 /* autoplay-check-in-iframe.html */; };
+		A17C46992C98E54B0023F3C7 /* autoplay-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F21E36BC55002C0D45 /* autoplay-check.html */; };
+		A17C469A2C98E54B0023F3C7 /* autoplay-inherits-gesture-from-document.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9B1043D1ECF9832000520FA /* autoplay-inherits-gesture-from-document.html */; };
+		A17C469B2C98E54B0023F3C7 /* autoplay-muted-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9BF06EE1E9C130400595E3E /* autoplay-muted-with-controls.html */; };
+		A17C469C2C98E54B0023F3C7 /* autoplay-no-audio-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F31E36BC55002C0D45 /* autoplay-no-audio-check.html */; };
+		A17C469D2C98E54B0023F3C7 /* autoplay-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99B675A1E3971FC00FC6C80 /* autoplay-with-controls.html */; };
+		A17C469E2C98E54B0023F3C7 /* autoplay-zero-volume-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99BDF881E8097E300C7170E /* autoplay-zero-volume-check.html */; };
+		A17C469F2C98E54B0023F3C7 /* basicITPDatabase.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4971B12C246239D30096994D /* basicITPDatabase.db */; };
+		A17C46A02C98E54B0023F3C7 /* beforeunload-slow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46FACF7323E883EE00A9EBC6 /* beforeunload-slow.html */; };
+		A17C46A12C98E54B0023F3C7 /* beforeunload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C3AEB223D0E50F001B0680 /* beforeunload.html */; };
+		A17C46A22C98E54B0023F3C7 /* bundle-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C486BA01AA1254B003F6F9B /* bundle-file.html */; };
+		A17C46A32C98E54B0023F3C7 /* chinese-character-with-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD4239B1E04BFD000200395 /* chinese-character-with-image.html */; };
+		A17C46A42C98E54B0023F3C7 /* close-from-within-create-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A50AA1F1A2A4EA500F4C345 /* close-from-within-create-page.html */; };
+		A17C46A52C98E54B0023F3C7 /* closed-shadow-tree-test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B270FED1DDC25FD002D53F3 /* closed-shadow-tree-test.html */; };
+		A17C46A62C98E54B0023F3C7 /* color-scheme.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31903C902764FE1400363472 /* color-scheme.html */; };
+		A17C46A72C98E54B0023F3C7 /* contentBlockerCheck.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E56861DF9148E00C9EE33 /* contentBlockerCheck.html */; };
+		A17C46A82C98E54B0023F3C7 /* cookie-consent-basic.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4034FA2275D5449003A81F8 /* cookie-consent-basic.html */; };
+		A17C46A92C98E54B0023F3C7 /* cube.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DDD4DA3270B8B3300659A61 /* cube.usdz */; };
+		A17C46AA2C98E54B0023F3C7 /* custom-protocol-sync-xhr.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 290F4274172A1FDE00939FF0 /* custom-protocol-sync-xhr.html */; };
+		A17C46AB2C98E54B0023F3C7 /* deferred-script-load.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 118153432208B7AC00B2CCD2 /* deferred-script-load.html */; };
+		A17C46AC2C98E54B0023F3C7 /* deferred-script.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = 118153452208B7E500B2CCD2 /* deferred-script.js */; };
+		A17C46AD2C98E54B0023F3C7 /* emptyTable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D902B228209B0500E2C3B8 /* emptyTable.html */; };
+		A17C46AE2C98E54B0023F3C7 /* encrypted.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = A14AAB641E78DC3F00C1ADC2 /* encrypted.pdf */; };
+		A17C46AF2C98E54B0023F3C7 /* enumerateMediaDevices.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07492B391DF8ADA400633DE1 /* enumerateMediaDevices.html */; };
+		A17C46B02C98E54B0023F3C7 /* execCopy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C5E1AFFD16B22179006CC1F2 /* execCopy.html */; };
+		A17C46B12C98E54B0023F3C7 /* file-with-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC2D004A12A9FEB300E732A3 /* file-with-anchor.html */; };
+		A17C46B22C98E54B0023F3C7 /* file-with-managedmse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E1007129C6D891009CEE99 /* file-with-managedmse.html */; };
+		A17C46B32C98E54B0023F3C7 /* file-with-mse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53219E910AA00CF1835 /* file-with-mse.html */; };
+		A17C46B42C98E54B0023F3C7 /* file-with-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 524BBC9B19DF3714002F1AF1 /* file-with-video.html */; };
+		A17C46B52C98E54B0023F3C7 /* find.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A02C84B125D4A5E00E3F4BD /* find.html */; };
+		A17C46B62C98E54B0023F3C7 /* findRanges.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C5101C4E176B8BB900EE9B15 /* findRanges.html */; };
+		A17C46B72C98E54B0023F3C7 /* fragment-navigation-before-load-event.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 462B4E7828E7B0AF00653230 /* fragment-navigation-before-load-event.html */; };
+		A17C46B82C98E54B0023F3C7 /* geolocationGetCurrentPosition.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EAC1828820E0023D412 /* geolocationGetCurrentPosition.html */; };
+		A17C46B92C98E54B0023F3C7 /* geolocationGetCurrentPositionWithHighAccuracy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EAE18288C040023D412 /* geolocationGetCurrentPositionWithHighAccuracy.html */; };
+		A17C46BA2C98E54B0023F3C7 /* geolocationWatchPosition.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EB018288F0F0023D412 /* geolocationWatchPosition.html */; };
+		A17C46BB2C98E54B0023F3C7 /* geolocationWatchPositionWithHighAccuracy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EB118288F0F0023D412 /* geolocationWatchPositionWithHighAccuracy.html */; };
+		A17C46BC2C98E54B0023F3C7 /* getUserMedia-webaudio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 41661C652355D98B00D33C27 /* getUserMedia-webaudio.html */; };
+		A17C46BD2C98E54B0023F3C7 /* getUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAB5 /* getUserMedia.html */; };
+		A17C46BE2C98E54B0023F3C7 /* getUserMedia2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 41BAF4E225AC9DB800D82F32 /* getUserMedia2.html */; };
+		A17C46BF2C98E54B0023F3C7 /* getUserMediaAudioVideoCapture.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAC5 /* getUserMediaAudioVideoCapture.html */; };
+		A17C46C02C98E54B0023F3C7 /* getUserMediaPermission.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4198524F27AD7B70005477B7 /* getUserMediaPermission.html */; };
+		A17C46C12C98E54B0023F3C7 /* icon.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = BCBD372E125ABBE600D2C29F /* icon.png */; };
+		A17C46C22C98E54B0023F3C7 /* idempotent-mode-autosizing-only-honors-percentages.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CC80CE92474F1F7004DC489 /* idempotent-mode-autosizing-only-honors-percentages.html */; };
+		A17C46C32C98E54B0023F3C7 /* input-focus-blur.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE3524F51B142BBB0028A7C5 /* input-focus-blur.html */; };
+		A17C46C42C98E54B0023F3C7 /* js-autoplay-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9B4AD2B1ECA6F7600F5FEA0 /* js-autoplay-audio.html */; };
+		A17C46C52C98E54B0023F3C7 /* js-play-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99B675B1E3971FC00FC6C80 /* js-play-with-controls.html */; };
+		A17C46C62C98E54B0023F3C7 /* large-red-square-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 55226A2E1EB969B600C36AD0 /* large-red-square-image.html */; };
+		A17C46C72C98E54B0023F3C7 /* link-with-download-attribute-with-slashes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8361F1771E610B2100759B25 /* link-with-download-attribute-with-slashes.html */; };
+		A17C46C82C98E54B0023F3C7 /* link-with-download-attribute.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8349D3C31DB9724F004A9F65 /* link-with-download-attribute.html */; };
+		A17C46C92C98E54B0023F3C7 /* link-with-title.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 378E647816326FDF00B6C676 /* link-with-title.html */; };
+		A17C46CA2C98E54B0023F3C7 /* long-email-viewport.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2D2FE8D9231745AB00B2E9C9 /* long-email-viewport.html */; };
+		A17C46CB2C98E54B0023F3C7 /* long-test.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9E8EE7421DED91E00797765 /* long-test.mp4 */; };
+		A17C46CC2C98E54B0023F3C7 /* lots-of-iframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9361002814DC957B0061379D /* lots-of-iframes.html */; };
+		A17C46CD2C98E54B0023F3C7 /* lots-of-images.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93AF4ECF1506F123007FD57E /* lots-of-images.html */; };
+		A17C46CE2C98E54B0023F3C7 /* lots-of-text-vertical-lr.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DD7D3AE178227AC0026E1E3 /* lots-of-text-vertical-lr.html */; };
+		A17C46CF2C98E54B0023F3C7 /* lots-of-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 930AD401150698B30067970F /* lots-of-text.html */; };
+		A17C46D02C98E54B0023F3C7 /* many-iframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = AD57AC1D1DA7463800FF1BDE /* many-iframes.html */; };
+		A17C46D12C98E54B0023F3C7 /* many-same-origin-iframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7772ECE022FE05E10009A799 /* many-same-origin-iframes.html */; };
+		A17C46D22C98E54B0023F3C7 /* media-loading.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD8394DE232AF15E00149495 /* media-loading.html */; };
+		A17C46D32C98E54B0023F3C7 /* mediastreamtrack-detached.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC9442B1EF1FBD20059C3C4 /* mediastreamtrack-detached.html */; };
+		A17C46D42C98E54B0023F3C7 /* missingTopFrameUniqueRedirectSameSiteStrictTableSchema.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4971B11F2453A87F0096994D /* missingTopFrameUniqueRedirectSameSiteStrictTableSchema.db */; };
+		A17C46D52C98E54B0023F3C7 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51CD1C711B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html */; };
+		A17C46D62C98E54B0023F3C7 /* mouse-button-listener.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A1458FB1AD5C03500E06772 /* mouse-button-listener.html */; };
+		A17C46D72C98E54B0023F3C7 /* mouse-move-listener.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 33E79E05137B5FCE00E32D99 /* mouse-move-listener.html */; };
+		A17C46D82C98E54B0023F3C7 /* navigation-client-default-crypto.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5797FE321EB15A8900B2F4A0 /* navigation-client-default-crypto.html */; };
+		A17C46D92C98E54B0023F3C7 /* no-autoplay-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99B675E1E39735C00FC6C80 /* no-autoplay-with-controls.html */; };
+		A17C46DA2C98E54B0023F3C7 /* ondevicechange.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAB6 /* ondevicechange.html */; };
+		A17C46DB2C98E54B0023F3C7 /* open-and-close-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEA6CF2719CCF69D0064F5A7 /* open-and-close-window.html */; };
+		A17C46DC2C98E54B0023F3C7 /* open-window-then-write-to-it.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 468BC454226539C800A36C96 /* open-window-then-write-to-it.html */; };
+		A17C46DD2C98E54B0023F3C7 /* open-window-with-file-url-with-host.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 41848F4324891815000E2588 /* open-window-with-file-url-with-host.html */; };
+		A17C46DE2C98E54B0023F3C7 /* orthogonal-flow-available-size.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CB2F27D24F883BE000A5BC1 /* orthogonal-flow-available-size.html */; };
+		A17C46DF2C98E54B0023F3C7 /* override-builtins-test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 83148B08202AC76800BADE99 /* override-builtins-test.html */; };
+		A17C46E02C98E54B0023F3C7 /* playable-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07492B391DF8ADA400633DQ1 /* playable-audio.html */; };
+		A17C46E12C98E54B0023F3C7 /* pop-up-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0EBBCC651FFF9DCE00FA42AB /* pop-up-check.html */; };
+		A17C46E22C98E54B0023F3C7 /* push-state.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F6FDDDD514241C48004F1729 /* push-state.html */; };
+		A17C46E32C98E54B0023F3C7 /* qr-code.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = E57B44C029ABFAA4006069DE /* qr-code.png */; };
+		A17C46E42C98E54B0023F3C7 /* red.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 95194CBF28A580E900343FDE /* red.html */; };
+		A17C46E52C98E54B0023F3C7 /* remove-node-on-drop.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4476F4A279082EB00931786 /* remove-node-on-drop.html */; };
+		A17C46E62C98E54B0023F3C7 /* scroll-to-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F5651F81FCE50E800310FBC /* scroll-to-anchor.html */; };
+		A17C46E72C98E54B0023F3C7 /* set-long-title.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A66BDB71EAF150100CCC924 /* set-long-title.html */; };
+		A17C46E82C98E54B0023F3C7 /* should-open-external-schemes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBABD481B71687C0051210A /* should-open-external-schemes.html */; };
+		A17C46E92C98E54B0023F3C7 /* simple-accelerated-compositing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1ADBEFBC130C6A0100D61D19 /* simple-accelerated-compositing.html */; };
+		A17C46EA2C98E54B0023F3C7 /* simple-form.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C0ADBE8412FCA6B600D2C129 /* simple-form.html */; };
+		A17C46EB2C98E54B0023F3C7 /* simple-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 33DC890E1419539300747EF7 /* simple-iframe.html */; };
+		A17C46EC2C98E54B0023F3C7 /* simple-image-overlay.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4EC8093260D2E620010311D /* simple-image-overlay.html */; };
+		A17C46ED2C98E54B0023F3C7 /* simple-responsive-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F460F668261262C70064F2B6 /* simple-responsive-page.html */; };
+		A17C46EE2C98E54B0023F3C7 /* simple-tall.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BCAA485514A021640088FAC4 /* simple-tall.html */; };
+		A17C46EF2C98E54B0023F3C7 /* simple.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC909778125571AB00083756 /* simple.html */; };
+		A17C46F02C98E54B0023F3C7 /* simple2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780361919AFF8001829A2 /* simple2.html */; };
+		A17C46F12C98E54B0023F3C7 /* simple3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780371919AFF8001829A2 /* simple3.html */; };
+		A17C46F22C98E54B0023F3C7 /* spacebar-scrolling.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C02B7882126615410026BF0F /* spacebar-scrolling.html */; };
+		A17C46F32C98E54B0023F3C7 /* test-mse-audio.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C234C72970E11400E35C4B /* test-mse-audio.webm */; };
+		A17C46F42C98E54B0023F3C7 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
+		A17C46F52C98E54B0023F3C7 /* test-mse.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BB6B7E296E8FFD0059B107 /* test-mse.webm */; };
+		A17C46F62C98E54B0023F3C7 /* test-without-audio-track.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F61E36BCD7002C0D45 /* test-without-audio-track.mp4 */; };
+		A17C46F72C98E54B0023F3C7 /* test.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 524BBCA019E30C63002F1AF1 /* test.mp4 */; };
+		A17C46F82C98E54B0023F3C7 /* test.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AE9E5081AE5AE8B00CF874B /* test.pdf */; };
+		A17C46F92C98E54B0023F3C7 /* test.xml in Copy Resources */ = {isa = PBXBuildFile; fileRef = 44D3F8422BE1DAD800BE0218 /* test.xml */; };
+		A17C46FA2C98E54B0023F3C7 /* UserInstalledAhem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */; };
+		A17C46FB2C98E54B0023F3C7 /* video-with-play-button.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9A91C21DED79400FDE96E /* video-with-play-button.html */; };
+		A17C46FC2C98E54B0023F3C7 /* video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07CD32F72065B72A0064A4BE /* video.html */; };
+		A17C46FD2C98E54B0023F3C7 /* webfont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C2B81841C8924A200A5529F /* webfont.html */; };
+		A17C46FE2C98E54B0023F3C7 /* window-open-then-document-open.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 468F2F932368DAA700F4B864 /* window-open-then-document-open.html */; };
+		A17C46FF2C98E58C0023F3C7 /* invalidDeviceIDHashSalts in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4A410F4D19AF7BEF002EBAB4 /* invalidDeviceIDHashSalts */; };
+		A17C47002C98E58C0023F3C7 /* LockdownModeFonts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4CC961E4294A36A000483F06 /* LockdownModeFonts.html */; };
+		A17C47012C98E58C0023F3C7 /* test_print.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C7101C625DD988700686200 /* test_print.pdf */; };
+		A17C47022C98E5C20023F3C7 /* 100x100-red.jp2 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 72F21E9728C9214C007BF315 /* 100x100-red.jp2 */; };
+		A17C47032C98E5C20023F3C7 /* 100x100-red.tga in Copy Resources */ = {isa = PBXBuildFile; fileRef = 55A817FE218101DF0004A39A /* 100x100-red.tga */; };
+		A17C47042C98E5C20023F3C7 /* 400x400-green.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = 55A817FD218101DF0004A39A /* 400x400-green.png */; };
+		A17C47052C98E5C20023F3C7 /* adaptive-image-glyph.heic in Copy Resources */ = {isa = PBXBuildFile; fileRef = E59CF8222C2D1E3700891383 /* adaptive-image-glyph.heic */; };
+		A17C47072C98E5C20023F3C7 /* alert.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C1EA9725758805005E409E /* alert.html */; };
+		A17C47082C98E5C20023F3C7 /* AllAhem.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = C25CCA0C1E5140E50026CB8A /* AllAhem.svg */; };
+		A17C47092C98E5C20023F3C7 /* apple-data-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A9202E1FEE34C800F59590 /* apple-data-url.html */; };
+		A17C470A2C98E5C20023F3C7 /* apple-pay-availability-existing-object.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB503C22A1C24400D4D979 /* apple-pay-availability-existing-object.html */; };
+		A17C470B2C98E5C20023F3C7 /* apple-pay-availability-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1798B8822435D2E000764BD /* apple-pay-availability-in-iframe.html */; };
+		A17C470C2C98E5C20023F3C7 /* apple-pay-availability.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1798B862243446B000764BD /* apple-pay-availability.html */; };
+		A17C470D2C98E5C20023F3C7 /* apple-pay-can-make-payment.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504222A2138F00D4D979 /* apple-pay-can-make-payment.html */; };
+		A17C470E2C98E5C20023F3C7 /* apple-pay-can-make-payments-with-active-card.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504022A2128400D4D979 /* apple-pay-can-make-payments-with-active-card.html */; };
+		A17C470F2C98E5C20023F3C7 /* apple-pay-can-make-payments.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB503E22A1E3B300D4D979 /* apple-pay-can-make-payments.html */; };
+		A17C47102C98E5C20023F3C7 /* apple-pay.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504422A2154B00D4D979 /* apple-pay.js */; };
+		A17C47112C98E5C20023F3C7 /* apple.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47D30EB1ED28619000482E1 /* apple.gif */; };
+		A17C47122C98E5C20023F3C7 /* ApplicationCache.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E593E1D3EB1DE00E3C62E /* ApplicationCache.db */; };
+		A17C47132C98E5C20023F3C7 /* ApplicationCache.db-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E593F1D3EB1DE00E3C62E /* ApplicationCache.db-shm */; };
+		A17C47142C98E5C20023F3C7 /* ApplicationCache.db-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C9E59401D3EB1DE00E3C62E /* ApplicationCache.db-wal */; };
+		A17C47152C98E5C20023F3C7 /* attachment-element.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4856CA21E6498A8009D7EE7 /* attachment-element.html */; };
+		A17C47162C98E5C20023F3C7 /* AttrStyle.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3760C4F221124BD000233ACC /* AttrStyle.html */; };
+		A17C47172C98E5C20023F3C7 /* audio-context-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46F03C1B255B2D3600AA51C5 /* audio-context-playing.html */; };
+		A17C47182C98E5C20023F3C7 /* audio-fingerprinting.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6332A2D51F800D47257 /* audio-fingerprinting.html */; };
+		A17C47192C98E5C20023F3C7 /* audio-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C94415FF21430B6700B1EDDA /* audio-with-controls.html */; };
+		A17C471A2C98E5C20023F3C7 /* audio-with-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779A211CE6B7001B371E /* audio-with-web-audio.html */; };
+		A17C471B2C98E5C20023F3C7 /* autofocus-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9981EF4692C0083FA08 /* autofocus-contenteditable.html */; };
+		A17C471C2C98E5C20023F3C7 /* autofocused-text-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93CFA8661CEB9DE1000565A8 /* autofocused-text-input.html */; };
+		A17C471D2C98E5C20023F3C7 /* autoplaying-multiple-media-elements.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9CD4221E6A6670019DB96 /* autoplaying-multiple-media-elements.html */; };
+		A17C471E2C98E5C20023F3C7 /* autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E14A5281D3FE8B80010F35B /* autoplaying-video-with-audio.html */; };
+		A17C471F2C98E5C20023F3C7 /* background-image-link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9971EF4692C0083FA08 /* background-image-link-and-input.html */; };
+		A17C47202C98E5C20023F3C7 /* BadServiceWorkerRegistrations-4.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 464C764C230DF83200AFB020 /* BadServiceWorkerRegistrations-4.sqlite3 */; };
+		A17C47212C98E5C20023F3C7 /* blinking-div.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DE71AFF1D49C2F000904094 /* blinking-div.html */; };
+		A17C47222C98E5C20023F3C7 /* camera-to-canvas.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EE /* camera-to-canvas.html */; };
+		A17C47232C98E5C20023F3C7 /* canvas-fingerprinting.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6362A2D51F900D47257 /* canvas-fingerprinting.html */; };
+		A17C47242C98E5C20023F3C7 /* canvas-image-data.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E7A66227222BB100E74D36 /* canvas-image-data.html */; };
+		A17C47252C98E5C20023F3C7 /* change-video-source-on-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06C41D8867700004BB30 /* change-video-source-on-click.html */; };
+		A17C47262C98E5C20023F3C7 /* change-video-source-on-end.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06C61D886A560004BB30 /* change-video-source-on-end.html */; };
+		A17C47272C98E5C20023F3C7 /* click-targets.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C3F2A32C44832B0029A47D /* click-targets.html */; };
+		A17C47282C98E5C20023F3C7 /* client-side-redirect.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 839AA35E21A26ACD00980DD6 /* client-side-redirect.html */; };
+		A17C47292C98E5C20023F3C7 /* clipboard.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F422A3EA235BB14500CF00CA /* clipboard.html */; };
+		A17C472A2C98E5C20023F3C7 /* cocoa-writer-markup-with-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B9332CD2320C73E002D50E8 /* cocoa-writer-markup-with-lists.html */; };
+		A17C472B2C98E5C20023F3C7 /* cocoa-writer-markup-with-system-fonts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BAE177A22E2BB6B00DF3098 /* cocoa-writer-markup-with-system-fonts.html */; };
+		A17C472C2C98E5C20023F3C7 /* color-drop.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E5036F77211BC22800BFDBE2 /* color-drop.html */; };
+		A17C472D2C98E5C20023F3C7 /* compressed-files.zip in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4B825D61EF4DBD4006E417F /* compressed-files.zip */; };
+		A17C472E2C98E5C20023F3C7 /* console-message-with-details.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = DF1C7CEB27F5305A00D8145C /* console-message-with-details.html */; };
+		A17C472F2C98E5C20023F3C7 /* contenteditable-and-target.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F469FB231F01803500401539 /* contenteditable-and-target.html */; };
+		A17C47302C98E5C20023F3C7 /* contenteditable-and-textarea.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99C1EF4692C0083FA08 /* contenteditable-and-textarea.html */; };
+		A17C47312C98E5C20023F3C7 /* contenteditable-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A32ECA1F0642F40047C544 /* contenteditable-in-iframe.html */; };
+		A17C47322C98E5C20023F3C7 /* contenteditable-user-select-user-drag.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E540058727B3A8320005653A /* contenteditable-user-select-user-drag.html */; };
+		A17C47332C98E5C20023F3C7 /* ContentFiltering.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A16F66B91C40EA2000BD4D24 /* ContentFiltering.html */; };
+		A17C47342C98E5C20023F3C7 /* CookieMessage.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C2936941D5BFD1900DEAB1E /* CookieMessage.html */; };
+		A17C47352C98E5C20023F3C7 /* copy-html.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B1056421F9047CC00D5583F /* copy-html.html */; };
+		A17C47362C98E5C20023F3C7 /* copy-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B62630B1F8C2510007EE29B /* copy-url.html */; };
+		A17C47372C98E5C20023F3C7 /* csp-document-uri-report.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4995A6EF25E876A300E5F0A9 /* csp-document-uri-report.html */; };
+		A17C47382C98E5C20023F3C7 /* CSSViewportUnits.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCC /* CSSViewportUnits.html */; };
+		A17C47392C98E5C20023F3C7 /* CSSViewportUnits.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCD /* CSSViewportUnits.svg */; };
+		A17C473A2C98E5C20023F3C7 /* cursor-styles.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4740A2C2A97C97E00B657B6 /* cursor-styles.html */; };
+		A17C473B2C98E5C20023F3C7 /* custom-draggable-div.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4AB57891F65164B00DB0DA1 /* custom-draggable-div.html */; };
+		A17C473C2C98E5C20023F3C7 /* data-detectors.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47DFB2421A8704A00021FB6 /* data-detectors.html */; };
+		A17C473D2C98E5C20023F3C7 /* DataTransfer-setDragImage.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F486B1CF1F6794FF00F34BDD /* DataTransfer-setDragImage.html */; };
+		A17C473E2C98E5C20023F3C7 /* DataTransfer.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F457A9B3202D535300F7E9D5 /* DataTransfer.html */; };
+		A17C473F2C98E5C20023F3C7 /* DataTransferItem-getAsEntry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4512E121F60C43400BB369E /* DataTransferItem-getAsEntry.html */; };
+		A17C47402C98E5C20023F3C7 /* disableGetUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */; };
+		A17C47412C98E5C20023F3C7 /* display-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 63A61B8A1FAD204D00F06885 /* display-mode.html */; };
+		A17C47422C98E5C20023F3C7 /* div-and-large-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99E1EF4692C0083FA08 /* div-and-large-image.html */; };
+		A17C47432C98E5C20023F3C7 /* DownloadRequestBlobURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 837A35F01D9A1E6400663C57 /* DownloadRequestBlobURL.html */; };
+		A17C47442C98E5C20023F3C7 /* DownloadRequestOriginalURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5714ECB81CA8B58800051AC8 /* DownloadRequestOriginalURL.html */; };
+		A17C47452C98E5C20023F3C7 /* DownloadRequestOriginalURL2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5714ECBC1CA8C21800051AC8 /* DownloadRequestOriginalURL2.html */; };
+		A17C47462C98E5C20023F3C7 /* DownloadRequestOriginalURLFrame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5714ECBA1CA8BFD100051AC8 /* DownloadRequestOriginalURLFrame.html */; };
+		A17C47472C98E5C20023F3C7 /* dragstart-change-selection-offscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */; };
+		A17C47482C98E5C20023F3C7 /* dragstart-clear-selection.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */; };
+		A17C47492C98E5C20023F3C7 /* dragstart-data.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46BD5682487062D008282D6 /* dragstart-data.html */; };
+		A17C474A2C98E5C20023F3C7 /* drop-targets.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4194AD01F5A2EA500ADD83F /* drop-targets.html */; };
+		A17C474B2C98E5C20023F3C7 /* dump-datatransfer-types.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EB29D5D1F762DA50023A5F1 /* dump-datatransfer-types.html */; };
+		A17C474C2C98E5C20023F3C7 /* duplicate-completion-handler-calls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A155022B1E050BC500A24C57 /* duplicate-completion-handler-calls.html */; };
+		A17C474D2C98E5C20023F3C7 /* editable-body-mixed-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CEF1562A102F4E00A370BE /* editable-body-mixed-text.html */; };
+		A17C474E2C98E5C20023F3C7 /* editable-body.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9984FACD1CFFB038008D198C /* editable-body.html */; };
+		A17C474F2C98E5C20023F3C7 /* editable-nested-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D9818E2196B911008230FC /* editable-nested-lists.html */; };
+		A17C47502C98E5C20023F3C7 /* editable-responsive-body.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4352F9E26D4037000E605E4 /* editable-responsive-body.html */; };
+		A17C47512C98E5C20023F3C7 /* editor-state-test-harness.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44D06441F395C0D001A0E29 /* editor-state-test-harness.html */; };
+		A17C47522C98E5C20023F3C7 /* element-fullscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */; };
+		A17C47532C98E5C20023F3C7 /* element-targeting-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4DADCFF2BABA80C008B398F /* element-targeting-1.html */; };
+		A17C47542C98E5C20023F3C7 /* element-targeting-10.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C127522C756B3A000BC609 /* element-targeting-10.html */; };
+		A17C47552C98E5C20023F3C7 /* element-targeting-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4365E232BB1181A005E8C1A /* element-targeting-2.html */; };
+		A17C47562C98E5C20023F3C7 /* element-targeting-3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41E44652BBCDC74002A856F /* element-targeting-3.html */; };
+		A17C47572C98E5C20023F3C7 /* element-targeting-4.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44A2A6E2BC202840044694E /* element-targeting-4.html */; };
+		A17C47582C98E5C20023F3C7 /* element-targeting-5.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FB84A02BC9F13A000D0B47 /* element-targeting-5.html */; };
+		A17C47592C98E5C20023F3C7 /* element-targeting-6.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */; };
+		A17C475A2C98E5C20023F3C7 /* element-targeting-7.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F405F8A42BD1D1B90020E6AB /* element-targeting-7.html */; };
+		A17C475B2C98E5C20023F3C7 /* element-targeting-8.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44CD9C92BD6ABF00080A6C7 /* element-targeting-8.html */; };
+		A17C475C2C98E5C20023F3C7 /* element-targeting-9.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */; };
+		A17C475D2C98E5C20023F3C7 /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */; };
+		A17C475E2C98E5C20023F3C7 /* enormous-video-with-sound.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */; };
+		A17C475F2C98E5C20023F3C7 /* enormous.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = F407FE381F1D0DE60017CF25 /* enormous.svg */; };
+		A17C47602C98E5C20023F3C7 /* event.ics in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41462AA2BC346130027261C /* event.ics */; };
+		A17C47612C98E5C20023F3C7 /* exif-orientation-8-llo.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */; };
+		A17C47622C98E5C20023F3C7 /* ExitFullscreenOnEnterPiP.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDA29B2A20FD344E00F15CED /* ExitFullscreenOnEnterPiP.html */; };
+		A17C47632C98E5C20023F3C7 /* fade-in-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F40B8D5D2810855900346417 /* fade-in-image.html */; };
+		A17C47642C98E5C20023F3C7 /* file-system-access.salt in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9358C33B273ED06A00F3B38C /* file-system-access.salt */; };
+		A17C47652C98E5C20023F3C7 /* file-uploading.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99B1EF4692C0083FA08 /* file-uploading.html */; };
+		A17C47662C98E5C20023F3C7 /* file-with-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D2E5C12731E37400BCCAED /* file-with-iframe.html */; };
+		A17C47672C98E5C20023F3C7 /* find.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = A17EAC542083056E0084B41B /* find.pdf */; };
+		A17C47682C98E5C20023F3C7 /* fingerprint-audio-worklet.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6342A2D51F800D47257 /* fingerprint-audio-worklet.js */; };
+		A17C47692C98E5C20023F3C7 /* fixed-nav-bar.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43E3BC020DADB8000A4E7ED /* fixed-nav-bar.html */; };
+		A17C476A2C98E5C20023F3C7 /* focus-inputs.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93575C551D30366E000D604D /* focus-inputs.html */; };
+		A17C476B2C98E5C20023F3C7 /* full-page-dropzone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46128D8211E496300D9FADB /* full-page-dropzone.html */; };
+		A17C476C2C98E5C20023F3C7 /* full-size-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F405BA1D4C0CF8007A9707 /* full-size-autoplaying-video-with-audio.html */; };
+		A17C476D2C98E5C20023F3C7 /* FullscreenDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */; };
+		A17C476E2C98E5C20023F3C7 /* FullscreenLayoutConstraints.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */; };
+		A17C476F2C98E5C20023F3C7 /* FullscreenTopContentInset.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDE195B21CFE0ADE0053D256 /* FullscreenTopContentInset.html */; };
+		A17C47702C98E5C20023F3C7 /* general-storage-directory-indexeddb.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A9BF6227BF67F4000B44D3 /* general-storage-directory-indexeddb.sqlite3 */; };
+		A17C47712C98E5C20023F3C7 /* general-storage-directory-localstorage.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A9BF5E27BF3678000B44D3 /* general-storage-directory-localstorage.sqlite3 */; };
+		A17C47722C98E5C20023F3C7 /* general-storage-directory.origin in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A9BF6027BF5AE4000B44D3 /* general-storage-directory.origin */; };
+		A17C47732C98E5C20023F3C7 /* general-storage-directory.salt in Copy Resources */ = {isa = PBXBuildFile; fileRef = 936EC36527BA3AF200AFA8AE /* general-storage-directory.salt */; };
+		A17C47742C98E5C20023F3C7 /* GeolocationGetCurrentPositionResult.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 636353A61E9861940009F8AF /* GeolocationGetCurrentPositionResult.html */; };
+		A17C47752C98E5C20023F3C7 /* getDisplayMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07E1F6A11FFC44F90096C7EC /* getDisplayMedia.html */; };
+		A17C47762C98E5C20023F3C7 /* GetSessionCookie.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 467C565121B5ECDF0057516D /* GetSessionCookie.html */; };
+		A17C47772C98E5C20023F3C7 /* gif-and-file-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47D30ED1ED28A6C000482E1 /* gif-and-file-input.html */; };
+		A17C47782C98E5C20023F3C7 /* green-400x400.webp in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45C63FF28178AC40090DFAB /* green-400x400.webp */; };
+		A17C47792C98E5C20023F3C7 /* Helvetica_light.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CC4C74C28890CE100A3B23D /* Helvetica_light.svg */; };
+		A17C477A2C98E5C20023F3C7 /* IDBCheckpointWAL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = EB230D3D245E722E00C66AD1 /* IDBCheckpointWAL.html */; };
+		A17C477B2C98E5C20023F3C7 /* IDBDeleteRecovery.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 510477761D298E57009747EB /* IDBDeleteRecovery.html */; };
+		A17C477C2C98E5C20023F3C7 /* IDBDeleteRecovery.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5104776F1D298D85009747EB /* IDBDeleteRecovery.sqlite3 */; };
+		A17C477D2C98E5C20023F3C7 /* IDBDeleteRecovery.sqlite3-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 510477701D298D85009747EB /* IDBDeleteRecovery.sqlite3-shm */; };
+		A17C477E2C98E5C20023F3C7 /* IDBDeleteRecovery.sqlite3-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 510477711D298D85009747EB /* IDBDeleteRecovery.sqlite3-wal */; };
+		A17C477F2C98E5C20023F3C7 /* IDBIndexUpgradeToV2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF01E01CD53006F8D0B /* IDBIndexUpgradeToV2.html */; };
+		A17C47802C98E5C20023F3C7 /* IDBIndexUpgradeToV2WithMultipleIndices.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A2749A251EF52A00A1B6D4 /* IDBIndexUpgradeToV2WithMultipleIndices.html */; };
+		A17C47812C98E5C20023F3C7 /* IDBObjectStoreInfoUpgrade.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93BCBC8123CC6EF500CA2221 /* IDBObjectStoreInfoUpgrade.sqlite3 */; };
+		A17C47822C98E5C20023F3C7 /* IDBObjectStoreInfoUpgradeToV2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93BCBC8223CC6EF500CA2221 /* IDBObjectStoreInfoUpgradeToV2.html */; };
+		A17C47832C98E5C20023F3C7 /* image-and-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9991EF4692C0083FA08 /* image-and-contenteditable.html */; };
+		A17C47842C98E5C20023F3C7 /* image-and-file-upload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E0A2B321223F2D00AF7C7F /* image-and-file-upload.html */; };
+		A17C47852C98E5C20023F3C7 /* image-and-textarea.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9931EF4692C0083FA08 /* image-and-textarea.html */; };
+		A17C47862C98E5C20023F3C7 /* image-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F491DBAD281DE0980081705F /* image-controls.html */; };
+		A17C47872C98E5C20023F3C7 /* image-in-link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4DEF6EC1E9B4D950048EF61 /* image-in-link-and-input.html */; };
+		A17C47882C98E5C20023F3C7 /* image-map.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45B63FA1F197F33009D38B9 /* image-map.html */; };
+		A17C47892C98E5C20023F3C7 /* image-with-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1F0559E42890A09D002E279C /* image-with-text.html */; };
+		A17C478A2C98E5C20023F3C7 /* image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3128A814237640FD00D90D40 /* image.html */; };
+		A17C478B2C98E5C20023F3C7 /* ImmediateFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C9C7F4F2891234500C4649E /* ImmediateFont.html */; };
+		A17C478C2C98E5C20023F3C7 /* in-app-browser-privacy-local-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D7FBA7241FDDDA00AB67FA /* in-app-browser-privacy-local-file.html */; };
+		A17C478D2C98E5C20023F3C7 /* incorrectCreateTableSchema.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4971B1172451F2780096994D /* incorrectCreateTableSchema.db */; };
+		A17C478E2C98E5C20023F3C7 /* indexeddb-persistence-third-party.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9341C95627CD50680023C0F4 /* indexeddb-persistence-third-party.sqlite3 */; };
+		A17C478F2C98E5C20023F3C7 /* IndexedDB.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 934FA5C720F69FEE0040DC1B /* IndexedDB.sqlite3 */; };
+		A17C47902C98E5C20023F3C7 /* IndexedDB.sqlite3-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 934FA5C620F69FED0040DC1B /* IndexedDB.sqlite3-shm */; };
+		A17C47912C98E5C20023F3C7 /* IndexedDB.sqlite3-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 934FA5C520F69FED0040DC1B /* IndexedDB.sqlite3-wal */; };
+		A17C47922C98E5C20023F3C7 /* IndexedDBDatabaseProcessKill-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51A587821D272EB5004BA9AF /* IndexedDBDatabaseProcessKill-1.html */; };
+		A17C47932C98E5C20023F3C7 /* IndexedDBFileName-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CAB0FF51223323F6006CA5B0 /* IndexedDBFileName-1.html */; };
+		A17C47942C98E5C20023F3C7 /* IndexedDBFileName-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CAB0FF50223323F6006CA5B0 /* IndexedDBFileName-2.html */; };
+		A17C47952C98E5C20023F3C7 /* IndexedDBInPageCache.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9399BA02237110BF008392BF /* IndexedDBInPageCache.html */; };
+		A17C47962C98E5C20023F3C7 /* IndexedDBMultiProcess-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4C1C84F52C0042C82E /* IndexedDBMultiProcess-1.html */; };
+		A17C47972C98E5C20023F3C7 /* IndexedDBMultiProcess-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4D1C84F52C0042C82E /* IndexedDBMultiProcess-2.html */; };
+		A17C47982C98E5C20023F3C7 /* IndexedDBMultiProcess-3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51A5877C1D1B3D8D004BA9AF /* IndexedDBMultiProcess-3.html */; };
+		A17C47992C98E5C20023F3C7 /* IndexedDBNotInPageCache.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9399BA03237110BF008392BF /* IndexedDBNotInPageCache.html */; };
+		A17C479A2C98E5C20023F3C7 /* IndexedDBPersistence-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE941C80FADD0064FB98 /* IndexedDBPersistence-1.html */; };
+		A17C479B2C98E5C20023F3C7 /* IndexedDBPersistence-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE951C80FADD0064FB98 /* IndexedDBPersistence-2.html */; };
+		A17C479C2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E241F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3 */; };
+		A17C479D2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E261F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-shm */; };
+		A17C479E2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-wal in Copy Resources */ = {isa = PBXBuildFile; fileRef = 571F7FCF1F2961E100946648 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-wal */; };
+		A17C479F2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibilityRead.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E251F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityRead.html */; };
+		A17C47A02C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibilityWrite.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57599E231F07192C00A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityWrite.html */; };
+		A17C47A12C98E5C20023F3C7 /* IndexedDBSuspendImminently.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA2879D9226E6978001026F5 /* IndexedDBSuspendImminently.html */; };
+		A17C47A22C98E5C20023F3C7 /* IndexedDBTempFileSize-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA5B94D02190C0E00059FE38 /* IndexedDBTempFileSize-1.html */; };
+		A17C47A32C98E5C20023F3C7 /* IndexedDBTempFileSize-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA5B94D12190C0E00059FE38 /* IndexedDBTempFileSize-2.html */; };
+		A17C47A42C98E5C20023F3C7 /* IndexedDBUserDelete.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA97B393219366470045DF6F /* IndexedDBUserDelete.html */; };
+		A17C47A52C98E5C20023F3C7 /* IndexUpgrade.blob in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF21E01CD77006F8D0B /* IndexUpgrade.blob */; };
+		A17C47A62C98E5C20023F3C7 /* IndexUpgrade.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF31E01CD77006F8D0B /* IndexUpgrade.sqlite3 */; };
+		A17C47A72C98E5C20023F3C7 /* IndexUpgradeWithMultipleIndices.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A274A1252163D600A1B6D4 /* IndexUpgradeWithMultipleIndices.sqlite3 */; };
+		A17C47A82C98E5C20023F3C7 /* IndexUpgradeWithMultipleIndicesHaveSameID.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93A274A4252241D000A1B6D4 /* IndexUpgradeWithMultipleIndicesHaveSameID.sqlite3 */; };
+		A17C47A92C98E5C20023F3C7 /* input-field-in-scrollable-document.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06CC1D8A42910004BB30 /* input-field-in-scrollable-document.html */; };
+		A17C47AA2C98E5C20023F3C7 /* InspectorExtension-basic-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 996EDCCA270E70AB006DF175 /* InspectorExtension-basic-page.html */; };
+		A17C47AB2C98E5C20023F3C7 /* InspectorExtension-basic-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 99E2846726F9413B0003F1FA /* InspectorExtension-basic-tab.html */; };
+		A17C47AC2C98E5C20023F3C7 /* InspectorExtension-TabIcon-30x30.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = 99E2846526F93D760003F1FA /* InspectorExtension-TabIcon-30x30.png */; };
+		A17C47AD2C98E5C20023F3C7 /* KillWebProcessWithOpenConnection-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 937A6C8824357BF300C3A6B0 /* KillWebProcessWithOpenConnection-1.html */; };
+		A17C47AE2C98E5C20023F3C7 /* KillWebProcessWithOpenConnection-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 937A6C8924357BF300C3A6B0 /* KillWebProcessWithOpenConnection-2.html */; };
+		A17C47AF2C98E5C20023F3C7 /* large-red-square.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4538EF01E846B4100B5C953 /* large-red-square.png */; };
+		A17C47B02C98E5C20023F3C7 /* large-video-hides-controls-after-seek-to-end.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1B7B011D41B1B3007558B4 /* large-video-hides-controls-after-seek-to-end.html */; };
+		A17C47B12C98E5C20023F3C7 /* large-video-mutes-onplaying.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E54F40C1D7BC83900921ADF /* large-video-mutes-onplaying.html */; };
+		A17C47B22C98E5C20023F3C7 /* large-video-offscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2EFF06C21D8862120004BB30 /* large-video-offscreen.html */; };
+		A17C47B32C98E5C20023F3C7 /* large-video-playing-scroll-away.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AF21D79E75400129407 /* large-video-playing-scroll-away.html */; };
+		A17C47B42C98E5C20023F3C7 /* large-video-seek-after-ending.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1B7AFF1D41A95F007558B4 /* large-video-seek-after-ending.html */; };
+		A17C47B52C98E5C20023F3C7 /* large-video-seek-to-beginning-and-play-after-ending.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1DFDF01D42E14400714A00 /* large-video-seek-to-beginning-and-play-after-ending.html */; };
+		A17C47B62C98E5C20023F3C7 /* large-video-test-now-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F137911D9B6832002BEC57 /* large-video-test-now-playing.html */; };
+		A17C47B72C98E5C20023F3C7 /* large-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 936F727E1CD7D9D00068A0FB /* large-video-with-audio.html */; };
+		A17C47B82C98E5C20023F3C7 /* large-video-with-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 936F727F1CD7D9D00068A0FB /* large-video-with-audio.mp4 */; };
+		A17C47B92C98E5C20023F3C7 /* large-video-without-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93625D261CD973AF006DC1F1 /* large-video-without-audio.html */; };
+		A17C47BA2C98E5C20023F3C7 /* large-videos-autoplaying-click-to-pause.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AEE1D79DE6F00129407 /* large-videos-autoplaying-click-to-pause.html */; };
+		A17C47BB2C98E5C20023F3C7 /* large-videos-autoplaying-scroll-to-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AF01D79E51400129407 /* large-videos-autoplaying-scroll-to-video.html */; };
+		A17C47BC2C98E5C20023F3C7 /* large-videos-paused-video-hides-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AE81D78B52B00129407 /* large-videos-paused-video-hides-controls.html */; };
+		A17C47BD2C98E5C20023F3C7 /* large-videos-playing-muted-video-hides-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AEC1D78B90200129407 /* large-videos-playing-muted-video-hides-controls.html */; };
+		A17C47BE2C98E5C20023F3C7 /* large-videos-playing-video-keeps-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E691AE91D78B52B00129407 /* large-videos-playing-video-keeps-controls.html */; };
+		A17C47BF2C98E5C20023F3C7 /* large-videos-with-audio-autoplay.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1DFDEE1D42A6EB00714A00 /* large-videos-with-audio-autoplay.html */; };
+		A17C47C02C98E5C20023F3C7 /* large-videos-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E1DFDEC1D42A41C00714A00 /* large-videos-with-audio.html */; };
+		A17C47C12C98E5C20023F3C7 /* LineBreaking.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C25CCA0A1E513F490026CB8A /* LineBreaking.html */; };
+		A17C47C22C98E5C20023F3C7 /* link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9961EF4692C0083FA08 /* link-and-input.html */; };
+		A17C47C32C98E5C20023F3C7 /* link-and-target-div.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99D1EF4692C0083FA08 /* link-and-target-div.html */; };
+		A17C47C42C98E5C20023F3C7 /* link-in-iframe-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46128D1211E2D2500D9FADB /* link-in-iframe-and-input.html */; };
+		A17C47C52C98E5C20023F3C7 /* link-with-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3128A81223763F0B00D90D40 /* link-with-image.html */; };
+		A17C47C62C98E5C20023F3C7 /* load-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F9AD13298C715D00F92EDF /* load-image.html */; };
+		A17C47C72C98E5C20023F3C7 /* local-storage-process-crashes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA7787FE228CEFC700E50463 /* local-storage-process-crashes.html */; };
+		A17C47C82C98E5C20023F3C7 /* local-storage-process-suspends-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9368A25D229EFB3A00A829CA /* local-storage-process-suspends-1.html */; };
+		A17C47C92C98E5C20023F3C7 /* local-storage-process-suspends-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9368A25C229EFB3A00A829CA /* local-storage-process-suspends-2.html */; };
+		A17C47CA2C98E5C20023F3C7 /* localstorage-empty-string-value.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8C10AF97206467830018FD90 /* localstorage-empty-string-value.html */; };
+		A17C47CB2C98E5C20023F3C7 /* localstorage-open-window-private.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93D119FB22C57112009BE3C7 /* localstorage-open-window-private.html */; };
+		A17C47CC2C98E5C20023F3C7 /* LocalStorageClear.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E6A8951D2F1C7700C004B6 /* LocalStorageClear.html */; };
+		A17C47CD2C98E5C20023F3C7 /* LocalStorageNullEntries.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C519E21D35629600DAA51A /* LocalStorageNullEntries.html */; };
+		A17C47CE2C98E5C20023F3C7 /* LocalStorageNullEntries.localstorage in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C519E31D35629600DAA51A /* LocalStorageNullEntries.localstorage */; };
+		A17C47CF2C98E5C20023F3C7 /* LocalStorageNullEntries.localstorage-shm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46C519E41D35629600DAA51A /* LocalStorageNullEntries.localstorage-shm */; };
+		A17C47D02C98E5C20023F3C7 /* LocalStorageQuirkEnabled.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A6A2C711DCCFB0200C0D085 /* LocalStorageQuirkEnabled.html */; };
+		A17C47D12C98E5C20023F3C7 /* LockdownModePDF.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A33FF2F27C82F0B00D7E03E /* LockdownModePDF.html */; };
+		A17C47D22C98E5C20023F3C7 /* media-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EB /* media-remote.html */; };
+		A17C47D32C98E5C20023F3C7 /* mso-list-compat-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B59F12920340854009E63D5 /* mso-list-compat-mode.html */; };
+		A17C47D42C98E5C20023F3C7 /* mso-list-on-h4.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BCD4119206D5ED7001D71BE /* mso-list-on-h4.html */; };
+		A17C47D52C98E5C20023F3C7 /* mso-list.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BF356CC202D44F200F71160 /* mso-list.html */; };
+		A17C47D62C98E5C20023F3C7 /* multiple-images.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42F0811274497C8007E0D90 /* multiple-images.html */; };
+		A17C47D72C98E5C20023F3C7 /* multiple-pages.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D2C66B2BCF9DE400DADC86 /* multiple-pages.pdf */; };
+		A17C47D82C98E5C20023F3C7 /* nested-frames.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F455DB8C2BAE37C100732E1B /* nested-frames.html */; };
+		A17C47D92C98E5C20023F3C7 /* nested-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E4838462169DD42002F4531 /* nested-lists.html */; };
+		A17C47DA2C98E5C20023F3C7 /* notify-resourceLoadObserver.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 466C3842210637CE006A88DE /* notify-resourceLoadObserver.html */; };
+		A17C47DB2C98E5C20023F3C7 /* now-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDB5DFFE21360ED800D3E189 /* now-playing.html */; };
+		A17C47DC2C98E5C20023F3C7 /* offscreen-iframe-of-media-document.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93E2D2751ED7D51700FA76F6 /* offscreen-iframe-of-media-document.html */; };
+		A17C47DD2C98E5C20023F3C7 /* offscreen-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F460BEE727A1F2D6007B87D9 /* offscreen-image.html */; };
+		A17C47DE2C98E5C20023F3C7 /* open-multiple-external-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7CCB99221D3B44E7003922F6 /* open-multiple-external-url.html */; };
+		A17C47DF2C98E5C20023F3C7 /* opendatabase-always-exists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 931C281B22BC5583001D98C4 /* opendatabase-always-exists.html */; };
+		A17C47E02C98E5C20023F3C7 /* overflow-hidden.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F49992C5248DABE400034167 /* overflow-hidden.html */; };
+		A17C47E12C98E5C20023F3C7 /* page-with-csp-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1341E3A803400C73293 /* page-with-csp-iframe.html */; };
+		A17C47E22C98E5C20023F3C7 /* page-with-csp.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1351E3A803400C73293 /* page-with-csp.html */; };
+		A17C47E32C98E5C20023F3C7 /* page-without-csp-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1361E3A803400C73293 /* page-without-csp-iframe.html */; };
+		A17C47E42C98E5C20023F3C7 /* page-without-csp.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1371E3A803400C73293 /* page-without-csp.html */; };
+		A17C47E52C98E5C20023F3C7 /* paint-significant-area-milestone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4B86D4E20BCD5970099A7E6 /* paint-significant-area-milestone.html */; };
+		A17C47E62C98E5C20023F3C7 /* password-protected.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1409AD81E7254AC004949D9 /* password-protected.pages */; };
+		A17C47E72C98E5C20023F3C7 /* paste-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D3A61F7B21CC00BD4962 /* paste-image.html */; };
+		A17C47E82C98E5C20023F3C7 /* paste-rtfd.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B7D740E1F8377E60006C432 /* paste-rtfd.html */; };
+		A17C47E92C98E5C20023F3C7 /* PictureInPictureDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FCC4FE61EC4E87E0076E37C /* PictureInPictureDelegate.html */; };
+		A17C47EA2C98E5C20023F3C7 /* play-audio-on-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F415086C1DA040C10044BE9B /* play-audio-on-click.html */; };
+		A17C47EB2C98E5C20023F3C7 /* postMessage-regularly.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 465C23AE2640C3C500F2FC7F /* postMessage-regularly.html */; };
+		A17C47EC2C98E5C20023F3C7 /* postMessage-various-types.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46FD40302A6B3E3500A1B210 /* postMessage-various-types.html */; };
+		A17C47ED2C98E5C20023F3C7 /* prevent-operation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9941EF4692C0083FA08 /* prevent-operation.html */; };
+		A17C47EE2C98E5C20023F3C7 /* prevent-start.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99A1EF4692C0083FA08 /* prevent-start.html */; };
+		A17C47EF2C98E5C20023F3C7 /* rendered-image-excluding-overflow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A12DDBFF1E8373C100CF6CAE /* rendered-image-excluding-overflow.html */; };
+		A17C47F02C98E5C20023F3C7 /* resourceLoadStatisticsMissingUniqueIndex.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 498D030926376B2C009CBFAD /* resourceLoadStatisticsMissingUniqueIndex.db */; };
+		A17C47F12C98E5C20023F3C7 /* rich-and-plain-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46849BF1EEF5EDC00B937FE /* rich-and-plain-text.html */; };
+		A17C47F22C98E5C20023F3C7 /* rich-color-filtered.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CE6FAC12320264F00E48F6E /* rich-color-filtered.html */; };
+		A17C47F32C98E5C20023F3C7 /* rich-text-attributes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E92B8F6216490C3005B64F0 /* rich-text-attributes.html */; };
+		A17C47F42C98E5C20023F3C7 /* selected-text-and-textarea.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E0A295211FC5A300AF7C7F /* selected-text-and-textarea.html */; };
+		A17C47F52C98E5C20023F3C7 /* selected-text-image-link-and-editable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D65DA71F5E46C0009D8C27 /* selected-text-image-link-and-editable.html */; };
+		A17C47F62C98E5C20023F3C7 /* SetSessionCookie.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 467C565221B5ECDF0057516D /* SetSessionCookie.html */; };
+		A17C47F72C98E5C20023F3C7 /* significant-text-milestone-article.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E3D80720F708E4007B58C5 /* significant-text-milestone-article.html */; };
+		A17C47F82C98E5C20023F3C7 /* significant-text-milestone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FC077620F0108100CA043C /* significant-text-milestone.html */; };
+		A17C47F92C98E5C20023F3C7 /* silence-long.m4a in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9B4AD291ECA6EA500F5FEA0 /* silence-long.m4a */; };
+		A17C47FA2C98E5C20023F3C7 /* simple-editor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D060072734A08C008FA67A /* simple-editor.html */; };
+		A17C47FB2C98E5C20023F3C7 /* skinny-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F405BB1D4C0CF8007A9707 /* skinny-autoplaying-video-with-audio.html */; };
+		A17C47FC2C98E5C20023F3C7 /* SpaceOnly.otf in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CFCDD8249FC9D900527482 /* SpaceOnly.otf */; };
+		A17C47FD2C98E5C20023F3C7 /* speechrecognition-basic.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9360270525A3B28E00367670 /* speechrecognition-basic.html */; };
+		A17C47FE2C98E5C20023F3C7 /* speechrecognition-user-permission-persistence.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9342589D255B66A00059EEDD /* speechrecognition-user-permission-persistence.html */; };
+		A17C47FF2C98E5C20023F3C7 /* start-offset.ts in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0721D4582838295400A95853 /* start-offset.ts */; };
+		A17C48002C98E5C20023F3C7 /* StoreBlobToBeDeleted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 515BE16E1D4288FF00DD7C68 /* StoreBlobToBeDeleted.html */; };
+		A17C48012C98E5C20023F3C7 /* sunset-in-cupertino-100px.tiff in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D3A11F7B202100BD4962 /* sunset-in-cupertino-100px.tiff */; };
+		A17C48022C98E5C20023F3C7 /* sunset-in-cupertino-200px.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D3A01F7B202000BD4962 /* sunset-in-cupertino-200px.png */; };
+		A17C48032C98E5C20023F3C7 /* sunset-in-cupertino-400px.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D39F1F7B202000BD4962 /* sunset-in-cupertino-400px.gif */; };
+		A17C48042C98E5C20023F3C7 /* sunset-in-cupertino-600px.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9BD6D39E1F7B201E00BD4962 /* sunset-in-cupertino-600px.jpg */; };
+		A17C48052C98E5C20023F3C7 /* SVGFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CC4C74B28890C5400A3B23D /* SVGFont.html */; };
+		A17C48062C98E5C20023F3C7 /* system-preview-trigger.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31B76E4423299BA3007FED2C /* system-preview-trigger.html */; };
+		A17C48072C98E5C20023F3C7 /* system-preview.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A4A29F7338C00A7FB0F /* system-preview.html */; };
+		A17C48082C98E5C20023F3C7 /* SystemPreviewBlobNaming.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 313C3A0121E5677A00DBA86E /* SystemPreviewBlobNaming.html */; };
+		A17C48092C98E5C20023F3C7 /* test.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46D43AA26D7090300969E5E /* test.jpg */; };
+		A17C480A2C98E5C20023F3C7 /* test.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49C64FD628349C19005BF0C2 /* test.pages */; };
+		A17C480B2C98E5C20023F3C7 /* TestModalContainerControls.mlmodelc in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45EB60327739F2B003571AE /* TestModalContainerControls.mlmodelc */; };
+		A17C480C2C98E5C20023F3C7 /* text-and-password-inputs.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E9896141D8F092B00739892 /* text-and-password-inputs.html */; };
+		A17C480D2C98E5C20023F3C7 /* text-with-async-script.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CD74C520FDACF500DE3794 /* text-with-async-script.html */; };
+		A17C480E2C98E5C20023F3C7 /* text-with-deferred-script.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44C7A0420FAAE320014478C /* text-with-deferred-script.html */; };
+		A17C480F2C98E5C20023F3C7 /* text-with-web-font.webarchive in Copy Resources */ = {isa = PBXBuildFile; fileRef = F40398892B2D0AC700A7AA85 /* text-with-web-font.webarchive */; };
+		A17C48102C98E5C20023F3C7 /* textarea-to-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9951EF4692C0083FA08 /* textarea-to-input.html */; };
+		A17C48112C98E5C20023F3C7 /* TextWidth.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C22FA32C228F877A009D7988 /* TextWidth.html */; };
+		A17C48122C98E5C20023F3C7 /* try-text-select-with-disabled-text-interaction.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4952BE5C2578113900B0AEF1 /* try-text-select-with-disabled-text-interaction.html */; };
+		A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4451C751EB8FD7C0020C5DA /* two-paragraph-contenteditable.html */; };
+		A17C48142C98E5C20023F3C7 /* UnitBox.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5229F733D300A7FB0F /* UnitBox.usdz */; };
+		A17C48152C98E5C20023F3C7 /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
+		A17C48162C98E5C20023F3C7 /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
+		A17C48172C98E5C20023F3C7 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DF22357E45D00E85E09 /* web-authentication-get-assertion-hid-cancel.html */; };
+		A17C48182C98E5C20023F3C7 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 521D1B7227713E80003900C5 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html */; };
+		A17C48192C98E5C20023F3C7 /* web-authentication-get-assertion-hid-internal-uv.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 52C8C1392706439000BDF3B7 /* web-authentication-get-assertion-hid-internal-uv.html */; };
+		A17C481A2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-multiple-accounts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 579F1BFF23C92FD300C7D4B4 /* web-authentication-get-assertion-hid-multiple-accounts.html */; };
+		A17C481B2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-no-credentials.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 577454CF2359B338008E1ED7 /* web-authentication-get-assertion-hid-no-credentials.html */; };
+		A17C481C2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-pin-auth-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44B23ECD20300246010 /* web-authentication-get-assertion-hid-pin-auth-blocked-error.html */; };
+		A17C481D2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44D23ECD26100246010 /* web-authentication-get-assertion-hid-pin-invalid-error-retry.html */; };
+		A17C481E2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-pin.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26FB23C3F86500D5CF67 /* web-authentication-get-assertion-hid-pin.html */; };
+		A17C481F2C98E5C20023F3C7 /* web-authentication-get-assertion-hid.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DEB234F1F8000E85E09 /* web-authentication-get-assertion-hid.html */; };
+		A17C48202C98E5C20023F3C7 /* web-authentication-get-assertion-la-no-mock.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57EDFC5F245A279900959521 /* web-authentication-get-assertion-la-no-mock.html */; };
+		A17C48212C98E5C20023F3C7 /* web-authentication-get-assertion-la.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 572CEF70240F86AE00C412A2 /* web-authentication-get-assertion-la.html */; };
+		A17C48222C98E5C20023F3C7 /* web-authentication-get-assertion-nfc-multiple-tags.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5798337B235EB65C008E5547 /* web-authentication-get-assertion-nfc-multiple-tags.html */; };
+		A17C48232C98E5C20023F3C7 /* web-authentication-get-assertion-nfc-pin-disconnect.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57537EE724BEA0190048DBA5 /* web-authentication-get-assertion-nfc-pin-disconnect.html */; };
+		A17C48242C98E5C20023F3C7 /* web-authentication-get-assertion-nfc.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DE9234EA60B00E85E09 /* web-authentication-get-assertion-nfc.html */; };
+		A17C48252C98E5C20023F3C7 /* web-authentication-get-assertion-u2f-no-credentials.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 577454D12359BAD5008E1ED7 /* web-authentication-get-assertion-u2f-no-credentials.html */; };
+		A17C48262C98E5C20023F3C7 /* web-authentication-get-assertion.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57C6244F2346C1EC00383FE7 /* web-authentication-get-assertion.html */; };
+		A17C48272C98E5C20023F3C7 /* web-authentication-make-credential-hid-internal-uv.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 52C8C1372706437C00BDF3B7 /* web-authentication-make-credential-hid-internal-uv.html */; };
+		A17C48282C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-auth-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44723ECD01300246010 /* web-authentication-make-credential-hid-pin-auth-blocked-error.html */; };
+		A17C48292C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26F323C3CA5500D5CF67 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html */; };
+		A17C482A2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5751B289249D5B9900664C2A /* web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry.html */; };
+		A17C482B2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44123ECC76B00246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error.html */; };
+		A17C482C2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44523ECCBD000246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry.html */; };
+		A17C482D2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26F923C3F24500D5CF67 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error.html */; };
+		A17C482E2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44323ECC8A800246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry.html */; };
+		A17C482F2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-retries-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5758598323C3C36200C74572 /* web-authentication-make-credential-hid-pin-get-retries-error.html */; };
+		A17C48302C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-invalid-error-retry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 578DA44923ECD15500246010 /* web-authentication-make-credential-hid-pin-invalid-error-retry.html */; };
+		A17C48312C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 570D26F523C3D32700D5CF67 /* web-authentication-make-credential-hid-pin.html */; };
+		A17C48322C98E5C20023F3C7 /* web-authentication-make-credential-hid.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5798337D2360196D008E5547 /* web-authentication-make-credential-hid.html */; };
+		A17C48332C98E5C20023F3C7 /* web-authentication-make-credential-la-duplicate-credential.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 574217892400AED0002B303D /* web-authentication-make-credential-la-duplicate-credential.html */; };
+		A17C48342C98E5C20023F3C7 /* web-authentication-make-credential-la-error.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 574217872400ABFD002B303D /* web-authentication-make-credential-la-error.html */; };
+		A17C48352C98E5C20023F3C7 /* web-authentication-make-credential-la-no-attestation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5703BB8C2463F87200475FB2 /* web-authentication-make-credential-la-no-attestation.html */; };
+		A17C48362C98E5C20023F3C7 /* web-authentication-make-credential-la-no-mock.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57EDFC5B245A18F500959521 /* web-authentication-make-credential-la-no-mock.html */; };
+		A17C48372C98E5C20023F3C7 /* web-authentication-make-credential-la.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5742178D2400D26C002B303D /* web-authentication-make-credential-la.html */; };
+		A17C48382C98E5C20023F3C7 /* webaudio-createMediaElementSource.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46A44A5325A782DD00F61E16 /* webaudio-createMediaElementSource.html */; };
+		A17C48392C98E5C20023F3C7 /* webgl-support.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6352A2D51F900D47257 /* webgl-support.js */; };
+		A17C483A2C98E5C20023F3C7 /* webkit-logo.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A33FF3227C8314D00D7E03E /* webkit-logo.pdf */; };
+		A17C483B2C98E5C20023F3C7 /* webp-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45C63FE28178A530090DFAB /* webp-image.html */; };
+		A17C483C2C98E5C20023F3C7 /* WebProcessKillIDBCleanup-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51714EB21CF8C761004723C4 /* WebProcessKillIDBCleanup-1.html */; };
+		A17C483D2C98E5C20023F3C7 /* WebProcessKillIDBCleanup-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51714EB31CF8C761004723C4 /* WebProcessKillIDBCleanup-2.html */; };
+		A17C483E2C98E5C20023F3C7 /* webrtc-remote-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */; };
+		A17C483F2C98E5C20023F3C7 /* webrtc-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EC /* webrtc-remote.html */; };
+		A17C48402C98E5C20023F3C7 /* WebsiteDataStoreCustomPaths.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5120C83B1E674E350025B250 /* WebsiteDataStoreCustomPaths.html */; };
+		A17C48412C98E5C20023F3C7 /* websql-database-tracker.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93F79A5928E649EC003E7CEB /* websql-database-tracker.db */; };
+		A17C48422C98E5C20023F3C7 /* websql-database.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93F79A5128E649EB003E7CEB /* websql-database.db */; };
+		A17C48432C98E5C20023F3C7 /* wide-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2E131C171D83A97E001BA36C /* wide-autoplaying-video-with-audio.html */; };
+		A17C48442C98E5C20023F3C7 /* WKInspectorExtensionEvaluateScriptOnPage.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2ED8882127711F1200DB7E99 /* WKInspectorExtensionEvaluateScriptOnPage.html */; };
+		A17C48452C98E5C20023F3C7 /* WKInspectorExtensionEvaluateScriptOnPageInnerFrame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2ED888222771203A00DB7E99 /* WKInspectorExtensionEvaluateScriptOnPageInnerFrame.html */; };
+		A17C48462C98E6360023F3C7 /* Ahem-10000A.ttf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4C453A43294A468200D91D2B /* Ahem-10000A.ttf */; };
+		A17C48472C98E6360023F3C7 /* audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD9E292D1C90C1BA000BB800 /* audio-only.html */; };
+		A17C48482C98E6360023F3C7 /* fullscreen-lifecycle-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1183D402C6C8F8600233D8B /* fullscreen-lifecycle-audio.html */; };
+		A17C48492C98E6360023F3C7 /* one-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1DAA52CB243BE621001A3159 /* one-video.html */; };
+		A17C484A2C98E6360023F3C7 /* two-videos.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1D67BFD92433DFD8006B5047 /* two-videos.html */; };
+		A17C484B2C98E6360023F3C7 /* video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E4891BC5C96200594FEC /* video-with-audio.html */; };
+		A17C484C2C98E6360023F3C7 /* video-with-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E48A1BC5C96200594FEC /* video-with-audio.mp4 */; };
+		A17C484D2C98E6360023F3C7 /* video-with-muted-audio-and-webaudio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD321B031E3A84B700EB21C8 /* video-with-muted-audio-and-webaudio.html */; };
+		A17C484E2C98E6360023F3C7 /* video-with-muted-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDB411591E09DA8E00EAD352 /* video-with-muted-audio.html */; };
+		A17C484F2C98E6360023F3C7 /* video-with-paused-audio-and-playing-muted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */; };
+		A17C48502C98E6360023F3C7 /* video-without-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E48B1BC5C96200594FEC /* video-without-audio.html */; };
+		A17C48512C98E6360023F3C7 /* video-without-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E48C1BC5C96200594FEC /* video-without-audio.mp4 */; };
+		A17C48522C98E6360023F3C7 /* webgl.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31E9BDA2247F4DD0002E51A2 /* webgl.html */; };
+		A17C48592C98FA3F0023F3C7 /* TestNSBundleExtras.m in Sources */ = {isa = PBXBuildFile; fileRef = A17C48582C98FA3F0023F3C7 /* TestNSBundleExtras.m */; };
 		A198D0A22BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */; };
 		A1AD382F2C3DA40B003499BE /* FullscreenLifecycle.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */; };
 		A1C142C224AA7B2E00444207 /* ContextMenuMouseEvents.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1C142C124AA7B2E00444207 /* ContextMenuMouseEvents.mm */; };
-		A1C4FB731BACD1CA003742D0 /* pages.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1C4FB721BACD1B7003742D0 /* pages.pages */; };
 		A1C7D7D32AB817A90055AD62 /* LoggerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1C7D7D22AB817A90055AD62 /* LoggerCocoa.mm */; };
 		A1EC11881F42541200D0146E /* PreviewConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1EC11871F42541200D0146E /* PreviewConverter.cpp */; };
-		A1FB503D22A1CBE200D4D979 /* apple-pay-availability-existing-object.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB503C22A1C24400D4D979 /* apple-pay-availability-existing-object.html */; };
-		A1FB503F22A20F6400D4D979 /* apple-pay-can-make-payments.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB503E22A1E3B300D4D979 /* apple-pay-can-make-payments.html */; };
-		A1FB504122A212A900D4D979 /* apple-pay-can-make-payments-with-active-card.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504022A2128400D4D979 /* apple-pay-can-make-payments-with-active-card.html */; };
-		A1FB504322A213A300D4D979 /* apple-pay-can-make-payment.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504222A2138F00D4D979 /* apple-pay-can-make-payment.html */; };
-		A1FB504522A2157100D4D979 /* apple-pay.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504422A2154B00D4D979 /* apple-pay.js */; };
 		A1FCFF2D2C292D0D0014463B /* NowPlayingSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */; };
 		A310827221F296FF00C28B97 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A310827121F296EC00C28B97 /* FileSystem.cpp */; };
-		A57A34F216AF6B2B00C2501F /* PageVisibilityStateWithWindowChanges.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A57A34F116AF69E200C2501F /* PageVisibilityStateWithWindowChanges.html */; };
 		A57D54F31F338C3600A97AA7 /* NeverDestroyed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F21F338C3600A97AA7 /* NeverDestroyed.cpp */; };
 		A57D54F61F3395D000A97AA7 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F41F3395D000A97AA7 /* Logger.cpp */; };
 		A57D54F91F3397B400A97AA7 /* LifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F71F3397B400A97AA7 /* LifecycleLogger.cpp */; };
 		A5B149DE1F5A19EA00C6DAFF /* MIMETypeRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */; };
-		A5E2027515B21F6E00C13E14 /* WindowlessWebViewWithMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A5E2027015B2180600C13E14 /* WindowlessWebViewWithMedia.html */; };
 		A73E66C42AB29574005FC327 /* EventTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A73E66C32AB29574005FC327 /* EventTests.cpp */; };
 		AA96CAB621C7DB5000FD2F97 /* ParsedContentType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */; };
 		AD57AC201DA7465000FF1BDE /* DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD57AC1E1DA7464D00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp */; };
 		AD57AC211DA7465B00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD57AC1F1DA7464D00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache.cpp */; };
-		AD57AC221DA7466E00FF1BDE /* many-iframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = AD57AC1D1DA7463800FF1BDE /* many-iframes.html */; };
 		AD7C434D1DD2A54E0026888B /* Expected.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD7C434C1DD2A5470026888B /* Expected.cpp */; };
 		B55AD1D5179F3B3000AC1494 /* PreventImageLoadWithAutoResizing_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B55AD1D3179F3ABF00AC1494 /* PreventImageLoadWithAutoResizing_Bundle.cpp */; };
-		B55F11B71517D03300915916 /* attributedStringCustomFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = B55F11B01517A2C400915916 /* attributedStringCustomFont.html */; };
 		B68735A32AA78E620006FB3A /* WKWebExtensionAPILocalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6D1708E2A9F9C9F004C72E6 /* WKWebExtensionAPILocalization.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		BC22D31914DC68B900FFB1DD /* UserMessage_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC22D31714DC68B800FFB1DD /* UserMessage_Bundle.cpp */; };
 		BC246D9C132F1FF000B56D7C /* CanHandleRequest_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC246D97132F1FE100B56D7C /* CanHandleRequest_Bundle.cpp */; };
-		BC2D006412AA04CE00E732A3 /* file-with-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC2D004A12A9FEB300E732A3 /* file-with-anchor.html */; };
 		BC575A97126E74F1006F0F12 /* InjectedBundleMain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575946126E7351006F0F12 /* InjectedBundleMain.cpp */; };
 		BC575AA2126E7660006F0F12 /* InjectedBundleController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575AA0126E7657006F0F12 /* InjectedBundleController.cpp */; };
 		BC575AB0126E83C8006F0F12 /* InjectedBundleBasic_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575AAF126E83C8006F0F12 /* InjectedBundleBasic_Bundle.cpp */; };
 		BC575BD9126F58E2006F0F12 /* PlatformUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575BBF126F5752006F0F12 /* PlatformUtilities.cpp */; };
 		BC575BE0126F590D006F0F12 /* PlatformUtilitiesMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC131884117114B600B69727 /* PlatformUtilitiesMac.mm */; };
-		BC909784125571CF00083756 /* simple.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC909778125571AB00083756 /* simple.html */; };
-		BCAA485614A0444C0088FAC4 /* simple-tall.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BCAA485514A021640088FAC4 /* simple-tall.html */; };
 		BCB68042126FBFF100642A61 /* DocumentStartUserScriptAlertCrash_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCB68041126FBFF100642A61 /* DocumentStartUserScriptAlertCrash_Bundle.cpp */; };
-		BCBD3737125ABBEB00D2C29F /* icon.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = BCBD372E125ABBE600D2C29F /* icon.png */; };
-		C01A23F21266156700C9ED55 /* spacebar-scrolling.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C02B7882126615410026BF0F /* spacebar-scrolling.html */; };
-		C07E6CB213FD73930038B22B /* devicePixelRatio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C07E6CB113FD738A0038B22B /* devicePixelRatio.html */; };
-		C0ADBE9612FCA79B00D2C129 /* simple-form.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C0ADBE8412FCA6B600D2C129 /* simple-form.html */; };
 		C0BD669F131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0BD669E131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp */; };
 		C0C5D3C61459912900A802A6 /* GetBackingScaleFactor_Bundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0C5D3BD14598B6F00A802A6 /* GetBackingScaleFactor_Bundle.mm */; };
 		C104BC1F2547237100C078C9 /* OverrideAppleLanguagesPreference.mm in Sources */ = {isa = PBXBuildFile; fileRef = C104BC1E2547237100C078C9 /* OverrideAppleLanguagesPreference.mm */; };
@@ -993,101 +1170,34 @@
 		C1F7B7392449083F00124557 /* AGXCompilerService.mm in Sources */ = {isa = PBXBuildFile; fileRef = C1F7B7382449083F00124557 /* AGXCompilerService.mm */; };
 		C1FF9EDB244644F000839AE4 /* WebFilter.mm in Sources */ = {isa = PBXBuildFile; fileRef = C1FF9EDA244644F000839AE4 /* WebFilter.mm */; };
 		C20F88A72295B96700D610FA /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C20F88A62295B96700D610FA /* CoreText.framework */; };
-		C22FA32D228F8AEB009D7988 /* TextWidth.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C22FA32C228F877A009D7988 /* TextWidth.html */; };
-		C25CCA0B1E5140C10026CB8A /* LineBreaking.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C25CCA0A1E513F490026CB8A /* LineBreaking.html */; };
-		C25CCA0D1E5141840026CB8A /* AllAhem.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = C25CCA0C1E5140E50026CB8A /* AllAhem.svg */; };
-		C2CF975A16CEC7140054E99D /* JSContextBackForwardCache2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C2CF975916CEC69E0054E99D /* JSContextBackForwardCache2.html */; };
-		C2CF975B16CEC71B0054E99D /* JSContextBackForwardCache1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C2CF975816CEC69E0054E99D /* JSContextBackForwardCache1.html */; };
-		C5101C4F176B8D9200EE9B15 /* findRanges.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C5101C4E176B8BB900EE9B15 /* findRanges.html */; };
-		C540F784152E5A9A00A40C8C /* verboseMarkup.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C540F783152E5A7800A40C8C /* verboseMarkup.html */; };
 		C54237F116B8957D00E638FC /* PasteboardNotifications_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C54237ED16B8955800E638FC /* PasteboardNotifications_Bundle.cpp */; };
-		C5E1AFFE16B221F1006CC1F2 /* execCopy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C5E1AFFD16B22179006CC1F2 /* execCopy.html */; };
-		C944160021430E8900B1EDDA /* audio-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C94415FF21430B6700B1EDDA /* audio-with-controls.html */; };
-		C95984F41E36BC6B002C0D45 /* autoplay-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F21E36BC55002C0D45 /* autoplay-check.html */; };
-		C95984F51E36BC6B002C0D45 /* autoplay-no-audio-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F31E36BC55002C0D45 /* autoplay-no-audio-check.html */; };
-		C95984F71E36BCEF002C0D45 /* test-without-audio-track.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = C95984F61E36BCD7002C0D45 /* test-without-audio-track.mp4 */; };
-		C99B675C1E39721A00FC6C80 /* autoplay-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99B675A1E3971FC00FC6C80 /* autoplay-with-controls.html */; };
-		C99B675D1E39722000FC6C80 /* js-play-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99B675B1E3971FC00FC6C80 /* js-play-with-controls.html */; };
-		C99B675F1E39736F00FC6C80 /* no-autoplay-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99B675E1E39735C00FC6C80 /* no-autoplay-with-controls.html */; };
-		C99BDF891E80980400C7170E /* autoplay-zero-volume-check.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C99BDF881E8097E300C7170E /* autoplay-zero-volume-check.html */; };
-		C9B1043E1ECF9848000520FA /* autoplay-inherits-gesture-from-document.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9B1043D1ECF9832000520FA /* autoplay-inherits-gesture-from-document.html */; };
-		C9B4AD2A1ECA6EBE00F5FEA0 /* silence-long.m4a in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9B4AD291ECA6EA500F5FEA0 /* silence-long.m4a */; };
-		C9B4AD2C1ECA6F7F00F5FEA0 /* js-autoplay-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9B4AD2B1ECA6F7600F5FEA0 /* js-autoplay-audio.html */; };
-		C9BF06EF1E9C132500595E3E /* autoplay-muted-with-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9BF06EE1E9C130400595E3E /* autoplay-muted-with-controls.html */; };
-		C9C60E651E53A9DC006DA181 /* autoplay-check-frame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C60E631E53A9BA006DA181 /* autoplay-check-frame.html */; };
-		C9C60E661E53A9DC006DA181 /* autoplay-check-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C60E641E53A9BA006DA181 /* autoplay-check-in-iframe.html */; };
-		C9C9A91B21DED28700FDE96E /* audio-with-play-button.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9A91A21DED24D00FDE96E /* audio-with-play-button.html */; };
-		C9C9A91D21DED7A000FDE96E /* video-with-play-button.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9A91C21DED79400FDE96E /* video-with-play-button.html */; };
-		C9C9CD4321E6A6860019DB96 /* autoplaying-multiple-media-elements.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9C9CD4221E6A6670019DB96 /* autoplaying-multiple-media-elements.html */; };
 		C9E6DD351EA97D0800DD78AA /* FirstResponderSuppression.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E6DD311EA972D800DD78AA /* FirstResponderSuppression.mm */; };
-		C9E8EE7521DED94300797765 /* long-test.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = C9E8EE7421DED91E00797765 /* long-test.mp4 */; };
-		CA2879DC226E69B6001026F5 /* IndexedDBSuspendImminently.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA2879D9226E6978001026F5 /* IndexedDBSuspendImminently.html */; };
-		CA5B94D22190C0F40059FE38 /* IndexedDBTempFileSize-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA5B94D02190C0E00059FE38 /* IndexedDBTempFileSize-1.html */; };
-		CA5B94D32190C0F40059FE38 /* IndexedDBTempFileSize-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA5B94D12190C0E00059FE38 /* IndexedDBTempFileSize-2.html */; };
-		CA7787FF228CEFDB00E50463 /* local-storage-process-crashes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA7787FE228CEFC700E50463 /* local-storage-process-crashes.html */; };
-		CA97B3952193667A0045DF6F /* IndexedDBUserDelete.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CA97B393219366470045DF6F /* IndexedDBUserDelete.html */; };
-		CAB0FF5222332407006CA5B0 /* IndexedDBFileName-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CAB0FF51223323F6006CA5B0 /* IndexedDBFileName-1.html */; };
-		CAB0FF5322332407006CA5B0 /* IndexedDBFileName-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CAB0FF50223323F6006CA5B0 /* IndexedDBFileName-2.html */; };
 		CD0BD0A61F79924D001AB2CF /* ContextMenuImgWithVideo.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */; };
-		CD0BD0A81F79982D001AB2CF /* ContextMenuImgWithVideo.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD0BD0A71F7997C2001AB2CF /* ContextMenuImgWithVideo.html */; };
 		CD27A1C123C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */; };
-		CD321B041E3A85FA00EB21C8 /* video-with-muted-audio-and-webaudio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD321B031E3A84B700EB21C8 /* video-with-muted-audio-and-webaudio.html */; };
 		CD48A87324C8A66F00F5800C /* Observer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD48A87224C8A66F00F5800C /* Observer.cpp */; };
-		CD577799211CE0E4001B371E /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
-		CD57779C211CE91F001B371E /* audio-with-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779A211CE6B7001B371E /* audio-with-web-audio.html */; };
-		CD57779D211CE91F001B371E /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
-		CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53219E910AA00CF1835 /* file-with-mse.html */; };
-		CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
-		CD758A6F20572EA00071834A /* video-with-paused-audio-and-playing-muted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */; };
 		CD780E762BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD780E752BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm */; };
-		CD78E11E1DB7EE2A0014A2DE /* FullscreenDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */; };
-		CD8394DF232AF7C000149495 /* media-loading.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD8394DE232AF15E00149495 /* media-loading.html */; };
-		CD9E292E1C90C33F000BB800 /* audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD9E292D1C90C1BA000BB800 /* audio-only.html */; };
-		CDA29B2B20FD358400F15CED /* ExitFullscreenOnEnterPiP.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDA29B2A20FD344E00F15CED /* ExitFullscreenOnEnterPiP.html */; };
 		CDA315981ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDA315961ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm */; };
-		CDA3159A1ED548F1009F60D3 /* MediaPlaybackSleepAssertion.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDA315991ED540A5009F60D3 /* MediaPlaybackSleepAssertion.html */; };
 		CDA3159D1ED5643F009F60D3 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDA3159C1ED5643F009F60D3 /* IOKit.framework */; };
 		CDA93DAD22F4F11E00490A69 /* FullscreenTouchSecheuristicTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDA93DAC22F4EC2200490A69 /* FullscreenTouchSecheuristicTests.cpp */; };
 		CDB213BD24EF522800FDE301 /* FullscreenFocus.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDB213BC24EF522800FDE301 /* FullscreenFocus.mm */; };
-		CDB4115A1E0B00DB00EAD352 /* video-with-muted-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDB411591E09DA8E00EAD352 /* video-with-muted-audio.html */; };
-		CDB5DFFF213610FA00D3E189 /* now-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDB5DFFE21360ED800D3E189 /* now-playing.html */; };
 		CDBFCC451A9FF45300A7B691 /* FullscreenZoomInitialFrame.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCC431A9FF44800A7B691 /* FullscreenZoomInitialFrame.mm */; };
-		CDBFCC461A9FF49E00A7B691 /* FullscreenZoomInitialFrame.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDBFCC421A9FF44800A7B691 /* FullscreenZoomInitialFrame.html */; };
 		CDC0932B21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC0932A21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm */; };
 		CDC8E48D1BC5CB4500594FEC /* AudioSessionCategoryIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC8E4851BC5B19400594FEC /* AudioSessionCategoryIOS.mm */; };
-		CDC8E4941BC6F10800594FEC /* video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E4891BC5C96200594FEC /* video-with-audio.html */; };
-		CDC8E4951BC6F10800594FEC /* video-with-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E48A1BC5C96200594FEC /* video-with-audio.mp4 */; };
-		CDC8E4961BC6F10800594FEC /* video-without-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E48B1BC5C96200594FEC /* video-without-audio.html */; };
-		CDC8E4971BC6F10800594FEC /* video-without-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC8E48C1BC5C96200594FEC /* video-without-audio.mp4 */; };
 		CDC9442E1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC9442C1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm */; };
-		CDC9442F1EF205D60059C3C4 /* mediastreamtrack-detached.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC9442B1EF1FBD20059C3C4 /* mediastreamtrack-detached.html */; };
 		CDCFA7AA1E45183200C2433D /* SampleMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDCFA7A91E45122F00C2433D /* SampleMap.cpp */; };
-		CDE195B51CFE0B880053D256 /* FullscreenTopContentInset.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDE195B21CFE0ADE0053D256 /* FullscreenTopContentInset.html */; };
 		CDE4E4E52B7E787900B3AE35 /* InWindowFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */; };
 		CDE4E4F42B7F278600B3AE35 /* MediaLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD0370E224A44B7A00BA3CAE /* MediaLoading.mm */; };
 		CDE77D2525A6591C00D4115E /* FullscreenPointerLeave.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE77D2425A6591C00D4115E /* FullscreenPointerLeave.mm */; };
 		CE06DF9B1E1851F200E570C9 /* SecurityOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */; };
-		CE14F1A4181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE14F1A2181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html */; };
 		CE1866491F72E8F100A0CAB6 /* MarkedText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE1866471F72E8F100A0CAB6 /* MarkedText.cpp */; };
 		CE3524F81B1431F60028A7C5 /* TextFieldDidBeginAndEndEditing_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE3524F21B142B8D0028A7C5 /* TextFieldDidBeginAndEndEditing_Bundle.cpp */; };
 		CE3524F91B1441C40028A7C5 /* TextFieldDidBeginAndEndEditing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE3524F11B142B8D0028A7C5 /* TextFieldDidBeginAndEndEditing.cpp */; };
-		CE3524FA1B1443890028A7C5 /* input-focus-blur.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE3524F51B142BBB0028A7C5 /* input-focus-blur.html */; };
 		CE4D5DE71F6743BA0072CFC6 /* StringWithDirection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE4D5DE51F6743BA0072CFC6 /* StringWithDirection.cpp */; };
-		CE6D0EE32426B932002AD901 /* insert-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE6D0EE22426B8ED002AD901 /* insert-text.html */; };
 		CE6E81A020A6935F00E2C80F /* SetTimeoutFunction.mm in Sources */ = {isa = PBXBuildFile; fileRef = CE6E819F20A6935F00E2C80F /* SetTimeoutFunction.mm */; };
-		CE6E81A420A933D500E2C80F /* set-timeout-function.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE6E81A320A933B800E2C80F /* set-timeout-function.html */; };
 		CE78705F2107AB980053AC67 /* MoveOnlyLifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE78705D2107AB8C0053AC67 /* MoveOnlyLifecycleLogger.cpp */; };
-		CEA6CF2819CCF69D0064F5A7 /* open-and-close-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEA6CF2719CCF69D0064F5A7 /* open-and-close-window.html */; };
 		CEA7F57D2089624B0078EF6E /* DidResignInputElementStrongPasswordAppearance.mm in Sources */ = {isa = PBXBuildFile; fileRef = CEA7F57B20895F5B0078EF6E /* DidResignInputElementStrongPasswordAppearance.mm */; };
-		CEBABD491B71687C0051210A /* should-open-external-schemes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBABD481B71687C0051210A /* should-open-external-schemes.html */; };
-		CEBCA1381E3A807A00C73293 /* page-with-csp.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1351E3A803400C73293 /* page-with-csp.html */; };
-		CEBCA1391E3A807A00C73293 /* page-with-csp-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1341E3A803400C73293 /* page-with-csp-iframe.html */; };
-		CEBCA13A1E3A807A00C73293 /* page-without-csp.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1371E3A803400C73293 /* page-without-csp.html */; };
-		CEBCA13B1E3A807A00C73293 /* page-without-csp-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEBCA1361E3A803400C73293 /* page-without-csp-iframe.html */; };
-		CEDA12412437C9FB00C28A9E /* editable-region-composited-and-non-composited-overlap.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CEDA12402437C9EA00C28A9E /* editable-region-composited-and-non-composited-overlap.html */; };
 		D04CF93F285C77CA005D6337 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D04CF93E285C77C9005D6337 /* MachSendRight.cpp */; };
-		D20C03B62B704A95004C414A /* download.example.webarchive in Copy Resources */ = {isa = PBXBuildFile; fileRef = D20C03AE2B704A26004C414A /* download.example.webarchive */; };
 		D84FAD9A29FAC1D0008D338F /* RenderStyleChange.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */; };
 		DD0EDF8D2798A6AD005152AD /* libgtest.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = F3FC3EE213678B7300126A65 /* libgtest.a */; };
 		DD403D4A28EB932F009B4684 /* libbmalloc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD403D4928EB932F009B4684 /* libbmalloc.a */; };
@@ -1100,11 +1210,8 @@
 		DDD2187627A21750002B7025 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = C081224813FC1B0300DC39AE /* WebKit.framework */; };
 		DDFBE4AC2A90556700CA7023 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */; };
 		DF1C7CE927F5161D00D8145C /* BundlePageConsoleMessageWithDetails.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF1C7CE827F5161D00D8145C /* BundlePageConsoleMessageWithDetails.mm */; };
-		DF1C7CEC27F5309700D8145C /* console-message-with-details.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = DF1C7CEB27F5305A00D8145C /* console-message-with-details.html */; };
 		DF6580942722168900B3F1C1 /* ASN1Utilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF6580922722168900B3F1C1 /* ASN1Utilities.cpp */; };
 		DFB80E38261512C1002D4771 /* TestAwakener.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFB80E362615124E002D4771 /* TestAwakener.mm */; };
-		E1220DCA155B28AA0013E2FC /* MemoryCacheDisableWithinResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E1220DC9155B287D0013E2FC /* MemoryCacheDisableWithinResourceLoadDelegate.html */; };
-		E194E1BD177E53C7009C4D4E /* StopLoadingFromDidReceiveResponse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E194E1BC177E534A009C4D4E /* StopLoadingFromDidReceiveResponse.html */; };
 		E302BDAA2404B92400865277 /* CompactRefPtrTuple.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E302BDA92404B92300865277 /* CompactRefPtrTuple.cpp */; };
 		E30F393428F4973800113EE7 /* SyscallUnixSandboxCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = E30F392C28F4973800113EE7 /* SyscallUnixSandboxCheck.mm */; };
 		E316D42027647A0200287B16 /* RefCountedFixedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E316D41F27647A0200287B16 /* RefCountedFixedVector.cpp */; };
@@ -1137,18 +1244,13 @@
 		E3EFB02F25506503003C2F96 /* SystemBeep.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3EFB02E25506503003C2F96 /* SystemBeep.mm */; };
 		E3F8AB92241AB9CE003E2A7E /* AccessibilityRemoteUIApp.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3F8AB91241AB9CE003E2A7E /* AccessibilityRemoteUIApp.mm */; };
 		E3FCFB7F274B70D5000E6B69 /* SentinelLinkedList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3FCFB7E274B70D5000E6B69 /* SentinelLinkedList.cpp */; };
-		E5036F78211BC25400BFDBE2 /* color-drop.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E5036F77211BC22800BFDBE2 /* color-drop.html */; };
 		E51A740E2B0442180047FEB1 /* ColorInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E51A740D2B0442180047FEB1 /* ColorInputTests.mm */; };
 		E520A36B25AFB76C00526CB9 /* WKWebViewTitlebarSeparatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E520A36A25AFB76C00526CB9 /* WKWebViewTitlebarSeparatorTests.mm */; };
 		E532A15F2BDA271F00E79810 /* DataListTextSuggestionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E532A15E2BDA271F00E79810 /* DataListTextSuggestionTests.mm */; };
-		E540058827B3A8B20005653A /* contenteditable-user-select-user-drag.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E540058727B3A8320005653A /* contenteditable-user-select-user-drag.html */; };
 		E55999F72B476C2F00A3719F /* FullscreenLayoutParameters.mm in Sources */ = {isa = PBXBuildFile; fileRef = E55999F62B476C2F00A3719F /* FullscreenLayoutParameters.mm */; };
-		E57B44C129ABFB3B006069DE /* qr-code.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = E57B44C029ABFAA4006069DE /* qr-code.png */; };
 		E589183C252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */; };
-		E59CF8232C2D1EAE00891383 /* adaptive-image-glyph.heic in Copy Resources */ = {isa = PBXBuildFile; fileRef = E59CF8222C2D1E3700891383 /* adaptive-image-glyph.heic */; };
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
 		E5AA8D1D25151CC60051CC45 /* DateInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */; };
-		EB230D41245E813F00C66AD1 /* IDBCheckpointWAL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = EB230D3D245E722E00C66AD1 /* IDBCheckpointWAL.html */; };
 		EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */; };
 		EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */; };
 		ECA680CE1E68CC0900731D20 /* StringUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECA680CD1E68CC0900731D20 /* StringUtilities.mm */; };
@@ -1156,170 +1258,69 @@
 		F4010B8324DA267F00A876E2 /* PoseAsClass.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B8124DA267F00A876E2 /* PoseAsClass.mm */; };
 		F402F56C23ECC2FB00865549 /* UIWKInteractionViewProtocol.mm in Sources */ = {isa = PBXBuildFile; fileRef = F402F56B23ECC2FB00865549 /* UIWKInteractionViewProtocol.mm */; };
 		F4034FA1275D5402003A81F8 /* CookieConsent.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4034FA0275D5402003A81F8 /* CookieConsent.mm */; };
-		F4034FA3275D5AC6003A81F8 /* cookie-consent-basic.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4034FA2275D5449003A81F8 /* cookie-consent-basic.html */; };
-		F40398922B2D0D2B00A7AA85 /* text-with-web-font.webarchive in Copy Resources */ = {isa = PBXBuildFile; fileRef = F40398892B2D0AC700A7AA85 /* text-with-web-font.webarchive */; };
-		F405F8AD2BD1D4DC0020E6AB /* element-targeting-7.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F405F8A42BD1D1B90020E6AB /* element-targeting-7.html */; };
-		F407FE391F1D0DFC0017CF25 /* enormous.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = F407FE381F1D0DE60017CF25 /* enormous.svg */; };
 		F4094CC725545BD5003D73E3 /* DisplayListTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4094CC625545BD5003D73E3 /* DisplayListTests.cpp */; };
-		F40B8D5E281086E500346417 /* fade-in-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F40B8D5D2810855900346417 /* fade-in-image.html */; };
-		F41289A92BCC97E700D6E0E7 /* element-targeting-6.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */; };
-		F41462BA2BC346B80027261C /* event.ics in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41462AA2BC346130027261C /* event.ics */; };
-		F415086D1DA040C50044BE9B /* play-audio-on-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F415086C1DA040C10044BE9B /* play-audio-on-click.html */; };
 		F418BE151F71B7DC001970E6 /* RoundedRectTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F418BE141F71B7DC001970E6 /* RoundedRectTests.cpp */; };
-		F4194AD11F5A320100ADD83F /* drop-targets.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4194AD01F5A2EA500ADD83F /* drop-targets.html */; };
-		F41AB99F1EF4696B0083FA08 /* autofocus-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9981EF4692C0083FA08 /* autofocus-contenteditable.html */; };
-		F41AB9A01EF4696B0083FA08 /* background-image-link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9971EF4692C0083FA08 /* background-image-link-and-input.html */; };
-		F41AB9A11EF4696B0083FA08 /* contenteditable-and-textarea.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99C1EF4692C0083FA08 /* contenteditable-and-textarea.html */; };
-		F41AB9A21EF4696B0083FA08 /* div-and-large-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99E1EF4692C0083FA08 /* div-and-large-image.html */; };
-		F41AB9A31EF4696B0083FA08 /* file-uploading.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99B1EF4692C0083FA08 /* file-uploading.html */; };
-		F41AB9A41EF4696B0083FA08 /* image-and-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9991EF4692C0083FA08 /* image-and-contenteditable.html */; };
-		F41AB9A51EF4696B0083FA08 /* image-and-textarea.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9931EF4692C0083FA08 /* image-and-textarea.html */; };
-		F41AB9A61EF4696B0083FA08 /* link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9961EF4692C0083FA08 /* link-and-input.html */; };
-		F41AB9A71EF4696B0083FA08 /* link-and-target-div.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99D1EF4692C0083FA08 /* link-and-target-div.html */; };
-		F41AB9A81EF4696B0083FA08 /* prevent-operation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9941EF4692C0083FA08 /* prevent-operation.html */; };
-		F41AB9A91EF4696B0083FA08 /* prevent-start.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99A1EF4692C0083FA08 /* prevent-start.html */; };
-		F41AB9AA1EF4696B0083FA08 /* textarea-to-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9951EF4692C0083FA08 /* textarea-to-input.html */; };
-		F41E446D2BBCDD81002A856F /* element-targeting-3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41E44652BBCDC74002A856F /* element-targeting-3.html */; };
-		F422A3EB235BB16200CF00CA /* clipboard.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F422A3EA235BB14500CF00CA /* clipboard.html */; };
 		F425831624F07CA5006B985D /* WKWebViewCoders.mm in Sources */ = {isa = PBXBuildFile; fileRef = F425831524F07CA5006B985D /* WKWebViewCoders.mm */; };
-		F42BD7D9245CC508001E207A /* attributedStringNewlineAtEndOfDocument.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42BD7D8245CC4E6001E207A /* attributedStringNewlineAtEndOfDocument.html */; };
 		F42D634422A1729F00D2FB3A /* AutocorrectionTestsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F42D634322A1729F00D2FB3A /* AutocorrectionTestsIOS.mm */; };
-		F42DA5161D8CEFE400336F40 /* large-input-field-focus-onload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42DA5151D8CEFDB00336F40 /* large-input-field-focus-onload.html */; };
-		F42F081227449892007E0D90 /* multiple-images.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42F0811274497C8007E0D90 /* multiple-images.html */; };
 		F434CA1A22E65BCA005DDB26 /* ScrollToRevealSelection.mm in Sources */ = {isa = PBXBuildFile; fileRef = F434CA1922E65BCA005DDB26 /* ScrollToRevealSelection.mm */; };
-		F4352F9F26D403DE00E605E4 /* editable-responsive-body.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4352F9E26D4037000E605E4 /* editable-responsive-body.html */; };
-		F4365E2B2BB11829005E8C1A /* element-targeting-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4365E232BB1181A005E8C1A /* element-targeting-2.html */; };
 		F43CAB1D278A326500C8D0A2 /* CloseWhileCommittingLoad.mm in Sources */ = {isa = PBXBuildFile; fileRef = F43CAB1C278A326500C8D0A2 /* CloseWhileCommittingLoad.mm */; };
 		F43E3BBF20DADA1E00A4E7ED /* WKScrollViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F43E3BBE20DADA1E00A4E7ED /* WKScrollViewTests.mm */; };
-		F43E3BC120DADBC500A4E7ED /* fixed-nav-bar.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43E3BC020DADB8000A4E7ED /* fixed-nav-bar.html */; };
 		F442851D2140DF2900CCDA22 /* NSFontPanelTesting.mm in Sources */ = {isa = PBXBuildFile; fileRef = F442851C2140DF2900CCDA22 /* NSFontPanelTesting.mm */; };
-		F4451C761EB8FD890020C5DA /* two-paragraph-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4451C751EB8FD7C0020C5DA /* two-paragraph-contenteditable.html */; };
-		F4476F4B279082F900931786 /* remove-node-on-drop.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4476F4A279082EB00931786 /* remove-node-on-drop.html */; };
-		F44A2A772BC205060044694E /* element-targeting-4.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44A2A6E2BC202840044694E /* element-targeting-4.html */; };
 		F44A531121B8990300DBB99C /* InstanceMethodSwizzler.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44A531021B8976900DBB99C /* InstanceMethodSwizzler.mm */; };
 		F44A9AF72649BBDD00E7CB16 /* ImmediateActionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44A9AF62649BBDD00E7CB16 /* ImmediateActionTests.mm */; };
 		F44C7A0020F9EEBF0014478C /* ParserYieldTokenPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44C79FB20F9E50C0014478C /* ParserYieldTokenPlugIn.mm */; };
-		F44C7A0520FAAE3C0014478C /* text-with-deferred-script.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44C7A0420FAAE320014478C /* text-with-deferred-script.html */; };
-		F44CD9D12BD6ABFD0080A6C7 /* element-targeting-8.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44CD9C92BD6ABF00080A6C7 /* element-targeting-8.html */; };
-		F44D06451F395C26001A0E29 /* editor-state-test-harness.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44D06441F395C0D001A0E29 /* editor-state-test-harness.html */; };
 		F45033F5206BEC95009351CE /* TextAutosizingBoost.mm in Sources */ = {isa = PBXBuildFile; fileRef = F45033F4206BEC95009351CE /* TextAutosizingBoost.mm */; };
-		F4512E131F60C44600BB369E /* DataTransferItem-getAsEntry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4512E121F60C43400BB369E /* DataTransferItem-getAsEntry.html */; };
 		F4517B672054C49500C26721 /* TestWKWebViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4517B662054C49500C26721 /* TestWKWebViewController.mm */; };
-		F4538EF71E8473E600B5C953 /* large-red-square.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4538EF01E846B4100B5C953 /* large-red-square.png */; };
-		F455DB952BAE45B600732E1B /* nested-frames.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F455DB8C2BAE37C100732E1B /* nested-frames.html */; };
 		F456AB1C213EDBA300CB2CEF /* FontManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F456AB1B213EDBA300CB2CEF /* FontManagerTests.mm */; };
 		F457275E25578D06007ACA34 /* DisplayListTestsCG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F457275D25578D06007ACA34 /* DisplayListTestsCG.cpp */; };
-		F457A9D6202D68AF00F7E9D5 /* DataTransfer.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F457A9B3202D535300F7E9D5 /* DataTransfer.html */; };
-		F45B63FB1F197F4A009D38B9 /* image-map.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45B63FA1F197F33009D38B9 /* image-map.html */; };
 		F45B63FE1F19D410009D38B9 /* ActionSheetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F45B63FC1F19D410009D38B9 /* ActionSheetTests.mm */; };
-		F45C640028178AD30090DFAB /* green-400x400.webp in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45C63FF28178AC40090DFAB /* green-400x400.webp */; };
-		F45C640128178AD70090DFAB /* webp-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45C63FE28178A530090DFAB /* webp-image.html */; };
 		F45D3891215A7B4B002A2979 /* TestInspectorBar.mm in Sources */ = {isa = PBXBuildFile; fileRef = F45D3890215A7B4B002A2979 /* TestInspectorBar.mm */; };
 		F45E15732112CE2900307E82 /* KeyboardInputTestsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F45E15722112CE2900307E82 /* KeyboardInputTestsIOS.mm */; };
 		F45E15762112CE6200307E82 /* TestInputDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = F45E15752112CE6200307E82 /* TestInputDelegate.mm */; };
-		F45EB60427739F34003571AE /* TestModalContainerControls.mlmodelc in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45EB60327739F2B003571AE /* TestModalContainerControls.mlmodelc */; };
-		F460BEEA27A1F416007B87D9 /* offscreen-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F460BEE727A1F2D6007B87D9 /* offscreen-image.html */; };
 		F460F657261116EA0064F2B6 /* InjectedBundleHitTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = F460F656261116EA0064F2B6 /* InjectedBundleHitTest.mm */; };
 		F460F65B261119580064F2B6 /* InjectedBundleHitTestPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = F460F659261117E70064F2B6 /* InjectedBundleHitTestPlugIn.mm */; };
-		F460F669261263370064F2B6 /* simple-responsive-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F460F668261262C70064F2B6 /* simple-responsive-page.html */; };
 		F460F6752614DE2F0064F2B6 /* UIFocusTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F460F6742614DE2F0064F2B6 /* UIFocusTests.mm */; };
 		F46128B7211C8ED500D9FADB /* DragAndDropSimulatorMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = F46128B6211C8ED500D9FADB /* DragAndDropSimulatorMac.mm */; };
 		F46128CB211D475100D9FADB /* TestDraggingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = F46128CA211D475100D9FADB /* TestDraggingInfo.mm */; };
-		F46128D4211E40FD00D9FADB /* link-in-iframe-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46128D1211E2D2500D9FADB /* link-in-iframe-and-input.html */; };
 		F4613F1D27DC2EDD007CCDE6 /* ContextMenuTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4613F1C27DC2EDD007CCDE6 /* ContextMenuTests.mm */; };
 		F4636A9A2A0DA61800C88CC0 /* GestureRecognizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4636A992A0DA61800C88CC0 /* GestureRecognizerTests.mm */; };
 		F464AF9220BB66EA007F9B18 /* RenderingProgressTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F464AF9120BB66EA007F9B18 /* RenderingProgressTests.mm */; };
 		F46512192A01E2220037CAD5 /* EditableLegacyWebView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F46512182A01E2220037CAD5 /* EditableLegacyWebView.mm */; };
 		F46849BE1EEF58E400B937FE /* UIPasteboardTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F46849BD1EEF58E400B937FE /* UIPasteboardTests.mm */; };
-		F46849C01EEF5EF300B937FE /* rich-and-plain-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46849BF1EEF5EDC00B937FE /* rich-and-plain-text.html */; };
-		F469FB241F01804B00401539 /* contenteditable-and-target.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F469FB231F01803500401539 /* contenteditable-and-target.html */; };
-		F46A095A1ED8A6E600D4AA55 /* apple.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47D30EB1ED28619000482E1 /* apple.gif */; };
-		F46A095B1ED8A6E600D4AA55 /* gif-and-file-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47D30ED1ED28A6C000482E1 /* gif-and-file-input.html */; };
-		F46BD56924870643008282D6 /* dragstart-data.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46BD5682487062D008282D6 /* dragstart-data.html */; };
 		F46C45C427D42A2F00ECED2C /* ApplicationStateTracking.mm in Sources */ = {isa = PBXBuildFile; fileRef = F46C45C327D42A2F00ECED2C /* ApplicationStateTracking.mm */; };
-		F46D43AB26D7092800969E5E /* test.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46D43AA26D7090300969E5E /* test.jpg */; };
 		F472874727816BCE003EBE7F /* NSResponderTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F43C3823278133190099ABCE /* NSResponderTests.mm */; };
 		F472E00327D966F200F3A172 /* TextAlternatives.mm in Sources */ = {isa = PBXBuildFile; fileRef = F472E00227D966F200F3A172 /* TextAlternatives.mm */; };
-		F4740A342A97C99900B657B6 /* cursor-styles.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4740A2C2A97C97E00B657B6 /* cursor-styles.html */; };
-		F47728991E4AE3C1007ABF6A /* full-page-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47728981E4AE3AD007ABF6A /* full-page-contenteditable.html */; };
-		F47DFB2621A878DF00021FB6 /* data-detectors.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F47DFB2421A8704A00021FB6 /* data-detectors.html */; };
-		F4856CA31E649EA8009D7EE7 /* attachment-element.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4856CA21E6498A8009D7EE7 /* attachment-element.html */; };
-		F486B1D01F67952300F34BDD /* DataTransfer-setDragImage.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F486B1CF1F6794FF00F34BDD /* DataTransfer-setDragImage.html */; };
 		F48D6C10224B377000E3E2FB /* PreferredContentMode.mm in Sources */ = {isa = PBXBuildFile; fileRef = F48D6C0F224B377000E3E2FB /* PreferredContentMode.mm */; };
 		F49153762901CEED004E2E97 /* CustomContentViewGestures.mm in Sources */ = {isa = PBXBuildFile; fileRef = F491536E2901CEED004E2E97 /* CustomContentViewGestures.mm */; };
-		F491DBAE281DE0E80081705F /* image-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F491DBAD281DE0980081705F /* image-controls.html */; };
 		F494B36A263120780060A310 /* TextServicesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F494B369263120780060A310 /* TextServicesTests.mm */; };
-		F49992C6248DABFD00034167 /* overflow-hidden.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F49992C5248DABE400034167 /* overflow-hidden.html */; };
 		F4A2E64D284541BA0001FEEF /* FocusWebView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A2E64C284541BA0001FEEF /* FocusWebView.mm */; };
-		F4A2E64F28455D3A0001FEEF /* open-in-new-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A2E64E28455D230001FEEF /* open-in-new-tab.html */; };
-		F4A32EC41F05F3850047C544 /* dragstart-change-selection-offscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */; };
-		F4A32ECB1F0643370047C544 /* contenteditable-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A32ECA1F0642F40047C544 /* contenteditable-in-iframe.html */; };
 		F4A715A82950C8D900B4D0D6 /* AdvancedPrivacyProtections.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A715A72950C8D900B4D0D6 /* AdvancedPrivacyProtections.mm */; };
 		F4A7CE782662D6E800228685 /* TouchEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A7CE772662D6E800228685 /* TouchEventTests.mm */; };
-		F4A7CE7A2662D86C00228685 /* active-touch-events.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A7CE792662D83E00228685 /* active-touch-events.html */; };
-		F4A9202F1FEE34E900F59590 /* apple-data-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A9202E1FEE34C800F59590 /* apple-data-url.html */; };
-		F4AB578A1F65165400DB0DA1 /* custom-draggable-div.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4AB57891F65164B00DB0DA1 /* custom-draggable-div.html */; };
 		F4AD183825ED791500B1A19F /* FloatQuadTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4AD183725ED791500B1A19F /* FloatQuadTests.cpp */; };
 		F4B0168425AE08F800E445C4 /* DisableSpellcheckPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B0167F25AE02D600E445C4 /* DisableSpellcheckPlugIn.mm */; };
-		F4B825D81EF4DBFB006E417F /* compressed-files.zip in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4B825D61EF4DBD4006E417F /* compressed-files.zip */; };
-		F4B86D4F20BCD5B20099A7E6 /* paint-significant-area-milestone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4B86D4E20BCD5970099A7E6 /* paint-significant-area-milestone.html */; };
 		F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */; };
 		F4BC0B142146C849002A0478 /* FocusPreservationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BC0B132146C849002A0478 /* FocusPreservationTests.mm */; };
-		F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */; };
 		F4BFA68E1E4AD08000154298 /* LegacyDragAndDropTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BFA68C1E4AD08000154298 /* LegacyDragAndDropTests.mm */; };
-		F4C1275A2C756B56000BC609 /* element-targeting-10.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C127522C756B3A000BC609 /* element-targeting-10.html */; };
-		F4C2AB221DD6D95E00E06D5B /* enormous-video-with-sound.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */; };
-		F4C3F2AB2C4488730029A47D /* click-targets.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C3F2A32C44832B0029A47D /* click-targets.html */; };
 		F4C8797F2059D8D3009CD00B /* ScrollViewInsetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */; };
 		F4CB8A7D2856462B0017ECD3 /* TestPDFHostViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4CB8A7C285644FB0017ECD3 /* TestPDFHostViewController.mm */; };
-		F4CC8F4D2C0A759D00D7E76E /* element-targeting-9.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */; };
-		F4CD74C620FDACFA00DE3794 /* text-with-async-script.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CD74C520FDACF500DE3794 /* text-with-async-script.html */; };
 		F4CDF3D227E97C7E00191928 /* SpellCheckerDocumentTag.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4CDF3D127E97C7E00191928 /* SpellCheckerDocumentTag.mm */; };
-		F4CEF1572A1030A400A370BE /* editable-body-mixed-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CEF1562A102F4E00A370BE /* editable-body-mixed-text.html */; };
 		F4CF32802366552200D3AD07 /* EnterKeyHintTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4CF327F2366552200D3AD07 /* EnterKeyHintTests.mm */; };
-		F4CFCDDA249FC9E400527482 /* SpaceOnly.otf in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CFCDD8249FC9D900527482 /* SpaceOnly.otf */; };
-		F4D060082734A1AB008FA67A /* simple-editor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D060072734A08C008FA67A /* simple-editor.html */; };
-		F4D0A6372A2D520800D47257 /* audio-fingerprinting.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6332A2D51F800D47257 /* audio-fingerprinting.html */; };
-		F4D0A6382A2D520800D47257 /* canvas-fingerprinting.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6362A2D51F900D47257 /* canvas-fingerprinting.html */; };
-		F4D0A6392A2D521100D47257 /* fingerprint-audio-worklet.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6342A2D51F800D47257 /* fingerprint-audio-worklet.js */; };
-		F4D0A63A2A2D521100D47257 /* webgl-support.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D0A6352A2D51F900D47257 /* webgl-support.js */; };
-		F4D2C66C2BCF9DED00DADC86 /* multiple-pages.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D2C66B2BCF9DE400DADC86 /* multiple-pages.pdf */; };
 		F4D4F3B61E4E2BCB00BB2767 /* DragAndDropSimulatorIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4D4F3B41E4E2BCB00BB2767 /* DragAndDropSimulatorIOS.mm */; };
 		F4D4F3B91E4E36E400BB2767 /* DragAndDropTestsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4D4F3B71E4E36E400BB2767 /* DragAndDropTestsIOS.mm */; };
 		F4D5C55827C6FF4800ED1C23 /* TestUIMenuBuilder.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4D5C55727C6EBDC00ED1C23 /* TestUIMenuBuilder.mm */; };
 		F4D5D69525AF8BE400205280 /* DisableAutomaticSpellingCorrection.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4D5D69425AF8BE400205280 /* DisableAutomaticSpellingCorrection.mm */; };
-		F4D5E4E81F0C5D38008C1A49 /* dragstart-clear-selection.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */; };
-		F4D65DA81F5E4704009D8C27 /* selected-text-image-link-and-editable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D65DA71F5E46C0009D8C27 /* selected-text-image-link-and-editable.html */; };
-		F4D9818F2196B920008230FC /* editable-nested-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D9818E2196B911008230FC /* editable-nested-lists.html */; };
-		F4DADD072BABAD0F008B398F /* element-targeting-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4DADCFF2BABA80C008B398F /* element-targeting-1.html */; };
-		F4DEF6ED1E9B4DB60048EF61 /* image-in-link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4DEF6EC1E9B4D950048EF61 /* image-in-link-and-input.html */; };
-		F4E0A28B211E4A2B00AF7C7F /* full-page-dropzone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46128D8211E496300D9FADB /* full-page-dropzone.html */; };
 		F4E0A28F211E5D5B00AF7C7F /* DragAndDropTestsMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A28E211E5D5B00AF7C7F /* DragAndDropTestsMac.mm */; };
-		F4E0A296211FC5FB00AF7C7F /* selected-text-and-textarea.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E0A295211FC5A300AF7C7F /* selected-text-and-textarea.html */; };
-		F4E0A2B42122402B00AF7C7F /* image-and-file-upload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E0A2B321223F2D00AF7C7F /* image-and-file-upload.html */; };
 		F4E0A2B82122847400AF7C7F /* TestFilePromiseReceiver.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A2B72122847400AF7C7F /* TestFilePromiseReceiver.mm */; };
-		F4E3D80820F70BB9007B58C5 /* significant-text-milestone-article.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E3D80720F708E4007B58C5 /* significant-text-milestone-article.html */; };
 		F4E5CCC92A6C79770051934C /* MouseEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E5CCC12A6C79770051934C /* MouseEventTests.mm */; };
-		F4E7A66327222CA900E74D36 /* canvas-image-data.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E7A66227222BB100E74D36 /* canvas-image-data.html */; };
 		F4EC78102ADF8BC300C37592 /* LoadWebViewWithEmptyAppName.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4EC780F2ADF8BC300C37592 /* LoadWebViewWithEmptyAppName.mm */; };
-		F4EC8094260D30540010311D /* simple-image-overlay.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4EC8093260D2E620010311D /* simple-image-overlay.html */; };
-		F4F137921D9B683E002BEC57 /* large-video-test-now-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F137911D9B6832002BEC57 /* large-video-test-now-playing.html */; };
-		F4F405BC1D4C0D1C007A9707 /* full-size-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F405BA1D4C0CF8007A9707 /* full-size-autoplaying-video-with-audio.html */; };
-		F4F405BD1D4C0D1C007A9707 /* skinny-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F405BB1D4C0CF8007A9707 /* skinny-autoplaying-video-with-audio.html */; };
 		F4F5BB5221667BAA002D06B9 /* TestFontOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4F5BB5121667BAA002D06B9 /* TestFontOptions.mm */; };
-		F4F9AD1C298C73DD00F92EDF /* load-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F9AD13298C715D00F92EDF /* load-image.html */; };
 		F4FA2A4F24D1F05700618A46 /* AttributedSubstringForProposedRange.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FA2A4E24D1F05700618A46 /* AttributedSubstringForProposedRange.mm */; };
 		F4FA91811E61849B007B8C1D /* WKWebViewMacEditingTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FA917F1E61849B007B8C1D /* WKWebViewMacEditingTests.mm */; };
-		F4FA91831E61857B007B8C1D /* double-click-does-not-select-trailing-space.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FA91821E618566007B8C1D /* double-click-does-not-select-trailing-space.html */; };
-		F4FB84A82BC9F1F6000D0B47 /* element-targeting-5.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FB84A02BC9F13A000D0B47 /* element-targeting-5.html */; };
-		F4FC077720F013B600CA043C /* significant-text-milestone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FC077620F0108100CA043C /* significant-text-milestone.html */; };
 		F660AA1115A5F631003A1243 /* GetInjectedBundleInitializationUserDataCallback_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F660AA0F15A5F624003A1243 /* GetInjectedBundleInitializationUserDataCallback_Bundle.cpp */; };
 		F660AA1515A61ABF003A1243 /* InjectedBundleInitializationUserDataCallbackWins_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F660AA1415A61ABF003A1243 /* InjectedBundleInitializationUserDataCallbackWins_Bundle.cpp */; };
 		F6B7BE9517469212008A3445 /* DidAssociateFormControls_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6B7BE92174691EF008A3445 /* DidAssociateFormControls_Bundle.cpp */; };
-		F6B7BE9717469B96008A3445 /* associate-form-controls.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F6B7BE9617469B7E008A3445 /* associate-form-controls.html */; };
 		F6D67D3826F90206006E0349 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3626F90206006E0349 /* Int128.cpp */; };
 		F6F49C6B15545CA70007F39D /* DOMWindowExtensionNoCache_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6F49C6615545C8D0007F39D /* DOMWindowExtensionNoCache_Bundle.cpp */; };
-		F6FDDDD614241C6F004F1729 /* push-state.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F6FDDDD514241C48004F1729 /* push-state.html */; };
 		FA8650342C7D062000117287 /* WebTransportServer.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA8650322C7D01CA00117287 /* WebTransportServer.mm */; };
 		FE2BCDC72470FDA300DEC33B /* StdLibExtrasTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2BCDC62470FC7000DEC33B /* StdLibExtrasTests.cpp */; };
 		FE2D9474245EB2F400E48135 /* BitSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2D9473245EB2DF00E48135 /* BitSet.cpp */; };
@@ -1403,6 +1404,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = A13EBB481B87339E00097110;
 			remoteInfo = WebProcessPlugIn;
+		};
+		A17C48552C98EBF50023F3C7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A17C46452C98E3430023F3C7;
+			remoteInfo = TestWebKitAPIResources;
 		};
 		BC575A95126E74E7006F0F12 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1506,526 +1514,517 @@
 			name = "Product Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8DD76F9E0486AA7600D96B5E /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 8;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
-		BCB9F4FB112384C000A137E0 /* Copy Resources */ = {
+		A17C464B2C98E4520023F3C7 /* Copy Resources */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = TestWebKitAPI.resources;
+			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
-				72F21E9828C9216B007BF315 /* 100x100-red.jp2 in Copy Resources */,
-				55A817FF2181021A0004A39A /* 100x100-red.tga in Copy Resources */,
-				1A9E52C913E65EF4006917F5 /* 18-characters.html in Copy Resources */,
-				55A81800218102210004A39A /* 400x400-green.png in Copy Resources */,
-				379028B914FAC24C007E6B43 /* acceptsFirstMouse.html in Copy Resources */,
-				F4A7CE7A2662D86C00228685 /* active-touch-events.html in Copy Resources */,
-				E59CF8232C2D1EAE00891383 /* adaptive-image-glyph.heic in Copy Resources */,
-				725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */,
-				4C453A44294A469500D91D2B /* Ahem-10000A.ttf in Copy Resources */,
-				1C2B81871C8925A000A5529F /* Ahem.ttf in Copy Resources */,
-				46C1EA9825758820005E409E /* alert.html in Copy Resources */,
-				1A63479F183D72A4005B1707 /* all-content-in-one-iframe.html in Copy Resources */,
-				C25CCA0D1E5141840026CB8A /* AllAhem.svg in Copy Resources */,
-				48354DD929F08047003E566D /* animated-red-green-blue-repeat-infinite.gif in Copy Resources */,
-				F4A9202F1FEE34E900F59590 /* apple-data-url.html in Copy Resources */,
-				A1FB503D22A1CBE200D4D979 /* apple-pay-availability-existing-object.html in Copy Resources */,
-				A1798B8922435E29000764BD /* apple-pay-availability-in-iframe.html in Copy Resources */,
-				A1798B872243449B000764BD /* apple-pay-availability.html in Copy Resources */,
-				A1FB504322A213A300D4D979 /* apple-pay-can-make-payment.html in Copy Resources */,
-				A1FB504122A212A900D4D979 /* apple-pay-can-make-payments-with-active-card.html in Copy Resources */,
-				A1FB503F22A20F6400D4D979 /* apple-pay-can-make-payments.html in Copy Resources */,
-				A1FB504522A2157100D4D979 /* apple-pay.js in Copy Resources */,
-				F46A095A1ED8A6E600D4AA55 /* apple.gif in Copy Resources */,
-				5C9E59411D3EB5AC00E3C62E /* ApplicationCache.db in Copy Resources */,
-				5C9E59421D3EB5AC00E3C62E /* ApplicationCache.db-shm in Copy Resources */,
-				5C9E59431D3EB5AC00E3C62E /* ApplicationCache.db-wal in Copy Resources */,
-				F6B7BE9717469B96008A3445 /* associate-form-controls.html in Copy Resources */,
-				11C2598D21FA6324004C9E23 /* async-script-load.html in Copy Resources */,
-				F4856CA31E649EA8009D7EE7 /* attachment-element.html in Copy Resources */,
-				B55F11B71517D03300915916 /* attributedStringCustomFont.html in Copy Resources */,
-				F42BD7D9245CC508001E207A /* attributedStringNewlineAtEndOfDocument.html in Copy Resources */,
-				7C9ED98B17A19F4B00E4DC33 /* attributedStringStrikethrough.html in Copy Resources */,
-				37137E4B21124D01002BEEA4 /* AttrStyle.html in Copy Resources */,
-				07FC26E8267A735A002B1BEF /* audio-buffer-size.html in Copy Resources */,
-				46F03C1C255B2D5A00AA51C5 /* audio-context-playing.html in Copy Resources */,
-				F4D0A6372A2D520800D47257 /* audio-fingerprinting.html in Copy Resources */,
-				CD9E292E1C90C33F000BB800 /* audio-only.html in Copy Resources */,
-				C944160021430E8900B1EDDA /* audio-with-controls.html in Copy Resources */,
-				C9C9A91B21DED28700FDE96E /* audio-with-play-button.html in Copy Resources */,
-				CD57779C211CE91F001B371E /* audio-with-web-audio.html in Copy Resources */,
-				76E182DF154767E600F1FADD /* auto-submitting-form.html in Copy Resources */,
-				F41AB99F1EF4696B0083FA08 /* autofocus-contenteditable.html in Copy Resources */,
-				93CFA8671CEB9E38000565A8 /* autofocused-text-input.html in Copy Resources */,
-				C9C60E651E53A9DC006DA181 /* autoplay-check-frame.html in Copy Resources */,
-				C9C60E661E53A9DC006DA181 /* autoplay-check-in-iframe.html in Copy Resources */,
-				C95984F41E36BC6B002C0D45 /* autoplay-check.html in Copy Resources */,
-				C9B1043E1ECF9848000520FA /* autoplay-inherits-gesture-from-document.html in Copy Resources */,
-				C9BF06EF1E9C132500595E3E /* autoplay-muted-with-controls.html in Copy Resources */,
-				C95984F51E36BC6B002C0D45 /* autoplay-no-audio-check.html in Copy Resources */,
-				C99B675C1E39721A00FC6C80 /* autoplay-with-controls.html in Copy Resources */,
-				C99BDF891E80980400C7170E /* autoplay-zero-volume-check.html in Copy Resources */,
-				C9C9CD4321E6A6860019DB96 /* autoplaying-multiple-media-elements.html in Copy Resources */,
-				2E14A5291D3FE96B0010F35B /* autoplaying-video-with-audio.html in Copy Resources */,
-				F41AB9A01EF4696B0083FA08 /* background-image-link-and-input.html in Copy Resources */,
-				464C764D230DF85C00AFB020 /* BadServiceWorkerRegistrations-4.sqlite3 in Copy Resources */,
-				4971B13124623A4F0096994D /* basicITPDatabase.db in Copy Resources */,
-				46FACF7423E8842300A9EBC6 /* beforeunload-slow.html in Copy Resources */,
-				46C3AEB323D0E529001B0680 /* beforeunload.html in Copy Resources */,
-				2DE71B001D49C3ED00904094 /* blinking-div.html in Copy Resources */,
-				7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */,
-				0794742D25CB33FD00C597EE /* camera-to-canvas.html in Copy Resources */,
-				26DF5A6315A2A27E003689C2 /* CancelLoadFromResourceLoadDelegate.html in Copy Resources */,
-				F4D0A6382A2D520800D47257 /* canvas-fingerprinting.html in Copy Resources */,
-				F4E7A66327222CA900E74D36 /* canvas-image-data.html in Copy Resources */,
-				2EFF06C51D8867760004BB30 /* change-video-source-on-click.html in Copy Resources */,
-				2EFF06C71D886A580004BB30 /* change-video-source-on-end.html in Copy Resources */,
-				9BD4239C1E04C01C00200395 /* chinese-character-with-image.html in Copy Resources */,
-				F4C3F2AB2C4488730029A47D /* click-targets.html in Copy Resources */,
-				839AA35F21A26B0300980DD6 /* client-side-redirect.html in Copy Resources */,
-				F422A3EB235BB16200CF00CA /* clipboard.html in Copy Resources */,
-				1A50AA201A2A51FC00F4C345 /* close-from-within-create-page.html in Copy Resources */,
-				9B270FEE1DDC2C0B002D53F3 /* closed-shadow-tree-test.html in Copy Resources */,
-				9B9332CE2320C745002D50E8 /* cocoa-writer-markup-with-lists.html in Copy Resources */,
-				9BAE177B22E2BBFB00DF3098 /* cocoa-writer-markup-with-system-fonts.html in Copy Resources */,
-				E5036F78211BC25400BFDBE2 /* color-drop.html in Copy Resources */,
-				31903C912765077400363472 /* color-scheme.html in Copy Resources */,
-				0F16BED82304A1F300B4A167 /* composited.html in Copy Resources */,
-				F4B825D81EF4DBFB006E417F /* compressed-files.zip in Copy Resources */,
-				DF1C7CEC27F5309700D8145C /* console-message-with-details.html in Copy Resources */,
-				5C9E56871DF914AE00C9EE33 /* contentBlockerCheck.html in Copy Resources */,
-				F469FB241F01804B00401539 /* contenteditable-and-target.html in Copy Resources */,
-				F41AB9A11EF4696B0083FA08 /* contenteditable-and-textarea.html in Copy Resources */,
-				F4A32ECB1F0643370047C544 /* contenteditable-in-iframe.html in Copy Resources */,
-				E540058827B3A8B20005653A /* contenteditable-user-select-user-drag.html in Copy Resources */,
-				A16F66BA1C40EB4F00BD4D24 /* ContentFiltering.html in Copy Resources */,
-				A13D1AD624AD468F003F92A8 /* context-menu-control-click.html in Copy Resources */,
-				5142B2731517C8C800C32B19 /* ContextMenuCanCopyURL.html in Copy Resources */,
-				CD0BD0A81F79982D001AB2CF /* ContextMenuImgWithVideo.html in Copy Resources */,
-				F4034FA3275D5AC6003A81F8 /* cookie-consent-basic.html in Copy Resources */,
-				5C2936961D5C00ED00DEAB1E /* CookieMessage.html in Copy Resources */,
-				9B1F6F791F90559E00B55744 /* copy-html.html in Copy Resources */,
-				9B62630C1F8C25C8007EE29B /* copy-url.html in Copy Resources */,
-				7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */,
-				4995A6F025E8772000E5F0A9 /* csp-document-uri-report.html in Copy Resources */,
-				952F7167270BD9CB00D00DCC /* CSSViewportUnits.html in Copy Resources */,
-				952F7167270BD9CB00D00DCD /* CSSViewportUnits.svg in Copy Resources */,
-				2DDD4DA4270B8B3500659A61 /* cube.usdz in Copy Resources */,
-				F4740A342A97C99900B657B6 /* cursor-styles.html in Copy Resources */,
-				F4AB578A1F65165400DB0DA1 /* custom-draggable-div.html in Copy Resources */,
-				290F4275172A221C00939FF0 /* custom-protocol-sync-xhr.html in Copy Resources */,
-				1CF59AE521E6977D006E37EC /* dark-mode.html in Copy Resources */,
-				F47DFB2621A878DF00021FB6 /* data-detectors.html in Copy Resources */,
-				F486B1D01F67952300F34BDD /* DataTransfer-setDragImage.html in Copy Resources */,
-				F457A9D6202D68AF00F7E9D5 /* DataTransfer.html in Copy Resources */,
-				F4512E131F60C44600BB369E /* DataTransferItem-getAsEntry.html in Copy Resources */,
-				118153442208B7AC00B2CCD2 /* deferred-script-load.html in Copy Resources */,
-				118153462208B7E500B2CCD2 /* deferred-script.js in Copy Resources */,
-				C07E6CB213FD73930038B22B /* devicePixelRatio.html in Copy Resources */,
-				0799C34B1EBA3301003B7532 /* disableGetUserMedia.html in Copy Resources */,
-				63A61B8B1FAD251100F06885 /* display-mode.html in Copy Resources */,
-				F41AB9A21EF4696B0083FA08 /* div-and-large-image.html in Copy Resources */,
-				37E1064C1697681800B78BD0 /* DOMHTMLTableCellElementCellAbove.html in Copy Resources */,
-				37DC6791140D7D7600ABCCDB /* DOMRangeOfString.html in Copy Resources */,
-				F4FA91831E61857B007B8C1D /* double-click-does-not-select-trailing-space.html in Copy Resources */,
-				D20C03B62B704A95004C414A /* download.example.webarchive in Copy Resources */,
-				837A35F11D9A1E7D00663C57 /* DownloadRequestBlobURL.html in Copy Resources */,
-				5714ECB91CA8B5B000051AC8 /* DownloadRequestOriginalURL.html in Copy Resources */,
-				5714ECBD1CA8C22A00051AC8 /* DownloadRequestOriginalURL2.html in Copy Resources */,
-				5714ECBB1CA8BFE400051AC8 /* DownloadRequestOriginalURLFrame.html in Copy Resources */,
-				F4A32EC41F05F3850047C544 /* dragstart-change-selection-offscreen.html in Copy Resources */,
-				F4D5E4E81F0C5D38008C1A49 /* dragstart-clear-selection.html in Copy Resources */,
-				F46BD56924870643008282D6 /* dragstart-data.html in Copy Resources */,
-				F4194AD11F5A320100ADD83F /* drop-targets.html in Copy Resources */,
-				2EB29D5E1F762DB90023A5F1 /* dump-datatransfer-types.html in Copy Resources */,
-				A155022C1E050D0300A24C57 /* duplicate-completion-handler-calls.html in Copy Resources */,
-				F4CEF1572A1030A400A370BE /* editable-body-mixed-text.html in Copy Resources */,
-				9984FACE1CFFB090008D198C /* editable-body.html in Copy Resources */,
-				F4D9818F2196B920008230FC /* editable-nested-lists.html in Copy Resources */,
-				CEDA12412437C9FB00C28A9E /* editable-region-composited-and-non-composited-overlap.html in Copy Resources */,
-				F4352F9F26D403DE00E605E4 /* editable-responsive-body.html in Copy Resources */,
-				F44D06451F395C26001A0E29 /* editor-state-test-harness.html in Copy Resources */,
-				F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */,
-				F4DADD072BABAD0F008B398F /* element-targeting-1.html in Copy Resources */,
-				F4C1275A2C756B56000BC609 /* element-targeting-10.html in Copy Resources */,
-				F4365E2B2BB11829005E8C1A /* element-targeting-2.html in Copy Resources */,
-				F41E446D2BBCDD81002A856F /* element-targeting-3.html in Copy Resources */,
-				F44A2A772BC205060044694E /* element-targeting-4.html in Copy Resources */,
-				F4FB84A82BC9F1F6000D0B47 /* element-targeting-5.html in Copy Resources */,
-				F41289A92BCC97E700D6E0E7 /* element-targeting-6.html in Copy Resources */,
-				F405F8AD2BD1D4DC0020E6AB /* element-targeting-7.html in Copy Resources */,
-				F44CD9D12BD6ABFD0080A6C7 /* element-targeting-8.html in Copy Resources */,
-				F4CC8F4D2C0A759D00D7E76E /* element-targeting-9.html in Copy Resources */,
-				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
-				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
-				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
-				F4C2AB221DD6D95E00E06D5B /* enormous-video-with-sound.html in Copy Resources */,
-				F407FE391F1D0DFC0017CF25 /* enormous.svg in Copy Resources */,
-				07492B3C1DF8B86600633DE1 /* enumerateMediaDevices.html in Copy Resources */,
-				F41462BA2BC346B80027261C /* event.ics in Copy Resources */,
-				C5E1AFFE16B221F1006CC1F2 /* execCopy.html in Copy Resources */,
-				7283A9D222FB1E0600B21C7D /* exif-orientation-8-llo.jpg in Copy Resources */,
-				CDA29B2B20FD358400F15CED /* ExitFullscreenOnEnterPiP.html in Copy Resources */,
-				F40B8D5E281086E500346417 /* fade-in-image.html in Copy Resources */,
-				9358C33C273ED07B00F3B38C /* file-system-access.salt in Copy Resources */,
-				F41AB9A31EF4696B0083FA08 /* file-uploading.html in Copy Resources */,
-				BC2D006412AA04CE00E732A3 /* file-with-anchor.html in Copy Resources */,
-				49D2E5C22731E3BC00BCCAED /* file-with-iframe.html in Copy Resources */,
-				51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */,
-				CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */,
-				524BBC9E19DF72C0002F1AF1 /* file-with-video.html in Copy Resources */,
-				1A02C870125D4CFD00E3F4BD /* find.html in Copy Resources */,
-				A17EAC55208305A00084B41B /* find.pdf in Copy Resources */,
-				C5101C4F176B8D9200EE9B15 /* findRanges.html in Copy Resources */,
-				F4D0A6392A2D521100D47257 /* fingerprint-audio-worklet.js in Copy Resources */,
-				F43E3BC120DADBC500A4E7ED /* fixed-nav-bar.html in Copy Resources */,
-				932AE53D1D371047005DFFAF /* focus-inputs.html in Copy Resources */,
-				462B4E8028E7B0E400653230 /* fragment-navigation-before-load-event.html in Copy Resources */,
-				1A7E8B3618120B2F00AEB74A /* FragmentNavigation.html in Copy Resources */,
-				F47728991E4AE3C1007ABF6A /* full-page-contenteditable.html in Copy Resources */,
-				F4E0A28B211E4A2B00AF7C7F /* full-page-dropzone.html in Copy Resources */,
-				F4F405BC1D4C0D1C007A9707 /* full-size-autoplaying-video-with-audio.html in Copy Resources */,
-				A1183D482C6C8FC400233D8B /* fullscreen-lifecycle-audio.html in Copy Resources */,
-				CD78E11E1DB7EE2A0014A2DE /* FullscreenDelegate.html in Copy Resources */,
-				3FBD1B4A1D3D66AB00E6D6FA /* FullscreenLayoutConstraints.html in Copy Resources */,
-				CDE195B51CFE0B880053D256 /* FullscreenTopContentInset.html in Copy Resources */,
-				CDBFCC461A9FF49E00A7B691 /* FullscreenZoomInitialFrame.html in Copy Resources */,
-				93A9BF6327BF6804000B44D3 /* general-storage-directory-indexeddb.sqlite3 in Copy Resources */,
-				93A9BF5F27BF3686000B44D3 /* general-storage-directory-localstorage.sqlite3 in Copy Resources */,
-				93A9BF6127BF5AF0000B44D3 /* general-storage-directory.origin in Copy Resources */,
-				936EC36627BA3B0D00AFA8AE /* general-storage-directory.salt in Copy Resources */,
-				26F52EAD1828827B0023D412 /* geolocationGetCurrentPosition.html in Copy Resources */,
-				636353A71E98665D0009F8AF /* GeolocationGetCurrentPositionResult.html in Copy Resources */,
-				26F52EAF18288C230023D412 /* geolocationGetCurrentPositionWithHighAccuracy.html in Copy Resources */,
-				26F52EB218288F240023D412 /* geolocationWatchPosition.html in Copy Resources */,
-				26F52EB318288F240023D412 /* geolocationWatchPositionWithHighAccuracy.html in Copy Resources */,
-				07E1F6A21FFC44FA0096C7EC /* getDisplayMedia.html in Copy Resources */,
-				467C565321B5ED130057516D /* GetSessionCookie.html in Copy Resources */,
-				41661C662355E85E00D33C27 /* getUserMedia-webaudio.html in Copy Resources */,
-				074994421EA5034B000DA44E /* getUserMedia.html in Copy Resources */,
-				074994521EA5034B000DA44E /* getUserMedia2.html in Copy Resources */,
-				074994421EA5034B000DA45E /* getUserMediaAudioVideoCapture.html in Copy Resources */,
-				074994521EA5034B000DA46E /* getUserMediaPermission.html in Copy Resources */,
-				F46A095B1ED8A6E600D4AA55 /* gif-and-file-input.html in Copy Resources */,
-				F45C640028178AD30090DFAB /* green-400x400.webp in Copy Resources */,
-				573255A522139BC700396AE8 /* helloworld.webarchive in Copy Resources */,
-				1CC4C74E28890D3700A3B23D /* Helvetica_light.svg in Copy Resources */,
-				9B4F8FA7159D52DD002D9F94 /* HTMLCollectionNamedItem.html in Copy Resources */,
-				9B26FCCA159D16DE00CC3765 /* HTMLFormCollectionNamedItem.html in Copy Resources */,
-				BCBD3737125ABBEB00D2C29F /* icon.png in Copy Resources */,
-				EB230D41245E813F00C66AD1 /* IDBCheckpointWAL.html in Copy Resources */,
-				510477771D298E72009747EB /* IDBDeleteRecovery.html in Copy Resources */,
-				510477721D298DDD009747EB /* IDBDeleteRecovery.sqlite3 in Copy Resources */,
-				510477731D298DDD009747EB /* IDBDeleteRecovery.sqlite3-shm in Copy Resources */,
-				510477741D298DDD009747EB /* IDBDeleteRecovery.sqlite3-wal in Copy Resources */,
-				5110FCF11E01CD64006F8D0B /* IDBIndexUpgradeToV2.html in Copy Resources */,
-				93A2749D251EF90700A1B6D4 /* IDBIndexUpgradeToV2WithMultipleIndices.html in Copy Resources */,
-				937B569E23CD23DB002AE640 /* IDBObjectStoreInfoUpgrade.sqlite3 in Copy Resources */,
-				93BCBC8423CC6F4400CA2221 /* IDBObjectStoreInfoUpgradeToV2.html in Copy Resources */,
-				1CC80CEA2474F249004DC489 /* idempotent-mode-autosizing-only-honors-percentages.html in Copy Resources */,
-				F41AB9A41EF4696B0083FA08 /* image-and-contenteditable.html in Copy Resources */,
-				F4E0A2B42122402B00AF7C7F /* image-and-file-upload.html in Copy Resources */,
-				F41AB9A51EF4696B0083FA08 /* image-and-textarea.html in Copy Resources */,
-				F491DBAE281DE0E80081705F /* image-controls.html in Copy Resources */,
-				F4DEF6ED1E9B4DB60048EF61 /* image-in-link-and-input.html in Copy Resources */,
-				F45B63FB1F197F4A009D38B9 /* image-map.html in Copy Resources */,
-				1F0559E52890A11B002E279C /* image-with-text.html in Copy Resources */,
-				3128A8152376413300D90D40 /* image.html in Copy Resources */,
-				48B288E929F7743300F00F78 /* img-animation-covered-by-link.html in Copy Resources */,
-				48354DDB29F092D1003E566D /* img-animation-in-anchor.html in Copy Resources */,
-				71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */,
-				1C9C7F512891238500C4649E /* ImmediateFont.html in Copy Resources */,
-				49897D6C241FE9E400ECF153 /* in-app-browser-privacy-local-file.html in Copy Resources */,
-				4971B1182451F29A0096994D /* incorrectCreateTableSchema.db in Copy Resources */,
-				9341C95727CD507A0023C0F4 /* indexeddb-persistence-third-party.sqlite3 in Copy Resources */,
-				935786CD20F6A2910000CDFC /* IndexedDB.sqlite3 in Copy Resources */,
-				935786CE20F6A2A10000CDFC /* IndexedDB.sqlite3-shm in Copy Resources */,
-				935786CC20F6A2700000CDFC /* IndexedDB.sqlite3-wal in Copy Resources */,
-				51A587851D2739E3004BA9AF /* IndexedDBDatabaseProcessKill-1.html in Copy Resources */,
-				CAB0FF5222332407006CA5B0 /* IndexedDBFileName-1.html in Copy Resources */,
-				CAB0FF5322332407006CA5B0 /* IndexedDBFileName-2.html in Copy Resources */,
-				9399BA052371114F008392BF /* IndexedDBInPageCache.html in Copy Resources */,
-				51BCEE4E1C84F53B0042C82E /* IndexedDBMultiProcess-1.html in Copy Resources */,
-				51BCEE4F1C84F53B0042C82E /* IndexedDBMultiProcess-2.html in Copy Resources */,
-				51A5877D1D1B49CD004BA9AF /* IndexedDBMultiProcess-3.html in Copy Resources */,
-				9399BA062371114F008392BF /* IndexedDBNotInPageCache.html in Copy Resources */,
-				51B1EE961C80FAEF0064FB98 /* IndexedDBPersistence-1.html in Copy Resources */,
-				51B1EE971C80FAEF0064FB98 /* IndexedDBPersistence-2.html in Copy Resources */,
-				57599E271F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3 in Copy Resources */,
-				57599E281F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-shm in Copy Resources */,
-				571F7FD01F2961FB00946648 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-wal in Copy Resources */,
-				57599E2A1F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityRead.html in Copy Resources */,
-				57599E2B1F071AA000A3FB8C /* IndexedDBStructuredCloneBackwardCompatibilityWrite.html in Copy Resources */,
-				CA2879DC226E69B6001026F5 /* IndexedDBSuspendImminently.html in Copy Resources */,
-				CA5B94D22190C0F40059FE38 /* IndexedDBTempFileSize-1.html in Copy Resources */,
-				CA5B94D32190C0F40059FE38 /* IndexedDBTempFileSize-2.html in Copy Resources */,
-				CA97B3952193667A0045DF6F /* IndexedDBUserDelete.html in Copy Resources */,
-				5110FCF91E01CD8A006F8D0B /* IndexUpgrade.blob in Copy Resources */,
-				5110FCF61E01CD83006F8D0B /* IndexUpgrade.sqlite3 in Copy Resources */,
-				93A274A2252163EE00A1B6D4 /* IndexUpgradeWithMultipleIndices.sqlite3 in Copy Resources */,
-				93A274A5252241DE00A1B6D4 /* IndexUpgradeWithMultipleIndicesHaveSameID.sqlite3 in Copy Resources */,
-				2EFF06CD1D8A429A0004BB30 /* input-field-in-scrollable-document.html in Copy Resources */,
-				CE3524FA1B1443890028A7C5 /* input-focus-blur.html in Copy Resources */,
-				CE6D0EE32426B932002AD901 /* insert-text.html in Copy Resources */,
-				996EDCCB270E70D7006DF175 /* InspectorExtension-basic-page.html in Copy Resources */,
-				99E2846826F941540003F1FA /* InspectorExtension-basic-tab.html in Copy Resources */,
-				99E2846626F93DB50003F1FA /* InspectorExtension-TabIcon-30x30.png in Copy Resources */,
-				074994421EA5034B000DA44D /* invalidDeviceIDHashSalts in Copy Resources */,
-				57F56A5C1C7F8CC100F31D7E /* IsNavigationActionTrusted.html in Copy Resources */,
-				C9B4AD2C1ECA6F7F00F5FEA0 /* js-autoplay-audio.html in Copy Resources */,
-				C99B675D1E39722000FC6C80 /* js-play-with-controls.html in Copy Resources */,
-				C2CF975B16CEC71B0054E99D /* JSContextBackForwardCache1.html in Copy Resources */,
-				C2CF975A16CEC7140054E99D /* JSContextBackForwardCache2.html in Copy Resources */,
-				937A6C8A24357C1700C3A6B0 /* KillWebProcessWithOpenConnection-1.html in Copy Resources */,
-				937A6C8B24357C1700C3A6B0 /* KillWebProcessWithOpenConnection-2.html in Copy Resources */,
-				F42DA5161D8CEFE400336F40 /* large-input-field-focus-onload.html in Copy Resources */,
-				55226A2F1EBA44B900C36AD0 /* large-red-square-image.html in Copy Resources */,
-				F4538EF71E8473E600B5C953 /* large-red-square.png in Copy Resources */,
-				2E1B7B021D41B1B9007558B4 /* large-video-hides-controls-after-seek-to-end.html in Copy Resources */,
-				2E54F40D1D7BC84200921ADF /* large-video-mutes-onplaying.html in Copy Resources */,
-				2EFF06C31D88621E0004BB30 /* large-video-offscreen.html in Copy Resources */,
-				2E691AF31D79E75E00129407 /* large-video-playing-scroll-away.html in Copy Resources */,
-				2E1B7B001D41ABA7007558B4 /* large-video-seek-after-ending.html in Copy Resources */,
-				2E1DFDF11D42E1E400714A00 /* large-video-seek-to-beginning-and-play-after-ending.html in Copy Resources */,
-				F4F137921D9B683E002BEC57 /* large-video-test-now-playing.html in Copy Resources */,
-				936F72801CD7D9EC0068A0FB /* large-video-with-audio.html in Copy Resources */,
-				936F72811CD7D9EC0068A0FB /* large-video-with-audio.mp4 in Copy Resources */,
-				93625D271CD9741C006DC1F1 /* large-video-without-audio.html in Copy Resources */,
-				2E691AEF1D79DE8400129407 /* large-videos-autoplaying-click-to-pause.html in Copy Resources */,
-				2E691AF11D79E51A00129407 /* large-videos-autoplaying-scroll-to-video.html in Copy Resources */,
-				2E691AEA1D78B53600129407 /* large-videos-paused-video-hides-controls.html in Copy Resources */,
-				2E691AED1D78B91000129407 /* large-videos-playing-muted-video-hides-controls.html in Copy Resources */,
-				2E691AEB1D78B53600129407 /* large-videos-playing-video-keeps-controls.html in Copy Resources */,
-				2E1DFDEF1D42A6F200714A00 /* large-videos-with-audio-autoplay.html in Copy Resources */,
-				2E1DFDED1D42A51100714A00 /* large-videos-with-audio.html in Copy Resources */,
-				C25CCA0B1E5140C10026CB8A /* LineBreaking.html in Copy Resources */,
-				F41AB9A61EF4696B0083FA08 /* link-and-input.html in Copy Resources */,
-				F41AB9A71EF4696B0083FA08 /* link-and-target-div.html in Copy Resources */,
-				F46128D4211E40FD00D9FADB /* link-in-iframe-and-input.html in Copy Resources */,
-				8361F1781E610B4E00759B25 /* link-with-download-attribute-with-slashes.html in Copy Resources */,
-				8349D3C41DB9728E004A9F65 /* link-with-download-attribute.html in Copy Resources */,
-				A11E7DA024A169F900026745 /* link-with-hover-menu.html in Copy Resources */,
-				3128A81323763FAC00D90D40 /* link-with-image.html in Copy Resources */,
-				378E64791632707400B6C676 /* link-with-title.html in Copy Resources */,
-				F4F9AD1C298C73DD00F92EDF /* load-image.html in Copy Resources */,
-				573255A622139BC700396AE8 /* load-web-archive-1.html in Copy Resources */,
-				573255A722139BC700396AE8 /* load-web-archive-2.html in Copy Resources */,
-				57901FB11CAF142D00ED64F9 /* LoadInvalidURLRequest.html in Copy Resources */,
-				CA7787FF228CEFDB00E50463 /* local-storage-process-crashes.html in Copy Resources */,
-				9368A25E229EFB4700A829CA /* local-storage-process-suspends-1.html in Copy Resources */,
-				9368A25F229EFB4700A829CA /* local-storage-process-suspends-2.html in Copy Resources */,
-				8C10AF98206467920018FD90 /* localstorage-empty-string-value.html in Copy Resources */,
-				93D119FC22C680F7009BE3C7 /* localstorage-open-window-private.html in Copy Resources */,
-				51E6A8961D2F1CA700C004B6 /* LocalStorageClear.html in Copy Resources */,
-				46C519E61D3563FD00DAA51A /* LocalStorageNullEntries.html in Copy Resources */,
-				46C519E71D3563FD00DAA51A /* LocalStorageNullEntries.localstorage in Copy Resources */,
-				46C519E81D3563FD00DAA51A /* LocalStorageNullEntries.localstorage-shm in Copy Resources */,
-				7A6A2C721DCCFB5200C0D085 /* LocalStorageQuirkEnabled.html in Copy Resources */,
-				4CC961EC294A36CE00483F06 /* LockdownModeFonts.html in Copy Resources */,
-				7A33FF3027C82F8100D7E03E /* LockdownModePDF.html in Copy Resources */,
-				2D2FE8DA231745C900B2E9C9 /* long-email-viewport.html in Copy Resources */,
-				C9E8EE7521DED94300797765 /* long-test.mp4 in Copy Resources */,
-				9361002914DC95A70061379D /* lots-of-iframes.html in Copy Resources */,
-				93AF4ED11506F130007FD57E /* lots-of-images.html in Copy Resources */,
-				2DD7D3AF178227B30026E1E3 /* lots-of-text-vertical-lr.html in Copy Resources */,
-				930AD402150698D00067970F /* lots-of-text.html in Copy Resources */,
-				AD57AC221DA7466E00FF1BDE /* many-iframes.html in Copy Resources */,
-				7772ECE122FE06C60009A799 /* many-same-origin-iframes.html in Copy Resources */,
-				CD8394DF232AF7C000149495 /* media-loading.html in Copy Resources */,
-				0794742D25CB33FD00C597EB /* media-remote.html in Copy Resources */,
-				CDA3159A1ED548F1009F60D3 /* MediaPlaybackSleepAssertion.html in Copy Resources */,
-				CDC9442F1EF205D60059C3C4 /* mediastreamtrack-detached.html in Copy Resources */,
-				E1220DCA155B28AA0013E2FC /* MemoryCacheDisableWithinResourceLoadDelegate.html in Copy Resources */,
-				517E7E04151119C100D0B008 /* MemoryCachePruneWithinResourceLoadDelegate.html in Copy Resources */,
-				4971B1202453A88C0096994D /* missingTopFrameUniqueRedirectSameSiteStrictTableSchema.db in Copy Resources */,
-				51CD1C721B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */,
-				7A1458FC1AD5C07000E06772 /* mouse-button-listener.html in Copy Resources */,
-				33E79E06137B5FD900E32D99 /* mouse-move-listener.html in Copy Resources */,
-				9B59F12A2034086F009E63D5 /* mso-list-compat-mode.html in Copy Resources */,
-				9BCD411A206DBCA3001D71BE /* mso-list-on-h4.html in Copy Resources */,
-				9BF356CD202D458500F71160 /* mso-list.html in Copy Resources */,
-				F42F081227449892007E0D90 /* multiple-images.html in Copy Resources */,
-				F4D2C66C2BCF9DED00DADC86 /* multiple-pages.pdf in Copy Resources */,
-				5797FE331EB15AB100B2F4A0 /* navigation-client-default-crypto.html in Copy Resources */,
-				F455DB952BAE45B600732E1B /* nested-frames.html in Copy Resources */,
-				2E4838472169DF30002F4531 /* nested-lists.html in Copy Resources */,
-				C99B675F1E39736F00FC6C80 /* no-autoplay-with-controls.html in Copy Resources */,
-				466C3843210637DE006A88DE /* notify-resourceLoadObserver.html in Copy Resources */,
-				CDB5DFFF213610FA00D3E189 /* now-playing.html in Copy Resources */,
-				93E2D2761ED7D53200FA76F6 /* offscreen-iframe-of-media-document.html in Copy Resources */,
-				F460BEEA27A1F416007B87D9 /* offscreen-image.html in Copy Resources */,
-				074994421EA5034B000DA44F /* ondevicechange.html in Copy Resources */,
-				1DAA52CC243BE805001A3159 /* one-video.html in Copy Resources */,
-				CEA6CF2819CCF69D0064F5A7 /* open-and-close-window.html in Copy Resources */,
-				F4A2E64F28455D3A0001FEEF /* open-in-new-tab.html in Copy Resources */,
-				7CCB99231D3B4A46003922F6 /* open-multiple-external-url.html in Copy Resources */,
-				468BC45522653A1000A36C96 /* open-window-then-write-to-it.html in Copy Resources */,
-				41848F4424891879000E2588 /* open-window-with-file-url-with-host.html in Copy Resources */,
-				931C281E22BC579A001D98C4 /* opendatabase-always-exists.html in Copy Resources */,
-				290A9BB91735F63800D71BBC /* OpenNewWindow.html in Copy Resources */,
-				1CB2F27E24F88A52000A5BC1 /* orthogonal-flow-available-size.html in Copy Resources */,
-				F49992C6248DABFD00034167 /* overflow-hidden.html in Copy Resources */,
-				0F340779230382870060A1A0 /* overflow-scroll.html in Copy Resources */,
-				83148B09202AC78D00BADE99 /* override-builtins-test.html in Copy Resources */,
-				CEBCA1391E3A807A00C73293 /* page-with-csp-iframe.html in Copy Resources */,
-				CEBCA1381E3A807A00C73293 /* page-with-csp.html in Copy Resources */,
-				CEBCA13B1E3A807A00C73293 /* page-without-csp-iframe.html in Copy Resources */,
-				CEBCA13A1E3A807A00C73293 /* page-without-csp.html in Copy Resources */,
-				A1C4FB731BACD1CA003742D0 /* pages.pages in Copy Resources */,
-				A57A34F216AF6B2B00C2501F /* PageVisibilityStateWithWindowChanges.html in Copy Resources */,
-				F4B86D4F20BCD5B20099A7E6 /* paint-significant-area-milestone.html in Copy Resources */,
-				A1409AD91E7254D4004949D9 /* password-protected.pages in Copy Resources */,
-				9BD6D3A71F7B21DC00BD4962 /* paste-image.html in Copy Resources */,
-				9B7D740F1F8378770006C432 /* paste-rtfd.html in Copy Resources */,
-				3FCC4FE81EC4E8CA0076E37C /* PictureInPictureDelegate.html in Copy Resources */,
-				F415086D1DA040C50044BE9B /* play-audio-on-click.html in Copy Resources */,
-				07492B3C1DF8B86600633EQ1 /* playable-audio.html in Copy Resources */,
-				0EBBCC661FFF9E0C00FA42AB /* pop-up-check.html in Copy Resources */,
-				465C23AF2640C3FE00F2FC7F /* postMessage-regularly.html in Copy Resources */,
-				46FD40382A6B3E6800A1B210 /* postMessage-various-types.html in Copy Resources */,
-				F41AB9A81EF4696B0083FA08 /* prevent-operation.html in Copy Resources */,
-				F41AB9A91EF4696B0083FA08 /* prevent-start.html in Copy Resources */,
-				F6FDDDD614241C6F004F1729 /* push-state.html in Copy Resources */,
-				E57B44C129ABFB3B006069DE /* qr-code.png in Copy Resources */,
-				95194CC028A5811F00343FDE /* red.html in Copy Resources */,
-				F4476F4B279082F900931786 /* remove-node-on-drop.html in Copy Resources */,
-				A12DDC001E8373E700CF6CAE /* rendered-image-excluding-overflow.html in Copy Resources */,
-				498D030A26376B34009CBFAD /* resourceLoadStatisticsMissingUniqueIndex.db in Copy Resources */,
-				F46849C01EEF5EF300B937FE /* rich-and-plain-text.html in Copy Resources */,
-				1CE6FAC32320267C00E48F6E /* rich-color-filtered.html in Copy Resources */,
-				2E92B8F7216490D4005B64F0 /* rich-text-attributes.html in Copy Resources */,
-				0F5651F91FCE513500310FBC /* scroll-to-anchor.html in Copy Resources */,
-				0FF1F0CD2AE205F5006ECC4F /* scrollable-page.html in Copy Resources */,
-				F4E0A296211FC5FB00AF7C7F /* selected-text-and-textarea.html in Copy Resources */,
-				F4D65DA81F5E4704009D8C27 /* selected-text-image-link-and-editable.html in Copy Resources */,
-				7A66BDB81EAF18D500CCC924 /* set-long-title.html in Copy Resources */,
-				CE6E81A420A933D500E2C80F /* set-timeout-function.html in Copy Resources */,
-				52B8CF9815868D9100281053 /* SetDocumentURI.html in Copy Resources */,
-				467C565421B5ED130057516D /* SetSessionCookie.html in Copy Resources */,
-				CEBABD491B71687C0051210A /* should-open-external-schemes.html in Copy Resources */,
-				F4E3D80820F70BB9007B58C5 /* significant-text-milestone-article.html in Copy Resources */,
-				F4FC077720F013B600CA043C /* significant-text-milestone.html in Copy Resources */,
-				C9B4AD2A1ECA6EBE00F5FEA0 /* silence-long.m4a in Copy Resources */,
-				1ADBEFE3130C6AA100D61D19 /* simple-accelerated-compositing.html in Copy Resources */,
-				F4D060082734A1AB008FA67A /* simple-editor.html in Copy Resources */,
-				C0ADBE9612FCA79B00D2C129 /* simple-form.html in Copy Resources */,
-				33DC8912141955FE00747EF7 /* simple-iframe.html in Copy Resources */,
-				F4EC8094260D30540010311D /* simple-image-overlay.html in Copy Resources */,
-				F460F669261263370064F2B6 /* simple-responsive-page.html in Copy Resources */,
-				BCAA485614A0444C0088FAC4 /* simple-tall.html in Copy Resources */,
-				BC909784125571CF00083756 /* simple.html in Copy Resources */,
-				51E5C7021919C3B200D8B3E1 /* simple2.html in Copy Resources */,
-				51E5C7031919C3B200D8B3E1 /* simple3.html in Copy Resources */,
-				F4F405BD1D4C0D1C007A9707 /* skinny-autoplaying-video-with-audio.html in Copy Resources */,
-				C01A23F21266156700C9ED55 /* spacebar-scrolling.html in Copy Resources */,
-				F4CFCDDA249FC9E400527482 /* SpaceOnly.otf in Copy Resources */,
-				9360270625A3CF7600367670 /* speechrecognition-basic.html in Copy Resources */,
-				9342589E255B6A120059EEDD /* speechrecognition-user-permission-persistence.html in Copy Resources */,
-				0721D4592838296C00A95853 /* start-offset.ts in Copy Resources */,
-				E194E1BD177E53C7009C4D4E /* StopLoadingFromDidReceiveResponse.html in Copy Resources */,
-				515BE16F1D428BB100DD7C68 /* StoreBlobToBeDeleted.html in Copy Resources */,
-				9BD6D3A21F7B218300BD4962 /* sunset-in-cupertino-100px.tiff in Copy Resources */,
-				9BD6D3A31F7B218300BD4962 /* sunset-in-cupertino-200px.png in Copy Resources */,
-				9BD6D3A41F7B218300BD4962 /* sunset-in-cupertino-400px.gif in Copy Resources */,
-				9BD6D3A51F7B218300BD4962 /* sunset-in-cupertino-600px.jpg in Copy Resources */,
-				1CC4C74D28890D3700A3B23D /* SVGFont.html in Copy Resources */,
-				31B76E4523299BDC007FED2C /* system-preview-trigger.html in Copy Resources */,
-				31727A5329F7518C00A7FB0F /* system-preview.html in Copy Resources */,
-				313C3A0221E567C300DBA86E /* SystemPreviewBlobNaming.html in Copy Resources */,
-				51C234CF2970E13500E35C4B /* test-mse-audio.webm in Copy Resources */,
-				CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */,
-				51BB6B86296E931F0059B107 /* test-mse.webm in Copy Resources */,
-				C95984F71E36BCEF002C0D45 /* test-without-audio-track.mp4 in Copy Resources */,
-				F46D43AB26D7092800969E5E /* test.jpg in Copy Resources */,
-				524BBCA119E30C77002F1AF1 /* test.mp4 in Copy Resources */,
-				49C64FD728349C38005BF0C2 /* test.pages in Copy Resources */,
-				7AE9E5091AE5AE8B00CF874B /* test.pdf in Copy Resources */,
-				44D3F8432BE1DB0000BE0218 /* test.xml in Copy Resources */,
-				5C7101C725DD98B600686200 /* test_print.pdf in Copy Resources */,
-				F45EB60427739F34003571AE /* TestModalContainerControls.mlmodelc in Copy Resources */,
-				2E9896151D8F093800739892 /* text-and-password-inputs.html in Copy Resources */,
-				F4CD74C620FDACFA00DE3794 /* text-with-async-script.html in Copy Resources */,
-				F44C7A0520FAAE3C0014478C /* text-with-deferred-script.html in Copy Resources */,
-				F40398922B2D0D2B00A7AA85 /* text-with-web-font.webarchive in Copy Resources */,
-				F41AB9AA1EF4696B0083FA08 /* textarea-to-input.html in Copy Resources */,
-				C22FA32D228F8AEB009D7988 /* TextWidth.html in Copy Resources */,
-				4952BE5F257816F800B0AEF1 /* try-text-select-with-disabled-text-interaction.html in Copy Resources */,
-				F4451C761EB8FD890020C5DA /* two-paragraph-contenteditable.html in Copy Resources */,
-				1D67BFDD2433EE66006B5047 /* two-videos.html in Copy Resources */,
-				31727A5429F7519400A7FB0F /* UnitBox.usdz in Copy Resources */,
-				1C51534C261596D700FBC4FE /* UserInstalledAhem.html in Copy Resources */,
-				C540F784152E5A9A00A40C8C /* verboseMarkup.html in Copy Resources */,
-				CD57779D211CE91F001B371E /* video-with-audio-and-web-audio.html in Copy Resources */,
-				CDC8E4941BC6F10800594FEC /* video-with-audio.html in Copy Resources */,
-				CDC8E4951BC6F10800594FEC /* video-with-audio.mp4 in Copy Resources */,
-				CD321B041E3A85FA00EB21C8 /* video-with-muted-audio-and-webaudio.html in Copy Resources */,
-				CDB4115A1E0B00DB00EAD352 /* video-with-muted-audio.html in Copy Resources */,
-				CD758A6F20572EA00071834A /* video-with-paused-audio-and-playing-muted.html in Copy Resources */,
-				C9C9A91D21DED7A000FDE96E /* video-with-play-button.html in Copy Resources */,
-				CDC8E4961BC6F10800594FEC /* video-without-audio.html in Copy Resources */,
-				CDC8E4971BC6F10800594FEC /* video-without-audio.mp4 in Copy Resources */,
-				2EBD9D0A2134730D002DA758 /* video.html in Copy Resources */,
-				CD577799211CE0E4001B371E /* web-audio-only.html in Copy Resources */,
-				57663DF32357E48900E85E09 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */,
-				521D1B7327713E80003900C5 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html in Copy Resources */,
-				52C8C13A2706439000BDF3B7 /* web-authentication-get-assertion-hid-internal-uv.html in Copy Resources */,
-				579F1C0123C93AF500C7D4B4 /* web-authentication-get-assertion-hid-multiple-accounts.html in Copy Resources */,
-				577454D02359B378008E1ED7 /* web-authentication-get-assertion-hid-no-credentials.html in Copy Resources */,
-				578DA44C23ECD23000246010 /* web-authentication-get-assertion-hid-pin-auth-blocked-error.html in Copy Resources */,
-				578DA44E23ECD28B00246010 /* web-authentication-get-assertion-hid-pin-invalid-error-retry.html in Copy Resources */,
-				570D26FC23C3F87000D5CF67 /* web-authentication-get-assertion-hid-pin.html in Copy Resources */,
-				57663DEC234F1F9300E85E09 /* web-authentication-get-assertion-hid.html in Copy Resources */,
-				57EDFC60245A299C00959521 /* web-authentication-get-assertion-la-no-mock.html in Copy Resources */,
-				572CEF71240F874700C412A2 /* web-authentication-get-assertion-la.html in Copy Resources */,
-				579833922368FA37008E5547 /* web-authentication-get-assertion-nfc-multiple-tags.html in Copy Resources */,
-				57537EE824BEA05F0048DBA5 /* web-authentication-get-assertion-nfc-pin-disconnect.html in Copy Resources */,
-				57663DEA234EA66D00E85E09 /* web-authentication-get-assertion-nfc.html in Copy Resources */,
-				577454D22359BB01008E1ED7 /* web-authentication-get-assertion-u2f-no-credentials.html in Copy Resources */,
-				57C624502346C21E00383FE7 /* web-authentication-get-assertion.html in Copy Resources */,
-				52C8C1382706437C00BDF3B7 /* web-authentication-make-credential-hid-internal-uv.html in Copy Resources */,
-				578DA44823ECD09B00246010 /* web-authentication-make-credential-hid-pin-auth-blocked-error.html in Copy Resources */,
-				570D26F423C3CA6A00D5CF67 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html in Copy Resources */,
-				5751B28A249D5BC500664C2A /* web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry.html in Copy Resources */,
-				578DA44223ECC7A000246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error.html in Copy Resources */,
-				578DA44623ECCC0A00246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry.html in Copy Resources */,
-				570D26FA23C3F25100D5CF67 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error.html in Copy Resources */,
-				578DA44423ECCAE900246010 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry.html in Copy Resources */,
-				5758598423C3C3A400C74572 /* web-authentication-make-credential-hid-pin-get-retries-error.html in Copy Resources */,
-				578DA44A23ECD18600246010 /* web-authentication-make-credential-hid-pin-invalid-error-retry.html in Copy Resources */,
-				570D26F623C3D33000D5CF67 /* web-authentication-make-credential-hid-pin.html in Copy Resources */,
-				5798337E236019A4008E5547 /* web-authentication-make-credential-hid.html in Copy Resources */,
-				5742178A2400AED8002B303D /* web-authentication-make-credential-la-duplicate-credential.html in Copy Resources */,
-				574217882400AC25002B303D /* web-authentication-make-credential-la-error.html in Copy Resources */,
-				5703BB8D2463F88700475FB2 /* web-authentication-make-credential-la-no-attestation.html in Copy Resources */,
-				57EDFC5C245A1A3F00959521 /* web-authentication-make-credential-la-no-mock.html in Copy Resources */,
-				5742178E2400D2DF002B303D /* web-authentication-make-credential-la.html in Copy Resources */,
-				46A44A5425A7830300F61E16 /* webaudio-createMediaElementSource.html in Copy Resources */,
-				1C2B81861C89259D00A5529F /* webfont.html in Copy Resources */,
-				F4D0A63A2A2D521100D47257 /* webgl-support.js in Copy Resources */,
-				31E9BDA3247F5729002E51A2 /* webgl.html in Copy Resources */,
-				7A33FF3427C8317D00D7E03E /* webkit-logo.pdf in Copy Resources */,
-				F45C640128178AD70090DFAB /* webp-image.html in Copy Resources */,
-				51714EB41CF8C78C004723C4 /* WebProcessKillIDBCleanup-1.html in Copy Resources */,
-				51714EB51CF8C78C004723C4 /* WebProcessKillIDBCleanup-2.html in Copy Resources */,
-				0794742D25CB33FD00C597ED /* webrtc-remote-iframe.html in Copy Resources */,
-				0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */,
-				536770361CC81B6100D425B1 /* WebScriptObjectDescription.html in Copy Resources */,
-				5120C83E1E67678F0025B250 /* WebsiteDataStoreCustomPaths.html in Copy Resources */,
-				93F79A5A28E64A06003E7CEB /* websql-database-tracker.db in Copy Resources */,
-				93F79A5B28E64A07003E7CEB /* websql-database.db in Copy Resources */,
-				2E131C181D83A98A001BA36C /* wide-autoplaying-video-with-audio.html in Copy Resources */,
-				CE14F1A4181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html in Copy Resources */,
-				468F2F942368DAF100F4B864 /* window-open-then-document-open.html in Copy Resources */,
-				A5E2027515B21F6E00C13E14 /* WindowlessWebViewWithMedia.html in Copy Resources */,
-				2ED88823277125AB00DB7E99 /* WKInspectorExtensionEvaluateScriptOnPage.html in Copy Resources */,
-				2ED88824277125AB00DB7E99 /* WKInspectorExtensionEvaluateScriptOnPageInnerFrame.html in Copy Resources */,
+				A17C47022C98E5C20023F3C7 /* 100x100-red.jp2 in Copy Resources */,
+				A17C47032C98E5C20023F3C7 /* 100x100-red.tga in Copy Resources */,
+				A17C468F2C98E54B0023F3C7 /* 18-characters.html in Copy Resources */,
+				A17C47042C98E5C20023F3C7 /* 400x400-green.png in Copy Resources */,
+				A17C46672C98E4D20023F3C7 /* acceptsFirstMouse.html in Copy Resources */,
+				A17C465A2C98E4BB0023F3C7 /* active-touch-events.html in Copy Resources */,
+				A17C47052C98E5C20023F3C7 /* adaptive-image-glyph.heic in Copy Resources */,
+				A17C46682C98E4D20023F3C7 /* AdditionalSupportedImageTypes.html in Copy Resources */,
+				A17C48462C98E6360023F3C7 /* Ahem-10000A.ttf in Copy Resources */,
+				A17C46902C98E54B0023F3C7 /* Ahem.ttf in Copy Resources */,
+				A17C47072C98E5C20023F3C7 /* alert.html in Copy Resources */,
+				A17C46912C98E54B0023F3C7 /* all-content-in-one-iframe.html in Copy Resources */,
+				A17C47082C98E5C20023F3C7 /* AllAhem.svg in Copy Resources */,
+				A17C465B2C98E4BB0023F3C7 /* animated-red-green-blue-repeat-infinite.gif in Copy Resources */,
+				A17C47092C98E5C20023F3C7 /* apple-data-url.html in Copy Resources */,
+				A17C470A2C98E5C20023F3C7 /* apple-pay-availability-existing-object.html in Copy Resources */,
+				A17C470B2C98E5C20023F3C7 /* apple-pay-availability-in-iframe.html in Copy Resources */,
+				A17C470C2C98E5C20023F3C7 /* apple-pay-availability.html in Copy Resources */,
+				A17C470D2C98E5C20023F3C7 /* apple-pay-can-make-payment.html in Copy Resources */,
+				A17C470E2C98E5C20023F3C7 /* apple-pay-can-make-payments-with-active-card.html in Copy Resources */,
+				A17C470F2C98E5C20023F3C7 /* apple-pay-can-make-payments.html in Copy Resources */,
+				A17C47102C98E5C20023F3C7 /* apple-pay.js in Copy Resources */,
+				A17C47112C98E5C20023F3C7 /* apple.gif in Copy Resources */,
+				A17C47122C98E5C20023F3C7 /* ApplicationCache.db in Copy Resources */,
+				A17C47132C98E5C20023F3C7 /* ApplicationCache.db-shm in Copy Resources */,
+				A17C47142C98E5C20023F3C7 /* ApplicationCache.db-wal in Copy Resources */,
+				A17C46922C98E54B0023F3C7 /* associate-form-controls.html in Copy Resources */,
+				A17C46932C98E54B0023F3C7 /* async-script-load.html in Copy Resources */,
+				A17C47152C98E5C20023F3C7 /* attachment-element.html in Copy Resources */,
+				A17C46692C98E4D20023F3C7 /* attributedStringCustomFont.html in Copy Resources */,
+				A17C466A2C98E4D20023F3C7 /* attributedStringNewlineAtEndOfDocument.html in Copy Resources */,
+				A17C466B2C98E4D20023F3C7 /* attributedStringStrikethrough.html in Copy Resources */,
+				A17C47162C98E5C20023F3C7 /* AttrStyle.html in Copy Resources */,
+				A17C46942C98E54B0023F3C7 /* audio-buffer-size.html in Copy Resources */,
+				A17C47172C98E5C20023F3C7 /* audio-context-playing.html in Copy Resources */,
+				A17C47182C98E5C20023F3C7 /* audio-fingerprinting.html in Copy Resources */,
+				A17C48472C98E6360023F3C7 /* audio-only.html in Copy Resources */,
+				A17C47192C98E5C20023F3C7 /* audio-with-controls.html in Copy Resources */,
+				A17C46952C98E54B0023F3C7 /* audio-with-play-button.html in Copy Resources */,
+				A17C471A2C98E5C20023F3C7 /* audio-with-web-audio.html in Copy Resources */,
+				A17C46962C98E54B0023F3C7 /* auto-submitting-form.html in Copy Resources */,
+				A17C471B2C98E5C20023F3C7 /* autofocus-contenteditable.html in Copy Resources */,
+				A17C471C2C98E5C20023F3C7 /* autofocused-text-input.html in Copy Resources */,
+				A17C46972C98E54B0023F3C7 /* autoplay-check-frame.html in Copy Resources */,
+				A17C46982C98E54B0023F3C7 /* autoplay-check-in-iframe.html in Copy Resources */,
+				A17C46992C98E54B0023F3C7 /* autoplay-check.html in Copy Resources */,
+				A17C469A2C98E54B0023F3C7 /* autoplay-inherits-gesture-from-document.html in Copy Resources */,
+				A17C469B2C98E54B0023F3C7 /* autoplay-muted-with-controls.html in Copy Resources */,
+				A17C469C2C98E54B0023F3C7 /* autoplay-no-audio-check.html in Copy Resources */,
+				A17C469D2C98E54B0023F3C7 /* autoplay-with-controls.html in Copy Resources */,
+				A17C469E2C98E54B0023F3C7 /* autoplay-zero-volume-check.html in Copy Resources */,
+				A17C471D2C98E5C20023F3C7 /* autoplaying-multiple-media-elements.html in Copy Resources */,
+				A17C471E2C98E5C20023F3C7 /* autoplaying-video-with-audio.html in Copy Resources */,
+				A17C471F2C98E5C20023F3C7 /* background-image-link-and-input.html in Copy Resources */,
+				A17C47202C98E5C20023F3C7 /* BadServiceWorkerRegistrations-4.sqlite3 in Copy Resources */,
+				A17C469F2C98E54B0023F3C7 /* basicITPDatabase.db in Copy Resources */,
+				A17C46A02C98E54B0023F3C7 /* beforeunload-slow.html in Copy Resources */,
+				A17C46A12C98E54B0023F3C7 /* beforeunload.html in Copy Resources */,
+				A17C47212C98E5C20023F3C7 /* blinking-div.html in Copy Resources */,
+				A17C46A22C98E54B0023F3C7 /* bundle-file.html in Copy Resources */,
+				A17C47222C98E5C20023F3C7 /* camera-to-canvas.html in Copy Resources */,
+				A17C466C2C98E4D20023F3C7 /* CancelLoadFromResourceLoadDelegate.html in Copy Resources */,
+				A17C47232C98E5C20023F3C7 /* canvas-fingerprinting.html in Copy Resources */,
+				A17C47242C98E5C20023F3C7 /* canvas-image-data.html in Copy Resources */,
+				A17C47252C98E5C20023F3C7 /* change-video-source-on-click.html in Copy Resources */,
+				A17C47262C98E5C20023F3C7 /* change-video-source-on-end.html in Copy Resources */,
+				A17C46A32C98E54B0023F3C7 /* chinese-character-with-image.html in Copy Resources */,
+				A17C47272C98E5C20023F3C7 /* click-targets.html in Copy Resources */,
+				A17C47282C98E5C20023F3C7 /* client-side-redirect.html in Copy Resources */,
+				A17C47292C98E5C20023F3C7 /* clipboard.html in Copy Resources */,
+				A17C46A42C98E54B0023F3C7 /* close-from-within-create-page.html in Copy Resources */,
+				A17C46A52C98E54B0023F3C7 /* closed-shadow-tree-test.html in Copy Resources */,
+				A17C472A2C98E5C20023F3C7 /* cocoa-writer-markup-with-lists.html in Copy Resources */,
+				A17C472B2C98E5C20023F3C7 /* cocoa-writer-markup-with-system-fonts.html in Copy Resources */,
+				A17C472C2C98E5C20023F3C7 /* color-drop.html in Copy Resources */,
+				A17C46A62C98E54B0023F3C7 /* color-scheme.html in Copy Resources */,
+				A17C465C2C98E4BB0023F3C7 /* composited.html in Copy Resources */,
+				A17C472D2C98E5C20023F3C7 /* compressed-files.zip in Copy Resources */,
+				A17C472E2C98E5C20023F3C7 /* console-message-with-details.html in Copy Resources */,
+				A17C46A72C98E54B0023F3C7 /* contentBlockerCheck.html in Copy Resources */,
+				A17C472F2C98E5C20023F3C7 /* contenteditable-and-target.html in Copy Resources */,
+				A17C47302C98E5C20023F3C7 /* contenteditable-and-textarea.html in Copy Resources */,
+				A17C47312C98E5C20023F3C7 /* contenteditable-in-iframe.html in Copy Resources */,
+				A17C47322C98E5C20023F3C7 /* contenteditable-user-select-user-drag.html in Copy Resources */,
+				A17C47332C98E5C20023F3C7 /* ContentFiltering.html in Copy Resources */,
+				A17C468C2C98E54B0023F3C7 /* context-menu-control-click.html in Copy Resources */,
+				A17C466D2C98E4D20023F3C7 /* ContextMenuCanCopyURL.html in Copy Resources */,
+				A17C468D2C98E54B0023F3C7 /* ContextMenuImgWithVideo.html in Copy Resources */,
+				A17C46A82C98E54B0023F3C7 /* cookie-consent-basic.html in Copy Resources */,
+				A17C47342C98E5C20023F3C7 /* CookieMessage.html in Copy Resources */,
+				A17C47352C98E5C20023F3C7 /* copy-html.html in Copy Resources */,
+				A17C47362C98E5C20023F3C7 /* copy-url.html in Copy Resources */,
+				A17C466E2C98E4D20023F3C7 /* CrossPartitionFileSchemeAccess.html in Copy Resources */,
+				A17C47372C98E5C20023F3C7 /* csp-document-uri-report.html in Copy Resources */,
+				A17C47382C98E5C20023F3C7 /* CSSViewportUnits.html in Copy Resources */,
+				A17C47392C98E5C20023F3C7 /* CSSViewportUnits.svg in Copy Resources */,
+				A17C46A92C98E54B0023F3C7 /* cube.usdz in Copy Resources */,
+				A17C473A2C98E5C20023F3C7 /* cursor-styles.html in Copy Resources */,
+				A17C473B2C98E5C20023F3C7 /* custom-draggable-div.html in Copy Resources */,
+				A17C46AA2C98E54B0023F3C7 /* custom-protocol-sync-xhr.html in Copy Resources */,
+				A17C468E2C98E54B0023F3C7 /* dark-mode.html in Copy Resources */,
+				A17C473C2C98E5C20023F3C7 /* data-detectors.html in Copy Resources */,
+				A17C473D2C98E5C20023F3C7 /* DataTransfer-setDragImage.html in Copy Resources */,
+				A17C473E2C98E5C20023F3C7 /* DataTransfer.html in Copy Resources */,
+				A17C473F2C98E5C20023F3C7 /* DataTransferItem-getAsEntry.html in Copy Resources */,
+				A17C46AB2C98E54B0023F3C7 /* deferred-script-load.html in Copy Resources */,
+				A17C46AC2C98E54B0023F3C7 /* deferred-script.js in Copy Resources */,
+				A17C466F2C98E4D20023F3C7 /* devicePixelRatio.html in Copy Resources */,
+				A17C47402C98E5C20023F3C7 /* disableGetUserMedia.html in Copy Resources */,
+				A17C47412C98E5C20023F3C7 /* display-mode.html in Copy Resources */,
+				A17C47422C98E5C20023F3C7 /* div-and-large-image.html in Copy Resources */,
+				A17C46702C98E4D20023F3C7 /* DOMHTMLTableCellElementCellAbove.html in Copy Resources */,
+				A17C46712C98E4D20023F3C7 /* DOMRangeOfString.html in Copy Resources */,
+				A17C46722C98E4D20023F3C7 /* double-click-does-not-select-trailing-space.html in Copy Resources */,
+				A17C46592C98E4A80023F3C7 /* download.example.webarchive in Copy Resources */,
+				A17C47432C98E5C20023F3C7 /* DownloadRequestBlobURL.html in Copy Resources */,
+				A17C47442C98E5C20023F3C7 /* DownloadRequestOriginalURL.html in Copy Resources */,
+				A17C47452C98E5C20023F3C7 /* DownloadRequestOriginalURL2.html in Copy Resources */,
+				A17C47462C98E5C20023F3C7 /* DownloadRequestOriginalURLFrame.html in Copy Resources */,
+				A17C47472C98E5C20023F3C7 /* dragstart-change-selection-offscreen.html in Copy Resources */,
+				A17C47482C98E5C20023F3C7 /* dragstart-clear-selection.html in Copy Resources */,
+				A17C47492C98E5C20023F3C7 /* dragstart-data.html in Copy Resources */,
+				A17C474A2C98E5C20023F3C7 /* drop-targets.html in Copy Resources */,
+				A17C474B2C98E5C20023F3C7 /* dump-datatransfer-types.html in Copy Resources */,
+				A17C474C2C98E5C20023F3C7 /* duplicate-completion-handler-calls.html in Copy Resources */,
+				A17C474D2C98E5C20023F3C7 /* editable-body-mixed-text.html in Copy Resources */,
+				A17C474E2C98E5C20023F3C7 /* editable-body.html in Copy Resources */,
+				A17C474F2C98E5C20023F3C7 /* editable-nested-lists.html in Copy Resources */,
+				A17C465D2C98E4BB0023F3C7 /* editable-region-composited-and-non-composited-overlap.html in Copy Resources */,
+				A17C47502C98E5C20023F3C7 /* editable-responsive-body.html in Copy Resources */,
+				A17C47512C98E5C20023F3C7 /* editor-state-test-harness.html in Copy Resources */,
+				A17C47522C98E5C20023F3C7 /* element-fullscreen.html in Copy Resources */,
+				A17C47532C98E5C20023F3C7 /* element-targeting-1.html in Copy Resources */,
+				A17C47542C98E5C20023F3C7 /* element-targeting-10.html in Copy Resources */,
+				A17C47552C98E5C20023F3C7 /* element-targeting-2.html in Copy Resources */,
+				A17C47562C98E5C20023F3C7 /* element-targeting-3.html in Copy Resources */,
+				A17C47572C98E5C20023F3C7 /* element-targeting-4.html in Copy Resources */,
+				A17C47582C98E5C20023F3C7 /* element-targeting-5.html in Copy Resources */,
+				A17C47592C98E5C20023F3C7 /* element-targeting-6.html in Copy Resources */,
+				A17C475A2C98E5C20023F3C7 /* element-targeting-7.html in Copy Resources */,
+				A17C475B2C98E5C20023F3C7 /* element-targeting-8.html in Copy Resources */,
+				A17C475C2C98E5C20023F3C7 /* element-targeting-9.html in Copy Resources */,
+				A17C475D2C98E5C20023F3C7 /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
+				A17C46AD2C98E54B0023F3C7 /* emptyTable.html in Copy Resources */,
+				A17C46AE2C98E54B0023F3C7 /* encrypted.pdf in Copy Resources */,
+				A17C475E2C98E5C20023F3C7 /* enormous-video-with-sound.html in Copy Resources */,
+				A17C475F2C98E5C20023F3C7 /* enormous.svg in Copy Resources */,
+				A17C46AF2C98E54B0023F3C7 /* enumerateMediaDevices.html in Copy Resources */,
+				A17C47602C98E5C20023F3C7 /* event.ics in Copy Resources */,
+				A17C46B02C98E54B0023F3C7 /* execCopy.html in Copy Resources */,
+				A17C47612C98E5C20023F3C7 /* exif-orientation-8-llo.jpg in Copy Resources */,
+				A17C47622C98E5C20023F3C7 /* ExitFullscreenOnEnterPiP.html in Copy Resources */,
+				A17C47632C98E5C20023F3C7 /* fade-in-image.html in Copy Resources */,
+				A17C47642C98E5C20023F3C7 /* file-system-access.salt in Copy Resources */,
+				A17C47652C98E5C20023F3C7 /* file-uploading.html in Copy Resources */,
+				A17C46B12C98E54B0023F3C7 /* file-with-anchor.html in Copy Resources */,
+				A17C47662C98E5C20023F3C7 /* file-with-iframe.html in Copy Resources */,
+				A17C46B22C98E54B0023F3C7 /* file-with-managedmse.html in Copy Resources */,
+				A17C46B32C98E54B0023F3C7 /* file-with-mse.html in Copy Resources */,
+				A17C46B42C98E54B0023F3C7 /* file-with-video.html in Copy Resources */,
+				A17C46B52C98E54B0023F3C7 /* find.html in Copy Resources */,
+				A17C47672C98E5C20023F3C7 /* find.pdf in Copy Resources */,
+				A17C46B62C98E54B0023F3C7 /* findRanges.html in Copy Resources */,
+				A17C47682C98E5C20023F3C7 /* fingerprint-audio-worklet.js in Copy Resources */,
+				A17C47692C98E5C20023F3C7 /* fixed-nav-bar.html in Copy Resources */,
+				A17C476A2C98E5C20023F3C7 /* focus-inputs.html in Copy Resources */,
+				A17C46B72C98E54B0023F3C7 /* fragment-navigation-before-load-event.html in Copy Resources */,
+				A17C46732C98E4D20023F3C7 /* FragmentNavigation.html in Copy Resources */,
+				A17C46742C98E4D20023F3C7 /* full-page-contenteditable.html in Copy Resources */,
+				A17C476B2C98E5C20023F3C7 /* full-page-dropzone.html in Copy Resources */,
+				A17C476C2C98E5C20023F3C7 /* full-size-autoplaying-video-with-audio.html in Copy Resources */,
+				A17C48482C98E6360023F3C7 /* fullscreen-lifecycle-audio.html in Copy Resources */,
+				A17C476D2C98E5C20023F3C7 /* FullscreenDelegate.html in Copy Resources */,
+				A17C476E2C98E5C20023F3C7 /* FullscreenLayoutConstraints.html in Copy Resources */,
+				A17C476F2C98E5C20023F3C7 /* FullscreenTopContentInset.html in Copy Resources */,
+				A17C46752C98E4D20023F3C7 /* FullscreenZoomInitialFrame.html in Copy Resources */,
+				A17C47702C98E5C20023F3C7 /* general-storage-directory-indexeddb.sqlite3 in Copy Resources */,
+				A17C47712C98E5C20023F3C7 /* general-storage-directory-localstorage.sqlite3 in Copy Resources */,
+				A17C47722C98E5C20023F3C7 /* general-storage-directory.origin in Copy Resources */,
+				A17C47732C98E5C20023F3C7 /* general-storage-directory.salt in Copy Resources */,
+				A17C46B82C98E54B0023F3C7 /* geolocationGetCurrentPosition.html in Copy Resources */,
+				A17C47742C98E5C20023F3C7 /* GeolocationGetCurrentPositionResult.html in Copy Resources */,
+				A17C46B92C98E54B0023F3C7 /* geolocationGetCurrentPositionWithHighAccuracy.html in Copy Resources */,
+				A17C46BA2C98E54B0023F3C7 /* geolocationWatchPosition.html in Copy Resources */,
+				A17C46BB2C98E54B0023F3C7 /* geolocationWatchPositionWithHighAccuracy.html in Copy Resources */,
+				A17C47752C98E5C20023F3C7 /* getDisplayMedia.html in Copy Resources */,
+				A17C47762C98E5C20023F3C7 /* GetSessionCookie.html in Copy Resources */,
+				A17C46BC2C98E54B0023F3C7 /* getUserMedia-webaudio.html in Copy Resources */,
+				A17C46BD2C98E54B0023F3C7 /* getUserMedia.html in Copy Resources */,
+				A17C46BE2C98E54B0023F3C7 /* getUserMedia2.html in Copy Resources */,
+				A17C46BF2C98E54B0023F3C7 /* getUserMediaAudioVideoCapture.html in Copy Resources */,
+				A17C46C02C98E54B0023F3C7 /* getUserMediaPermission.html in Copy Resources */,
+				A17C47772C98E5C20023F3C7 /* gif-and-file-input.html in Copy Resources */,
+				A17C47782C98E5C20023F3C7 /* green-400x400.webp in Copy Resources */,
+				A17C46762C98E4D20023F3C7 /* helloworld.webarchive in Copy Resources */,
+				A17C47792C98E5C20023F3C7 /* Helvetica_light.svg in Copy Resources */,
+				A17C46772C98E4D20023F3C7 /* HTMLCollectionNamedItem.html in Copy Resources */,
+				A17C46782C98E4D20023F3C7 /* HTMLFormCollectionNamedItem.html in Copy Resources */,
+				A17C46C12C98E54B0023F3C7 /* icon.png in Copy Resources */,
+				A17C477A2C98E5C20023F3C7 /* IDBCheckpointWAL.html in Copy Resources */,
+				A17C477B2C98E5C20023F3C7 /* IDBDeleteRecovery.html in Copy Resources */,
+				A17C477C2C98E5C20023F3C7 /* IDBDeleteRecovery.sqlite3 in Copy Resources */,
+				A17C477D2C98E5C20023F3C7 /* IDBDeleteRecovery.sqlite3-shm in Copy Resources */,
+				A17C477E2C98E5C20023F3C7 /* IDBDeleteRecovery.sqlite3-wal in Copy Resources */,
+				A17C477F2C98E5C20023F3C7 /* IDBIndexUpgradeToV2.html in Copy Resources */,
+				A17C47802C98E5C20023F3C7 /* IDBIndexUpgradeToV2WithMultipleIndices.html in Copy Resources */,
+				A17C47812C98E5C20023F3C7 /* IDBObjectStoreInfoUpgrade.sqlite3 in Copy Resources */,
+				A17C47822C98E5C20023F3C7 /* IDBObjectStoreInfoUpgradeToV2.html in Copy Resources */,
+				A17C46C22C98E54B0023F3C7 /* idempotent-mode-autosizing-only-honors-percentages.html in Copy Resources */,
+				A17C47832C98E5C20023F3C7 /* image-and-contenteditable.html in Copy Resources */,
+				A17C47842C98E5C20023F3C7 /* image-and-file-upload.html in Copy Resources */,
+				A17C47852C98E5C20023F3C7 /* image-and-textarea.html in Copy Resources */,
+				A17C47862C98E5C20023F3C7 /* image-controls.html in Copy Resources */,
+				A17C47872C98E5C20023F3C7 /* image-in-link-and-input.html in Copy Resources */,
+				A17C47882C98E5C20023F3C7 /* image-map.html in Copy Resources */,
+				A17C47892C98E5C20023F3C7 /* image-with-text.html in Copy Resources */,
+				A17C478A2C98E5C20023F3C7 /* image.html in Copy Resources */,
+				A17C465E2C98E4BB0023F3C7 /* img-animation-covered-by-link.html in Copy Resources */,
+				A17C465F2C98E4BB0023F3C7 /* img-animation-in-anchor.html in Copy Resources */,
+				A17C46602C98E4BB0023F3C7 /* img-with-base64-url.html in Copy Resources */,
+				A17C478B2C98E5C20023F3C7 /* ImmediateFont.html in Copy Resources */,
+				A17C478C2C98E5C20023F3C7 /* in-app-browser-privacy-local-file.html in Copy Resources */,
+				A17C478D2C98E5C20023F3C7 /* incorrectCreateTableSchema.db in Copy Resources */,
+				A17C478E2C98E5C20023F3C7 /* indexeddb-persistence-third-party.sqlite3 in Copy Resources */,
+				A17C478F2C98E5C20023F3C7 /* IndexedDB.sqlite3 in Copy Resources */,
+				A17C47902C98E5C20023F3C7 /* IndexedDB.sqlite3-shm in Copy Resources */,
+				A17C47912C98E5C20023F3C7 /* IndexedDB.sqlite3-wal in Copy Resources */,
+				A17C47922C98E5C20023F3C7 /* IndexedDBDatabaseProcessKill-1.html in Copy Resources */,
+				A17C47932C98E5C20023F3C7 /* IndexedDBFileName-1.html in Copy Resources */,
+				A17C47942C98E5C20023F3C7 /* IndexedDBFileName-2.html in Copy Resources */,
+				A17C47952C98E5C20023F3C7 /* IndexedDBInPageCache.html in Copy Resources */,
+				A17C47962C98E5C20023F3C7 /* IndexedDBMultiProcess-1.html in Copy Resources */,
+				A17C47972C98E5C20023F3C7 /* IndexedDBMultiProcess-2.html in Copy Resources */,
+				A17C47982C98E5C20023F3C7 /* IndexedDBMultiProcess-3.html in Copy Resources */,
+				A17C47992C98E5C20023F3C7 /* IndexedDBNotInPageCache.html in Copy Resources */,
+				A17C479A2C98E5C20023F3C7 /* IndexedDBPersistence-1.html in Copy Resources */,
+				A17C479B2C98E5C20023F3C7 /* IndexedDBPersistence-2.html in Copy Resources */,
+				A17C479C2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3 in Copy Resources */,
+				A17C479D2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-shm in Copy Resources */,
+				A17C479E2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibility.sqlite3-wal in Copy Resources */,
+				A17C479F2C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibilityRead.html in Copy Resources */,
+				A17C47A02C98E5C20023F3C7 /* IndexedDBStructuredCloneBackwardCompatibilityWrite.html in Copy Resources */,
+				A17C47A12C98E5C20023F3C7 /* IndexedDBSuspendImminently.html in Copy Resources */,
+				A17C47A22C98E5C20023F3C7 /* IndexedDBTempFileSize-1.html in Copy Resources */,
+				A17C47A32C98E5C20023F3C7 /* IndexedDBTempFileSize-2.html in Copy Resources */,
+				A17C47A42C98E5C20023F3C7 /* IndexedDBUserDelete.html in Copy Resources */,
+				A17C47A52C98E5C20023F3C7 /* IndexUpgrade.blob in Copy Resources */,
+				A17C47A62C98E5C20023F3C7 /* IndexUpgrade.sqlite3 in Copy Resources */,
+				A17C47A72C98E5C20023F3C7 /* IndexUpgradeWithMultipleIndices.sqlite3 in Copy Resources */,
+				A17C47A82C98E5C20023F3C7 /* IndexUpgradeWithMultipleIndicesHaveSameID.sqlite3 in Copy Resources */,
+				A17C47A92C98E5C20023F3C7 /* input-field-in-scrollable-document.html in Copy Resources */,
+				A17C46C32C98E54B0023F3C7 /* input-focus-blur.html in Copy Resources */,
+				A17C46612C98E4BB0023F3C7 /* insert-text.html in Copy Resources */,
+				A17C47AA2C98E5C20023F3C7 /* InspectorExtension-basic-page.html in Copy Resources */,
+				A17C47AB2C98E5C20023F3C7 /* InspectorExtension-basic-tab.html in Copy Resources */,
+				A17C47AC2C98E5C20023F3C7 /* InspectorExtension-TabIcon-30x30.png in Copy Resources */,
+				A17C46FF2C98E58C0023F3C7 /* invalidDeviceIDHashSalts in Copy Resources */,
+				A17C46792C98E4D20023F3C7 /* IsNavigationActionTrusted.html in Copy Resources */,
+				A17C46C42C98E54B0023F3C7 /* js-autoplay-audio.html in Copy Resources */,
+				A17C46C52C98E54B0023F3C7 /* js-play-with-controls.html in Copy Resources */,
+				A17C467A2C98E4D20023F3C7 /* JSContextBackForwardCache1.html in Copy Resources */,
+				A17C467B2C98E4D20023F3C7 /* JSContextBackForwardCache2.html in Copy Resources */,
+				A17C47AD2C98E5C20023F3C7 /* KillWebProcessWithOpenConnection-1.html in Copy Resources */,
+				A17C47AE2C98E5C20023F3C7 /* KillWebProcessWithOpenConnection-2.html in Copy Resources */,
+				A17C467C2C98E4D20023F3C7 /* large-input-field-focus-onload.html in Copy Resources */,
+				A17C46C62C98E54B0023F3C7 /* large-red-square-image.html in Copy Resources */,
+				A17C47AF2C98E5C20023F3C7 /* large-red-square.png in Copy Resources */,
+				A17C47B02C98E5C20023F3C7 /* large-video-hides-controls-after-seek-to-end.html in Copy Resources */,
+				A17C47B12C98E5C20023F3C7 /* large-video-mutes-onplaying.html in Copy Resources */,
+				A17C47B22C98E5C20023F3C7 /* large-video-offscreen.html in Copy Resources */,
+				A17C47B32C98E5C20023F3C7 /* large-video-playing-scroll-away.html in Copy Resources */,
+				A17C47B42C98E5C20023F3C7 /* large-video-seek-after-ending.html in Copy Resources */,
+				A17C47B52C98E5C20023F3C7 /* large-video-seek-to-beginning-and-play-after-ending.html in Copy Resources */,
+				A17C47B62C98E5C20023F3C7 /* large-video-test-now-playing.html in Copy Resources */,
+				A17C47B72C98E5C20023F3C7 /* large-video-with-audio.html in Copy Resources */,
+				A17C47B82C98E5C20023F3C7 /* large-video-with-audio.mp4 in Copy Resources */,
+				A17C47B92C98E5C20023F3C7 /* large-video-without-audio.html in Copy Resources */,
+				A17C47BA2C98E5C20023F3C7 /* large-videos-autoplaying-click-to-pause.html in Copy Resources */,
+				A17C47BB2C98E5C20023F3C7 /* large-videos-autoplaying-scroll-to-video.html in Copy Resources */,
+				A17C47BC2C98E5C20023F3C7 /* large-videos-paused-video-hides-controls.html in Copy Resources */,
+				A17C47BD2C98E5C20023F3C7 /* large-videos-playing-muted-video-hides-controls.html in Copy Resources */,
+				A17C47BE2C98E5C20023F3C7 /* large-videos-playing-video-keeps-controls.html in Copy Resources */,
+				A17C47BF2C98E5C20023F3C7 /* large-videos-with-audio-autoplay.html in Copy Resources */,
+				A17C47C02C98E5C20023F3C7 /* large-videos-with-audio.html in Copy Resources */,
+				A17C47C12C98E5C20023F3C7 /* LineBreaking.html in Copy Resources */,
+				A17C47C22C98E5C20023F3C7 /* link-and-input.html in Copy Resources */,
+				A17C47C32C98E5C20023F3C7 /* link-and-target-div.html in Copy Resources */,
+				A17C47C42C98E5C20023F3C7 /* link-in-iframe-and-input.html in Copy Resources */,
+				A17C46C72C98E54B0023F3C7 /* link-with-download-attribute-with-slashes.html in Copy Resources */,
+				A17C46C82C98E54B0023F3C7 /* link-with-download-attribute.html in Copy Resources */,
+				A17C46622C98E4BB0023F3C7 /* link-with-hover-menu.html in Copy Resources */,
+				A17C47C52C98E5C20023F3C7 /* link-with-image.html in Copy Resources */,
+				A17C46C92C98E54B0023F3C7 /* link-with-title.html in Copy Resources */,
+				A17C47C62C98E5C20023F3C7 /* load-image.html in Copy Resources */,
+				A17C467D2C98E4D20023F3C7 /* load-web-archive-1.html in Copy Resources */,
+				A17C467E2C98E4D20023F3C7 /* load-web-archive-2.html in Copy Resources */,
+				A17C467F2C98E4D20023F3C7 /* LoadInvalidURLRequest.html in Copy Resources */,
+				A17C47C72C98E5C20023F3C7 /* local-storage-process-crashes.html in Copy Resources */,
+				A17C47C82C98E5C20023F3C7 /* local-storage-process-suspends-1.html in Copy Resources */,
+				A17C47C92C98E5C20023F3C7 /* local-storage-process-suspends-2.html in Copy Resources */,
+				A17C47CA2C98E5C20023F3C7 /* localstorage-empty-string-value.html in Copy Resources */,
+				A17C47CB2C98E5C20023F3C7 /* localstorage-open-window-private.html in Copy Resources */,
+				A17C47CC2C98E5C20023F3C7 /* LocalStorageClear.html in Copy Resources */,
+				A17C47CD2C98E5C20023F3C7 /* LocalStorageNullEntries.html in Copy Resources */,
+				A17C47CE2C98E5C20023F3C7 /* LocalStorageNullEntries.localstorage in Copy Resources */,
+				A17C47CF2C98E5C20023F3C7 /* LocalStorageNullEntries.localstorage-shm in Copy Resources */,
+				A17C47D02C98E5C20023F3C7 /* LocalStorageQuirkEnabled.html in Copy Resources */,
+				A17C47002C98E58C0023F3C7 /* LockdownModeFonts.html in Copy Resources */,
+				A17C47D12C98E5C20023F3C7 /* LockdownModePDF.html in Copy Resources */,
+				A17C46CA2C98E54B0023F3C7 /* long-email-viewport.html in Copy Resources */,
+				A17C46CB2C98E54B0023F3C7 /* long-test.mp4 in Copy Resources */,
+				A17C46CC2C98E54B0023F3C7 /* lots-of-iframes.html in Copy Resources */,
+				A17C46CD2C98E54B0023F3C7 /* lots-of-images.html in Copy Resources */,
+				A17C46CE2C98E54B0023F3C7 /* lots-of-text-vertical-lr.html in Copy Resources */,
+				A17C46CF2C98E54B0023F3C7 /* lots-of-text.html in Copy Resources */,
+				A17C46D02C98E54B0023F3C7 /* many-iframes.html in Copy Resources */,
+				A17C46D12C98E54B0023F3C7 /* many-same-origin-iframes.html in Copy Resources */,
+				A17C46D22C98E54B0023F3C7 /* media-loading.html in Copy Resources */,
+				A17C47D22C98E5C20023F3C7 /* media-remote.html in Copy Resources */,
+				A17C46802C98E4D20023F3C7 /* MediaPlaybackSleepAssertion.html in Copy Resources */,
+				A17C46D32C98E54B0023F3C7 /* mediastreamtrack-detached.html in Copy Resources */,
+				A17C46812C98E4D20023F3C7 /* MemoryCacheDisableWithinResourceLoadDelegate.html in Copy Resources */,
+				A17C46822C98E4D20023F3C7 /* MemoryCachePruneWithinResourceLoadDelegate.html in Copy Resources */,
+				A17C46D42C98E54B0023F3C7 /* missingTopFrameUniqueRedirectSameSiteStrictTableSchema.db in Copy Resources */,
+				A17C46D52C98E54B0023F3C7 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */,
+				A17C46D62C98E54B0023F3C7 /* mouse-button-listener.html in Copy Resources */,
+				A17C46D72C98E54B0023F3C7 /* mouse-move-listener.html in Copy Resources */,
+				A17C47D32C98E5C20023F3C7 /* mso-list-compat-mode.html in Copy Resources */,
+				A17C47D42C98E5C20023F3C7 /* mso-list-on-h4.html in Copy Resources */,
+				A17C47D52C98E5C20023F3C7 /* mso-list.html in Copy Resources */,
+				A17C47D62C98E5C20023F3C7 /* multiple-images.html in Copy Resources */,
+				A17C47D72C98E5C20023F3C7 /* multiple-pages.pdf in Copy Resources */,
+				A17C46D82C98E54B0023F3C7 /* navigation-client-default-crypto.html in Copy Resources */,
+				A17C47D82C98E5C20023F3C7 /* nested-frames.html in Copy Resources */,
+				A17C47D92C98E5C20023F3C7 /* nested-lists.html in Copy Resources */,
+				A17C46D92C98E54B0023F3C7 /* no-autoplay-with-controls.html in Copy Resources */,
+				A17C47DA2C98E5C20023F3C7 /* notify-resourceLoadObserver.html in Copy Resources */,
+				A17C47DB2C98E5C20023F3C7 /* now-playing.html in Copy Resources */,
+				A17C47DC2C98E5C20023F3C7 /* offscreen-iframe-of-media-document.html in Copy Resources */,
+				A17C47DD2C98E5C20023F3C7 /* offscreen-image.html in Copy Resources */,
+				A17C46DA2C98E54B0023F3C7 /* ondevicechange.html in Copy Resources */,
+				A17C48492C98E6360023F3C7 /* one-video.html in Copy Resources */,
+				A17C46DB2C98E54B0023F3C7 /* open-and-close-window.html in Copy Resources */,
+				A17C46832C98E4D20023F3C7 /* open-in-new-tab.html in Copy Resources */,
+				A17C47DE2C98E5C20023F3C7 /* open-multiple-external-url.html in Copy Resources */,
+				A17C46DC2C98E54B0023F3C7 /* open-window-then-write-to-it.html in Copy Resources */,
+				A17C46DD2C98E54B0023F3C7 /* open-window-with-file-url-with-host.html in Copy Resources */,
+				A17C47DF2C98E5C20023F3C7 /* opendatabase-always-exists.html in Copy Resources */,
+				A17C46842C98E4D20023F3C7 /* OpenNewWindow.html in Copy Resources */,
+				A17C46DE2C98E54B0023F3C7 /* orthogonal-flow-available-size.html in Copy Resources */,
+				A17C47E02C98E5C20023F3C7 /* overflow-hidden.html in Copy Resources */,
+				A17C46632C98E4BB0023F3C7 /* overflow-scroll.html in Copy Resources */,
+				A17C46DF2C98E54B0023F3C7 /* override-builtins-test.html in Copy Resources */,
+				A17C47E12C98E5C20023F3C7 /* page-with-csp-iframe.html in Copy Resources */,
+				A17C47E22C98E5C20023F3C7 /* page-with-csp.html in Copy Resources */,
+				A17C47E32C98E5C20023F3C7 /* page-without-csp-iframe.html in Copy Resources */,
+				A17C47E42C98E5C20023F3C7 /* page-without-csp.html in Copy Resources */,
+				A17C46642C98E4BB0023F3C7 /* pages.pages in Copy Resources */,
+				A17C46852C98E4D20023F3C7 /* PageVisibilityStateWithWindowChanges.html in Copy Resources */,
+				A17C47E52C98E5C20023F3C7 /* paint-significant-area-milestone.html in Copy Resources */,
+				A17C47E62C98E5C20023F3C7 /* password-protected.pages in Copy Resources */,
+				A17C47E72C98E5C20023F3C7 /* paste-image.html in Copy Resources */,
+				A17C47E82C98E5C20023F3C7 /* paste-rtfd.html in Copy Resources */,
+				A17C47E92C98E5C20023F3C7 /* PictureInPictureDelegate.html in Copy Resources */,
+				A17C47EA2C98E5C20023F3C7 /* play-audio-on-click.html in Copy Resources */,
+				A17C46E02C98E54B0023F3C7 /* playable-audio.html in Copy Resources */,
+				A17C46E12C98E54B0023F3C7 /* pop-up-check.html in Copy Resources */,
+				A17C47EB2C98E5C20023F3C7 /* postMessage-regularly.html in Copy Resources */,
+				A17C47EC2C98E5C20023F3C7 /* postMessage-various-types.html in Copy Resources */,
+				A17C47ED2C98E5C20023F3C7 /* prevent-operation.html in Copy Resources */,
+				A17C47EE2C98E5C20023F3C7 /* prevent-start.html in Copy Resources */,
+				A17C46E22C98E54B0023F3C7 /* push-state.html in Copy Resources */,
+				A17C46E32C98E54B0023F3C7 /* qr-code.png in Copy Resources */,
+				A17C46E42C98E54B0023F3C7 /* red.html in Copy Resources */,
+				A17C46E52C98E54B0023F3C7 /* remove-node-on-drop.html in Copy Resources */,
+				A17C47EF2C98E5C20023F3C7 /* rendered-image-excluding-overflow.html in Copy Resources */,
+				A17C47F02C98E5C20023F3C7 /* resourceLoadStatisticsMissingUniqueIndex.db in Copy Resources */,
+				A17C47F12C98E5C20023F3C7 /* rich-and-plain-text.html in Copy Resources */,
+				A17C47F22C98E5C20023F3C7 /* rich-color-filtered.html in Copy Resources */,
+				A17C47F32C98E5C20023F3C7 /* rich-text-attributes.html in Copy Resources */,
+				A17C46E62C98E54B0023F3C7 /* scroll-to-anchor.html in Copy Resources */,
+				A17C46652C98E4BB0023F3C7 /* scrollable-page.html in Copy Resources */,
+				A17C47F42C98E5C20023F3C7 /* selected-text-and-textarea.html in Copy Resources */,
+				A17C47F52C98E5C20023F3C7 /* selected-text-image-link-and-editable.html in Copy Resources */,
+				A17C46E72C98E54B0023F3C7 /* set-long-title.html in Copy Resources */,
+				A17C46662C98E4BB0023F3C7 /* set-timeout-function.html in Copy Resources */,
+				A17C46862C98E4D20023F3C7 /* SetDocumentURI.html in Copy Resources */,
+				A17C47F62C98E5C20023F3C7 /* SetSessionCookie.html in Copy Resources */,
+				A17C46E82C98E54B0023F3C7 /* should-open-external-schemes.html in Copy Resources */,
+				A17C47F72C98E5C20023F3C7 /* significant-text-milestone-article.html in Copy Resources */,
+				A17C47F82C98E5C20023F3C7 /* significant-text-milestone.html in Copy Resources */,
+				A17C47F92C98E5C20023F3C7 /* silence-long.m4a in Copy Resources */,
+				A17C46E92C98E54B0023F3C7 /* simple-accelerated-compositing.html in Copy Resources */,
+				A17C47FA2C98E5C20023F3C7 /* simple-editor.html in Copy Resources */,
+				A17C46EA2C98E54B0023F3C7 /* simple-form.html in Copy Resources */,
+				A17C46EB2C98E54B0023F3C7 /* simple-iframe.html in Copy Resources */,
+				A17C46EC2C98E54B0023F3C7 /* simple-image-overlay.html in Copy Resources */,
+				A17C46ED2C98E54B0023F3C7 /* simple-responsive-page.html in Copy Resources */,
+				A17C46EE2C98E54B0023F3C7 /* simple-tall.html in Copy Resources */,
+				A17C46EF2C98E54B0023F3C7 /* simple.html in Copy Resources */,
+				A17C46F02C98E54B0023F3C7 /* simple2.html in Copy Resources */,
+				A17C46F12C98E54B0023F3C7 /* simple3.html in Copy Resources */,
+				A17C47FB2C98E5C20023F3C7 /* skinny-autoplaying-video-with-audio.html in Copy Resources */,
+				A17C46F22C98E54B0023F3C7 /* spacebar-scrolling.html in Copy Resources */,
+				A17C47FC2C98E5C20023F3C7 /* SpaceOnly.otf in Copy Resources */,
+				A17C47FD2C98E5C20023F3C7 /* speechrecognition-basic.html in Copy Resources */,
+				A17C47FE2C98E5C20023F3C7 /* speechrecognition-user-permission-persistence.html in Copy Resources */,
+				A17C47FF2C98E5C20023F3C7 /* start-offset.ts in Copy Resources */,
+				A17C46872C98E4D20023F3C7 /* StopLoadingFromDidReceiveResponse.html in Copy Resources */,
+				A17C48002C98E5C20023F3C7 /* StoreBlobToBeDeleted.html in Copy Resources */,
+				A17C48012C98E5C20023F3C7 /* sunset-in-cupertino-100px.tiff in Copy Resources */,
+				A17C48022C98E5C20023F3C7 /* sunset-in-cupertino-200px.png in Copy Resources */,
+				A17C48032C98E5C20023F3C7 /* sunset-in-cupertino-400px.gif in Copy Resources */,
+				A17C48042C98E5C20023F3C7 /* sunset-in-cupertino-600px.jpg in Copy Resources */,
+				A17C48052C98E5C20023F3C7 /* SVGFont.html in Copy Resources */,
+				A17C48062C98E5C20023F3C7 /* system-preview-trigger.html in Copy Resources */,
+				A17C48072C98E5C20023F3C7 /* system-preview.html in Copy Resources */,
+				A17C48082C98E5C20023F3C7 /* SystemPreviewBlobNaming.html in Copy Resources */,
+				A17C46F32C98E54B0023F3C7 /* test-mse-audio.webm in Copy Resources */,
+				A17C46F42C98E54B0023F3C7 /* test-mse.mp4 in Copy Resources */,
+				A17C46F52C98E54B0023F3C7 /* test-mse.webm in Copy Resources */,
+				A17C46F62C98E54B0023F3C7 /* test-without-audio-track.mp4 in Copy Resources */,
+				A17C48092C98E5C20023F3C7 /* test.jpg in Copy Resources */,
+				A17C46F72C98E54B0023F3C7 /* test.mp4 in Copy Resources */,
+				A17C480A2C98E5C20023F3C7 /* test.pages in Copy Resources */,
+				A17C46F82C98E54B0023F3C7 /* test.pdf in Copy Resources */,
+				A17C46F92C98E54B0023F3C7 /* test.xml in Copy Resources */,
+				A17C47012C98E58C0023F3C7 /* test_print.pdf in Copy Resources */,
+				A17C480B2C98E5C20023F3C7 /* TestModalContainerControls.mlmodelc in Copy Resources */,
+				A17C480C2C98E5C20023F3C7 /* text-and-password-inputs.html in Copy Resources */,
+				A17C480D2C98E5C20023F3C7 /* text-with-async-script.html in Copy Resources */,
+				A17C480E2C98E5C20023F3C7 /* text-with-deferred-script.html in Copy Resources */,
+				A17C480F2C98E5C20023F3C7 /* text-with-web-font.webarchive in Copy Resources */,
+				A17C48102C98E5C20023F3C7 /* textarea-to-input.html in Copy Resources */,
+				A17C48112C98E5C20023F3C7 /* TextWidth.html in Copy Resources */,
+				A17C48122C98E5C20023F3C7 /* try-text-select-with-disabled-text-interaction.html in Copy Resources */,
+				A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */,
+				A17C484A2C98E6360023F3C7 /* two-videos.html in Copy Resources */,
+				A17C48142C98E5C20023F3C7 /* UnitBox.usdz in Copy Resources */,
+				A17C46FA2C98E54B0023F3C7 /* UserInstalledAhem.html in Copy Resources */,
+				A17C46882C98E4D20023F3C7 /* verboseMarkup.html in Copy Resources */,
+				A17C48152C98E5C20023F3C7 /* video-with-audio-and-web-audio.html in Copy Resources */,
+				A17C484B2C98E6360023F3C7 /* video-with-audio.html in Copy Resources */,
+				A17C484C2C98E6360023F3C7 /* video-with-audio.mp4 in Copy Resources */,
+				A17C484D2C98E6360023F3C7 /* video-with-muted-audio-and-webaudio.html in Copy Resources */,
+				A17C484E2C98E6360023F3C7 /* video-with-muted-audio.html in Copy Resources */,
+				A17C484F2C98E6360023F3C7 /* video-with-paused-audio-and-playing-muted.html in Copy Resources */,
+				A17C46FB2C98E54B0023F3C7 /* video-with-play-button.html in Copy Resources */,
+				A17C48502C98E6360023F3C7 /* video-without-audio.html in Copy Resources */,
+				A17C48512C98E6360023F3C7 /* video-without-audio.mp4 in Copy Resources */,
+				A17C46FC2C98E54B0023F3C7 /* video.html in Copy Resources */,
+				A17C48162C98E5C20023F3C7 /* web-audio-only.html in Copy Resources */,
+				A17C48172C98E5C20023F3C7 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */,
+				A17C48182C98E5C20023F3C7 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html in Copy Resources */,
+				A17C48192C98E5C20023F3C7 /* web-authentication-get-assertion-hid-internal-uv.html in Copy Resources */,
+				A17C481A2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-multiple-accounts.html in Copy Resources */,
+				A17C481B2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-no-credentials.html in Copy Resources */,
+				A17C481C2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-pin-auth-blocked-error.html in Copy Resources */,
+				A17C481D2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-pin-invalid-error-retry.html in Copy Resources */,
+				A17C481E2C98E5C20023F3C7 /* web-authentication-get-assertion-hid-pin.html in Copy Resources */,
+				A17C481F2C98E5C20023F3C7 /* web-authentication-get-assertion-hid.html in Copy Resources */,
+				A17C48202C98E5C20023F3C7 /* web-authentication-get-assertion-la-no-mock.html in Copy Resources */,
+				A17C48212C98E5C20023F3C7 /* web-authentication-get-assertion-la.html in Copy Resources */,
+				A17C48222C98E5C20023F3C7 /* web-authentication-get-assertion-nfc-multiple-tags.html in Copy Resources */,
+				A17C48232C98E5C20023F3C7 /* web-authentication-get-assertion-nfc-pin-disconnect.html in Copy Resources */,
+				A17C48242C98E5C20023F3C7 /* web-authentication-get-assertion-nfc.html in Copy Resources */,
+				A17C48252C98E5C20023F3C7 /* web-authentication-get-assertion-u2f-no-credentials.html in Copy Resources */,
+				A17C48262C98E5C20023F3C7 /* web-authentication-get-assertion.html in Copy Resources */,
+				A17C48272C98E5C20023F3C7 /* web-authentication-make-credential-hid-internal-uv.html in Copy Resources */,
+				A17C48282C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-auth-blocked-error.html in Copy Resources */,
+				A17C48292C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html in Copy Resources */,
+				A17C482A2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry.html in Copy Resources */,
+				A17C482B2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error.html in Copy Resources */,
+				A17C482C2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry.html in Copy Resources */,
+				A17C482D2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error.html in Copy Resources */,
+				A17C482E2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry.html in Copy Resources */,
+				A17C482F2C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-get-retries-error.html in Copy Resources */,
+				A17C48302C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin-invalid-error-retry.html in Copy Resources */,
+				A17C48312C98E5C20023F3C7 /* web-authentication-make-credential-hid-pin.html in Copy Resources */,
+				A17C48322C98E5C20023F3C7 /* web-authentication-make-credential-hid.html in Copy Resources */,
+				A17C48332C98E5C20023F3C7 /* web-authentication-make-credential-la-duplicate-credential.html in Copy Resources */,
+				A17C48342C98E5C20023F3C7 /* web-authentication-make-credential-la-error.html in Copy Resources */,
+				A17C48352C98E5C20023F3C7 /* web-authentication-make-credential-la-no-attestation.html in Copy Resources */,
+				A17C48362C98E5C20023F3C7 /* web-authentication-make-credential-la-no-mock.html in Copy Resources */,
+				A17C48372C98E5C20023F3C7 /* web-authentication-make-credential-la.html in Copy Resources */,
+				A17C48382C98E5C20023F3C7 /* webaudio-createMediaElementSource.html in Copy Resources */,
+				A17C46FD2C98E54B0023F3C7 /* webfont.html in Copy Resources */,
+				A17C48392C98E5C20023F3C7 /* webgl-support.js in Copy Resources */,
+				A17C48522C98E6360023F3C7 /* webgl.html in Copy Resources */,
+				A17C483A2C98E5C20023F3C7 /* webkit-logo.pdf in Copy Resources */,
+				A17C483B2C98E5C20023F3C7 /* webp-image.html in Copy Resources */,
+				A17C483C2C98E5C20023F3C7 /* WebProcessKillIDBCleanup-1.html in Copy Resources */,
+				A17C483D2C98E5C20023F3C7 /* WebProcessKillIDBCleanup-2.html in Copy Resources */,
+				A17C483E2C98E5C20023F3C7 /* webrtc-remote-iframe.html in Copy Resources */,
+				A17C483F2C98E5C20023F3C7 /* webrtc-remote.html in Copy Resources */,
+				A17C46892C98E4D20023F3C7 /* WebScriptObjectDescription.html in Copy Resources */,
+				A17C48402C98E5C20023F3C7 /* WebsiteDataStoreCustomPaths.html in Copy Resources */,
+				A17C48412C98E5C20023F3C7 /* websql-database-tracker.db in Copy Resources */,
+				A17C48422C98E5C20023F3C7 /* websql-database.db in Copy Resources */,
+				A17C48432C98E5C20023F3C7 /* wide-autoplaying-video-with-audio.html in Copy Resources */,
+				A17C468A2C98E4D20023F3C7 /* WillPerformClientRedirectToURLCrash.html in Copy Resources */,
+				A17C46FE2C98E54B0023F3C7 /* window-open-then-document-open.html in Copy Resources */,
+				A17C468B2C98E4D20023F3C7 /* WindowlessWebViewWithMedia.html in Copy Resources */,
+				A17C48442C98E5C20023F3C7 /* WKInspectorExtensionEvaluateScriptOnPage.html in Copy Resources */,
+				A17C48452C98E5C20023F3C7 /* WKInspectorExtensionEvaluateScriptOnPageInnerFrame.html in Copy Resources */,
 			);
 			name = "Copy Resources";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3192,6 +3191,10 @@
 		A17991891E1CA24100A505ED /* SharedBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedBufferTest.cpp; sourceTree = "<group>"; };
 		A179918A1E1CA24100A505ED /* SharedBufferTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedBufferTest.h; sourceTree = "<group>"; };
 		A17A5A3422A887EC0065C5F0 /* AppKitTestSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppKitTestSPI.h; sourceTree = "<group>"; };
+		A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestWebKitAPIResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		A17C464A2C98E3640023F3C7 /* TestWebKitAPIResources.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestWebKitAPIResources.xcconfig; sourceTree = "<group>"; };
+		A17C48572C98FA3F0023F3C7 /* TestNSBundleExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestNSBundleExtras.h; sourceTree = "<group>"; };
+		A17C48582C98FA3F0023F3C7 /* TestNSBundleExtras.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestNSBundleExtras.m; sourceTree = "<group>"; };
 		A17EAC542083056E0084B41B /* find.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; name = find.pdf; path = Tests/WebKit/find.pdf; sourceTree = SOURCE_ROOT; };
 		A180C0F91EE67DF000468F47 /* RunOpenPanel.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RunOpenPanel.mm; sourceTree = "<group>"; };
 		A18AA8CC1C3FA218009B2B97 /* ContentFiltering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentFiltering.h; sourceTree = "<group>"; };
@@ -3993,6 +3996,8 @@
 				5C72E8CE244FFCE400381EB7 /* TestLegacyDownloadDelegate.mm */,
 				2D1C04A51D76298B000A6816 /* TestNavigationDelegate.h */,
 				2D1C04A61D76298B000A6816 /* TestNavigationDelegate.mm */,
+				A17C48572C98FA3F0023F3C7 /* TestNSBundleExtras.h */,
+				A17C48582C98FA3F0023F3C7 /* TestNSBundleExtras.m */,
 				516281232325C17A00BB7E42 /* TestPDFDocument.h */,
 				516281242325C17B00BB7E42 /* TestPDFDocument.mm */,
 				A14FC58D1B8AE36500D107EB /* TestProtocol.h */,
@@ -4071,6 +4076,7 @@
 				7CCE7E8C1A41144E00447C4C /* libTestWebKitAPI.a */,
 				7C83DF681D0A590C00FEBCF3 /* libTestWTF.a */,
 				A13EBB491B87339E00097110 /* TestWebKitAPI.wkbundle */,
+				A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -5275,6 +5281,7 @@
 				7AB0173923FB2BF0002F8366 /* TestWebKitAPI-macOS.entitlements */,
 				BC90958012554CF900083756 /* TestWebKitAPI.xcconfig */,
 				7CCE7EA31A4115CB00447C4C /* TestWebKitAPILibrary.xcconfig */,
+				A17C464A2C98E3640023F3C7 /* TestWebKitAPIResources.xcconfig */,
 				3A5DDADB28D15328004DA950 /* TestWGSL.xcconfig */,
 				7C83E0261D0A5B8D00FEBCF3 /* TestWTF.xcconfig */,
 				7C83E0271D0A5B8D00FEBCF3 /* TestWTFLibrary.xcconfig */,
@@ -6133,15 +6140,14 @@
 			buildPhases = (
 				8DD76F990486AA7600D96B5E /* Sources */,
 				8DD76F9B0486AA7600D96B5E /* Frameworks */,
-				8DD76F9E0486AA7600D96B5E /* CopyFiles */,
-				BCB9F4FB112384C000A137E0 /* Copy Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				A13EBBB31B87441900097110 /* PBXTargetDependency */,
 				BC575A96126E74E7006F0F12 /* PBXTargetDependency */,
 				7CCE7F511A4124DB00447C4C /* PBXTargetDependency */,
+				A17C48562C98EBF50023F3C7 /* PBXTargetDependency */,
+				A13EBBB31B87441900097110 /* PBXTargetDependency */,
 			);
 			name = TestWebKitAPI;
 			productInstallPath = "$(HOME)/bin";
@@ -6164,6 +6170,21 @@
 			name = WebProcessPlugIn;
 			productName = WebProcessPlugIn;
 			productReference = A13EBB491B87339E00097110 /* TestWebKitAPI.wkbundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		A17C46452C98E3430023F3C7 /* TestWebKitAPIResources */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A17C46472C98E3440023F3C7 /* Build configuration list for PBXNativeTarget "TestWebKitAPIResources" */;
+			buildPhases = (
+				A17C464B2C98E4520023F3C7 /* Copy Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestWebKitAPIResources;
+			productName = TestWebKitAPIResources;
+			productReference = A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */ = {
@@ -6212,6 +6233,9 @@
 						CreatedOnToolsVersion = 7.0;
 						ProvisioningStyle = Manual;
 					};
+					A17C46452C98E3430023F3C7 = {
+						CreatedOnToolsVersion = 16.0;
+					};
 					BC57597F126E74AF006F0F12 = {
 						ProvisioningStyle = Manual;
 					};
@@ -6241,6 +6265,7 @@
 				7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */,
 				7B9FC39428A26137007570E7 /* TestIPC */,
 				8DD76F960486AA7600D96B5E /* TestWebKitAPI */,
+				A17C46452C98E3430023F3C7 /* TestWebKitAPIResources */,
 				3A15783C28D1505B00142DB1 /* TestWGSL */,
 				7C83DF951D0A5AE400FEBCF3 /* TestWTF */,
 				BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */,
@@ -6919,6 +6944,7 @@
 				7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */,
 				F45E15762112CE6200307E82 /* TestInputDelegate.mm in Sources */,
 				F45D3891215A7B4B002A2979 /* TestInspectorBar.mm in Sources */,
+				A17C48592C98FA3F0023F3C7 /* TestNSBundleExtras.m in Sources */,
 				516281252325C18000BB7E42 /* TestPDFDocument.mm in Sources */,
 				F4CB8A7D2856462B0017ECD3 /* TestPDFHostViewController.mm in Sources */,
 				7B774906267CCE72009873B4 /* TestRunnerTests.cpp in Sources */,
@@ -7224,6 +7250,11 @@
 			target = A13EBB481B87339E00097110 /* WebProcessPlugIn */;
 			targetProxy = A13EBBB21B87441900097110 /* PBXContainerItemProxy */;
 		};
+		A17C48562C98EBF50023F3C7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A17C46452C98E3430023F3C7 /* TestWebKitAPIResources */;
+			targetProxy = A17C48552C98EBF50023F3C7 /* PBXContainerItemProxy */;
+		};
 		BC575A96126E74E7006F0F12 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */;
@@ -7403,6 +7434,20 @@
 			};
 			name = Release;
 		};
+		A17C46482C98E3440023F3C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A17C464A2C98E3640023F3C7 /* TestWebKitAPIResources.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		A17C46492C98E3440023F3C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A17C464A2C98E3640023F3C7 /* TestWebKitAPIResources.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		BC575984126E74AF006F0F12 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC575AE2126E88B1006F0F12 /* InjectedBundle.xcconfig */;
@@ -7515,6 +7560,15 @@
 			buildConfigurations = (
 				A13EBB4D1B87339E00097110 /* Debug */,
 				A13EBB4E1B87339E00097110 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A17C46472C98E3440023F3C7 /* Build configuration list for PBXNativeTarget "TestWebKitAPIResources" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A17C46482C98E3440023F3C7 /* Debug */,
+				A17C46492C98E3440023F3C7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm
@@ -75,7 +75,7 @@ static void testAFewStrings(Vector<Vector<UInt16>> testStrings)
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"LineBreaking" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"LineBreaking" withExtension:@"html"]]];
     [webView _test_waitForDidFinishNavigation];
 
     for (auto& testCodePoints : testStrings) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreNSURLSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreNSURLSession.mm
@@ -27,7 +27,7 @@
 
 #if !PLATFORM(IOS_FAMILY)
 
-#import "Utilities.h"
+#import "PlatformUtilities.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/FrameLoadRequest.h>
 #import <WebCore/LocalFrame.h>
@@ -51,8 +51,8 @@ static bool didRecieveData;
 static bool didComplete;
 static bool didInvalidate;
 
-static NSURL *documentURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-static NSURL *resourceURL = [[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"];
+static NSURL *documentURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+static NSURL *resourceURL = [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"];
 
 @interface TestNSURLSessionLoaderDelegate : NSObject<WebFrameLoadDelegate>
 @end

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
@@ -103,7 +103,7 @@ TEST_F(XMLParsing, WebCoreDoesNotBreakLibxml2)
     xmlSetExternalEntityLoader(origEntityLoader);
 
     // Parse an XML document in libxml2.
-    NSString *resourceURL = [[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"xml" subdirectory:@"TestWebKitAPI.resources"] path];
+    NSString *resourceURL = [[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"xml"] path];
     xmlParserCtxtPtr ctxt = xmlNewParserCtxt();
     EXPECT_TRUE(!!ctxt);
     xmlDocPtr doc = xmlCtxtReadFile(ctxt, resourceURL.UTF8String, nullptr, XML_PARSE_NONET);

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -905,8 +905,8 @@ TEST(AdvancedPrivacyProtections, ClampScreenSizeToFixedValues)
 
 TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)
 {
-    auto testURL = [NSBundle.mainBundle URLForResource:@"audio-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
+    auto testURL = [NSBundle.test_resourcesBundle URLForResource:@"audio-fingerprinting" withExtension:@"html"];
+    auto resourcesURL = NSBundle.test_resourcesBundle.resourceURL;
 
     auto webView = createWebViewWithAdvancedPrivacyProtections();
     [webView loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
@@ -1013,8 +1013,8 @@ TEST(AdvancedPrivacyProtections, DISABLED_VerifyHashFromNoisyCanvas2DAPI)
 TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
 #endif
 {
-    auto testURL = [NSBundle.mainBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
+    auto testURL = [NSBundle.test_resourcesBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html"];
+    auto resourcesURL = NSBundle.test_resourcesBundle.resourceURL;
 
     auto webView1 = createWebViewWithAdvancedPrivacyProtections(NO);
     auto webView2 = createWebViewWithAdvancedPrivacyProtections(NO);
@@ -1055,8 +1055,8 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     constexpr auto zeroPrefix = 380;
     constexpr auto channelsPerPixel = 4;
 
-    auto testURL = [NSBundle.mainBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
+    auto testURL = [NSBundle.test_resourcesBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html"];
+    auto resourcesURL = NSBundle.test_resourcesBundle.resourceURL;
 
     auto webView1 = createWebViewWithAdvancedPrivacyProtections(NO);
     auto webView2 = createWebViewWithAdvancedPrivacyProtections(NO);
@@ -1161,8 +1161,8 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
 
 TEST(AdvancedPrivacyProtections, VerifyDataURLFromNoisyWebGLAPI)
 {
-    auto testURL = [NSBundle.mainBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
+    auto testURL = [NSBundle.test_resourcesBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html"];
+    auto resourcesURL = NSBundle.test_resourcesBundle.resourceURL;
 
     auto webView1 = createWebViewWithAdvancedPrivacyProtections(NO);
     auto webView2 = createWebViewWithAdvancedPrivacyProtections(NO);

--- a/Tools/TestWebKitAPI/Tests/WebKit/FontRegistrySandboxCheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FontRegistrySandboxCheck.mm
@@ -56,7 +56,7 @@ TEST(WebKit, FontdSandboxCheck)
 
 TEST(WebKit, UserInstalledFontsWork)
 {
-    NSURL *fontURL = [[NSBundle mainBundle] URLForResource:@"Ahem" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *fontURL = [NSBundle.test_resourcesBundle URLForResource:@"Ahem" withExtension:@"ttf"];
     CFErrorRef error = nil;
     auto registrationSucceeded = CTFontManagerRegisterFontsForURL(static_cast<CFURLRef>(fontURL), kCTFontManagerScopeUser, &error);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -1161,7 +1161,7 @@ TEST(WebKit, InvalidDeviceIdHashSalts)
     // Prepare invalid data.
     if ([fileManager fileExistsAtPath:filePath.path])
         [fileManager removeItemAtPath:filePath.path error:nil];
-    auto *fileData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"invalidDeviceIDHashSalts" withExtension:@"" subdirectory:@"TestWebKitAPI.resources"]];
+    auto *fileData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"invalidDeviceIDHashSalts" withExtension:@""]];
     EXPECT_TRUE([fileManager createFileAtPath:filePath.path contents:fileData attributes: nil]);
     while (![fileManager fileExistsAtPath:filePath.path])
         Util::spinRunLoop();

--- a/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
@@ -94,7 +94,7 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
     Util::run(&networkProcessCrashed);
     networkProcessCrashed = false;
 
-    [webView1.get() loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView1.get() loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     [webView1.get() _test_waitForDidFinishNavigation];
 
     pid_t relaunchedNetworkProcessIdentifier = [configuration.get().websiteDataStore _networkProcessIdentifier];
@@ -103,7 +103,7 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
 
     kill(relaunchedNetworkProcessIdentifier, SIGSTOP);
 
-    [webView2.get() loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView2.get() loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     Util::runFor(0.5_s); // Wait for the WebContent process to send CreateNetworkConnectionToWebProcess
     kill(relaunchedNetworkProcessIdentifier, SIGKILL);
     Util::run(&networkProcessCrashed);
@@ -153,7 +153,7 @@ TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
     auto delegate = adoptNS([[MonitorWebContentCrashNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&loaded);
 
     EXPECT_TRUE(networkProcessCrashed);

--- a/Tools/TestWebKitAPI/Tests/WebKit/NoHistoryItemScrollToFragment.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NoHistoryItemScrollToFragment.mm
@@ -84,7 +84,7 @@ TEST(WebKit, NoHistoryItemScrollToFragment)
     [webView scrollView].delegate = delegateForScrollView.get();
 #endif
 
-    NSURL* resourceURL = [[NSBundle mainBundle] URLForResource:@"scroll-to-anchor" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL* resourceURL = [NSBundle.test_resourcesBundle URLForResource:@"scroll-to-anchor" withExtension:@"html"];
     NSString *testFileContents = [NSString stringWithContentsOfURL:resourceURL encoding:NSUTF8StringEncoding error:nil];
     [webView synchronouslyLoadHTMLString:testFileContents];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/OrthogonalFlowAvailableSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/OrthogonalFlowAvailableSize.mm
@@ -36,7 +36,7 @@ TEST(WebKit, OrthogonalFlowAvailableSize)
     CGPoint origin = CGPointMake(0, 0);
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(origin.x, origin.y, 500, 500)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"orthogonal-flow-available-size" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"orthogonal-flow-available-size" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -165,8 +165,8 @@ static size_t navigations;
 
 TEST(WKBackForwardList, WindowLocationAsyncPolicyDecision)
 {
-    NSURL *simple = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *simple2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *simple = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *simple2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[AsyncPolicyDecisionDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
@@ -179,9 +179,9 @@ TEST(WKBackForwardList, InteractionStateRestoration)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url3 = [[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    NSURL *url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [webView _test_waitForDidFinishNavigation];
@@ -260,9 +260,9 @@ TEST(WKBackForwardList, InteractionStateRestorationNil)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url3 = [[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    NSURL *url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [webView _test_waitForDidFinishNavigation];
@@ -290,9 +290,9 @@ TEST(WKBackForwardList, InteractionStateRestorationInvalid)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url3 = [[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    NSURL *url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [webView _test_waitForDidFinishNavigation];
@@ -381,8 +381,8 @@ TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)
     auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -423,8 +423,8 @@ TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)
     auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -459,9 +459,9 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url3 = [[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    NSURL *url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -676,8 +676,8 @@ static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function
     // Test case: url1 -> url2 -> url2#a (with user gesture)
     // No item should be skipped when navigating backwards or forwards.
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -765,8 +765,8 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUse
     auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"fragment-navigation-before-load-event" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"fragment-navigation-before-load-event" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -796,8 +796,8 @@ TEST(WKBackForwardList, BackNavigationHijacking)
     auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url1]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
@@ -278,7 +278,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAsPictureElement)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -321,7 +321,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAtLargerFontSize)
     [webView synchronouslyLoadHTMLString:@"<body style='font-size: 64px;'></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -352,7 +352,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphMatchStyle)
         "})();";
     [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -373,7 +373,7 @@ TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -427,7 +427,7 @@ TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)
 
 TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)
 {
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -497,7 +497,7 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)
     [copyWebView synchronouslyLoadHTMLString:@"<body></body>"];
     [copyWebView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -564,7 +564,7 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)
     "})();";
     [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -618,7 +618,7 @@ TEST(AdaptiveImageGlyph, InsertMultiple)
     "})();";
     [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -680,7 +680,7 @@ TEST(AdaptiveImageGlyph, InsertTextAfterAdaptiveImageGlyph)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -707,7 +707,7 @@ TEST(AdaptiveImageGlyph, CopyRTF)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -744,7 +744,7 @@ TEST(AdaptiveImageGlyph, ContentsAsAttributedString)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -800,7 +800,7 @@ TEST(AdaptiveImageGlyph, DragAdaptiveImageGlyphFromContentEditable)
 
     [webView focusElementAndEnsureEditorStateUpdate:@"source"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
 
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
@@ -821,7 +821,7 @@ TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsText)
     RetainPtr webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><body style='width: 100%; height: 100%;' contenteditable>"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
     RetainPtr font = [WebCore::CocoaFont systemFontOfSize:36];
@@ -853,7 +853,7 @@ TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsSticker)
     RetainPtr webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><body style='width: 100%; height: 100%;' contenteditable>"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
     RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
 
     RetainPtr font = [WebCore::CocoaFont systemFontOfSize:36];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm
@@ -119,13 +119,13 @@ TEST(WebKit, NSAttributedStringWithReadOnlyPaths)
 
     auto [readableDirectoryURL, unreadableDirectoryURL] = readableAndUnreadableDirectories();
 
-    NSURL *iconImagePath = [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *iconImagePath = [NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"];
     NSURL *readableFileURL = [readableDirectoryURL URLByAppendingPathComponent:@"readable.png"];
     NSError *error;
     if (![NSFileManager.defaultManager copyItemAtURL:iconImagePath toURL:readableFileURL error:&error])
         EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
 
-    NSURL *redImagePath = [[NSBundle mainBundle] URLForResource:@"large-red-square" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *redImagePath = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square" withExtension:@"png"];
     NSURL *unreadableFileURL = [unreadableDirectoryURL URLByAppendingPathComponent:@"unreadable.png"];
     if (![NSFileManager.defaultManager copyItemAtURL:redImagePath toURL:unreadableFileURL error:&error])
         EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
@@ -170,13 +170,13 @@ TEST(WebKit, NSAttributedStringWithAndWithoutReadOnlyPaths)
 
     auto [readableDirectoryURL, unreadableDirectoryURL] = readableAndUnreadableDirectories();
 
-    NSURL *iconImagePath = [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *iconImagePath = [NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"];
     NSURL *readableFileURL = [readableDirectoryURL URLByAppendingPathComponent:@"readable.png"];
     NSError *error;
     if (![NSFileManager.defaultManager copyItemAtURL:iconImagePath toURL:readableFileURL error:&error])
         EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
 
-    NSURL *redImagePath = [[NSBundle mainBundle] URLForResource:@"large-red-square" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *redImagePath = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square" withExtension:@"png"];
     NSURL *unreadableFileURL = [unreadableDirectoryURL URLByAppendingPathComponent:@"unreadable.png"];
     if (![NSFileManager.defaultManager copyItemAtURL:redImagePath toURL:unreadableFileURL error:&error])
         EXPECT_TRUE(error.code == NSFileWriteFileExistsError);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalSupportedImageTypes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalSupportedImageTypes.mm
@@ -41,7 +41,7 @@ static void runTest(NSArray<NSString *> *additionalSupportedImageTypes, NSString
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:imageURL withExtension:imageExtension subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:imageURL withExtension:imageExtension];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -98,7 +98,7 @@ static RetainPtr<TestNavigationDelegate> createFirstVisuallyNonEmptyWatchingNavi
 TEST(AnimatedResize, DISABLED_ResizeWithHiddenContentDoesNotHang)
 {
     auto webView = createAnimatedResizeWebView();
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"blinking-div" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"blinking-div" withExtension:@"html"]]];
 
     auto navigationDelegate = createFirstVisuallyNonEmptyWatchingNavigationDelegate();
     [webView setNavigationDelegate:navigationDelegate.get()];
@@ -122,7 +122,7 @@ TEST(AnimatedResize, DISABLED_ResizeWithHiddenContentDoesNotHang)
 TEST(AnimatedResize, AnimatedResizeDoesNotHang)
 {
     auto webView = createAnimatedResizeWebView();
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"blinking-div" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"blinking-div" withExtension:@"html"]]];
 
     auto navigationDelegate = createFirstVisuallyNonEmptyWatchingNavigationDelegate();
     [webView setNavigationDelegate:navigationDelegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
@@ -210,7 +210,7 @@ TEST(AppPrivacyReport, AppInitiatedRequestWithSubFrame)
 
     __block bool isDone = false;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSMutableURLRequest *appInitiatedRequest = [NSMutableURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"page-with-csp" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSMutableURLRequest *appInitiatedRequest = [NSMutableURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
     appInitiatedRequest.attribution = NSURLRequestAttributionDeveloper;
 
     [webView loadRequest:appInitiatedRequest];
@@ -234,7 +234,7 @@ TEST(AppPrivacyReport, NonAppInitiatedRequestWithSubFrame)
 
     __block bool isDone = false;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSMutableURLRequest *nonAppInitiatedRequest = [NSMutableURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"page-with-csp" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSMutableURLRequest *nonAppInitiatedRequest = [NSMutableURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
     nonAppInitiatedRequest.attribution = NSURLRequestAttributionUser;
 
     [webView loadRequest:nonAppInitiatedRequest];
@@ -840,7 +840,7 @@ static void loadFileTest(IsAppInitiated isAppInitiated)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
-    NSURL *file = [[NSBundle mainBundle] URLForResource:@"file-with-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"file-with-iframe" withExtension:@"html"];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:file];
     request.attribution = isAppInitiated == IsAppInitiated::Yes ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -130,7 +130,7 @@ TEST(ApplicationManifest, DisplayMode)
         @"fullscreen": @"(display-mode) (display-mode: fullscreen)",
     };
 
-    NSURL *baseURL = [[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
+    NSURL *baseURL = NSBundle.test_resourcesBundle.resourceURL;
     [displayModesAndExpectedContent enumerateKeysAndObjectsUsingBlock:^(NSString *displayMode, NSString *expectedPageContent, BOOL* stop) {
         @autoreleasepool {
             NSString *m2 = displayMode.length ? [NSString stringWithFormat:@"{\"display\": \"%@\"}", displayMode] : @"{}";

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AsyncPolicyForNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AsyncPolicyForNavigationResponse.mm
@@ -77,7 +77,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, RespondToPolicyForNavigationResponseAsynchronously)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[TestAsyncNavigationDelegate alloc] init]);
@@ -95,7 +95,7 @@ TEST(WebKit, RespondToPolicyForNavigationResponseAsynchronously)
 
 TEST(WebKit, PolicyForNavigationResponseCancelAsynchronously)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[TestAsyncNavigationDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AttrStyle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AttrStyle.mm
@@ -42,7 +42,7 @@ TEST(WebKit, AttrStyle)
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"AttrStyle" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"AttrStyle" withExtension:@"html"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
     __block bool isDone = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
@@ -1650,7 +1650,7 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
 TEST(CSSViewportUnits, SVGDocument)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"CSSViewportUnits" withExtension:@"svg" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"CSSViewportUnits" withExtension:@"svg"]]];
     [webView _test_waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
@@ -171,7 +171,7 @@ TEST(ClipboardTests, WriteSanitizedMarkup)
 TEST(ClipboardTests, ConvertTIFFToPNGWhenPasting)
 {
     auto webView = createWebViewForClipboardTests();
-    auto url = [[NSBundle mainBundle] URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff" subdirectory:@"TestWebKitAPI.resources"];
+    auto url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"];
     auto pasteboard = NSPasteboard.generalPasteboard;
     [pasteboard clearContents];
     [pasteboard setData:[NSData dataWithContentsOfURL:url] forType:NSPasteboardTypeTIFF];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CommandBackForward.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CommandBackForward.mm
@@ -140,11 +140,11 @@ public:
     
     void loadFiles()
     {
-        NSURL *file1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *file1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
         [webView loadFileURL:file1 allowingReadAccessToURL:file1];
         [webView _test_waitForDidFinishNavigation];
 
-        NSURL *file2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *file2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
         [webView loadFileURL:file2 allowingReadAccessToURL:file2];
         [webView _test_waitForDidFinishNavigation];
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
@@ -436,7 +436,7 @@ TEST(ContentFiltering, LazilyLoadPlatformFrameworks)
         [controller expectParentalControlsLoaded:NO];
 
         isDone = false;
-        NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"ContentFiltering" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"ContentFiltering" withExtension:@"html"];
         [[controller webView] loadFileURL:fileURL allowingReadAccessToURL:fileURL];
         TestWebKitAPI::Util::run(&isDone);
         [controller expectParentalControlsLoaded:NO];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
@@ -37,7 +37,7 @@ TEST(WKWebView, DISABLED_SetOverrideContentSecurityPolicyWithEmptyStringForPageW
         [configuration _setOverrideContentSecurityPolicy:@""];
 
         RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"page-with-csp" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
         [webView loadRequest:request];
 
         [webView waitForMessage:@"MainFrame: A"];
@@ -54,7 +54,7 @@ TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithCSP)
         [configuration _setOverrideContentSecurityPolicy:@"script-src 'nonce-b'"];
 
         RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"page-with-csp" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
         [webView loadRequest:request];
 
         [webView waitForMessage:@"MainFrame: B"];
@@ -69,7 +69,7 @@ TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithoutCSP)
         [configuration _setOverrideContentSecurityPolicy:@"script-src 'nonce-b'"];
 
         RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"page-without-csp" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-without-csp" withExtension:@"html"]];
         [webView loadRequest:request];
 
         [webView waitForMessage:@"MainFrame: B"];
@@ -82,7 +82,7 @@ TEST(WKWebView, CheckViolationReportDocumentURIForFileProtocol)
     @autoreleasepool {
         auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"csp-document-uri-report" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"csp-document-uri-report" withExtension:@"html"]];
         [webView loadRequest:request];
 
         [webView waitForMessage:@"document-uri: file"];
@@ -94,7 +94,7 @@ TEST(WKWebView, CheckViolationReportDocumentURIForDataProtocol)
     @autoreleasepool {
         auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSString *path = [NSBundle.mainBundle pathForResource:@"csp-document-uri-report" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"];
+        NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"csp-document-uri-report" ofType:@"html"];
         NSString* content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
 
         NSURLRequest *loadRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html"]];
@@ -111,7 +111,7 @@ TEST(WKWebView, CheckViolationReportDocumentURIForAboutProtocol)
     @autoreleasepool {
         auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSString *path = [NSBundle.mainBundle pathForResource:@"csp-document-uri-report" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"];
+        NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"csp-document-uri-report" ofType:@"html"];
         NSString* content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
 
         [webView loadHTMLString:content baseURL:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
@@ -59,7 +59,7 @@ TEST(WebKit, CookieAcceptPolicy)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"CookieMessage" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"CookieMessage" withExtension:@"html"]];
     __block bool setPolicy = false;
     [configuration.get().websiteDataStore.httpCookieStore _setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyNever completionHandler:^{
         setPolicy = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
@@ -181,7 +181,7 @@ TEST(WebArchive, SaveResourcesBasic)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [@"<head><script src=\"script.js\"></script></head><img src=\"image.png\" onload=\"onImageLoad()\"><script>function onImageLoad() { notifyTestRunner(); }</script>" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *scriptData = [@"function notifyTestRunner() { window.webkit.messageHandlers.testHandler.postMessage(\"done\"); }" dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -273,7 +273,7 @@ TEST(WebArchive, SaveResourcesIframe)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForIframe length:strlen(htmlDataBytesForIframe)];
     NSData *iframeHTMLData = [NSData dataWithBytes:iframeHTMLDataBytes length:strlen(iframeHTMLDataBytes)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForIframe length:strlen(cssDataBytesForIframe)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -382,7 +382,7 @@ TEST(WebArchive, SaveResourcesFrame)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForFrame length:strlen(htmlDataBytesForFrame)];
     NSData *frameHTMLData = [NSData dataWithBytes:frameHTMLDataBytes length:strlen(frameHTMLDataBytes)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -474,7 +474,7 @@ TEST(WebArchive, SaveResourcesValidFileName)
     for (NSString *item in tests)
         [mutableHTMLString appendString:[NSString stringWithFormat:@"<img src='%@' onload='onImageLoad()'>", item]];
     NSData *htmlData = [[NSString stringWithString:mutableHTMLString] dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     NSString *cssString = @"img { width: 10px; }";
     NSData *cssData = [cssString dataUsingEncoding:NSUTF8StringEncoding];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -564,7 +564,7 @@ TEST(WebArchive, SaveResourcesBlobURL)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
 
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForBlobURL length:strlen(htmlDataBytesForBlobURL)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -674,7 +674,7 @@ TEST(WebArchive, SaveResourcesResponsiveImages)
     auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForResponsiveImages length:strlen(htmlDataBytesForResponsiveImages)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -747,7 +747,7 @@ TEST(WebArchive, SaveResourcesDataURL)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
 
     NSData *htmlData = [NSData dataWithBytes:hTMLDataBytesForDataURL length:strlen(hTMLDataBytesForDataURL)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1175,8 +1175,8 @@ TEST(WebArchive, SaveResourcesStyle)
     auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForStyle length:strlen(htmlDataBytesForStyle)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
-    NSData *fontData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"Ahem-10000A" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
+    NSData *fontData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1248,7 +1248,7 @@ TEST(WebArchive, SaveResourcesInlineStyle)
     auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForInlineStyle length:strlen(htmlDataBytesForInlineStyle)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1346,9 +1346,9 @@ TEST(WebArchive, SaveResourcesLink)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForLink length:strlen(htmlDataBytesForLink)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLink length:strlen(cssDataBytesForLink)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     NSData *manifestData = [NSData dataWithBytes:manifestDataBytesForLink length:strlen(manifestDataBytesForLink)];
-    NSData *fontData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"Ahem-10000A" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *fontData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1602,7 +1602,7 @@ TEST(WebArchive, SaveResourcesCSSImportRule)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCSSImportRule length:strlen(htmlDataBytesForCSSImportRule)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLink length:strlen(cssDataBytesForLink)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1690,7 +1690,7 @@ TEST(WebArchive, SaveResourcesCSSSupportsRule)
     auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCSSSupportsRule length:strlen(htmlDataBytesForCSSSupportsRule)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1769,7 +1769,7 @@ TEST(WebArchive, SaveResourcesCSSMediaRule)
     RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     RetainPtr htmlData = [NSData dataWithBytes:htmlDataBytesForCSSMediaRule length:strlen(htmlDataBytesForCSSMediaRule)];
-    RetainPtr imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -1912,7 +1912,7 @@ TEST(WebArchive, SaveResourcesExcludeBaseElement)
     auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForExcludeBaseElement length:strlen(htmlDataBytesForExcludeBaseElement)];
-    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;
@@ -2153,7 +2153,7 @@ TEST(WebArchive, SaveResourcesStyleWithUnloadedResources)
     auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     RetainPtr htmlData = [NSData dataWithBytes:htmlDataBytesForUnsavedSubresources length:strlen(htmlDataBytesForUnsavedSubresources)];
-    RetainPtr fontData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"Ahem-10000A" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr fontData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSData *data = nil;
         NSString *mimeType = nil;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
@@ -659,7 +659,7 @@ TEST(WebKit, DelayDecidePolicyForNavigationAction)
     auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     TestWebKitAPI::Util::run(&decidedPolicy);
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceManagementRestrictions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceManagementRestrictions.mm
@@ -56,7 +56,7 @@ TEST(WebKit, DeviceManagementRestrictions)
         done = true;
     }];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm
@@ -111,7 +111,7 @@ static void runDeviceOrientationTest(DeviceOrientationPermission deviceOrientati
     }
     [webView setUIDelegate:uiDelegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
 
     [webView _test_waitForDidFinishNavigation];
@@ -184,7 +184,7 @@ TEST(DeviceOrientation, RememberPermissionForSession)
     RetainPtr<DeviceOrientationPermissionUIDelegate> uiDelegate = adoptNS([[DeviceOrientationPermissionUIDelegate alloc] initWithHandler:[] { return true; }]);
     [webView setUIDelegate:uiDelegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -279,7 +279,7 @@ TEST(DeviceOrientation, FireOrientationEventsRightAwayIfPermissionAlreadyGranted
     RetainPtr<DeviceOrientationPermissionUIDelegate> uiDelegate = adoptNS([[DeviceOrientationPermissionUIDelegate alloc] initWithHandler:[] { return true; }]);
     [webView setUIDelegate:uiDelegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -68,7 +68,7 @@
 
 static unsigned redirectCount = 0;
 static bool hasReceivedResponse;
-static NSURL *sourceURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+static NSURL *sourceURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 static WKWebView* expectedOriginatingWebView;
 static bool expectedUserInitiatedState = false;
 
@@ -343,13 +343,13 @@ TEST(_WKDownload, OriginatingWebView)
 
 TEST(_WKDownload, DownloadRequestOriginalURL)
 {
-    NSURL *originalURL = [[NSBundle mainBundle] URLForResource:@"DownloadRequestOriginalURL" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *originalURL = [NSBundle.test_resourcesBundle URLForResource:@"DownloadRequestOriginalURL" withExtension:@"html"];
     runTest(adoptNS([[DownloadRequestOriginalURLNavigationDelegate alloc] init]).get(), adoptNS([[DownloadRequestOriginalURLDelegate alloc] initWithExpectedOriginalURL:originalURL]).get(), originalURL);
 }
 
 TEST(_WKDownload, DownloadRequestOriginalURLFrame)
 {
-    NSURL *originalURL = [[NSBundle mainBundle] URLForResource:@"DownloadRequestOriginalURL2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *originalURL = [NSBundle.test_resourcesBundle URLForResource:@"DownloadRequestOriginalURL2" withExtension:@"html"];
     runTest(adoptNS([[DownloadRequestOriginalURLNavigationDelegate alloc] init]).get(), adoptNS([[DownloadRequestOriginalURLDelegate alloc] initWithExpectedOriginalURL:originalURL]).get(), originalURL);
 }
 
@@ -367,7 +367,7 @@ TEST(_WKDownload, DownloadRequestOriginalURLDirectDownloadWithLoadedContent)
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
     expectedUserInitiatedState = false;
-    NSURL *contentURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     // Here is to test if the original URL can be set correctly when the current document
     // is completely unrelated to the download.
     [webView loadRequest:[NSURLRequest requestWithURL:contentURL]];
@@ -454,7 +454,7 @@ IGNORE_WARNINGS_END
 
 TEST(_WKDownload, DownloadRequestBlobURL)
 {
-    NSURL *originalURL = [[NSBundle mainBundle] URLForResource:@"DownloadRequestBlobURL" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *originalURL = [NSBundle.test_resourcesBundle URLForResource:@"DownloadRequestBlobURL" withExtension:@"html"];
     runTest(adoptNS([[DownloadBlobURLNavigationDelegate alloc] init]).get(), adoptNS([[BlobDownloadDelegate alloc] init]).get(), originalURL);
 }
 
@@ -665,7 +665,7 @@ TEST(_WKDownload, DownloadCanceledWhileDecidingDestination)
 
 TEST(_WKDownload, SystemPreviewUSDZBlobNaming)
 {
-    NSURL *originalURL = [[NSBundle mainBundle] URLForResource:@"SystemPreviewBlobNaming" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *originalURL = [NSBundle.test_resourcesBundle URLForResource:@"SystemPreviewBlobNaming" withExtension:@"html"];
     runTest(adoptNS([[DownloadBlobURLNavigationDelegate alloc] init]).get(), adoptNS([[BlobWithUSDZExtensionDownloadDelegate alloc] init]).get(), originalURL);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
@@ -154,7 +154,7 @@ TEST(DragAndDropTests, DragAndDropOnEmptyView)
     simulator.get().dragDestinationAction = WKDragDestinationActionAny;
     auto webView = [simulator webView];
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
     [pasteboard writeObjects:@[ url ]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DuplicateCompletionHandlerCalls.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DuplicateCompletionHandlerCalls.mm
@@ -132,7 +132,7 @@ TEST(WebKit, DuplicateCompletionHandlerCalls)
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     [webView _setInputDelegate:delegate.get()];
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"duplicate-completion-handler-calls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"duplicate-completion-handler-calls" withExtension:@"html"]]];
 
     Util::run(&testFinished);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FileSystemAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FileSystemAccess.mm
@@ -279,7 +279,7 @@ TEST(FileSystemAccess, MigrateToNewStorageDirectory)
     [fileManager createFileAtPath:oldFilePath contents:nil attributes:nil];
     EXPECT_TRUE([fileManager fileExistsAtPath:oldFilePath]);
 
-    NSString *resourceSaltPath = [[NSBundle mainBundle] URLForResource:@"file-system-access" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"].path;
+    NSString *resourceSaltPath = [NSBundle.test_resourcesBundle URLForResource:@"file-system-access" withExtension:@"salt"].path;
     NSString *oldSaltPath = [oldStorageDirectory stringByAppendingPathComponent:@"salt"];
     [fileManager copyItemAtPath:resourceSaltPath toPath:oldSaltPath error:nil];
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:oldSaltPath]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -108,7 +108,7 @@ TEST(WebKit, FindInPage)
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 200, 200)]);
     [webView _setOverrideDeviceScaleFactor:2];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -156,7 +156,7 @@ TEST(WebKit, FindInPage)
 TEST(WebKit, FindInPageSelectMatch)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 200, 200)]);
-    auto request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    auto request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView _setUsePlatformFindUI:NO];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -177,7 +177,7 @@ TEST(WebKit, FindInPageWithPlatformPresentation)
     [webView _setOverrideDeviceScaleFactor:2];
     [webView _setUsePlatformFindUI:NO];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -572,7 +572,7 @@ TEST(WebKit, FindInPage)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -584,7 +584,7 @@ TEST(WebKit, FindInPageCaseInsensitive)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -599,7 +599,7 @@ TEST(WebKit, FindInPageStartsWith)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -618,7 +618,7 @@ TEST(WebKit, FindInPageFullWord)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -636,7 +636,7 @@ TEST(WebKit, FindInPageDoNotCrashWhenUsingMutableString)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -876,7 +876,7 @@ TEST(WebKit, CannotHaveMultipleFindOverlays)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -905,7 +905,7 @@ TEST(WebKit, FindOverlayCloseWebViewCrash)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView setFindInteractionEnabled:YES];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -930,7 +930,7 @@ TEST(WebKit, FindOverlaySPI)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView _setFindDelegate:findDelegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -981,7 +981,7 @@ TEST(WebKit, FindInPDF)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -1000,7 +1000,7 @@ TEST(WebKit, FindInPDFAfterReload)
     auto webView = adoptNS([[FindInPageTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     auto searchForText = [&] {
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
         [webView loadRequest:request];
         [webView _test_waitForDidFinishNavigation];
 
@@ -1035,7 +1035,7 @@ TEST(WebKit, FindInPDFAfterFindInPage)
     [findInteraction dismissFindNavigator];
     [webView waitForNextPresentationUpdate];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FirstVisuallyNonEmptyMilestone.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FirstVisuallyNonEmptyMilestone.mm
@@ -73,7 +73,7 @@ TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithDeferredScript)
     receivedMessage = false;
     didFirstVisuallyNonEmptyLayout = false;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"deferred-script-load" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"deferred-script-load" withExtension:@"html"]]];
 
     TestWebKitAPI::Util::run(&receivedMessage);
     EXPECT_TRUE(didFirstVisuallyNonEmptyLayout);
@@ -102,7 +102,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
     NSURL *requestURL = task.request.URL;
     NSString *fileName = requestURL.lastPathComponent;
     NSString *fileExtension = fileName.pathExtension;
-    NSURL *bundleURL = [NSBundle.mainBundle URLForResource:fileName.stringByDeletingPathExtension withExtension:fileExtension subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *bundleURL = [NSBundle.test_resourcesBundle URLForResource:fileName.stringByDeletingPathExtension withExtension:fileExtension];
 
     NSData *responseData = [NSData dataWithContentsOfURL:bundleURL];
     NSUInteger responseLength = responseData.length;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FixedLayoutSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FixedLayoutSize.mm
@@ -67,7 +67,7 @@ TEST(WebKit, FixedLayoutSize)
 
     TestWebKitAPI::Util::run(&fixedLayoutSizeDone);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm
@@ -92,7 +92,7 @@ TEST(Fullscreen, Delegate)
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"FullscreenDelegate" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"FullscreenDelegate" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&receivedLoadedMessage);
 
@@ -131,7 +131,7 @@ TEST(Fullscreen, VisibilityChangeNotDispatched)
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"FullscreenDelegate" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"FullscreenDelegate" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&receivedLoadedMessage);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLayoutConstraints.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLayoutConstraints.mm
@@ -69,7 +69,7 @@ TEST(Fullscreen, LayoutConstraints)
     
     NSArray* originalConstraints = [[window contentView] constraints];
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"FullscreenLayoutConstraints" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"FullscreenLayoutConstraints" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&receivedLoadedMessage);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetResourceData.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetResourceData.mm
@@ -48,7 +48,7 @@ TEST(WebKit, GetPDFResourceData)
     TestWebKitAPI::Util::run(&isDone);
     isDone = false;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
 
     [webView _test_waitForDidFinishNavigation];
@@ -66,7 +66,7 @@ TEST(WebKit, GetPDFResourceDataInUnparentedWebView)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:NO]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
 
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
@@ -87,7 +87,7 @@ TEST(IndexedDB, CheckpointsWALAutomatically)
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBCheckpointWAL" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IDBCheckpointWAL" withExtension:@"html"]];
     [webView loadRequest:request.get()];
     TestWebKitAPI::Util::run([handler receivedScriptMessagePointer]);
     EXPECT_STREQ([[[handler lastScriptMessage] body] UTF8String], "Success");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBDeleteRecovery.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBDeleteRecovery.mm
@@ -59,9 +59,9 @@ TEST(IndexedDB, DeleteRecovery)
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
     // Copy the inconsistent database files to the database directory
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"IDBDeleteRecovery" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"IDBDeleteRecovery" withExtension:@"sqlite3-shm" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url3 = [[NSBundle mainBundle] URLForResource:@"IDBDeleteRecovery" withExtension:@"sqlite3-wal" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"IDBDeleteRecovery" withExtension:@"sqlite3"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"IDBDeleteRecovery" withExtension:@"sqlite3-shm"];
+    NSURL *url3 = [NSBundle.test_resourcesBundle URLForResource:@"IDBDeleteRecovery" withExtension:@"sqlite3-wal"];
 
     NSURL *targetURL = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/file__0/IDBDeleteRecovery" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] createDirectoryAtURL:targetURL withIntermediateDirectories:YES attributes:nil error:nil];
@@ -72,7 +72,7 @@ TEST(IndexedDB, DeleteRecovery)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBDeleteRecovery" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IDBDeleteRecovery" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&receivedScriptMessage);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
@@ -60,8 +60,8 @@ TEST(IndexedDB, IndexUpgradeToV2)
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
     // Copy the inconsistent database files to the database directory
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"IndexUpgrade" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"IndexUpgrade" withExtension:@"blob" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"IndexUpgrade" withExtension:@"sqlite3"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"IndexUpgrade" withExtension:@"blob"];
 
     NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
     NSString *originDirectory = @"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/v1/file__0/";
@@ -75,7 +75,7 @@ TEST(IndexedDB, IndexUpgradeToV2)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBIndexUpgradeToV2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IDBIndexUpgradeToV2" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -90,7 +90,7 @@ static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
-    RetainPtr url = [[NSBundle mainBundle] URLForResource:databaseName withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:databaseName withExtension:@"sqlite3"];
     String hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
     RetainPtr originURL = [NSURL URLWithString:@"file://"];
     __block RetainPtr<NSString> originDirectoryString;
@@ -105,7 +105,7 @@ static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
     [[NSFileManager defaultManager] copyItemAtURL:url.get() toURL:[databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBIndexUpgradeToV2WithMultipleIndices" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IDBIndexUpgradeToV2WithMultipleIndices" withExtension:@"html"]];
     [webView loadRequest:request.get()];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm
@@ -59,7 +59,7 @@ TEST(IndexedDB, IDBObjectStoreInfoUpgradeToV2)
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
     // Copy database files with old ObjectStoreInfo schema to the database directory.
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"IDBObjectStoreInfoUpgrade" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"IDBObjectStoreInfoUpgrade" withExtension:@"sqlite3"];
 
     NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("objectstoreinfo-upgrade-test"_s);
     NSString *originDirectory = @"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/v1/file__0/";
@@ -72,7 +72,7 @@ TEST(IndexedDB, IDBObjectStoreInfoUpgradeToV2)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBObjectStoreInfoUpgradeToV2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IDBObjectStoreInfoUpgradeToV2" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&receivedScriptMessage);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
@@ -202,7 +202,7 @@ TEST(IconLoading, AlreadyCachedIcon)
     NSData *mainData = [NSData dataWithBytesNoCopy:(void*)mainBytes2 length:sizeof(mainBytes2) freeWhenDone:NO];
     RetainPtr<IconLoadingSchemeHandler> handler = adoptNS([[IconLoadingSchemeHandler alloc] initWithData:mainData]);
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"large-red-square-image" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square-image" withExtension:@"html"];
     RetainPtr<NSData> iconDataFromDisk = [NSData dataWithContentsOfURL:url];
     [handler.get() setFaviconData:iconDataFromDisk.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -321,7 +321,7 @@ TEST(ImageAnalysisTests, ImageAnalysisWithTransparentImages)
 
 static RetainPtr<CGImageRef> iconImage()
 {
-    auto iconPath = [NSBundle.mainBundle pathForResource:@"icon" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"];
+    auto iconPath = [NSBundle.test_resourcesBundle pathForResource:@"icon" ofType:@"png"];
 #if PLATFORM(IOS_FAMILY)
     return [UIImage imageWithContentsOfFile:iconPath].CGImage;
 #else

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/InAppBrowserPrivacy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/InAppBrowserPrivacy.mm
@@ -312,7 +312,7 @@ TEST(InAppBrowserPrivacy, LocalFilesAreAppBound)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"in-app-browser-privacy-local-file" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"in-app-browser-privacy-local-file" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -550,7 +550,7 @@ TEST(InAppBrowserPrivacy, AppBoundDomainCanAccessMessageHandlers)
     }];
 
     // Navigate to an app-bound domain and wait for the 'pass' message to test the handler is working fine.
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"in-app-browser-privacy-local-file" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"in-app-browser-privacy-local-file" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBDatabaseProcessKill.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBDatabaseProcessKill.mm
@@ -85,7 +85,7 @@ TEST(IndexedDB, DatabaseProcessKill)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBDatabaseProcessKill-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBDatabaseProcessKill-1" withExtension:@"html"]];
     [webView loadRequest:request];
 
     bool killedDBProcess = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
@@ -61,7 +61,7 @@ static void runTest()
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
     // Open a database which does not have a database file on disk yet.
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBFileName-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBFileName-1" withExtension:@"html"]];
     [webView loadRequest:request];
     
     receivedScriptMessage = false;
@@ -70,7 +70,7 @@ static void runTest()
     EXPECT_WK_STREQ(@"Success", string.get());
 
     // Open a database which already has a database file on disk.
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBFileName-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBFileName-2" withExtension:@"html"]];
     [webView loadRequest:request];
 
     receivedScriptMessage = false;
@@ -119,7 +119,7 @@ static void createDirectories(StringView testName)
     NSURL *directOriginDirectoryURL = [idbRootURL URLByAppendingPathComponent:@"file__0"];
     NSURL *directExistingDatabaseDirectoryURL = [directOriginDirectoryURL URLByAppendingPathComponent:existingDatabaseName];
     NSURL *directUnusedDatabaseDirectoryURL = [directOriginDirectoryURL URLByAppendingPathComponent:unusedDatabaseName];
-    NSURL *resourceDatabaseFileURL = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceDatabaseFileURL = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDB" withExtension:@"sqlite3"];
     [defaultFileManager createDirectoryAtURL:directExistingDatabaseDirectoryURL withIntermediateDirectories:YES attributes:nil error:nil];
     [defaultFileManager createDirectoryAtURL:directUnusedDatabaseDirectoryURL withIntermediateDirectories:YES attributes:nil error:nil];
     [defaultFileManager copyItemAtURL:resourceDatabaseFileURL toURL:[directExistingDatabaseDirectoryURL URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
@@ -219,7 +219,7 @@ TEST(IndexedDB, IndexedDBFileHashCollision)
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBFileName-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBFileName-1" withExtension:@"html"]];
     [webView loadRequest:request];
 
     receivedScriptMessage = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
@@ -60,7 +60,7 @@ TEST(IndexedDB, IndexedDBInPageCache)
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Load page that holds open database connection.
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBInPageCache" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBInPageCache" withExtension:@"html"]];
     [webView loadRequest:request];
 
     receivedScriptMessage = false;
@@ -69,7 +69,7 @@ TEST(IndexedDB, IndexedDBInPageCache)
     EXPECT_WK_STREQ(@"First Database Connection Opened", string1.get());
 
     // Load another page that deletes database.
-    NSURLRequest *request2 = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBNotInPageCache" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request2 = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBNotInPageCache" withExtension:@"html"]];
     [webView loadRequest:request2];
 
     receivedScriptMessage = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm
@@ -62,7 +62,7 @@ TEST(IndexedDB, IndexedDBMultiProcess)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBMultiProcess-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBMultiProcess-1" withExtension:@"html"]];
     [webView loadRequest:request];
 
     RetainPtr<NSString> string1 = (NSString *)[getNextMessage() body];
@@ -72,7 +72,7 @@ TEST(IndexedDB, IndexedDBMultiProcess)
     // Make a new web view with a new web process to continue the test
     RetainPtr<WKWebView> webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBMultiProcess-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBMultiProcess-2" withExtension:@"html"]];
     [webView2 loadRequest:request];
 
     RetainPtr<NSString> string4 = (NSString *)[getNextMessage() body];
@@ -87,7 +87,7 @@ TEST(IndexedDB, IndexedDBMultiProcess)
 
     // Make a new web view with a new web process to continue the test
     RetainPtr<WKWebView> webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBMultiProcess-3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBMultiProcess-3" withExtension:@"html"]];
     [webView3 loadRequest:request];
 
     RetainPtr<NSString> string6 = (NSString *)[getNextMessage() body];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -64,7 +64,7 @@ TEST(IndexedDB, IndexedDBPersistence)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBPersistence-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-1" withExtension:@"html"]];
     [webView loadRequest:request];
 
     RetainPtr<NSString> string1 = (NSString *)[getNextMessage() body];
@@ -79,7 +79,7 @@ TEST(IndexedDB, IndexedDBPersistence)
     // Make a new web view to finish the test
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBPersistence-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-2" withExtension:@"html"]];
     [webView loadRequest:request];
     RetainPtr<NSString> string3 = (NSString *)[getNextMessage() body];
 
@@ -99,7 +99,7 @@ TEST(IndexedDB, IndexedDBPersistencePrivate)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBPersistence-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-1" withExtension:@"html"]];
     [webView loadRequest:request];
 
     RetainPtr<NSString> string1 = (NSString *)[getNextMessage() body];
@@ -112,7 +112,7 @@ TEST(IndexedDB, IndexedDBPersistencePrivate)
     // Make a new web view to finish the test
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBPersistence-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-2" withExtension:@"html"]];
     [webView loadRequest:request];
     RetainPtr<NSString> string3 = (NSString *)[getNextMessage() body];
 
@@ -146,7 +146,7 @@ TEST(IndexedDB, IndexedDBDataRemoval)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBPersistence-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-1" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
 
@@ -357,8 +357,8 @@ TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
 
 TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
 {
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceDatabase = [[NSBundle mainBundle] URLForResource:@"indexeddb-persistence-third-party" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
+    NSURL *resourceDatabase = [NSBundle.test_resourcesBundle URLForResource:@"indexeddb-persistence-third-party" withExtension:@"sqlite3"];
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *webkitOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"EAO66s8JvCWNn4D3YQut5pXfiGF_UXNZGvMGN6aKILg/EAO66s8JvCWNn4D3YQut5pXfiGF_UXNZGvMGN6aKILg"];
     NSURL *webkitOriginFile = [webkitOriginDirectory URLByAppendingPathComponent:@"origin"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBStructuredCloneBackwardCompatibility.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBStructuredCloneBackwardCompatibility.mm
@@ -70,9 +70,9 @@ TEST(IndexedDB, StructuredCloneBackwardCompatibility)
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
     // Copy the baked database files to the database directory
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"IndexedDBStructuredCloneBackwardCompatibility" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"IndexedDBStructuredCloneBackwardCompatibility" withExtension:@"sqlite3-shm" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url3 = [[NSBundle mainBundle] URLForResource:@"IndexedDBStructuredCloneBackwardCompatibility" withExtension:@"sqlite3-wal" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDBStructuredCloneBackwardCompatibility" withExtension:@"sqlite3"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDBStructuredCloneBackwardCompatibility" withExtension:@"sqlite3-shm"];
+    NSURL *url3 = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDBStructuredCloneBackwardCompatibility" withExtension:@"sqlite3-wal"];
 
     NSURL *idbPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB/" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] removeItemAtURL:idbPath error:nil];
@@ -93,7 +93,7 @@ TEST(IndexedDB, StructuredCloneBackwardCompatibility)
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     auto delegate = adoptNS([[StructuredCloneBackwardCompatibilityNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBStructuredCloneBackwardCompatibilityRead" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBStructuredCloneBackwardCompatibilityRead" withExtension:@"html"]];
     [webView loadRequest:request];
 
     EXPECT_STREQ([getNextMessage().body UTF8String], "Pass");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
@@ -83,7 +83,7 @@ TEST(IndexedDB, IndexedDBSuspendImminently)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBSuspendImminently" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBSuspendImminently" withExtension:@"html"]];
     [webView loadRequest:request];
     runUntilMessageReceived(@"Continue");
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
@@ -82,7 +82,7 @@ TEST(IndexedDB, IndexedDBTempFileSize)
 
     // Do some IndexedDB operations to generate WAL file.
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBTempFileSize-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBTempFileSize-1" withExtension:@"html"]];
     [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::waitForConditionWithLogging([&] {
@@ -99,7 +99,7 @@ TEST(IndexedDB, IndexedDBTempFileSize)
 
     // Open the same database again.
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBTempFileSize-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBTempFileSize-2" withExtension:@"html"]];
 
     receivedScriptMessage = false;
     [webView loadRequest:request.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm
@@ -59,7 +59,7 @@ TEST(IndexedDB, IndexedDBUserDelete)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IndexedDBUserDelete" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBUserDelete" withExtension:@"html"]];
     [webView loadRequest:request];
 
     receivedScriptMessage = false;
@@ -79,7 +79,7 @@ TEST(IndexedDB, IndexedDBUserDeleteBeforeLoading)
 {
     NSURL *idbURL = [[[WKWebsiteDataStore defaultDataStore] _configuration] _indexedDBDatabaseDirectory];
     NSURL *fileIDBURL = [[idbURL URLByAppendingPathComponent:@"file__0"] URLByAppendingPathComponent:@"IndexedDBUserDeleteBeforeLoading"];
-    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDB" withExtension:@"sqlite3"];
     [[NSFileManager defaultManager] createDirectoryAtURL:fileIDBURL withIntermediateDirectories:YES attributes:nil error:nil];
     [[NSFileManager defaultManager] copyItemAtURL:fileURL toURL:[fileIDBURL URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:fileIDBURL.path]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JavaScriptDuringNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JavaScriptDuringNavigation.mm
@@ -78,8 +78,8 @@ static RetainPtr<NSURL> secondURL;
 
 TEST(WebKit, JavaScriptDuringNavigation)
 {
-    firstURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    secondURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    firstURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    secondURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[JSNavigationDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
@@ -43,13 +43,13 @@ TEST(WebKit, LoadAndDecodeImage)
         return result;
     };
     auto pngData = [&] {
-        return contentsToVector([[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]);
+        return contentsToVector([NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]);
     };
     auto untaggedPNGData = [&] {
-        return contentsToVector([[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]);
+        return contentsToVector([NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]);
     };
     auto gifData = [&] {
-        return contentsToVector([[NSBundle mainBundle] URLForResource:@"apple" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"]);
+        return contentsToVector([NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"]);
     };
 
     HTTPServer server {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadFileThenReload.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadFileThenReload.mm
@@ -60,7 +60,7 @@ TEST(WKWebView, LoadFileThenReload)
     auto delegate = adoptNS([[LoadFileThenReloadDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURL *file = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadFileURL:file allowingReadAccessToURL:file.URLByDeletingLastPathComponent];
     [webView reload];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadFileURL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadFileURL.mm
@@ -41,7 +41,7 @@ TEST(WKWebView, LoadFileWithLoadRequest)
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [delegate waitForDidFinishNavigation];
 }
@@ -53,13 +53,13 @@ TEST(WKWebView, LoadTwoFiles)
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURL *file = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadFileURL:file allowingReadAccessToURL:file.URLByDeletingLastPathComponent];
     [delegate waitForDidFinishNavigation];
     EXPECT_WK_STREQ(webView.get()._resourceDirectoryURL.path, file.URLByDeletingLastPathComponent.path);
 
     // Load a second file: resource that is in a completely different directory from the above
-    file = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    file = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     NSURL *targetURL = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/simple2.html" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] createDirectoryAtURL:targetURL.URLByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:nil];
     [[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
@@ -87,7 +87,7 @@ TEST(WKWebView, LoadRelativeFileURL)
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
-    NSString *path = [NSBundle.mainBundle pathForResource:@"simple" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"];
+    NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"];
     NSURL *baseURL = [NSURL fileURLWithPath:path.stringByDeletingLastPathComponent];
     NSURL *fileURL = [NSURL fileURLWithPath:path.lastPathComponent relativeToURL:baseURL];
     EXPECT_NOT_NULL([webView loadFileURL:fileURL allowingReadAccessToURL:fileURL.URLByDeletingLastPathComponent]);
@@ -109,7 +109,7 @@ TEST(WKWebView, RepeatLoadFileURL)
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
-    NSString *path = [NSBundle.mainBundle pathForResource:@"simple" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"];
+    NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"];
     NSURL *baseURL = [NSURL fileURLWithPath:path.stringByDeletingLastPathComponent];
     NSURL *fileURL = [NSURL fileURLWithPath:path.lastPathComponent relativeToURL:baseURL];
     EXPECT_NOT_NULL([webView loadFileURL:fileURL allowingReadAccessToURL:fileURL.URLByDeletingLastPathComponent]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
@@ -139,7 +139,7 @@ TEST(WebKit, LoadNSURLRequestSubclass)
 
 TEST(WebKit, LoadNSURLRequestWithMutablePropertiesAndKeys)
 {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [NSURLProtocol setProperty:[NSMutableData data] forKey:[NSMutableString stringWithString:@"mutablestring"] inRequest:request];
     [NSURLProtocol setProperty:[NSMutableArray array] forKey:@"key1" inRequest:request];
     [NSURLProtocol setProperty:[NSMutableDictionary dictionary] forKey:@"key2" inRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageClear.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageClear.mm
@@ -61,7 +61,7 @@ TEST(WKWebView, LocalStorageClear)
     @autoreleasepool {
         RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"LocalStorageClear" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"LocalStorageClear" withExtension:@"html"]];
         [webView loadRequest:request];
 
         TestWebKitAPI::Util::run(&readyToContinue);
@@ -148,9 +148,9 @@ TEST(WKWebView, ClearStaleAppCache)
         [[NSFileManager defaultManager] removeItemAtURL:appCacheURL error:nil];
     }
 
-    NSURL *dbResourceURL = [[NSBundle mainBundle] URLForResource:@"ApplicationCache" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *shmResourceURL = [[NSBundle mainBundle] URLForResource:@"ApplicationCache" withExtension:@"db-shm" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *walResourceURL = [[NSBundle mainBundle] URLForResource:@"ApplicationCache" withExtension:@"db-wal" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *dbResourceURL = [NSBundle.test_resourcesBundle URLForResource:@"ApplicationCache" withExtension:@"db"];
+    NSURL *shmResourceURL = [NSBundle.test_resourcesBundle URLForResource:@"ApplicationCache" withExtension:@"db-shm"];
+    NSURL *walResourceURL = [NSBundle.test_resourcesBundle URLForResource:@"ApplicationCache" withExtension:@"db-wal"];
 
     NSURL *targetURL = [NSURL fileURLWithPath:[defaultApplicationCacheDirectory() stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] createDirectoryAtURL:targetURL withIntermediateDirectories:YES attributes:nil error:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageNullEntries.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageNullEntries.mm
@@ -58,8 +58,8 @@ TEST(WKWebView, LocalStorageNullEntries)
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
 
     // Copy the inconsistent database files to the LocalStorage directory
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"LocalStorageNullEntries" withExtension:@"localstorage" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"LocalStorageNullEntries" withExtension:@"localstorage-shm" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"LocalStorageNullEntries" withExtension:@"localstorage"];
+    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"LocalStorageNullEntries" withExtension:@"localstorage-shm"];
 
     NSURL *targetURL = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/LocalStorage/" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] createDirectoryAtURL:targetURL withIntermediateDirectories:YES attributes:nil error:nil];
@@ -69,7 +69,7 @@ TEST(WKWebView, LocalStorageNullEntries)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"LocalStorageNullEntries" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"LocalStorageNullEntries" withExtension:@"html"]];
     [webView loadRequest:request];
 
     readyToContinue = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
@@ -103,7 +103,7 @@ TEST(WKWebView, LocalStorageProcessCrashes)
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"local-storage-process-crashes" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"local-storage-process-crashes" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::waitForConditionWithLogging([&] {
@@ -157,7 +157,7 @@ TEST(WKWebView, LocalStorageProcessSuspends)
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
 
     RetainPtr<WKWebView> webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"local-storage-process-suspends-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"local-storage-process-suspends-1" withExtension:@"html"]];
     [webView1 loadRequest:request];
 
     receivedScriptMessage = false;
@@ -165,7 +165,7 @@ TEST(WKWebView, LocalStorageProcessSuspends)
     EXPECT_WK_STREQ(@"value", [lastScriptMessage body]);
     
     RetainPtr<WKWebView> webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"local-storage-process-suspends-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"local-storage-process-suspends-2" withExtension:@"html"]];
     [webView2 loadRequest:request];
 
     receivedScriptMessage = false;
@@ -210,7 +210,7 @@ TEST(WKWebView, LocalStorageEmptyString)
     
         RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"localstorage-empty-string-value" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"localstorage-empty-string-value" withExtension:@"html"]];
         [webView loadRequest:request];
     
         TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -233,7 +233,7 @@ TEST(WKWebView, LocalStorageEmptyString)
     // Make a new web view to finish the test.
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"localstorage-empty-string-value" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"localstorage-empty-string-value" withExtension:@"html"]];
     [webView loadRequest:request];
     
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -255,7 +255,7 @@ TEST(WKWebView, LocalStorageOpenWindowPrivate)
     [webView setUIDelegate:delegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"localstorage-open-window-private" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"localstorage-open-window-private" withExtension:@"html"]];
     [webView loadRequest:request];
     
     receivedScriptMessage = false;
@@ -273,7 +273,7 @@ TEST(WKWebView, PrivateBrowsingAffectsLocalStorage)
     auto delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     
     TestWebKitAPI::Util::run(&didFinishNavigationBoolean);
@@ -369,7 +369,7 @@ TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     
     TestWebKitAPI::Util::run(&didFinishNavigationBoolean);
@@ -534,7 +534,7 @@ TEST(WKWebView, LocalStorageNoSizeOverflow)
 TEST(WebKit, LocalStorageCorruptedDatabase)
 {
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *localStorageDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/LocalStorage"];
     NSURL *localStorageFile = [localStorageDirectory URLByAppendingPathComponent:@"localstorage.sqlite3"];
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -603,7 +603,7 @@ TEST(WKWebView, LocalStorageDirectoryExcludedFromBackup)
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     didFinishNavigationBoolean = false;
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&didFinishNavigationBoolean);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageQuirkTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageQuirkTest.mm
@@ -61,7 +61,7 @@ TEST(WKWebView, LocalStorageQuirkEnabled)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"LocalStorageQuirkEnabled" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"LocalStorageQuirkEnabled" withExtension:@"html"]];
     [webView loadRequest:request];
 
     readyToContinue = false;
@@ -84,7 +84,7 @@ TEST(WKWebView, LocalStorageQuirkDisabledAccessPermitted)
     
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"LocalStorageQuirkEnabled" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"LocalStorageQuirkEnabled" withExtension:@"html"]];
     [webView loadRequest:request];
     
     readyToContinue = false;
@@ -107,7 +107,7 @@ TEST(WKWebView, LocalStorageQuirkDisabledAccessDenied)
     
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"LocalStorageQuirkEnabled" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"LocalStorageQuirkEnabled" withExtension:@"html"]];
     [webView loadRequest:request];
     
     readyToContinue = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm
@@ -36,7 +36,7 @@ TEST(LockdownMode, SVGFonts)
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"SVGFont" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"SVGFont" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -53,11 +53,11 @@ TEST(LockdownMode, NotAllowedFontLoadingAPI)
         auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-        NSURL *url = [[NSBundle mainBundle] URLForResource:@"ImmediateFont" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
 
-        NSURL *fontURL = [[NSBundle mainBundle] URLForResource:@"Ahem" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fontURL = [NSBundle.test_resourcesBundle URLForResource:@"Ahem" withExtension:@"ttf"];
         NSData *fontData = [NSData dataWithContentsOfURL:fontURL];
         NSError *error = nil;
         NSMutableArray<NSNumber *> *array = [NSMutableArray arrayWithCapacity:fontData.length];
@@ -90,11 +90,11 @@ TEST(LockdownMode, AllowedFontLoadingAPI)
         auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-        NSURL *url = [[NSBundle mainBundle] URLForResource:@"ImmediateFont" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
 
-        NSURL *fontURL = [[NSBundle mainBundle] URLForResource:@"Ahem-10000A" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fontURL = [NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"];
         NSData *fontData = [NSData dataWithContentsOfURL:fontURL];
         NSError *error = nil;
         NSMutableArray<NSNumber *> *array = [NSMutableArray arrayWithCapacity:fontData.length];
@@ -127,7 +127,7 @@ TEST(LockdownMode, AllowedFont)
         auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-        NSURL *url = [[NSBundle mainBundle] URLForResource:@"LockdownModeFonts" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"LockdownModeFonts" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
 
@@ -147,7 +147,7 @@ TEST(LockdownMode, NotAllowedFont)
         auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-        NSURL *url = [[NSBundle mainBundle] URLForResource:@"LockdownModeFonts" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"LockdownModeFonts" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
@@ -134,7 +134,7 @@ constexpr auto videoPlayTestHTML ="<script>"
 
 static Vector<uint8_t> testVideoBytes()
 {
-    return makeVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]]);
+    return makeVector([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]]);
 }
 
 static void runVideoTest(NSURLRequest *request, const char* expectedMessage)
@@ -203,7 +203,7 @@ TEST(MediaLoading, LockdownModeHLS)
     "<body onload='createVideoElement()'></body>"_s;
 
     auto testTransportStreamBytes = [&] () -> Vector<uint8_t> {
-        return makeVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"start-offset" withExtension:@"ts" subdirectory:@"TestWebKitAPI.resources"]]);
+        return makeVector([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"start-offset" withExtension:@"ts"]]);
     };
 
     HTTPServer server({

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm
@@ -137,7 +137,7 @@ TEST(WebKit, ModalAlerts)
 
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"modal-alerts-in-new-about-blank-window" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"modal-alerts-in-new-about-blank-window" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&isDone);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
@@ -100,7 +100,7 @@ TEST(NSAttributedStringWebKitAdditions, DirectoriesNotCreated)
 
 TEST(NSAttributedStringWebKitAdditions, FontDataURL)
 {
-    NSURL *fontURL = [[NSBundle mainBundle] URLForResource:@"Ahem" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *fontURL = [NSBundle.test_resourcesBundle URLForResource:@"Ahem" withExtension:@"ttf"];
     NSData *fontData = [NSData dataWithContentsOfURL:fontURL];
     NSString *fontBase64 = [fontData base64EncodedStringWithOptions:0];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -129,7 +129,7 @@ TEST(WKNavigation, LoadRequest)
     RetainPtr<NavigationDelegate> delegate = adoptNS([[NavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
 
     currentNavigation = [webView loadRequest:request];
     ASSERT_NOT_NULL(currentNavigation);
@@ -703,7 +703,7 @@ static bool navigationComplete;
 @implementation BackForwardDelegate
 - (void)_webView:(WKWebView *)webView willGoToBackForwardListItem:(WKBackForwardListItem *)item inPageCache:(BOOL)inPageCache
 {
-    const char* expectedURL = [[[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"] absoluteString] UTF8String];
+    const char* expectedURL = [[[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"] absoluteString] UTF8String];
     EXPECT_STREQ(item.URL.absoluteString.UTF8String, expectedURL);
     EXPECT_TRUE(item.title == nil);
     EXPECT_STREQ(item.initialURL.absoluteString.UTF8String, expectedURL);
@@ -721,10 +721,10 @@ TEST(WKNavigation, WillGoToBackForwardListItem)
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[BackForwardDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
     navigationComplete = false;
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
     [webView goBack];
     TestWebKitAPI::Util::run(&isDone);
@@ -740,8 +740,8 @@ RetainPtr<WKBackForwardListItem> secondItem;
 @implementation ListItemDelegate
 - (void)_webView:(WKWebView *)webView backForwardListItemAdded:(WKBackForwardListItem *)itemAdded removed:(NSArray<WKBackForwardListItem *> *)itemsRemoved
 {
-    NSString *firstURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"].absoluteString;
-    NSString *secondURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"].absoluteString;
+    NSString *firstURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"].absoluteString;
+    NSString *secondURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"].absoluteString;
 
     if (!firstItem) {
         EXPECT_NULL(firstItem);
@@ -779,10 +779,10 @@ TEST(WKNavigation, ListItemAddedRemoved)
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[ListItemDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
     navigationComplete = false;
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
     [[webView backForwardList] _removeAllItems];
     TestWebKitAPI::Util::run(&isDone);
@@ -870,7 +870,7 @@ TEST(WKNavigation, SimultaneousNavigationWithFontsFinishes)
     "</body>"
     "</html>"_s;
 
-    NSString *svg = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"AllAhem" withExtension:@"svg" subdirectory:@"TestWebKitAPI.resources"] encoding:NSUTF8StringEncoding error:nil];
+    NSString *svg = [NSString stringWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"AllAhem" withExtension:@"svg"] encoding:NSUTF8StringEncoding error:nil];
 
     using namespace TestWebKitAPI;
     HTTPServer server({
@@ -2665,7 +2665,7 @@ TEST(WKNavigation, GeneratePageLoadTiming)
         done = true;
     };
 
-    auto request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"multiple-images" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    auto request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"multiple-images" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&done);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcessCrashNonPersistentDataStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcessCrashNonPersistentDataStore.mm
@@ -58,8 +58,8 @@
 
 static void checkRecoveryAfterCrash(WKWebsiteDataStore *dataStore)
 {
-    NSURL *simple = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *simple2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *simple = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    NSURL *simple2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm
@@ -90,7 +90,7 @@ TEST(WebKit, OpenAndCloseWindow)
 
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"open-and-close-window" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"open-and-close-window" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&isDone);
@@ -153,7 +153,7 @@ TEST(WebKit, OpenAndCloseWindowAsync)
 
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"open-and-close-window" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"open-and-close-window" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&isDone);
@@ -172,7 +172,7 @@ TEST(WebKit, OpenAsyncWithNil)
 
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"open-and-close-window" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"open-and-close-window" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&isDone);
@@ -191,7 +191,7 @@ TEST(WebKit, OpenAsyncWithNil)
 //
 //    [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 //
-//    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"open-and-close-window" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+//    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"open-and-close-window" withExtension:@"html"]];
 //    [webView loadRequest:request];
 //
 //    TestWebKitAPI::Util::run(&isDone);
@@ -409,7 +409,7 @@ TEST(WebKit, OpenWindowThenDocumentOpen)
     [webView setUIDelegate:uiDelegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"open-window-then-write-to-it" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"open-window-then-write-to-it" withExtension:@"html"]];
     [webView loadRequest:request];
 
     while (!openedWebView)
@@ -432,7 +432,7 @@ TEST(WebKit, OpenFileURLWithHost)
     [webView setUIDelegate:uiDelegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"open-window-with-file-url-with-host" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"open-window-with-file-url-with-host" withExtension:@"html"]];
     [webView loadRequest:request];
 
     while (![[[webView URL] absoluteString] hasSuffix:@"#test"])

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PageZoom.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PageZoom.mm
@@ -51,13 +51,13 @@ TEST(WKWebView, PageZoomAfterPDF)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
     webView.get().pageZoom = 2.0;
     auto beforePageZoom = webView.get().pageZoom;
 
-    NSURLRequest *pdfRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *pdfRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:pdfRequest];
     [webView _test_waitForDidFinishNavigation];
 
@@ -82,7 +82,7 @@ TEST(WKWebView, MinimumMagnificationPDF)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
-    NSURLRequest *pdfRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *pdfRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:pdfRequest];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ParserYieldTokenTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ParserYieldTokenTests.mm
@@ -176,7 +176,7 @@ TEST(ParserYieldTokenTests, AsyncScriptRunsWhenFetched)
 
     [[webView bundle] takeDocumentParserTokenAfterCommittingLoad];
 
-    NSURL *pageURL = [[NSBundle mainBundle] URLForResource:@"text-with-async-script" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *pageURL = [NSBundle.test_resourcesBundle URLForResource:@"text-with-async-script" withExtension:@"html"];
     [webView loadHTMLString:[NSString stringWithContentsOfURL:pageURL encoding:NSUTF8StringEncoding error:nil] baseURL:[NSURL URLWithString:@"custom://"]];
 
     waitForDelay(0.5_s);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
@@ -170,7 +170,7 @@ TEST(PasteHTML, KeepsHTTPURLs)
 
 TEST(PasteHTML, PreservesMSOList)
 {
-    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"]
+    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list" ofType:@"html"]
         encoding:NSUTF8StringEncoding error:NULL]);
 
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
@@ -222,7 +222,7 @@ TEST(PasteHTML, PreservesMSOList)
 
 TEST(PasteHTML, PreservesMSOListInCompatibilityMode)
 {
-    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list-compat-mode" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"]
+    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list-compat-mode" ofType:@"html"]
         encoding:NSUTF8StringEncoding error:NULL]);
 
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
@@ -258,7 +258,7 @@ TEST(PasteHTML, PreservesMSOListInCompatibilityMode)
 
 TEST(PasteHTML, PreservesMSOListOnH4)
 {
-    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list-on-h4" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"]
+    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list-on-h4" ofType:@"html"]
         encoding:NSUTF8StringEncoding error:NULL]);
 
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
@@ -294,7 +294,7 @@ TEST(PasteHTML, PreservesMSOListOnH4)
 
 TEST(PasteHTML, StripsMSOListWhenMissingMSOHTMLElement)
 {
-    auto *markup = [NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"] encoding:NSUTF8StringEncoding error:NULL];
+    auto *markup = [NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL];
 
     writeHTMLToPasteboard([markup substringFromIndex:[markup rangeOfString:@">"].location + 1]);
 
@@ -341,7 +341,7 @@ TEST(PasteHTML, StripsMSOListWhenMissingMSOHTMLElement)
 
 TEST(PasteHTML, StripsSystemFontNames)
 {
-    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"cocoa-writer-markup-with-system-fonts" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"] encoding:NSUTF8StringEncoding error:NULL]);
+    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"cocoa-writer-markup-with-system-fonts" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL]);
 
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];
@@ -371,7 +371,7 @@ TEST(PasteHTML, StripsSystemFontNames)
 
 TEST(PasteHTML, DoesNotAddStandardFontFamily)
 {
-    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"cocoa-writer-markup-with-lists" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"] encoding:NSUTF8StringEncoding error:NULL]);
+    writeHTMLToPasteboard([NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"cocoa-writer-markup-with-lists" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL]);
 
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteImage.mm
@@ -110,7 +110,7 @@ TEST(PasteImage, PasteGIFImage)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    auto *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-400px" ofType:@"gif" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-400px" ofType:@"gif"]];
     writeImageDataToPasteboard((__bridge NSString *)kUTTypeGIF, data);
     [webView paste:nil];
 
@@ -132,7 +132,7 @@ TEST(PasteImage, PasteJPEGImage)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    auto *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg"]];
     writeImageDataToPasteboard((__bridge NSString *)kUTTypeJPEG, data);
     [webView paste:nil];
 
@@ -154,7 +154,7 @@ TEST(PasteImage, PastePNGImage)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    auto *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
     writeImageDataToPasteboard((__bridge NSString *)kUTTypePNG, data);
     [webView paste:nil];
 
@@ -176,8 +176,8 @@ TEST(PasteImage, PasteImageWithMultipleRepresentations)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    auto pngData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
-    auto jpegData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg" inDirectory:@"TestWebKitAPI.resources"]];
+    auto pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
+    auto jpegData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg"]];
     writeImageDataToPasteboard(@{
         (__bridge NSString *)kUTTypePNG : pngData,
         (__bridge NSString *)kUTTypeJPEG : jpegData
@@ -203,7 +203,7 @@ TEST(PasteImage, RevealSelectionAfterPastingImage)
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];
     [webView _synchronouslyExecuteEditCommand:@"InsertParagraph" argument:nil];
 
-    writeImageDataToPasteboard((__bridge NSString *)kUTTypeJPEG, [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg" inDirectory:@"TestWebKitAPI.resources"]]);
+    writeImageDataToPasteboard((__bridge NSString *)kUTTypeJPEG, [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg"]]);
     [webView paste:nil];
 
     while ([[webView stringByEvaluatingJavaScript:@"document.scrollingElement.scrollTop"] doubleValue] <= 0)
@@ -222,7 +222,7 @@ TEST(PasteImage, PasteGIFFile)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"sunset-in-cupertino-400px" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-400px" withExtension:@"gif"];
     writeBundleFileToPasteboard(url);
     [webView paste:nil];
 
@@ -243,7 +243,7 @@ TEST(PasteImage, PasteJPEGFile)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"sunset-in-cupertino-600px" withExtension:@"jpg" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-600px" withExtension:@"jpg"];
     writeBundleFileToPasteboard(url);
     [webView paste:nil];
 
@@ -264,7 +264,7 @@ TEST(PasteImage, PastePNGFile)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"sunset-in-cupertino-200px" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-200px" withExtension:@"png"];
     writeBundleFileToPasteboard(url);
     [webView paste:nil];
 
@@ -285,7 +285,7 @@ TEST(PasteImage, PasteTIFFFile)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"];
     writeBundleFileToPasteboard(url);
     [webView paste:nil];
 
@@ -306,7 +306,7 @@ TEST(PasteImage, PasteLegacyTIFFImage)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    auto *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-100px" ofType:@"tiff" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-100px" ofType:@"tiff"]];
     writeImageDataToPasteboard(NSTIFFPboardType, data);
     [webView paste:nil];
 
@@ -327,7 +327,7 @@ TEST(PasteImage, PasteTIFFImage)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
-    auto *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-100px" ofType:@"tiff" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-100px" ofType:@"tiff"]];
     writeImageDataToPasteboard((__bridge NSString *)kUTTypeTIFF, data);
     [webView paste:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteMixedContent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteMixedContent.mm
@@ -42,7 +42,7 @@ namespace TestWebKitAPI {
 
 static NSString *imagePath()
 {
-    return [[NSBundle mainBundle] pathForResource:@"icon" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle pathForResource:@"icon" ofType:@"png"];
 }
 
 void writeTypesAndDataToPasteboard(id type, ...)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteRTFD.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteRTFD.mm
@@ -142,7 +142,7 @@ TEST(PasteRTFD, ImageElementUsesBlobURL)
     auto webView = createWebViewWithCustomPasteboardDataEnabled();
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];
 
-    auto *pngData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
     auto attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:(__bridge NSString *)kUTTypePNG]);
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
@@ -160,7 +160,7 @@ TEST(PasteRTFD, ImageElementUsesBlobURLInHTML)
     auto webView = createWebViewWithCustomPasteboardDataEnabled();
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];
 
-    auto *pngData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
     auto attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:(__bridge NSString *)kUTTypePNG]);
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm
@@ -96,7 +96,7 @@ TEST(PasteWebArchive, SanitizesHTML)
 TEST(PasteWebArchive, PreservesMSOList)
 {
     auto *url = [NSURL URLWithString:@"file:///some-file.html"];
-    auto *markup = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *markup = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list" ofType:@"html"]];
     auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
     auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
@@ -147,7 +147,7 @@ TEST(PasteWebArchive, PreservesMSOList)
 TEST(PasteWebArchive, PreservesMSOListInCompatibilityMode)
 {
     auto *url = [NSURL URLWithString:@"file:///some-file.html"];
-    auto *markup = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list-compat-mode" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *markup = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list-compat-mode" ofType:@"html"]];
     auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
     auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
@@ -187,7 +187,7 @@ TEST(PasteWebArchive, PreservesMSOListInCompatibilityMode)
 
 static NSData *msoListMarkupWithoutProperHTMLElement()
 {
-    auto *markup = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"mso-list" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *markup = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list" ofType:@"html"]];
     auto *markupBytes = (uint8_t *)markup.bytes;
     unsigned length = markup.length;
     for (unsigned i = 0; i < length; i++) {
@@ -238,10 +238,10 @@ TEST(PasteWebArchive, PreservesPictureInsideSpan)
 
     auto mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
 
-    auto pngData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    auto pngData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
     auto pngResource = adoptNS([[WebResource alloc] initWithData:pngData URL:[NSURL URLWithString:@"1.png"] MIMEType:@"image/png" textEncodingName:nil frameName:nil]);
 
-    auto gifData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"apple" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"]];
+    auto gifData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"]];
     auto gifResource = adoptNS([[WebResource alloc] initWithData:gifData URL:[NSURL URLWithString:@"2.gif"] MIMEType:@"image/gif" textEncodingName:nil frameName:nil]);
 
     auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ pngResource.get(), gifResource.get() ] subframeArchives:@[ ]]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
@@ -120,7 +120,7 @@ TEST(PictureInPicture, WKUIDelegate)
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"PictureInPictureDelegate" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"PictureInPictureDelegate" withExtension:@"html"]];
 
     receivedLoadedMessage = false;
     

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
@@ -41,7 +41,7 @@ TEST(WKWebView, PrepareForMoveToWindow)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
 
     [webView _test_waitForDidFinishNavigation];
@@ -91,7 +91,7 @@ TEST(WKWebView, PrepareForMoveToWindowThenClose)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
 
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSuspension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSuspension.mm
@@ -222,7 +222,7 @@ TEST(ProcessSuspension, DeallocateSuspendedView)
     // Deallocating a suspended WebView should not throw or crash.
     @autoreleasepool {
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-        [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
         [webView _test_waitForDidFinishNavigation];
 
         __block bool done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -671,14 +671,14 @@ TEST(ProcessSwap, NoProcessSwappingWithinSameNonHTTPFamilyProtocol)
     EXPECT_EQ(pid1, [webView _webProcessIdentifier]);
 
     // Switch to the file protocol.
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
     auto pid2 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, pid2);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
@@ -2281,7 +2281,7 @@ TEST(ProcessSwap, CrossSiteClientSideRedirectFromFileURL)
     willPerformClientRedirect = false;
     didPerformClientRedirect = false;
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"client-side-redirect" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"client-side-redirect" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -5152,7 +5152,7 @@ TEST(ProcessSwap, ClosePageAfterCrossSiteProvisionalLoad)
     done = false;
 
     didStartProvisionalLoad = false;
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
 
     navigationDelegate->decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyAllow);
@@ -5850,7 +5850,7 @@ TEST(ProcessSwap, UsePrewarmedProcessAfterTerminatingNetworkProcess)
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -5862,7 +5862,7 @@ TEST(ProcessSwap, UsePrewarmedProcessAfterTerminatingNetworkProcess)
 
     auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]];
     [webView2 loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -5897,7 +5897,7 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInPrivateBrowsing)
     }];
     TestWebKitAPI::Util::run(&setPolicy);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"SetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"SetSessionCookie" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -5916,7 +5916,7 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInPrivateBrowsing)
     EXPECT_NE(pid1, pid2);
 
     // Should process-swap.
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -5975,7 +5975,7 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInNonDefaultPersistentSession
     }];
     TestWebKitAPI::Util::run(&setPolicy);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"SetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"SetSessionCookie" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -5994,7 +5994,7 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInNonDefaultPersistentSession
     EXPECT_NE(pid1, pid2);
 
     // Should process-swap.
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&done);
@@ -7286,7 +7286,7 @@ TEST(ProcessSwap, QuickLookRequestsPasswordAfterSwap)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"password-protected" withExtension:@"pages" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"password-protected" withExtension:@"pages"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&didStartQuickLookLoad);
@@ -7408,7 +7408,7 @@ TEST(ProcessSwap, PassSandboxExtension)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    NSURL *file = [[NSBundle mainBundle] URLForResource:@"autoplay-with-controls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"autoplay-with-controls" withExtension:@"html"];
     [webView loadFileURL:file allowingReadAccessToURL:file.URLByDeletingLastPathComponent];
     [webView waitForMessage:@"loaded"];
 
@@ -7468,7 +7468,7 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
 
     EXPECT_EQ(pid1, pid2);
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"blinking-div" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"blinking-div" withExtension:@"html"];
     EXPECT_TRUE([url.scheme isEqualToString:@"file"]);
 
     [createdWebView loadRequest:[NSURLRequest requestWithURL:url]];
@@ -8525,7 +8525,7 @@ TEST(ProcessSwap, NavigatingToLockdownMode)
         finishedNavigation = true;
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8537,7 +8537,7 @@ TEST(ProcessSwap, NavigatingToLockdownMode)
 
     finishedNavigation = false;
     receivedScriptMessage = false;
-    url = [[NSBundle mainBundle] URLForResource:@"LockdownModePDF" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    url = [NSBundle.test_resourcesBundle URLForResource:@"LockdownModePDF" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8551,7 +8551,7 @@ TEST(ProcessSwap, NavigatingToLockdownMode)
     };
 
     finishedNavigation = false;
-    url = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    url = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8562,7 +8562,7 @@ TEST(ProcessSwap, NavigatingToLockdownMode)
 
     finishedNavigation = false;
     receivedScriptMessage = false;
-    url = [[NSBundle mainBundle] URLForResource:@"LockdownModePDF" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    url = [NSBundle.test_resourcesBundle URLForResource:@"LockdownModePDF" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8589,7 +8589,7 @@ TEST(ProcessSwap, LockdownModeSystemSettingChange)
         finishedNavigation = true;
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8749,7 +8749,7 @@ TEST(ProcessSwap, CannotDisableLockdownModeWithoutBrowserEntitlement)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8785,7 +8785,7 @@ TEST(ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8794,7 +8794,7 @@ TEST(ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)
     EXPECT_EQ(pid1, [webView _webProcessIdentifier]);
 
     finishedNavigation = false;
-    url = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    url = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8809,7 +8809,7 @@ TEST(ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)
     };
 
     finishedNavigation = false;
-    url = [[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    url = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8831,7 +8831,7 @@ TEST(ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)
     delegate.get().decidePolicyForNavigationActionWithPreferences = nil;
 
     finishedNavigation = false;
-    url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView2 loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_TRUE(isJITEnabled(webView2.get()));
@@ -8858,7 +8858,7 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
         finishedNavigation = true;
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8903,7 +8903,7 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
         finishedNavigation = true;
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -8950,7 +8950,7 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -9000,7 +9000,7 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm
@@ -55,7 +55,7 @@ static NSString * const pagesDocumentPreviewMIMEType = @"application/pdf";
 
 static RetainPtr<NSURL> pagesDocumentURL()
 {
-    static NeverDestroyed<RetainPtr<NSURL>> pagesDocumentURL = [NSBundle.mainBundle URLForResource:@"pages" withExtension:@"pages" subdirectory:@"TestWebKitAPI.resources"];
+    static NeverDestroyed<RetainPtr<NSURL>> pagesDocumentURL = [NSBundle.test_resourcesBundle URLForResource:@"pages" withExtension:@"pages"];
     return pagesDocumentURL;
 }
 
@@ -412,7 +412,7 @@ TEST(QuickLook, DownloadResponseAfterLoadingPreview)
 #if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 TEST(QuickLook, RequestPasswordBeforeLoadingPreview)
 {
-    NSURL *passwordProtectedDocumentURL = [NSBundle.mainBundle URLForResource:@"password-protected" withExtension:@"pages" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *passwordProtectedDocumentURL = [NSBundle.test_resourcesBundle URLForResource:@"password-protected" withExtension:@"pages"];
     auto delegate = adoptNS([[QuickLookPasswordDelegate alloc] initWithExpectedFileURL:passwordProtectedDocumentURL responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:passwordProtectedDocumentURL]);
     EXPECT_FALSE([delegate didFailNavigation]);
@@ -424,7 +424,7 @@ TEST(QuickLook, RequestPasswordBeforeLoadingPreview)
 
 TEST(QuickLook, RequestPasswordAfterLoadingPreview)
 {
-    NSURL *passwordProtectedDocumentURL = [NSBundle.mainBundle URLForResource:@"password-protected" withExtension:@"pages" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *passwordProtectedDocumentURL = [NSBundle.test_resourcesBundle URLForResource:@"password-protected" withExtension:@"pages"];
     auto delegate = adoptNS([[QuickLookPasswordDelegate alloc] initWithExpectedFileURL:passwordProtectedDocumentURL previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideAfterLoading(delegate.get(), [NSURLRequest requestWithURL:passwordProtectedDocumentURL]);
     EXPECT_FALSE([delegate didFailNavigation]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RenderedImageWithOptions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RenderedImageWithOptions.mm
@@ -45,7 +45,7 @@ static void runTestWithWidth(NSNumber *width, CGSize expectedSize)
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(RenderedImageWithOptionsProtocol)];
     auto remoteObject = retainPtr([[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface]);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"rendered-image-excluding-overflow" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"rendered-image-excluding-overflow" withExtension:@"html"]]];
     [webView _test_waitForDidFinishNavigation];
 
     __block bool testFinished = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequestTextInputContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequestTextInputContext.mm
@@ -191,7 +191,7 @@ static void webViewLoadHTMLStringAndWaitForAllFramesToPaint(TestWKWebView *webVi
     ASSERT(webView); // Make passing a nil web view a more obvious failure than a hang.
     bool didFireDOMLoadEvent = false;
     [webView performAfterLoading:[&] { didFireDOMLoadEvent = true; }];
-    [webView loadHTMLString:htmlString baseURL:[NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"]];
+    [webView loadHTMLString:htmlString baseURL:NSBundle.test_resourcesBundle.resourceURL];
     TestWebKitAPI::Util::run(&didFireDOMLoadEvent);
     [webView waitForNextPresentationUpdate];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequiresUserActionForPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequiresUserActionForPlayback.mm
@@ -77,7 +77,7 @@ public:
 
     void testVideoWithAudio()
     {
-        NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"video-with-audio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"html"];
         [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
         [webView _test_waitForDidFinishNavigation];
 
@@ -87,7 +87,7 @@ public:
 
     void testVideoWithoutAudio()
     {
-        NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"video-without-audio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"video-without-audio" withExtension:@"html"];
         [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
         [webView _test_waitForDidFinishNavigation];
 
@@ -97,7 +97,7 @@ public:
 
     void testAudioOnly()
     {
-        NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"audio-only" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"audio-only" withExtension:@"html"];
         [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
         [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
@@ -56,7 +56,7 @@ TEST(ResourceLoadDelegate, Basic)
         requestFromDelegate = request;
     }];
 
-    RetainPtr<NSURLRequest> requestLoaded = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr<NSURLRequest> requestLoaded = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:requestLoaded.get()];
     TestWebKitAPI::Util::run(&done);
     

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -226,7 +226,7 @@ TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)
     auto navigationDelegate = adoptNS([[DisableITPDuringNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"notify-resourceLoadObserver" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"notify-resourceLoadObserver" withExtension:@"html"]]];
 
     TestWebKitAPI::Util::run(&finishedNavigation);
 }
@@ -905,7 +905,7 @@ TEST(ResourceLoadStatistics, MigrateDataFromIncorrectCreateTableSchema)
     // Load an incorrect database schema with pre-seeded ITP data.
     // This data should be migrated into the new database.
     [defaultFileManager createDirectoryAtURL:itpRootURL withIntermediateDirectories:YES attributes:nil error:nil];
-    NSURL *newFileURL = [[NSBundle mainBundle] URLForResource:@"incorrectCreateTableSchema" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *newFileURL = [NSBundle.test_resourcesBundle URLForResource:@"incorrectCreateTableSchema" withExtension:@"db"];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:newFileURL.path]);
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
@@ -987,7 +987,7 @@ TEST(ResourceLoadStatistics, MigrateDataFromMissingTopFrameUniqueRedirectSameSit
 
     // Load an incorrect database schema with pre-seeded ITP data.
     [defaultFileManager createDirectoryAtURL:itpRootURL withIntermediateDirectories:YES attributes:nil error:nil];
-    NSURL *newFileURL = [[NSBundle mainBundle] URLForResource:@"missingTopFrameUniqueRedirectSameSiteStrictTableSchema" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *newFileURL = [NSBundle.test_resourcesBundle URLForResource:@"missingTopFrameUniqueRedirectSameSiteStrictTableSchema" withExtension:@"db"];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:newFileURL.path]);
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
@@ -1031,7 +1031,7 @@ TEST(ResourceLoadStatistics, CanAccessDataSummaryWithNoProcessPool)
 
     // Load a a pre-seeded ITP database.
     [defaultFileManager createDirectoryAtURL:itpRootURL withIntermediateDirectories:YES attributes:nil error:nil];
-    NSURL *newFileURL = [[NSBundle mainBundle] URLForResource:@"basicITPDatabase" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *newFileURL = [NSBundle.test_resourcesBundle URLForResource:@"basicITPDatabase" withExtension:@"db"];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:newFileURL.path]);
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
@@ -1274,7 +1274,7 @@ TEST(ResourceLoadStatistics, MigrateDistinctDataFromTableWithMissingIndexes)
     // repeatedly stored as subframes, subresources, and unique redirects. It also has them as repeated source and destination sites for PCM.
     // Once we add unique indexes, each entry should be migrated exactly once. Debug asserts when running the test will indicate failure.
     [defaultFileManager createDirectoryAtURL:itpRootURL withIntermediateDirectories:YES attributes:nil error:nil];
-    NSURL *newFileURL = [[NSBundle mainBundle] URLForResource:@"resourceLoadStatisticsMissingUniqueIndex" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *newFileURL = [NSBundle.test_resourcesBundle URLForResource:@"resourceLoadStatisticsMissingUniqueIndex" withExtension:@"db"];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:newFileURL.path]);
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimer.mm
@@ -62,7 +62,7 @@ TEST(WebKit, ResponsivenessTimerShouldNotFireAfterTearDown)
     [configuration setProcessPool:processPool.get()];
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView1 setNavigationDelegate:delegate.get()];
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView1 loadRequest:request];
     Util::run(&didFinishLoad);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimerDoesntFireEarly.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimerDoesntFireEarly.mm
@@ -82,7 +82,7 @@ TEST(WebKit, ResponsivenessTimerDoesntFireEarly)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
 
     WKContextPostMessageToInjectedBundle(context.get(), Util::toWK("BrieflyPause").get(), 0);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStateWithoutNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStateWithoutNavigation.mm
@@ -72,7 +72,7 @@ static WKRetainPtr<WKDataRef> createSessionStateData()
     auto delegate = adoptNS([SessionStateDelegate new]);
     auto view = adoptNS([WKWebView new]);
     [view setNavigationDelegate:delegate.get()];
-    [view loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [view loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     Util::run(&didFinishNavigationForSessionState);
     didFinishNavigationForSessionState = false;
 
@@ -98,7 +98,7 @@ TEST(WebKit, RestoreSessionStateWithoutNavigation)
     auto currentItem = WKBackForwardListGetCurrentItem(backForwardList);
     auto currentItemURL = adoptWK(WKBackForwardListItemCopyURL(currentItem));
     
-    auto expectedURL = adoptWK(WKURLCreateWithCFURL((__bridge CFURLRef)[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]));
+    auto expectedURL = adoptWK(WKURLCreateWithCFURL((__bridge CFURLRef)[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]));
     EXPECT_NOT_NULL(expectedURL);
     EXPECT_TRUE(WKURLIsEqual(currentItemURL.get(), expectedURL.get()));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -460,7 +460,7 @@ namespace TestWebKitAPI {
 TEST(SOAuthorizationRedirect, NoInterceptions)
 {
     resetState();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -478,7 +478,7 @@ TEST(SOAuthorizationRedirect, DisableSSO)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = configuration.get().preferences;
@@ -504,7 +504,7 @@ TEST(SOAuthorizationRedirect, InterceptionError)
     ClassMethodSwizzler swizzler1(PAL::getSOAuthorizationClass(), @selector(canPerformAuthorizationWithURL:responseCode:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURL));
     InstanceMethodSwizzler swizzler2(PAL::getSOAuthorizationClass(), @selector(getAuthorizationHintsWithURL:responseCode:completion:), reinterpret_cast<IMP>(overrideGetAuthorizationHintsWithURL));
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -522,7 +522,7 @@ TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -544,7 +544,7 @@ TEST(SOAuthorizationRedirect, InterceptionCancel)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -567,7 +567,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -589,7 +589,7 @@ TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -612,7 +612,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationBasicDelegate alloc] init]);
@@ -627,7 +627,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
 #elif PLATFORM(VISION)
     EXPECT_FALSE(gAuthorization.enableEmbeddedAuthorizationViewController);
 #endif
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -679,7 +679,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
 #endif
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -713,7 +713,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
 #endif
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -726,7 +726,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     // A separate delegate that implements decidePolicyForNavigationAction.
@@ -739,7 +739,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -755,7 +755,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -766,7 +766,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1029,7 +1029,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1040,7 +1040,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1063,7 +1063,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1074,7 +1074,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8, qwerty=219ffwef9w0f, id=a3fWa;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1117,7 +1117,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
 #endif
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1136,7 +1136,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1159,7 +1159,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1178,7 +1178,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1194,8 +1194,8 @@ TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr<NSURL> testURL2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1223,7 +1223,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1237,7 +1237,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
     // Should be a no op.
     [webView addToTestWindow];
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1253,7 +1253,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1268,7 +1268,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
         EXPECT_TRUE(policyForAppSSOPerformed);
 
         navigationCompleted = false;
-        RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
         auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
         [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
         Util::run(&navigationCompleted);
@@ -1285,7 +1285,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1305,7 +1305,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1321,7 +1321,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1347,7 +1347,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1363,7 +1363,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"SAML"]]);
@@ -1394,7 +1394,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
@@ -1447,7 +1447,7 @@ TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1467,7 +1467,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1478,7 +1478,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     // Test passes if no crashes.
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
@@ -1489,7 +1489,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1508,7 +1508,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1519,7 +1519,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
     checkAuthorizationOptions(false, ""_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1535,7 +1535,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnoreAsync)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1558,7 +1558,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1577,7 +1577,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
     }];
     Util::run(&uiShowed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1590,7 +1590,7 @@ TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1621,7 +1621,7 @@ TEST(SOAuthorizationRedirect, InterceptionErrorWithUI)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1651,7 +1651,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1678,7 +1678,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)
     Util::run(&authorizationPerformed);
     EXPECT_FALSE(uiShowed);
 
-    RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
@@ -1690,7 +1690,7 @@ TEST(SOAuthorizationRedirect, ShowUITwice)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1726,7 +1726,7 @@ TEST(SOAuthorizationRedirect, NSNotificationCenter)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1756,7 +1756,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturization)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1800,7 +1800,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringHiding)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1847,7 +1847,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturizationThenAnother)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1901,7 +1901,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringHidingThenAnother)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1951,7 +1951,7 @@ TEST(SOAuthorizationPopUp, NoInterceptions)
 {
     resetState();
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateHtml(openerTemplate, testURL.get().absoluteString);
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
@@ -1981,8 +1981,8 @@ TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto iframeTestHtml = generateHtml(openerTemplate, testURL.get().absoluteString);
     auto testHtml = makeString("<iframe style='width:400px;height:400px' srcdoc=\""_s, iframeTestHtml, "\" />"_s);
 
@@ -2025,8 +2025,8 @@ TEST(SOAuthorizationPopUp, InterceptionError)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateHtml(openerTemplate, testURL.get().absoluteString);
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
@@ -2062,8 +2062,8 @@ TEST(SOAuthorizationPopUp, InterceptionCancel)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateHtml(openerTemplate, testURL.get().absoluteString);
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2098,7 +2098,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string());
 
@@ -2136,7 +2136,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string(), emptyString(), "event.source.close();"_s); // The parent closes the pop up.
 
@@ -2174,7 +2174,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string());
 
@@ -2212,8 +2212,8 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateHtml(openerTemplate, testURL.get().absoluteString);
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
@@ -2253,7 +2253,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string());
 
@@ -2291,7 +2291,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string());
 
@@ -2335,7 +2335,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string());
 
@@ -2401,7 +2401,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string(), makeString("newWindow.location = '"_s, span(baseURL.get().absoluteString.UTF8String), "';"_s)); // Starts a new navigation on the new window.
 
@@ -2490,7 +2490,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHtml(openerTemplate, testURL.string());
 
@@ -2555,8 +2555,8 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)
 TEST(SOAuthorizationSubFrame, NoInterceptions)
 {
     resetState();
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHtml(parentTemplate, testURL.get().absoluteString);
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2597,8 +2597,8 @@ TEST(SOAuthorizationSubFrame, InterceptionError)
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
     SWIZZLE_AKAUTH();
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHtml(parentTemplate, testURL.get().absoluteString);
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2629,8 +2629,8 @@ TEST(SOAuthorizationSubFrame, InterceptionCancel)
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
     SWIZZLE_AKAUTH();
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHtml(parentTemplate, testURL.get().absoluteString);
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2692,8 +2692,8 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
     SWIZZLE_AKAUTH();
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHtml(parentTemplate, testURL.get().absoluteString);
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -3009,8 +3009,8 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
     SWIZZLE_AKAUTH();
 
-    RetainPtr<NSURL> baseURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"GetSessionCookie" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHtml(parentTemplate, testURL.get().absoluteString);
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
@@ -179,7 +179,7 @@ static bool didCloseCalled;
 
 static NSURL *resourceURL(NSString *resource)
 {
-    return [[NSBundle mainBundle] URLForResource:resource withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle URLForResource:resource withExtension:@"html"];
 }
 
 TEST(SafeBrowsing, Preference)
@@ -265,7 +265,7 @@ TEST(SafeBrowsing, GoBack)
 TEST(SafeBrowsing, GoBackAfterRestoreFromSessionState)
 {
     auto webView1 = adoptNS([WKWebView new]);
-    [webView1 loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView1 loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     [webView1 _test_waitForDidFinishNavigation];
     _WKSessionState *state = [webView1 _sessionState];
 
@@ -319,7 +319,7 @@ TEST(SafeBrowsing, NavigationClearsWarning)
 {
     auto webView = safeBrowsingView();
     EXPECT_NE([webView _safeBrowsingWarning], nil);
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
     while ([webView _safeBrowsingWarning])
         TestWebKitAPI::Util::spinRunLoop();
 }
@@ -369,8 +369,8 @@ TEST(SafeBrowsing, URLObservation)
 {
     ClassMethodSwizzler swizzler(objc_getClass("SSBLookupContext"), @selector(sharedLookupContext), [TestLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    RetainPtr<NSURL> simpleURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> simple2URL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> simpleURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr<NSURL> simple2URL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto observer = adoptNS([SafeBrowsingObserver new]);
 
     auto webViewWithWarning = [&] () -> RetainPtr<WKWebView> {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -2326,7 +2326,7 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
 TEST(WebKit, ServiceWorkerDatabaseWithRecordsTableButUnexpectedSchema)
 {
     // Copy the baked database files to the database directory
-    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"BadServiceWorkerRegistrations-4" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"BadServiceWorkerRegistrations-4" withExtension:@"sqlite3"];
 
     NSURL *swPath = [NSURL fileURLWithPath:[@"~/Library/Caches/com.apple.WebKit.TestWebKitAPI/WebKit/ServiceWorkers/" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] removeItemAtURL:swPath error:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldGoToBackForwardListItem.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldGoToBackForwardListItem.mm
@@ -58,11 +58,11 @@ TEST(WebKit, ShouldGoToBackForwardListItem)
     auto webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     Util::run(&finished);
     
     finished = false;
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple-iframe" withExtension:@"html"]]];
     Util::run(&finished);
 
     finished = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
@@ -217,7 +217,7 @@ TEST(WebKit, RestoreShouldOpenExternalURLsPolicyAfterCrash)
     [webView setUIDelegate:controller.get()];
 
     finishedNavigation = false;
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"should-open-external-schemes" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"should-open-external-schemes" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&finishedNavigation);
     finishedNavigation = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShrinkToFit.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShrinkToFit.mm
@@ -49,7 +49,7 @@ TEST(WebKit, ShrinkToFit)
 
     TestWebKitAPI::Util::run(&shrinkToFitDone);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -1544,7 +1544,7 @@ TEST(SiteIsolation, PasteGIF)
     [webView mouseUpAtPoint:eventLocationInWindow];
     [webView waitForPendingMouseEvents];
 
-    auto *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-400px" ofType:@"gif" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-400px" ofType:@"gif"]];
     writeImageDataToPasteboard((__bridge NSString *)kUTTypeGIF, data);
     [webView paste:nil];
 
@@ -3038,7 +3038,7 @@ TEST(SiteIsolation, NavigateNestedIframeSameOriginBackForward)
 
 TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)
 {
-    auto frameHTML = [NSString stringWithContentsOfFile:[NSBundle.mainBundle pathForResource:@"audio-fingerprinting" ofType:@"html" inDirectory:@"TestWebKitAPI.resources"] encoding:NSUTF8StringEncoding error:NULL];
+    auto frameHTML = [NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"audio-fingerprinting" ofType:@"html"] encoding:NSUTF8StringEncoding error:NULL];
     HTTPServer server({
         { "/example"_s, { "<iframe src='https://frame.com/frame'></iframe>"_s } },
         { "/frame"_s, { frameHTML } }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
@@ -57,7 +57,7 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"StoreBlobToBeDeleted" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"StoreBlobToBeDeleted" withExtension:@"html"]];
     [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&readyToContinue);
@@ -137,7 +137,7 @@ TEST(IndexedDB, StoreBlobThenDeleteDatabase)
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"StoreBlobToBeDeleted" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"StoreBlobToBeDeleted" withExtension:@"html"]];
     [webView loadRequest:request.get()];
     TestWebKitAPI::Util::run(&readyToContinue);
     EXPECT_WK_STREQ(@"Success", (NSString *)[lastScriptMessage body]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
@@ -157,7 +157,7 @@ TEST(WebKit, SystemPreviewBlobRevokedImmediately)
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];
 
-    NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"UnitBox" withExtension:@"usdz" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *modelURL = [NSBundle.test_resourcesBundle URLForResource:@"UnitBox" withExtension:@"usdz"];
     NSData *modelData = [NSData dataWithContentsOfURL:modelURL];
     NSString *modelBase64 = [modelData base64EncodedStringWithOptions:0];
     NSString *html = [NSString stringWithFormat:@"<script>let base64URL = 'data:model/vnd.usdz+zip;base64,%@';"
@@ -221,7 +221,7 @@ TEST(WebKit, SystemPreviewUnknownMIMEType)
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];
 
-    NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"UnitBox" withExtension:@"usdz" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *modelURL = [NSBundle.test_resourcesBundle URLForResource:@"UnitBox" withExtension:@"usdz"];
     NSData *modelData = [NSData dataWithContentsOfURL:modelURL];
     NSString *modelBase64 = [modelData base64EncodedStringWithOptions:0];
     NSString *html = [NSString stringWithFormat:@"<script>let base64URL = 'data:application/octet-stream;base64,%@';"

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm
@@ -266,7 +266,7 @@ TEST(TLSVersion, NegotiatedLegacyTLS)
     [observer waitUntilNegotiatedLegacyTLSChanged];
     EXPECT_TRUE([webView _negotiatedLegacyTLS]);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     [observer waitUntilNegotiatedLegacyTLSChanged];
     EXPECT_FALSE([webView _negotiatedLegacyTLS]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
@@ -871,32 +871,52 @@ TEST(TextManipulation, StartTextManipulationExtractsUserInfo)
     EXPECT_WK_STREQ("Fourth", items[4].tokens[0].content);
     {
         auto userInfo = items[0].tokens[0].userInfo;
-        EXPECT_WK_STREQ("TestWebKitAPI.resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#if PLATFORM(MAC)
+        EXPECT_WK_STREQ("Resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#else
+        EXPECT_WK_STREQ("TestWebKitAPIResources.bundle", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#endif
         EXPECT_WK_STREQ("TITLE", (NSString *)userInfo[_WKTextManipulationTokenUserInfoTagNameKey]);
         EXPECT_FALSE([userInfo[_WKTextManipulationTokenUserInfoVisibilityKey] boolValue]);
     }
     {
         auto userInfo = items[1].tokens[0].userInfo;
-        EXPECT_WK_STREQ("TestWebKitAPI.resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#if PLATFORM(MAC)
+        EXPECT_WK_STREQ("Resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#else
+        EXPECT_WK_STREQ("TestWebKitAPIResources.bundle", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#endif
         EXPECT_WK_STREQ("P", (NSString *)userInfo[_WKTextManipulationTokenUserInfoTagNameKey]);
         EXPECT_FALSE([userInfo[_WKTextManipulationTokenUserInfoVisibilityKey] boolValue]);
     }
     {
         auto userInfo = items[2].tokens[0].userInfo;
-        EXPECT_WK_STREQ("TestWebKitAPI.resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#if PLATFORM(MAC)
+        EXPECT_WK_STREQ("Resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#else
+        EXPECT_WK_STREQ("TestWebKitAPIResources.bundle", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#endif
         EXPECT_WK_STREQ("DIV", (NSString *)userInfo[_WKTextManipulationTokenUserInfoTagNameKey]);
         EXPECT_WK_STREQ("button", (NSString *)userInfo[_WKTextManipulationTokenUserInfoRoleAttributeKey]);
         EXPECT_FALSE([userInfo[_WKTextManipulationTokenUserInfoVisibilityKey] boolValue]);
     }
     {
         auto userInfo = items[3].tokens[0].userInfo;
-        EXPECT_WK_STREQ("TestWebKitAPI.resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#if PLATFORM(MAC)
+        EXPECT_WK_STREQ("Resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#else
+        EXPECT_WK_STREQ("TestWebKitAPIResources.bundle", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#endif
         EXPECT_WK_STREQ("SPAN", (NSString *)userInfo[_WKTextManipulationTokenUserInfoTagNameKey]);
         EXPECT_FALSE([userInfo[_WKTextManipulationTokenUserInfoVisibilityKey] boolValue]);
     }
     {
         auto userInfo = items[4].tokens[0].userInfo;
-        EXPECT_WK_STREQ("TestWebKitAPI.resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#if PLATFORM(MAC)
+        EXPECT_WK_STREQ("Resources", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#else
+        EXPECT_WK_STREQ("TestWebKitAPIResources.bundle", [(NSURL *)userInfo[_WKTextManipulationTokenUserInfoDocumentURLKey] lastPathComponent]);
+#endif
         EXPECT_WK_STREQ("DIV", (NSString *)userInfo[_WKTextManipulationTokenUserInfoTagNameKey]);
         EXPECT_TRUE([userInfo[_WKTextManipulationTokenUserInfoVisibilityKey] boolValue]);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
@@ -36,7 +36,7 @@ TEST(WebKit, TextWidth)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"TextWidth" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"TextWidth" withExtension:@"html"]]];
     [webView _test_waitForDidFinishNavigation];
     
     __block bool didEvaluateJavaScript = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TopContentInset.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TopContentInset.mm
@@ -65,7 +65,7 @@ TEST(TopContentInset, Fullscreen)
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"FullscreenTopContentInset" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"FullscreenTopContentInset" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&receivedLoadedMessage);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -94,7 +94,7 @@ TEST(WebKit, WKWebViewIsPlayingAudio)
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
-    if ([navigationAction.request.URL.absoluteString isEqualToString:[[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"] absoluteString]])
+    if ([navigationAction.request.URL.absoluteString isEqualToString:[[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"] absoluteString]])
         done = true;
     decisionHandler(WKNavigationActionPolicyAllow);
 }
@@ -107,7 +107,7 @@ TEST(WebKit, WindowOpenWithoutUIDelegate)
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[NoUIDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
-    [webView loadHTMLString:@"<script>window.open('simple2.html');window.location='simple.html'</script>" baseURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    [webView loadHTMLString:@"<script>window.open('simple2.html');window.location='simple.html'</script>" baseURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]];
     TestWebKitAPI::Util::run(&done);
 }
 
@@ -1399,7 +1399,7 @@ TEST(WebKit, TabDoesNotTakeFocusFromEditableWebView)
 
 - (void)_webView:(WKWebView *)webView saveDataToFile:(NSData *)data suggestedFilename:(NSString *)suggestedFilename mimeType:(NSString *)mimeType originatingURL:(NSURL *)url
 {
-    NSURL *pdfURL = [[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *pdfURL = [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"];
     EXPECT_TRUE([data isEqualToData:[NSData dataWithContentsOfURL:pdfURL]]);
     EXPECT_STREQ([suggestedFilename UTF8String], "test.pdf");
     EXPECT_STREQ([mimeType UTF8String], "application/pdf");
@@ -1422,7 +1422,7 @@ TEST(WebKit, SaveDataToFile)
     auto delegate = adoptNS([[SaveDataToFileDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView setNavigationDelegate:delegate.get()];
-    NSURL *pdfURL = [[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *pdfURL = [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"];
     [webView loadRequest:[NSURLRequest requestWithURL:pdfURL]];
     TestWebKitAPI::Util::run(&done);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -79,7 +79,7 @@ UNIFIED_PDF_TEST(KeyboardScrollingInSinglePageMode)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
     [webView setForceWindowToBecomeKey:YES];
 
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"multiple-pages" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"multiple-pages" withExtension:@"pdf"]];
     [webView synchronouslyLoadRequest:request.get()];
     [[webView window] makeFirstResponder:webView.get()];
     [[webView window] makeKeyAndOrderFront:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
@@ -89,7 +89,7 @@ TEST(WKUserContentController, ScriptMessageHandlerBasicPost)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
 
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -121,7 +121,7 @@ TEST(WKUserContentController, ScriptMessageHandlerBasicPostIsolatedWorld)
     RetainPtr<SimpleNavigationDelegate> delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
 
     isDoneWithNavigation = false;
     [webView loadRequest:request];
@@ -167,7 +167,7 @@ TEST(WKUserContentController, ScriptMessageHandlerBasicRemove)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
 
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -213,7 +213,7 @@ TEST(WKUserContentController, ScriptMessageHandlerCallRemovedHandler)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
 
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -245,7 +245,7 @@ static RetainPtr<WKWebView> webViewForScriptMessageHandlerMultipleHandlerRemoval
     [[configurationCopy userContentController] addScriptMessageHandler:handler.get() name:@"handlerToRemove"];
     [[configurationCopy userContentController] addScriptMessageHandler:handler.get() name:@"handlerToPost"];
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationCopy.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -292,7 +292,7 @@ TEST(WKUserContentController, ScriptMessageHandlerWithNavigation)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -327,7 +327,7 @@ TEST(WKUserContentController, ScriptMessageHandlerReplaceWithSameName)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
 
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -876,7 +876,7 @@ TEST(WKUserContentController, InjectUserScriptImmediately)
     auto delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple-iframe" withExtension:@"html"]];
 
     isDoneWithNavigation = false;
     [webView loadRequest:request];
@@ -972,7 +972,7 @@ TEST(WKUserContentController, AddUserScriptInWorldWithGlobalObjectAvailableInIfr
     auto delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple-iframe" withExtension:@"html"]];
 
     isDoneWithNavigation = false;
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserInitiatedActionInNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserInitiatedActionInNavigationAction.mm
@@ -76,7 +76,7 @@ public:
         delegate = adoptNS([[UserInitiatedActionInNavigationActionDelegate alloc] init]);
         [webView setNavigationDelegate:delegate.get()];
 
-        URL = [[NSBundle mainBundle] URLForResource:@"open-multiple-external-url" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        URL = [NSBundle.test_resourcesBundle URLForResource:@"open-multiple-external-url" withExtension:@"html"];
     }
 
     NSURL *URLWithFragment(NSString *fragment)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
@@ -427,7 +427,7 @@ TEST(VideoControlsManager, VideoControlsManagerTearsDownMediaControlsOnDealloc)
 {
     RetainPtr<VideoControlsManagerTestWebView> webView = setUpWebViewForTestingVideoControlsManager(NSMakeRect(0, 0, 100, 100));
 
-    NSURL *urlOfVideo = [[NSBundle mainBundle] URLForResource:@"video-with-audio" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *urlOfVideo = [NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"mp4"];
     [webView loadFileURL:urlOfVideo allowingReadAccessToURL:[urlOfVideo URLByDeletingLastPathComponent]];
 
     __block bool finishedTest = false;
@@ -479,7 +479,7 @@ TEST(VideoControlsManager, VideoControlsManagerSmallVideoInMediaDocument)
         finishedLoad = true;
     }];
     
-    NSURL *urlOfVideo = [[NSBundle mainBundle] URLForResource:@"video-with-audio" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *urlOfVideo = [NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"mp4"];
     [webView loadFileURL:urlOfVideo allowingReadAccessToURL:[urlOfVideo URLByDeletingLastPathComponent]];
     
     TestWebKitAPI::Util::run(&finishedLoad);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -150,7 +150,7 @@ using CocoaPasteboard = UIPasteboard;
 
 static NSURL *testiWorkAttachmentFileURL()
 {
-    return [[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pages" subdirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pages"];
 }
 
 static NSData *testiWorkAttachmentData()
@@ -273,7 +273,7 @@ static RetainPtr<TestWKWebView> webViewForTestingAttachments()
 
 static NSData *testZIPData()
 {
-    NSURL *zipFileURL = [[NSBundle mainBundle] URLForResource:@"compressed-files" withExtension:@"zip" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *zipFileURL = [NSBundle.test_resourcesBundle URLForResource:@"compressed-files" withExtension:@"zip"];
     return [NSData dataWithContentsOfURL:zipFileURL];
 }
 
@@ -284,7 +284,7 @@ static NSData *testHTMLData()
 
 static NSURL *testImageFileURL()
 {
-    return [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"];
 }
 
 static NSData *testImageData()
@@ -294,7 +294,7 @@ static NSData *testImageData()
 
 static NSURL *testGIFFileURL()
 {
-    return [[NSBundle mainBundle] URLForResource:@"apple" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"];
 }
 
 static NSData *testGIFData()
@@ -304,7 +304,7 @@ static NSData *testGIFData()
 
 static NSURL *testPDFFileURL()
 {
-    return [[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"];
 }
 
 static NSData *testPDFData()
@@ -314,7 +314,7 @@ static NSData *testPDFData()
 
 static NSURL *testJPEGFileURL()
 {
-    return [[NSBundle mainBundle] URLForResource:@"sunset-in-cupertino-600px" withExtension:@"jpg" subdirectory:@"TestWebKitAPI.resources"];
+    return [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-600px" withExtension:@"jpg"];
 }
 
 static NSData *testJPEGData()
@@ -2299,7 +2299,7 @@ TEST(WKAttachmentTestsIOS, TargetedPreviewIsClippedWhenDroppingTallImage)
     [webView stringByEvaluatingJavaScript:@"document.body.style.margin = '0'"];
     [webView _setEditable:YES];
 
-    auto imageData = retainPtr([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]]);
+    auto imageData = retainPtr([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]]);
     auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     auto preview = targetedImageDragPreview(webView.get(), imageData.get(), CGSizeMake(100, 100));
@@ -2561,7 +2561,7 @@ static RetainPtr<NSItemProvider> mapItemForTesting()
 
 static RetainPtr<NSItemProvider> calendarInviteForTesting()
 {
-    RetainPtr url = [[NSBundle mainBundle] URLForResource:@"event" withExtension:@"ics" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"event" withExtension:@"ics"];
     RetainPtr data = [NSData dataWithContentsOfURL:url.get()];
     RetainPtr text = adoptNS([[NSString alloc] initWithData:data.get() encoding:NSUTF8StringEncoding]);
     RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -460,7 +460,7 @@ TEST_F(WKContentRuleListStoreTest, AddRemove)
     auto delegate = adoptNS([[ContentRuleListDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"contentBlockerCheck" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"contentBlockerCheck" withExtension:@"html"]];
     alertCount = 0;
     receivedAlert = false;
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKInspectorExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKInspectorExtension.mm
@@ -393,7 +393,7 @@ TEST(WKInspectorExtension, EvaluateScriptOnPage)
     auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
-    auto *testPageFileURL = [NSBundle.mainBundle URLForResource:@"WKInspectorExtensionEvaluateScriptOnPage" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    auto *testPageFileURL = [NSBundle.test_resourcesBundle URLForResource:@"WKInspectorExtensionEvaluateScriptOnPage" withExtension:@"html"];
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView setNavigationDelegate:navigationDelegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm
@@ -27,9 +27,9 @@
 
 #import "DeprecatedGlobalValues.h"
 #import "HTTPServer.h"
+#import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
-#import "Utilities.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKNavigationResponsePrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
@@ -270,7 +270,7 @@ TEST(WebKit, SkipDecidePolicyForResponse)
     [delegate waitForDidFinishNavigation];
     EXPECT_FALSE(responseDelegateCalled);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.mainBundle URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     [delegate waitForDidFinishNavigation];
     EXPECT_TRUE(std::exchange(responseDelegateCalled, false));
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
@@ -47,7 +47,7 @@
 #if PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(VISION)
 static NSData *pdfData()
 {
-    return [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    return [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
 }
 #endif
 
@@ -65,7 +65,7 @@ TEST(WebKit, WKPDFViewResizeCrash)
 {
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -84,7 +84,7 @@ TEST(WebKit, WKPDFViewStablePresentationUpdateCallback)
 {
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -154,7 +154,7 @@ TEST(WebKit, WKPDFViewFindActions)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -180,10 +180,10 @@ TEST(WKPDFView, BackgroundColor)
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"red" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"red" withExtension:@"html"]]];
     EXPECT_TRUE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, redColor.get()));
 
-    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
     EXPECT_FALSE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, redColor.get()));
 
     [webView synchronouslyGoBack];
@@ -494,7 +494,7 @@ TEST(PDF, PrintSize)
         } else {
             EXPECT_WK_STREQ(url.path, "/test_print.pdf");
             mimeType = @"application/pdf";
-            data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test_print" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+            data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test_print" withExtension:@"pdf"]];
         }
         auto response = adoptNS([[NSURLResponse alloc] initWithURL:url MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
@@ -79,7 +79,7 @@ TEST(Printing, PrintWithDelayedCompletion)
     auto delegate = adoptNS([PrintWithSimulatedPageComputationUIDelegate new]);
     [webView setUIDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -138,7 +138,7 @@ TEST(Printing, PrintPageBorders)
     auto delegate = adoptNS([PrintShowingPrintPanelUIDelegate new]);
     [webView setUIDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
@@ -77,7 +77,7 @@ TEST(_WKActivatedElementInfo, InfoForLink)
 TEST(_WKActivatedElementInfo, InfoForImage)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 215, 174)]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"image" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"image" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -97,7 +97,7 @@ TEST(_WKActivatedElementInfo, InfoForImage)
 TEST(_WKActivatedElementInfo, InfoForMediaDocument)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 215, 174)]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -121,7 +121,7 @@ TEST(_WKActivatedElementInfo, InfoForMediaDocument)
 TEST(_WKActivatedElementInfo, InfoForLinkAroundImage)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"link-with-image" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"link-with-image" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -1090,7 +1090,7 @@ TEST(URLSchemeHandler, DisableCORSCanvas)
             done = true;
         } else if ([task.request.URL.path isEqualToString:@"/image.png"]) {
             mimeType = @"image/png";
-            response = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+            response = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
         } else
             ASSERT_NOT_REACHED();
 
@@ -1690,7 +1690,7 @@ TEST(URLSchemeHandler, APIRedirect)
 
 TEST(URLSchemeHandler, Ranges)
 {
-    RetainPtr<NSData> videoData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr<NSData> videoData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]];
 
     auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -51,7 +51,7 @@ TEST(WKWebView, EvaluateJavaScriptBlockCrash)
     @autoreleasepool {
         RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
         [webView loadRequest:request];
 
         [webView evaluateJavaScript:@"" completionHandler:^(id result, NSError *error) {
@@ -77,7 +77,7 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
 {
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -199,7 +199,7 @@ TEST(WKWebView, AttributedStringAccessibilityLabel)
 {
     auto webView = adoptNS([TestWKWebView new]);
 
-    NSString *imagePath = [[NSBundle mainBundle] pathForResource:@"icon" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"];
+    NSString *imagePath = [NSBundle.test_resourcesBundle pathForResource:@"icon" ofType:@"png"];
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<html><body><b>Hello</b> <img src='file://%@' width='100' height='100' alt='alt text'> <img src='file://%@' width='100' height='100' alt='aria label text'></body></html>", imagePath, imagePath]];
 
     __block bool finished = false;
@@ -511,7 +511,7 @@ TEST(WKWebView, AttributedStringWithSourceApplicationBundleID)
 
 TEST(WKWebView, TextWithWebFontAsAttributedString)
 {
-    auto archiveURL = [NSBundle.mainBundle URLForResource:@"text-with-web-font" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    auto archiveURL = [NSBundle.test_resourcesBundle URLForResource:@"text-with-web-font" withExtension:@"webarchive"];
     auto archiveData = adoptNS([[NSData alloc] initWithContentsOfURL:archiveURL]);
 
     RetainPtr<NSAttributedString> result;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewLoadAPIs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewLoadAPIs.mm
@@ -145,7 +145,7 @@ TEST(WKWebView, LoadFileRequest)
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURL *file = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     NSURLRequest *request = [NSURLRequest requestWithURL:file];
     [webView loadFileRequest:request allowingReadAccessToURL:file.URLByDeletingLastPathComponent];
     [delegate waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -392,7 +392,7 @@ TEST(WKWebView, SnapshotImageLargeAsyncDecoding)
     // FIXME: This test fails when adopting TestWKWebView; it might be interesting to investigate why.
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
-    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"large-red-square-image" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square-image" withExtension:@"html"];
     [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
     [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
@@ -191,7 +191,7 @@ TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)
     startedLoad = false;
     finishedLoad = false;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"rich-and-plain-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"rich-and-plain-text" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&finishedLoad);
 
     startedLoad = false;
@@ -229,7 +229,7 @@ TEST(WKNavigation, AutomaticHiddenViewDelayedReloadAfterWebProcessCrash)
     startedLoad = false;
     finishedLoad = false;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"rich-and-plain-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"rich-and-plain-text" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&finishedLoad);
 
     startedLoad = false;
@@ -262,7 +262,7 @@ TEST(WKNavigation, ProcessCrashDuringCallback)
     startedLoad = false;
     finishedLoad = false;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"rich-and-plain-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"rich-and-plain-text" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&finishedLoad);
 
     startedLoad = false;
@@ -496,7 +496,7 @@ TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)
     }];
 
     webview1FinishedLoad = false;
-    [webView1 loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView1 loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&webview1FinishedLoad);
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -513,7 +513,7 @@ TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)
     }];
 
     webview2FinishedLoad = false;
-    [webView2 loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView2 loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&webview2FinishedLoad);
 
     // The 2 WebViews should use the same process since they're related.
@@ -524,7 +524,7 @@ TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)
         decisionHandler(_WKNavigationActionPolicyAllowInNewProcess);
     };
     webview1FinishedLoad = false;
-    [webView1 loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView1 loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&webview1FinishedLoad);
 
     navigationDelegate.get().decidePolicyForNavigationAction = nil;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm
@@ -58,7 +58,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, WebCryptoNilMasterKey)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"navigation-client-default-crypto" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"navigation-client-default-crypto" withExtension:@"html"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[WebCryptoMasterKeyNavigationDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm
@@ -59,7 +59,7 @@ TEST(IndexedDB, WebProcessKillIDBCleanup)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebProcessKillIDBCleanup-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebProcessKillIDBCleanup-1" withExtension:@"html"]];
     [webView loadRequest:request];
 
     auto string1 = RetainPtr { getNextMessage().body };
@@ -70,7 +70,7 @@ TEST(IndexedDB, WebProcessKillIDBCleanup)
     // Make a new web view with a new web process to finish the test
     RetainPtr<WKWebView> webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebProcessKillIDBCleanup-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebProcessKillIDBCleanup-2" withExtension:@"html"]];
     [webView2 loadRequest:request];
 
     auto string5 = RetainPtr { getNextMessage().body };
@@ -101,13 +101,13 @@ TEST(IndexedDB, KillWebProcessWithOpenConnection)
     TestWebKitAPI::Util::run(&readyToContinue);
 
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request1 = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"KillWebProcessWithOpenConnection-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request1 = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"KillWebProcessWithOpenConnection-1" withExtension:@"html"]];
     [webView1 loadRequest:request1];
     auto string1 = RetainPtr { getNextMessage().body };
     EXPECT_WK_STREQ(@"Open Succeeded", string1.get());
 
     auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request2 = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"KillWebProcessWithOpenConnection-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request2 = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"KillWebProcessWithOpenConnection-2" withExtension:@"html"]];
     [webView2 loadRequest:request2];
     auto string2 = RetainPtr { getNextMessage().body };
     EXPECT_WK_STREQ(@"Version Change", string2.get());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSQLBasics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSQLBasics.mm
@@ -56,7 +56,7 @@ TEST(WebSQL, OpenDatabaseAlwaysExists)
     receivedScriptMessage = false;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"opendatabase-always-exists" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"opendatabase-always-exists" withExtension:@"html"]];
     [webView loadRequest:request];
 
     TestWebKitAPI::Util::run(&receivedScriptMessage);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -122,7 +122,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:handler.get()];
 
-    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html"]];
     [webView loadRequest:request.get()];
 
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
@@ -212,9 +212,9 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
         RetainPtr fileWebKitIDBPath = [NSURL fileURLWithPath:idbPathString.get() isDirectory:YES];
 
         // Subframe of different origins may also create IndexedDB files.
-        RetainPtr<NSURL> url1 = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-        RetainPtr<NSURL> url2 = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3-shm" subdirectory:@"TestWebKitAPI.resources"];
-        RetainPtr<NSURL> url3 = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3-wal" subdirectory:@"TestWebKitAPI.resources"];
+        RetainPtr<NSURL> url1 = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDB" withExtension:@"sqlite3"];
+        RetainPtr<NSURL> url2 = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDB" withExtension:@"sqlite3-shm"];
+        RetainPtr<NSURL> url3 = [NSBundle.test_resourcesBundle URLForResource:@"IndexedDB" withExtension:@"sqlite3-wal"];
 
         [[NSFileManager defaultManager] createDirectoryAtURL:fileAppleIDBPath.get() withIntermediateDirectories:YES attributes:nil error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url1.get() toURL:[fileAppleIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
@@ -355,7 +355,7 @@ TEST(WebKit, WebsiteDataStoreEphemeral)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html"]];
     [webView loadRequest:request];
 
     __block bool flushed = false;
@@ -427,7 +427,7 @@ TEST(WebKit, WebsiteDataStoreEphemeralViaConfiguration)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html"]];
     [webView loadRequest:request];
 
     __block bool flushed = false;
@@ -461,7 +461,7 @@ TEST(WebKit, DoLoadWithNonDefaultDataStoreAfterTerminatingNetworkProcess)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
@@ -469,7 +469,7 @@ TEST(WebKit, DoLoadWithNonDefaultDataStoreAfterTerminatingNetworkProcess)
 
     [webViewConfiguration.get().websiteDataStore _terminateNetworkProcess];
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 }
@@ -759,7 +759,7 @@ TEST(WebKit, MediaCache)
     JSC::Config::configureForTesting();
 
     using namespace TestWebKitAPI;
-    RetainPtr<NSData> data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr<NSData> data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]];
 
     HTTPServer server([&] (Connection connection) {
         connection.receiveHTTPRequest([=] (Vector<char>&&) {
@@ -804,7 +804,7 @@ TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)
     NSURL *localStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *localStorageFile = [localStorageDirectory URLByAppendingPathComponent:@"https_webkit.org_0.localstorage"];
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *newLocalStorageFile = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/LocalStorage/localstorage.sqlite3"];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:localStorageDirectory error:nil];
@@ -868,7 +868,7 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
     NSURL *indexedDBDatabaseDirectory = [indexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName];
     NSURL *indexedDBFile = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *newIndexedDBOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/IndexedDB/"];
     NSURL *newIndexedDBDirectory = [newIndexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName];
     NSURL *newIndexedDBFile = [newIndexedDBDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
@@ -940,10 +940,10 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
 
 TEST(WebKit, FetchDataAfterEnablingGeneralStorageDirectory)
 {
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceLocalStorageFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory-localstorage" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceIndexedDBFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory-indexeddb" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceOriginFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"origin" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
+    NSURL *resourceLocalStorageFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory-localstorage" withExtension:@"sqlite3"];
+    NSURL *resourceIndexedDBFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory-indexeddb" withExtension:@"sqlite3"];
+    NSURL *resourceOriginFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"origin"];
 
     NSURL *customLocalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *appleCustomLocalStorageFile = [customLocalStorageDirectory URLByAppendingPathComponent:@"https_apple.com_0.localstorage"];
@@ -1020,10 +1020,10 @@ TEST(WebKit, FetchDataAfterEnablingGeneralStorageDirectory)
 
 TEST(WebKit, DeleteDataAfterEnablingGeneralStorageDirectory)
 {
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceLocalStorageFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory-localstorage" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceIndexedDBFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory-indexeddb" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceOriginFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"origin" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
+    NSURL *resourceLocalStorageFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory-localstorage" withExtension:@"sqlite3"];
+    NSURL *resourceIndexedDBFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory-indexeddb" withExtension:@"sqlite3"];
+    NSURL *resourceOriginFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"origin"];
 
     NSURL *customLocalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *appleCustomLocalStorageFile = [customLocalStorageDirectory URLByAppendingPathComponent:@"https_apple.com_0.localstorage"];
@@ -1088,7 +1088,7 @@ TEST(WebKit, DeleteDataAfterEnablingGeneralStorageDirectory)
 TEST(WebKit, CreateOriginFileWhenNeeded)
 {
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:generalStorageDirectory error:nil];
     [fileManager createDirectoryAtURL:generalStorageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
@@ -1142,7 +1142,7 @@ TEST(WKWebsiteDataStoreConfiguration, SameCustomPathForDifferentTypes)
         auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html"]];
         [webView loadRequest:request];
 
         EXPECT_STREQ([getNextMessage().body UTF8String], "localstorage written");
@@ -1180,8 +1180,8 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenFetchData)
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *topOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs"];
     NSURL *originDirectory = [topOriginDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs"];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceOriginFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"origin" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
+    NSURL *resourceOriginFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"origin"];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:generalStorageDirectory error:nil];
     [fileManager createDirectoryAtURL:generalStorageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
@@ -1208,8 +1208,8 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenOriginIsGone)
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *topOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs"];
     NSURL *originDirectory = [topOriginDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs"];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceOriginFile = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"origin" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
+    NSURL *resourceOriginFile = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"origin"];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:generalStorageDirectory error:nil];
     [fileManager createDirectoryAtURL:generalStorageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
@@ -1252,7 +1252,7 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenOriginIsGone)
 
 TEST(WebKit, OriginDirectoryExcludedFromBackup)
 {
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:generalStorageDirectory error:nil];
@@ -1306,9 +1306,9 @@ TEST(WebKit, OriginDirectoryExcludedFromBackup)
 
 TEST(WebKit, RemoveStaleWebSQLData)
 {
-    NSURL *resourceWebSQLDatabaseTrackerFile = [[NSBundle mainBundle] URLForResource:@"websql-database-tracker" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceWebSQLDatabaseFile = [[NSBundle mainBundle] URLForResource:@"websql-database" withExtension:@"db" subdirectory:@"TestWebKitAPI.resources"];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceWebSQLDatabaseTrackerFile = [NSBundle.test_resourcesBundle URLForResource:@"websql-database-tracker" withExtension:@"db"];
+    NSURL *resourceWebSQLDatabaseFile = [NSBundle.test_resourcesBundle URLForResource:@"websql-database" withExtension:@"db"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *customWebSQLDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebSQL" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *databaseTrackerFile = [customWebSQLDirectory URLByAppendingPathComponent:@"Databases.db"];
     NSURL *webkitSQLDirectory = [customWebSQLDirectory URLByAppendingPathComponent:@"http_webkit.org_0"];
@@ -1525,7 +1525,7 @@ TEST(WKWebsiteDataStore, MigrateCacheStorageDataToGeneralStorageDirectory)
     RetainPtr<NSURL> cacheStorageOriginDirectory = nullptr;
     NSURL *cacheStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CacheStorage" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Origins" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *newCacheStorageOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/CacheStorage/"];
     NSURL *newCacheStorageCachesListFile = [newCacheStorageOriginDirectory URLByAppendingPathComponent:@"cacheslist"];
 
@@ -1830,7 +1830,7 @@ TEST(WKWebsiteDataStore, FetchAndDeleteMediaKeysData)
     FileSystem::updateFileModificationTime(customMediaKeysStorageFile.path);
     NSURL *customVersionDirectory = [customMediaKeysStorageDirectory URLByAppendingPathComponent:@"v1"];
     [fileManager createDirectoryAtURL:customVersionDirectory withIntermediateDirectories:YES attributes:nil error:nil];
-    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     [fileManager copyItemAtURL:resourceSalt toURL:[customVersionDirectory URLByAppendingPathComponent:@"salt"] error:nil];
     NSURL *newWebKitDirectory = [customVersionDirectory URLByAppendingPathComponent:@"XLb5EY_51d2Xcs65bSUthGKAVscdhhcHXCR6DndbBnc"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -163,7 +163,7 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"contentBlockerCheck" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"contentBlockerCheck" withExtension:@"html"]];
     alertCount = 0;
     receivedAlert = false;
     [webView loadRequest:request];
@@ -276,12 +276,12 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayEnabled)
     auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
-    NSURLRequest *requestWithoutAudio = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-no-audio-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
+    NSURLRequest *requestWithoutAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-no-audio-check" withExtension:@"html"]];
 
     // iOS does not support volume changes to media elements.
 #if PLATFORM(MAC)
-    NSURLRequest *requestWithoutVolume = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-zero-volume-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithoutVolume = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-zero-volume-check" withExtension:@"html"]];
 #endif
 
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
@@ -334,7 +334,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayEnabled)
     [webView waitForMessage:@"autoplayed"];
 #endif
 
-    NSURLRequest *requestWithAudioInIFrame = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check-in-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudioInIFrame = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check-in-iframe" withExtension:@"html"]];
 
     // If the top-level document allows autoplay, any iframes should also autoplay.
     [delegate setAutoplayPolicyForURL:^(NSURL *url) {
@@ -379,7 +379,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)
     NSPoint playButtonClickPoint = NSMakePoint(20, 256);
 
     receivedAutoplayEvent = std::nullopt;
-    NSURLRequest *jsPlayRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"js-play-with-controls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *jsPlayRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"js-play-with-controls" withExtension:@"html"]];
     [webView loadRequest:jsPlayRequest];
     [webView waitForMessage:@"loaded"];
     runUntilReceivesAutoplayEvent(_WKAutoplayEventDidPreventFromAutoplaying);
@@ -393,7 +393,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
 
-    NSURLRequest *autoplayRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-with-controls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *autoplayRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-with-controls" withExtension:@"html"]];
     [webView loadRequest:autoplayRequest];
     [webView waitForMessage:@"loaded"];
     runUntilReceivesAutoplayEvent(_WKAutoplayEventDidPreventFromAutoplaying);
@@ -408,7 +408,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
 
-    NSURLRequest *noAutoplayRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"no-autoplay-with-controls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *noAutoplayRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"no-autoplay-with-controls" withExtension:@"html"]];
     [webView loadRequest:noAutoplayRequest];
     [webView waitForMessage:@"loaded"];
     [webView mouseDownAtPoint:playButtonClickPoint simulatePressure:NO];
@@ -423,7 +423,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)
         return _WKWebsiteAutoplayPolicyAllowWithoutSound;
     }];
 
-    NSURLRequest *autoplayMutedRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-muted-with-controls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *autoplayMutedRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-muted-with-controls" withExtension:@"html"]];
     [webView loadRequest:autoplayMutedRequest];
     [webView waitForMessage:@"loaded"];
     runUntilReceivesAutoplayEvent(_WKAutoplayEventDidPreventFromAutoplaying);
@@ -459,7 +459,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayingWithUserGesture)
     NSPoint playButtonClickPoint = NSMakePoint(20, 580);
 #endif
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"audio-with-play-button" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"audio-with-play-button" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView waitForMessage:@"loaded"];
 
@@ -476,7 +476,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayingWithUserGesture)
 
     receivedAutoplayEvent = std::nullopt;
 
-    request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"video-with-play-button" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-with-play-button" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView waitForMessage:@"loaded"];
 
@@ -510,7 +510,7 @@ TEST(WebpagePreferences, WebsitePoliciesPlayingWithoutInterference)
     [webView setUIDelegate:delegate.get()];
 
     receivedAutoplayEvent = std::nullopt;
-    NSURLRequest *jsPlayRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"js-autoplay-audio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *jsPlayRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"js-autoplay-audio" withExtension:@"html"]];
     [webView loadRequest:jsPlayRequest];
     runUntilReceivesAutoplayEvent(_WKAutoplayEventDidAutoplayMediaPastThresholdWithoutUserInterference);
     ASSERT_TRUE(*receivedAutoplayEventFlags & _WKAutoplayEventFlagsHasAudio);
@@ -534,7 +534,7 @@ TEST(WebpagePreferences, WebsitePoliciesUserInterferenceWithPlaying)
     [webView setUIDelegate:delegate.get()];
 
     receivedAutoplayEvent = std::nullopt;
-    NSURLRequest *jsPlayRequest = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"js-play-with-controls" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *jsPlayRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"js-play-with-controls" withExtension:@"html"]];
     [webView loadRequest:jsPlayRequest];
     [webView waitForMessage:@"playing"];
     ASSERT_TRUE(receivedAutoplayEvent == std::nullopt);
@@ -689,7 +689,7 @@ struct ParsedRange {
     if ([task.request.URL.path isEqualToString:@"/should-redirect"]) {
         [(id<WKURLSchemeTaskPrivate>)task _didPerformRedirection:adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]).get() newRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///autoplay-check.html"]]];
         
-        NSData *data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSData *data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
         [task didReceiveResponse:adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:data.length textEncodingName:nil]).get()];
         [task didReceiveData:data];
         [task didFinish];
@@ -718,7 +718,7 @@ struct ParsedRange {
 TEST(WebpagePreferences, WebsitePoliciesDuringRedirect)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto videoData = adoptNS([[NSData alloc] initWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]]);
+    auto videoData = adoptNS([[NSData alloc] initWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]]);
     [configuration setURLSchemeHandler:adoptNS([[TestSchemeHandler alloc] initWithVideoData:WTFMove(videoData)]).get() forURLScheme:@"test"];
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
@@ -749,7 +749,7 @@ TEST(WebpagePreferences, WebsitePoliciesUpdates)
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
-    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
 
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
         return _WKWebsiteAutoplayPolicyDeny;
@@ -788,7 +788,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
 
     configuration.get().preferences._needsSiteSpecificQuirks = YES;
 
-    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
 
     [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *url) {
         return _WKWebsiteAutoplayQuirkSynthesizedPauseEvents;
@@ -803,7 +803,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
 
-    NSURLRequest *requestWithAudioInFrame = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check-in-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudioInFrame = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check-in-iframe" withExtension:@"html"]];
 
     [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *url) {
         if ([url.lastPathComponent isEqualToString:@"autoplay-check-frame.html"])
@@ -821,7 +821,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
 
-    NSURLRequest *requestThatInheritsGesture = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-inherits-gesture-from-document" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestThatInheritsGesture = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-inherits-gesture-from-document" withExtension:@"html"]];
     [webView loadRequest:requestThatInheritsGesture];
     [webView waitForMessage:@"loaded"];
 
@@ -846,7 +846,7 @@ TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)
 
     receivedAutoplayEvent = std::nullopt;
 
-    NSURLRequest *requestWithMultipleMediaElements = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplaying-multiple-media-elements" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithMultipleMediaElements = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplaying-multiple-media-elements" withExtension:@"html"]];
 
     [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *url) {
         return _WKWebsiteAutoplayQuirkPerDocumentAutoplayBehavior;
@@ -920,7 +920,7 @@ TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirksAsyncPolicyDelega
     auto delegate = adoptNS([[AsyncAutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
-    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
 
     [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *url) {
         return _WKWebsiteAutoplayQuirkSynthesizedPauseEvents;
@@ -935,7 +935,7 @@ TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirksAsyncPolicyDelega
     receivedAutoplayEvent = std::nullopt;
     [webView loadHTMLString:@"" baseURL:nil];
 
-    NSURLRequest *requestWithAudioInFrame = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"autoplay-check-in-iframe" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *requestWithAudioInFrame = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check-in-iframe" withExtension:@"html"]];
 
     [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *url) {
         if ([url.lastPathComponent isEqualToString:@"autoplay-check-frame.html"])
@@ -1554,7 +1554,7 @@ TEST(WebpagePreferences, WebsitePoliciesPopUp)
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"pop-up-check" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"pop-up-check" withExtension:@"html"]];
 
     [delegate setPopUpPolicyForURL:^_WKWebsitePopUpPolicy(NSURL *) {
         return _WKWebsitePopUpPolicyBlock;
@@ -2128,7 +2128,7 @@ TEST(WebpagePreferences, PushAndNotificationsEnabled)
     }];
     [delegate setPushAndNotificationAPIEnabled:YES];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
@@ -2152,7 +2152,7 @@ TEST(WebpagePreferences, PushAndNotificationsDisabled)
     }];
     [delegate setPushAndNotificationAPIEnabled:NO];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&finishedNavigation);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -1441,7 +1441,7 @@ TEST(WritingTools, CompositionWithTextAttachment)
     [[webView writingToolsDelegate] willBeginWritingToolsSession:session.get() requestContexts:^(NSArray<WTContext *> *contexts) {
         [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-        RetainPtr pngData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+        RetainPtr pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
         RetainPtr attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData.get() ofType:UTTypePNG.identifier]);
 
         RetainPtr attributedText = [NSAttributedString attributedStringWithAttachment:attachment.get()];
@@ -1519,7 +1519,7 @@ TEST(WritingTools, CompositionWithImageAttachmentRoundTrip)
     RetainPtr attachmentIdentifier = [webView ensureAttachmentForImageElement];
     RetainPtr attachment = [webView _attachmentForIdentifier:attachmentIdentifier.get()];
 
-    RetainPtr pngData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
     RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:pngData.get()]);
     [fileWrapper setPreferredFilename:@"sunset-in-cupertino-200px.png"];
 
@@ -1572,7 +1572,7 @@ TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)
 
     modifySelection(5, 9);
 
-    RetainPtr zipData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"compressed-files" ofType:@"zip" inDirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr zipData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"compressed-files" ofType:@"zip"]];
     RetainPtr attachment = synchronouslyInsertAttachmentWithFilename(webView.get(), @"compressed-files.zip", @"application/zip", zipData.get());
 
     [webView selectAll:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -410,7 +410,7 @@ void cleanUpKeychain(const String& rpId)
 #if HAVE(NEAR_FIELD)
 TEST(WebAuthenticationPanel, NoPanelNfcSucceed)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -424,7 +424,7 @@ TEST(WebAuthenticationPanel, NoPanelNfcSucceed)
 
 TEST(WebAuthenticationPanel, NoPanelHidSuccess)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -438,7 +438,7 @@ TEST(WebAuthenticationPanel, NoPanelHidSuccess)
 TEST(WebAuthenticationPanel, PanelHidSuccess1)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -459,7 +459,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess1)
 TEST(WebAuthenticationPanel, PanelHidSuccess2)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -485,7 +485,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess2)
 TEST(WebAuthenticationPanel, PanelRacy1)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -508,7 +508,7 @@ TEST(WebAuthenticationPanel, PanelRacy1)
 TEST(WebAuthenticationPanel, PanelRacy2)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -531,7 +531,7 @@ TEST(WebAuthenticationPanel, PanelRacy2)
 TEST(WebAuthenticationPanel, PanelTwice)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -553,7 +553,7 @@ TEST(WebAuthenticationPanel, PanelTwice)
 TEST(WebAuthenticationPanel, ReloadHidCancel)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -571,8 +571,8 @@ TEST(WebAuthenticationPanel, ReloadHidCancel)
 TEST(WebAuthenticationPanel, LocationChangeHidCancel)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> otherURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
+    RetainPtr<NSURL> otherURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -590,8 +590,8 @@ TEST(WebAuthenticationPanel, LocationChangeHidCancel)
 TEST(WebAuthenticationPanel, NewLoadHidCancel)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> otherURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
+    RetainPtr<NSURL> otherURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -609,7 +609,7 @@ TEST(WebAuthenticationPanel, NewLoadHidCancel)
 TEST(WebAuthenticationPanel, CloseHidCancel)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -712,7 +712,7 @@ TEST(WebAuthenticationPanel, SubFrameDestructionHidCancel)
 TEST(WebAuthenticationPanel, PanelHidCancel)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -735,7 +735,7 @@ TEST(WebAuthenticationPanel, PanelHidCancel)
 TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -752,7 +752,7 @@ TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)
 TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-u2f-no-credentials" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-u2f-no-credentials" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -769,7 +769,7 @@ TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)
 TEST(WebAuthenticationPanel, FakePanelHidSuccess)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -787,7 +787,7 @@ TEST(WebAuthenticationPanel, FakePanelHidSuccess)
 TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -805,7 +805,7 @@ TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)
 TEST(WebAuthenticationPanel, NullPanelHidSuccess)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -823,7 +823,7 @@ TEST(WebAuthenticationPanel, NullPanelHidSuccess)
 TEST(WebAuthenticationPanel, NullPanelHidCtapNoCredentialsFound)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -842,7 +842,7 @@ TEST(WebAuthenticationPanel, NullPanelHidCtapNoCredentialsFound)
 TEST(WebAuthenticationPanel, PanelMultipleNFCTagsPresent)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-nfc-multiple-tags" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-multiple-tags" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -860,7 +860,7 @@ TEST(WebAuthenticationPanel, PanelMultipleNFCTagsPresent)
 TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -879,7 +879,7 @@ TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)
 TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -896,7 +896,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
 TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -913,7 +913,7 @@ TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)
 TEST(WebAuthenticationPanel, PinGetRetriesError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-retries-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-retries-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -926,7 +926,7 @@ TEST(WebAuthenticationPanel, PinGetRetriesError)
 TEST(WebAuthenticationPanel, PinGetKeyAgreementError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-key-agreement-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-key-agreement-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -939,7 +939,7 @@ TEST(WebAuthenticationPanel, PinGetKeyAgreementError)
 TEST(WebAuthenticationPanel, PinRequestPinErrorNoDelegate)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -952,7 +952,7 @@ TEST(WebAuthenticationPanel, PinRequestPinErrorNoDelegate)
 TEST(WebAuthenticationPanel, PinRequestPinErrorNullDelegate)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -969,7 +969,7 @@ TEST(WebAuthenticationPanel, PinRequestPinErrorNullDelegate)
 TEST(WebAuthenticationPanel, PinRequestPinError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -988,7 +988,7 @@ TEST(WebAuthenticationPanel, PinRequestPinError)
 TEST(WebAuthenticationPanel, PinGetPinTokenPinBlockedError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1007,7 +1007,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinBlockedError)
 TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthBlockedError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1026,7 +1026,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthBlockedError)
 TEST(WebAuthenticationPanel, PinGetPinTokenPinInvalidErrorAndRetry)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1044,7 +1044,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinInvalidErrorAndRetry)
 TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthInvalidErrorAndRetry)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1062,7 +1062,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthInvalidErrorAndRetry)
 TEST(WebAuthenticationPanel, MakeCredentialInternalUV)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-internal-uv" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-internal-uv" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1078,7 +1078,7 @@ TEST(WebAuthenticationPanel, MakeCredentialInternalUV)
 TEST(WebAuthenticationPanel, MakeCredentialPin)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1095,7 +1095,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPin)
 TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-auth-blocked-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-auth-blocked-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1114,7 +1114,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)
 TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin-invalid-error-retry" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-invalid-error-retry" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1132,7 +1132,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
 TEST(WebAuthenticationPanel, GetAssertionPin)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-pin" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1149,7 +1149,7 @@ TEST(WebAuthenticationPanel, GetAssertionPin)
 TEST(WebAuthenticationPanel, GetAssertionInternalUV)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-internal-uv" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1165,7 +1165,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUV)
 TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-internal-uv-pin-fallback" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv-pin-fallback" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1182,7 +1182,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
 TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-pin-auth-blocked-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-auth-blocked-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1201,7 +1201,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
 TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-pin-invalid-error-retry" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-invalid-error-retry" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1220,7 +1220,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)
 TEST(WebAuthenticationPanel, NfcPinCachedDisconnect)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-nfc-pin-disconnect" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-pin-disconnect" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1238,7 +1238,7 @@ TEST(WebAuthenticationPanel, NfcPinCachedDisconnect)
 TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1255,7 +1255,7 @@ TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)
 TEST(WebAuthenticationPanel, MultipleAccounts)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1276,7 +1276,7 @@ TEST(WebAuthenticationPanel, MultipleAccounts)
 TEST(WebAuthenticationPanel, LAError)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-error" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1292,7 +1292,7 @@ TEST(WebAuthenticationPanel, LAError)
 TEST(WebAuthenticationPanel, LADuplicateCredential)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1310,7 +1310,7 @@ TEST(WebAuthenticationPanel, LADuplicateCredential)
 TEST(WebAuthenticationPanel, LADuplicateCredentialWithConsent)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1334,7 +1334,7 @@ TEST(WebAuthenticationPanel, LANoCredential)
     // In case this wasn't cleaned up by another test.
     cleanUpKeychain(emptyString());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1350,7 +1350,7 @@ TEST(WebAuthenticationPanel, LANoCredential)
 TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1371,7 +1371,7 @@ TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
 TEST(WebAuthenticationPanel, LAGetAssertion)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1390,7 +1390,7 @@ TEST(WebAuthenticationPanel, LAGetAssertion)
 TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1418,7 +1418,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
 {
     reset();
     webAuthenticationPanelRequestNoGesture = false;
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la-no-mock" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la-no-mock" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
@@ -1438,7 +1438,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
 TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 {
     reset();
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm
@@ -100,7 +100,7 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
 
     EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"video-with-audio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 
@@ -113,7 +113,7 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
 
     didBeginPlaying = false;
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"video-without-audio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-without-audio" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 
@@ -123,7 +123,7 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
 
     didBeginPlaying = false;
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"video-with-muted-audio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-with-muted-audio" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 
@@ -133,7 +133,7 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
 
     didBeginPlaying = false;
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"video-with-muted-audio-and-webaudio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-with-muted-audio-and-webaudio" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 
@@ -143,7 +143,7 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
 
     didBeginPlaying = false;
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"video-with-paused-audio-and-playing-muted" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-with-paused-audio-and-playing-muted" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 
@@ -156,7 +156,7 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
 
     didBeginPlaying = false;
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"audio-only" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"audio-only" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/PreemptVideoFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/PreemptVideoFullscreen.mm
@@ -101,7 +101,7 @@ TEST(WebKitLegacy, PreemptVideoFullscreen)
     RetainPtr<PreemptVideoFullscreenUIWebViewDelegate> uiDelegate = adoptNS([[PreemptVideoFullscreenUIWebViewDelegate alloc] init]);
     uiWebView.get().delegate = uiDelegate.get();
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"two-videos" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"two-videos" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
     Util::run(&gotMainFrame);

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollingDoesNotPauseMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollingDoesNotPauseMedia.mm
@@ -93,7 +93,7 @@ TEST(WebKitLegacy, ScrollingDoesNotPauseMedia)
     RetainPtr<ScrollingDoesNotPauseMediaDelegate> testController = adoptNS([ScrollingDoesNotPauseMediaDelegate new]);
     uiWebView.get().delegate = testController.get();
 
-    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.mainBundle URLForResource:@"one-video" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"one-video" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
     Util::run(&gotMainFrame);

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
@@ -89,7 +89,7 @@ TEST(WebKitLegacy, RenderInContextSnapshot)
     RetainPtr<RenderInContextWebViewDelegate> uiDelegate = adoptNS([[RenderInContextWebViewDelegate alloc] init]);
     uiWebView.get().delegate = uiDelegate.get();
     
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"large-red-square-image" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square-image" withExtension:@"html"];
     NSLog(@"Loading %@", url);
     [uiWebView loadRequest:[NSURLRequest requestWithURL:url]];
     

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLPrepareDisplayOnWebThread.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLPrepareDisplayOnWebThread.mm
@@ -79,7 +79,7 @@ TEST(WebKitLegacy, WebGLPrepareDisplayOnWebThread)
     RetainPtr<WebGLPrepareDisplayOnWebThreadDelegate> uiDelegate = adoptNS([[WebGLPrepareDisplayOnWebThreadDelegate alloc] init]);
     uiWebView.get().delegate = uiDelegate.get();
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"webgl" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"webgl" withExtension:@"html"];
     NSLog(@"Loading %@", url);
     [uiWebView loadRequest:[NSURLRequest requestWithURL:url]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/AccessingPastedImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/AccessingPastedImage.mm
@@ -87,11 +87,11 @@ TEST(WebKitLegacy, AccessingImageInPastedRTFD)
     [webView.get() setUIDelegate:delegate.get()];
 
     auto *mainFrame = webView.get().mainFrame;
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"paste-rtfd" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"paste-rtfd" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     [webView.get() setEditable:YES];
 
-    auto *pngData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"sunset-in-cupertino-200px" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+    auto *pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
     auto attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:(__bridge NSString *)kUTTypePNG]);
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
@@ -124,12 +124,12 @@ TEST(WebKitLegacy, AccessingImageInPastedWebArchive)
     [destinationWebView.get() setFrameLoadDelegate:delegate.get()];
     [destinationWebView.get() setUIDelegate:delegate.get()];
 
-    [[sourceWebView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"image-and-contenteditable" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[sourceWebView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"image-and-contenteditable" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     [sourceWebView.get() setEditable:YES];
 
     didFinishLoad = false;
-    [[destinationWebView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"paste-rtfd" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[destinationWebView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"paste-rtfd" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     [destinationWebView.get() setEditable:YES];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DownloadThread.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DownloadThread.mm
@@ -83,7 +83,7 @@ TEST(WebKitLegacy, DownloadThread)
     [webView setPolicyDelegate:delegate.get()];
     [webView setDownloadDelegate:delegate.get()];
 
-    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     Util::run(&done);
 
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:destination.get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKitObjC/WKBrowsingContextLoadDelegateTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitObjC/WKBrowsingContextLoadDelegateTest.mm
@@ -100,7 +100,7 @@ TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoad)
     view.get().navigationDelegate = loadDelegate.get();
 
     // Load the file.
-    NSURL *nsURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *nsURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [view.get() loadFileURL:nsURL allowingReadAccessToURL:nsURL];
 
     // Wait for the load to finish.

--- a/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
@@ -81,7 +81,7 @@ TEST(ApplicationStateTracking, NavigatingFromPDFDoesNotLeaveWebViewInactive)
     [webView waitForNextPresentationUpdate];
 
     RetainPtr fakeURL = [NSURL URLWithString:@"https://bar.com"];
-    RetainPtr pdfData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr pdfData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     auto response = adoptNS([[NSURLResponse alloc] initWithURL:fakeURL.get() MIMEType:@"application/pdf" expectedContentLength:[pdfData length] textEncodingName:nil]);
     [webView loadSimulatedRequest:[NSURLRequest requestWithURL:fakeURL.get()] response:response.get() responseData:pdfData.get()];
     [delegate waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -76,12 +76,12 @@ static NSString *InjectedBundlePasteboardDataType = @"org.webkit.data";
 
 static UIImage *testIconImage()
 {
-    return [UIImage imageNamed:@"TestWebKitAPI.resources/icon.png"];
+    return [UIImage imageNamed:@"TestWebKitAPIResources.bundle/icon.png"];
 }
 
 static NSData *testZIPArchive()
 {
-    NSURL *zipFileURL = [[NSBundle mainBundle] URLForResource:@"compressed-files" withExtension:@"zip" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *zipFileURL = [NSBundle.test_resourcesBundle URLForResource:@"compressed-files" withExtension:@"zip"];
     return [NSData dataWithContentsOfURL:zipFileURL];
 }
 
@@ -204,7 +204,7 @@ static void checkJSONWithLogging(NSString *jsonString, NSDictionary *expected)
 
 static NSData *testIconImageData()
 {
-    return [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    return [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
 }
 
 static void runTestWithTemporaryTextFile(void(^runTest)(NSURL *fileURL))
@@ -1707,7 +1707,7 @@ TEST(DragAndDropTests, DragLiftPreviewDataTransferSetDragImage)
 
 static NSData *testIconImageData()
 {
-    return [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"icon" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"]];
+    return [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"icon" ofType:@"png"]];
 }
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageAndMarkup)
@@ -1804,7 +1804,7 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageWithFileURL)
     auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
-    NSURL *iconURL = [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *iconURL = [NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"];
     [itemProvider registerFileRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypePNG fileOptions:0 visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[protectedIconURL = retainPtr(iconURL)] (FileLoadCompletionBlock completionHandler) -> NSProgress * {
         completionHandler(protectedIconURL.get(), NO, nil);
         return nil;
@@ -2217,7 +2217,7 @@ TEST(DragAndDropTests, CanStartDragOnModel)
     // FIXME: Remove this after <rdar://problem/83863149> is fixed.
     // It should not be necessary to use WKURLSchemeHandler here, but CFNetwork does not correctly identify USDZ files.
     auto handler = adoptNS([TestURLSchemeHandler new]);
-    RetainPtr<NSData> modelData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"cube" withExtension:@"usdz" subdirectory:@"TestWebKitAPI.resources"]];
+    RetainPtr<NSData> modelData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"cube" withExtension:@"usdz"]];
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSURLResponse *response = [[[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"model/vnd.usdz+zip" expectedContentLength:[modelData length] textEncodingName:nil] autorelease];
         [task didReceiveResponse:response];

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -80,7 +80,7 @@ enum class CaretVisibility : bool { Hidden, Visible };
 
 + (UIImage *)barButtonIcon
 {
-    return [UIImage imageNamed:@"TestWebKitAPI.resources/icon.png"];
+    return [UIImage imageNamed:@"TestWebKitAPIResources.bundle/icon.png"];
 }
 
 + (UIBarButtonItemGroup *)leadingItemsForWebView:(WKWebView *)webView
@@ -847,7 +847,7 @@ TEST(KeyboardInputTests, InsertTextSimulatingKeyboardInput)
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&](WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"insert-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"insert-text" withExtension:@"html"];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.body.focus()"];
     [[webView textInputContentView] insertText:@"hello"];
@@ -863,7 +863,7 @@ TEST(KeyboardInputTests, InsertDictationAlternativesSimulatingKeyboardInput)
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&](WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"insert-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"insert-text" withExtension:@"html"];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.body.focus()"];
     [[webView textInputContentView] insertText:@"hello" alternatives:@[ @"helo" ] style:UITextAlternativeStyleNone];

--- a/Tools/TestWebKitAPI/Tests/ios/OverflowScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/OverflowScrollViewTests.mm
@@ -49,7 +49,7 @@ TEST(OverflowScrollViewTests, ContentChangeMaintainsScrollbars)
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"overflow-scroll" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"overflow-scroll" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView _test_waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];
@@ -80,7 +80,7 @@ TEST(OverflowScrollViewTests, CompositingChangeMaintainsCustomView)
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"composited" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"composited" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView _test_waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
@@ -196,7 +196,7 @@ TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrashWithAsyncPolicyD
     [webView scrollView].contentInset = UIEdgeInsetsMake(400, 0, 0, 0);
     [webView setNavigationDelegate:delegate.get()];
     delegate->_navigationComplete = false;
-    NSURL *testResourceURL = [[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
+    NSURL *testResourceURL = NSBundle.test_resourcesBundle.resourceURL;
     [webView loadHTMLString:veryTallDocumentMarkup baseURL:testResourceURL];
     Util::run(&delegate->_navigationComplete);
 
@@ -228,7 +228,7 @@ TEST(ScrollViewInsetTests, RestoreContentOffsetAfterBackWithInsetChange)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(100, 0, 0, 0);
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"scrollable-page" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"scrollable-page" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView _test_waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];
@@ -240,7 +240,7 @@ TEST(ScrollViewInsetTests, RestoreContentOffsetAfterBackWithInsetChange)
     EXPECT_EQ(0, contentOffsetAfterScrolling.x);
     EXPECT_EQ(1000, contentOffsetAfterScrolling.y);
 
-    RetainPtr<NSURL> secondPageURL = [[NSBundle mainBundle] URLForResource:@"composited" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> secondPageURL = [NSBundle.test_resourcesBundle URLForResource:@"composited" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:secondPageURL.get()]];
     [webView _test_waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm
@@ -151,7 +151,7 @@ TEST(ScrollViewScrollabilityTests, ScrollableAfterNavigateToPDF)
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ([[webView scrollView] isScrollEnabled], NO);
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];
 
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/ios/SetTimeoutFunction.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/SetTimeoutFunction.mm
@@ -83,7 +83,7 @@ TEST(WebKitLegacy, SetTimeoutFunction)
     RetainPtr<SetTimeoutFunctionWebViewDelegate> uiDelegate = adoptNS([[SetTimeoutFunctionWebViewDelegate alloc] init]);
     uiWebView.get().delegate = uiDelegate.get();
 
-    RetainPtr<NSURL> url = [[NSBundle mainBundle] URLForResource:@"set-timeout-function" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> url = [NSBundle.test_resourcesBundle URLForResource:@"set-timeout-function" withExtension:@"html"];
     [uiWebView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     Util::run(&loadComplete);
     EXPECT_TRUE(loadComplete);

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -137,7 +137,7 @@ TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)
         [hostWindow setHidden:NO];
         [hostWindow addSubview:globalWebView];
 
-        [globalWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.mainBundle URLForResource:@"active-touch-events" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [globalWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"active-touch-events" withExtension:@"html"]]];
         [globalWebView _test_waitForDidFinishNavigation];
 
         updateSimulatedTouchEvent(CGPointMake(100, 100), UITouchPhaseBegan);

--- a/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
@@ -264,7 +264,7 @@ TEST(UIPasteboardTests, DataTransferGetDataWhenPastingImageAndText)
     auto copiedText = retainPtr(@"Apple Inc.");
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypePNG visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
-        completionHandler([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]], nil);
+        completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
         return nil;
     }];
     [itemProvider registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypeUTF8PlainText visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[copiedText] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
@@ -377,7 +377,7 @@ TEST(UIPasteboardTests, ValidPreferredPresentationSizeForImage)
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider setPreferredPresentationSize:CGSizeMake(10, 20)];
     [itemProvider registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypePNG visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
-        completionHandler([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]], nil);
+        completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
         return nil;
     }];
     [UIPasteboard generalPasteboard].itemProviders = @[ itemProvider.get() ];
@@ -393,7 +393,7 @@ TEST(UIPasteboardTests, InvalidPreferredPresentationSizeForImage)
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider setPreferredPresentationSize:CGSizeMake(-10, -20)];
     [itemProvider registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypePNG visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
-        completionHandler([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]], nil);
+        completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
         return nil;
     }];
     [UIPasteboard generalPasteboard].itemProviders = @[ itemProvider.get() ];
@@ -408,7 +408,7 @@ TEST(UIPasteboardTests, MissingPreferredPresentationSizeForImage)
     auto webView = setUpWebViewForPasteboardTests(@"autofocus-contenteditable");
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypePNG visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
-        completionHandler([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]], nil);
+        completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
         return nil;
     }];
     [UIPasteboard generalPasteboard].itemProviders = @[ itemProvider.get() ];

--- a/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
@@ -41,7 +41,7 @@ public:
     template <typename View> void runTest(View);
 
     // WebKitAgnosticTest
-    virtual NSURL *url() const { return [[NSBundle mainBundle] URLForResource:@"acceptsFirstMouse" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    virtual NSURL *url() const { return [NSBundle.test_resourcesBundle URLForResource:@"acceptsFirstMouse" withExtension:@"html"]; }
     virtual void didLoadURL(WebView *webView) { runTest(webView); }
     virtual void didLoadURL(WKWebView *wkView) { runTest(wkView); }
 };

--- a/Tools/TestWebKitAPI/Tests/mac/AdditionalSupportedImageTypes.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AdditionalSupportedImageTypes.mm
@@ -60,7 +60,7 @@ static void runTest(NSArray *additionalSupportedImageTypes, Boolean expectedToLo
     RetainPtr<AdditionalSupportedImageTypesTest> testController = adoptNS([AdditionalSupportedImageTypesTest new]);
     webView.get().frameLoadDelegate = testController.get();
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"AdditionalSupportedImageTypes" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"AdditionalSupportedImageTypes" withExtension:@"html"];
     [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
 
     Util::run(&didFinishLoad);

--- a/Tools/TestWebKitAPI/Tests/mac/AttributedString.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AttributedString.mm
@@ -47,7 +47,7 @@ public:
     // FIXME: Reimplement the test using async NSTextInputClient interface.
     virtual void didLoadURL(WKWebView *wkView) { }
 
-    virtual NSURL *url() const { return [[NSBundle mainBundle] URLForResource:@"attributedStringCustomFont" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    virtual NSURL *url() const { return [NSBundle.test_resourcesBundle URLForResource:@"attributedStringCustomFont" withExtension:@"html"]; }
 };
 
 template <typename View>
@@ -71,7 +71,7 @@ public:
     // FIXME: Reimplement the test using async NSTextInputClient interface.
     virtual void didLoadURL(WKWebView *wkView) { }
 
-    virtual NSURL *url() const { return [[NSBundle mainBundle] URLForResource:@"attributedStringStrikethrough" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    virtual NSURL *url() const { return [NSBundle.test_resourcesBundle URLForResource:@"attributedStringStrikethrough" withExtension:@"html"]; }
 };
 
 template <typename View>
@@ -99,7 +99,7 @@ public:
     virtual void didLoadURL(WebView *webView) { runSyncTest(webView); }
     virtual void didLoadURL(WKWebView *wkView) { }
 
-    virtual NSURL *url() const { return [[NSBundle mainBundle] URLForResource:@"attributedStringNewlineAtEndOfDocument" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    virtual NSURL *url() const { return [NSBundle.test_resourcesBundle URLForResource:@"attributedStringNewlineAtEndOfDocument" withExtension:@"html"]; }
 };
 
 template <typename View>

--- a/Tools/TestWebKitAPI/Tests/mac/CancelLoadFromResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CancelLoadFromResourceLoadDelegate.mm
@@ -70,7 +70,7 @@ TEST(WebKitLegacy, CancelLoadFromResourceLoadDelegate)
         RetainPtr<CancelLoadFromResourceLoadDelegateFrameLoadDelegate> frameLoadDelegate = adoptNS([[CancelLoadFromResourceLoadDelegateFrameLoadDelegate alloc] init]);
         webView.get().frameLoadDelegate = frameLoadDelegate.get();
 
-        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"CancelLoadFromResourceLoadDelegate" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"CancelLoadFromResourceLoadDelegate" withExtension:@"html"]]];
 
         Util::run(&didFinishLoad);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/CandidateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CandidateTests.mm
@@ -93,7 +93,7 @@ TEST(CandidateTests, DISABLED_DoNotLeakViewThatLoadsEditableArea)
     auto delegate = adoptNS([[DoNotLeakFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     
-    NSURL *contentURL = [[NSBundle mainBundle] URLForResource:@"autofocused-text-input" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"autofocused-text-input" withExtension:@"html"];
     [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:contentURL]];
     
     TestWebKitAPI::Util::run(&didFinishLoad);
@@ -110,7 +110,7 @@ TEST(CandidateTests, DISABLED_RequestCandidatesForTextInput)
     auto delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     
-    NSURL *contentURL = [[NSBundle mainBundle] URLForResource:@"focus-inputs" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"focus-inputs" withExtension:@"html"];
     [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:contentURL]];
     
     TestWebKitAPI::Util::run(&didFinishLoad);
@@ -131,7 +131,7 @@ TEST(CandidateTests, DoNotRequestCandidatesForPasswordInput)
     auto delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     
-    NSURL *contentURL = [[NSBundle mainBundle] URLForResource:@"focus-inputs" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"focus-inputs" withExtension:@"html"];
     [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:contentURL]];
     
     TestWebKitAPI::Util::run(&didFinishLoad);

--- a/Tools/TestWebKitAPI/Tests/mac/CloseNewWindowInNavigationPolicyDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CloseNewWindowInNavigationPolicyDelegate.mm
@@ -73,7 +73,7 @@ TEST(WebKitLegacy, CloseNewWindowInNavigationPolicyDelegate)
         RetainPtr<WebView> webView = adoptNS([[WebView alloc] init]);
         webView.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
         webView.get().UIDelegate = [TestDelegate shared];
-        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"OpenNewWindow" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"OpenNewWindow" withExtension:@"html"]]];
 
         Util::run(&testFinished);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/CloseWhileCommittingLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CloseWhileCommittingLoad.mm
@@ -54,7 +54,7 @@ TEST(WebKitLegacy, CloseWhileCommittingLoad)
     [webView setFrameLoadDelegate:delegate.get()];
 
     didCloseWhileCommittingLoad = false;
-    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
 
     Util::run(&didCloseWhileCommittingLoad);
 }

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuCanCopyURL.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuCanCopyURL.mm
@@ -94,7 +94,7 @@ TEST(WebKitLegacy, ContextMenuCanCopyURL)
     [window.get().contentView addSubview:webView.get()];
     webView.get().frameLoadDelegate = delegate.get();
 
-    [webView.get().mainFrame loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"ContextMenuCanCopyURL" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView.get().mainFrame loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"ContextMenuCanCopyURL" withExtension:@"html"]]];
     
     Util::run(&didFinishLoad);
 

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -210,7 +210,7 @@ TEST(ContextMenuTests, NavigationTypeWhenOpeningLink)
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    [webView loadHTMLString:@"<a href='simple.html' style='font-size: 100px;'>Hello world</a>" baseURL:[NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"]];
+    [webView loadHTMLString:@"<a href='simple.html' style='font-size: 100px;'>Hello world</a>" baseURL:NSBundle.test_resourcesBundle.resourceURL];
     [navigationDelegate waitForDidFinishNavigation];
 
     __block bool didDecideNavigationPolicy = false;

--- a/Tools/TestWebKitAPI/Tests/mac/CrossPartitionFileSchemeAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CrossPartitionFileSchemeAccess.mm
@@ -89,7 +89,7 @@ namespace TestWebKitAPI {
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101600
 TEST(WebKitLegacy, CrossPartitionFileSchemeAccess)
 {
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"CrossPartitionFileSchemeAccess" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"CrossPartitionFileSchemeAccess" withExtension:@"html"];
     const char *filePath = [url fileSystemRepresentation];
     WTFLogAlways("Cleaning up from previous run...");
     cleanUp();

--- a/Tools/TestWebKitAPI/Tests/mac/DOMHTMLTableCellCellAbove.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DOMHTMLTableCellCellAbove.mm
@@ -60,8 +60,8 @@ TEST(WebKitLegacy, HTMLTableCellElementCellAbove)
     RetainPtr<HTMLTableCellElementCellAboveTest> testController = adoptNS([HTMLTableCellElementCellAboveTest new]);
 
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle]
-        URLForResource:@"DOMHTMLTableCellElementCellAbove" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle
+        URLForResource:@"DOMHTMLTableCellElementCellAbove" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
     didFinishLoad = false;

--- a/Tools/TestWebKitAPI/Tests/mac/DOMRangeOfString.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DOMRangeOfString.mm
@@ -52,7 +52,7 @@ TEST(WebKitLegacy, DOMRangeOfString)
     RetainPtr<DOMRangeOfStringFrameLoadDelegate> frameLoadDelegate = adoptNS([DOMRangeOfStringFrameLoadDelegate new]);
 
     webView.get().frameLoadDelegate = frameLoadDelegate.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"DOMRangeOfString" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"DOMRangeOfString" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
 

--- a/Tools/TestWebKitAPI/Tests/mac/DeviceScaleFactorOnBack.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DeviceScaleFactorOnBack.mm
@@ -41,7 +41,7 @@ public:
     template <typename View> void runTest(View);
 
     // WebKitAgnosticTest
-    virtual NSURL *url() const { return [[NSBundle mainBundle] URLForResource:@"devicePixelRatio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    virtual NSURL *url() const { return [NSBundle.test_resourcesBundle URLForResource:@"devicePixelRatio" withExtension:@"html"]; }
     virtual void didLoadURL(WebView *webView) { runTest(webView); }
     virtual void didLoadURL(WKWebView *wkView) { runTest(wkView); }
     virtual void initializeView(WebView *);

--- a/Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
@@ -107,7 +107,7 @@ TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"image-and-file-upload"];
 
-    NSURL *imageURL = [NSBundle.mainBundle URLForResource:@"apple" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *imageURL = [NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"];
     [simulator writePromisedFiles:@[ imageURL ]];
     [simulator runFrom:NSMakePoint(100, 100) to:NSMakePoint(100, 300)];
 
@@ -153,7 +153,7 @@ TEST(DragAndDropTests, DragImageFileIntoFileUpload)
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"image-and-file-upload"];
 
-    NSURL *imageURL = [NSBundle.mainBundle URLForResource:@"apple" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *imageURL = [NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"];
     [simulator writeFiles:@[ imageURL ]];
     [simulator runFrom:NSMakePoint(100, 100) to:NSMakePoint(100, 300)];
 

--- a/Tools/TestWebKitAPI/Tests/mac/DynamicDeviceScaleFactor.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DynamicDeviceScaleFactor.mm
@@ -40,7 +40,7 @@ public:
     template <typename View> void runTest(View);
 
     // WebKitAgnosticTest
-    virtual NSURL *url() const { return [[NSBundle mainBundle] URLForResource:@"devicePixelRatio" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    virtual NSURL *url() const { return [NSBundle.test_resourcesBundle URLForResource:@"devicePixelRatio" withExtension:@"html"]; }
     virtual void didLoadURL(WebView *webView) { runTest(webView); }
     virtual void didLoadURL(WKWebView *wkView) { runTest(wkView); }
 };

--- a/Tools/TestWebKitAPI/Tests/mac/FragmentNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FragmentNavigation.mm
@@ -118,7 +118,7 @@ TEST(WebKitLegacy, FragmentNavigation)
         [webView setPolicyDelegate:[WebKit1FragmentNavigationTestDelegate shared]];
         [webView setFrameLoadDelegate:[WebKit1FragmentNavigationTestDelegate shared]];
         [webView setUIDelegate:[WebKit1FragmentNavigationTestDelegate shared]];
-        [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"FragmentNavigation" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"FragmentNavigation" withExtension:@"html"]]];
 
         Util::run(&testFinished);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
@@ -73,7 +73,7 @@ public:
     template <typename View> void runTest(View);
 
     // WebKitAgnosticTest
-    NSURL *url() const override { return [[NSBundle mainBundle] URLForResource:@"FullscreenZoomInitialFrame" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    NSURL *url() const override { return [NSBundle.test_resourcesBundle URLForResource:@"FullscreenZoomInitialFrame" withExtension:@"html"]; }
     void didLoadURL(WebView *webView) override { runTest(webView); }
     void didLoadURL(WKWebView *wkView) override { runTest(wkView); }
 

--- a/Tools/TestWebKitAPI/Tests/mac/HTMLCollectionNamedItem.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/HTMLCollectionNamedItem.mm
@@ -54,8 +54,8 @@ TEST(WebKitLegacy, HTMLCollectionNamedItemTest)
     RetainPtr<HTMLCollectionNamedItemTest> testController = adoptNS([HTMLCollectionNamedItemTest new]);
 
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle]
-        URLForResource:@"HTMLCollectionNamedItem" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle
+        URLForResource:@"HTMLCollectionNamedItem" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
     didFinishLoad = false;

--- a/Tools/TestWebKitAPI/Tests/mac/HTMLFormCollectionNamedItem.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/HTMLFormCollectionNamedItem.mm
@@ -54,8 +54,8 @@ TEST(WebKitLegacy, HTMLFormCollectionNamedItemTest)
     RetainPtr<HTMLFormCollectionNamedItemTest> testController = adoptNS([HTMLFormCollectionNamedItemTest new]);
 
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle]
-        URLForResource:@"HTMLFormCollectionNamedItem" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle
+        URLForResource:@"HTMLFormCollectionNamedItem" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
     didFinishLoad = false;

--- a/Tools/TestWebKitAPI/Tests/mac/IsNavigationActionTrusted.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/IsNavigationActionTrusted.mm
@@ -83,7 +83,7 @@ TEST(WebKit, IsNavigationActionTrusted)
         RetainPtr<NavigationActionDelegate> delegate = adoptNS([[NavigationActionDelegate alloc] init]);
         [webView setNavigationDelegate:delegate.get()];
 
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IsNavigationActionTrusted" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IsNavigationActionTrusted" withExtension:@"html"]];
         [webView loadRequest:request];
 
         didFinishTest = false;
@@ -98,7 +98,7 @@ TEST(WebKitLegacy, IsNavigationActionTrusted)
 
         RetainPtr<WebPolicyActionDelegate> delegate = adoptNS([[WebPolicyActionDelegate alloc] init]);
         [webView setPolicyDelegate:delegate.get()];
-        [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IsNavigationActionTrusted" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IsNavigationActionTrusted" withExtension:@"html"]]];
 
         didFinishTest = false;
         Util::run(&didFinishTest);

--- a/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
@@ -218,7 +218,7 @@ namespace TestWebKitAPI {
 
 static NSImage *getTestImage()
 {
-    return adoptNS([[NSImage alloc] initWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]]).autorelease();
+    return adoptNS([[NSImage alloc] initWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]]).autorelease();
 }
 
 static WebView *webViewAfterPerformingDragOperation(NSPasteboard *pasteboard)
@@ -239,7 +239,7 @@ static WebView *webViewAfterPerformingDragOperation(NSPasteboard *pasteboard)
         EXPECT_TRUE([destination performDragOperation:info.get()]);
         isDone = true;
     }]];
-    [[destination mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"full-page-contenteditable" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[destination mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"full-page-contenteditable" withExtension:@"html"]]];
 
     TestWebKitAPI::Util::run(&isDone);
     return destination.get();

--- a/Tools/TestWebKitAPI/Tests/mac/LimitTitleSize.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LimitTitleSize.mm
@@ -62,8 +62,8 @@ TEST(WebKitLegacy, LimitTitleSize)
     RetainPtr<LimitTitleSizeTest> testController = adoptNS([LimitTitleSizeTest new]);
 
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle]
-        URLForResource:@"set-long-title" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle
+        URLForResource:@"set-long-title" withExtension:@"html"]]];
 
     TestWebKitAPI::Util::run(&didFinishLoad);
 }
@@ -86,7 +86,7 @@ TEST(WebKitLegacy, LimitTitleSize)
 TEST(WebKit, LimitTitleSize)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
-    [webView loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"set-long-title" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"set-long-title" withExtension:@"html"]]];
     
     auto observer = adoptNS([LimitTitleSizeTestObserver new]);
     [webView addObserver:observer.get() forKeyPath:@"title" options:NSKeyValueObservingOptionNew context:nil];

--- a/Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm
@@ -70,7 +70,7 @@ TEST(WebKitLegacy, LoadInvalidURLRequest)
         RetainPtr<LoadInvalidURLWebFrameLoadDelegate> delegate = adoptNS([[LoadInvalidURLWebFrameLoadDelegate alloc] init]);
         [webView setFrameLoadDelegate:delegate.get()];
 
-        NSURL *contentURL = [[NSBundle mainBundle] URLForResource:@"LoadInvalidURLRequest" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"LoadInvalidURLRequest" withExtension:@"html"];
         [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:contentURL]];
 
         didFinishTest = false;

--- a/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
@@ -83,7 +83,7 @@ namespace TestWebKitAPI {
 TEST(LoadWebArchive, FailNavigation1)
 {
     // Using `document.location.href = 'helloworld.webarchive';`.
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"load-web-archive-1" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"load-web-archive-1" withExtension:@"html"];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
@@ -106,7 +106,7 @@ TEST(LoadWebArchive, FailNavigation1)
 TEST(LoadWebArchive, FailNavigation2)
 {
     // Using `window.open('helloworld.webarchive');`.
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"load-web-archive-2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"load-web-archive-2" withExtension:@"html"];
 
     auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     gDelegate = delegate.get();
@@ -131,7 +131,7 @@ TEST(LoadWebArchive, FailNavigation2)
 
 TEST(LoadWebArchive, ClientNavigationSucceed)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"helloworld" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
     auto webView = adoptNS([[WKWebView alloc] init]);
     auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
@@ -146,7 +146,7 @@ TEST(LoadWebArchive, ClientNavigationSucceed)
 
 TEST(LoadWebArchive, ClientNavigationReload)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"helloworld" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
@@ -173,7 +173,7 @@ TEST(LoadWebArchive, ClientNavigationReload)
 
 TEST(LoadWebArchive, ClientNavigationWithStorageReload)
 {
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"helloworld" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
@@ -222,8 +222,8 @@ TEST(LoadWebArchive, ClientNavigationWithStorageReload)
 
 TEST(LoadWebArchive, DragNavigationSucceed)
 {
-    RetainPtr<NSURL> webArchiveURL = [[NSBundle mainBundle] URLForResource:@"helloworld" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> simpleURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> webArchiveURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
+    RetainPtr<NSURL> simpleURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     [pasteboard clearContents];
@@ -258,8 +258,8 @@ TEST(LoadWebArchive, DragNavigationSucceed)
 
 TEST(LoadWebArchive, DragNavigationReload)
 {
-    RetainPtr<NSURL> webArchiveURL = [[NSBundle mainBundle] URLForResource:@"helloworld" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
-    RetainPtr<NSURL> simpleURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> webArchiveURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
+    RetainPtr<NSURL> simpleURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     [pasteboard clearContents];
@@ -387,7 +387,7 @@ TEST(LoadWebArchive, SiteToWebArchiveAndBack)
 
     navigationComplete = false;
 
-    RetainPtr<NSURL> webArchiveURL = [[NSBundle mainBundle] URLForResource:@"download.example" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> webArchiveURL = [NSBundle.test_resourcesBundle URLForResource:@"download.example" withExtension:@"webarchive"];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://download.example/page1.html"]]];
     Util::run(&navigationComplete);
     EXPECT_WK_STREQ([webView URL].absoluteString, @"http://download.example/page1.html");
@@ -480,7 +480,7 @@ TEST(LoadWebArchive, WebArchiveToSiteAndBack)
 
     navigationComplete = false;
 
-    RetainPtr<NSURL> webArchiveURL = [[NSBundle mainBundle] URLForResource:@"download.example" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> webArchiveURL = [NSBundle.test_resourcesBundle URLForResource:@"download.example" withExtension:@"webarchive"];
     [webView loadFileURL:webArchiveURL.get() allowingReadAccessToURL:webArchiveURL.get()];
     Util::run(&navigationComplete);
     EXPECT_WK_STREQ(finalURL, @"download.example.webarchive");
@@ -577,7 +577,7 @@ TEST(LoadWebArchive, FileWebArchiveToDataWebArchiveAndBack)
 
     navigationComplete = false;
 
-    RetainPtr<NSURL> webArchiveURL = [[NSBundle mainBundle] URLForResource:@"download.example" withExtension:@"webarchive" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr<NSURL> webArchiveURL = [NSBundle.test_resourcesBundle URLForResource:@"download.example" withExtension:@"webarchive"];
     [webView loadFileURL:webArchiveURL.get() allowingReadAccessToURL:webArchiveURL.get()];
     Util::run(&navigationComplete);
     EXPECT_WK_STREQ(finalURL, @"download.example.webarchive");

--- a/Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.mm
@@ -164,7 +164,7 @@ TEST(WebKitLegacy, MediaPlaybackSleepAssertion)
         webView.get().frameLoadDelegate = frameLoadDelegate.get();
         WebFrame *mainFrame = webView.get().mainFrame;
 
-        NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"MediaPlaybackSleepAssertion" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"MediaPlaybackSleepAssertion" withExtension:@"html"]];
         [mainFrame loadRequest:request];
 
         Util::run(&didFinishLoad);

--- a/Tools/TestWebKitAPI/Tests/mac/MemoryCacheDisableWithinResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MemoryCacheDisableWithinResourceLoadDelegate.mm
@@ -78,7 +78,7 @@ TEST(WebKitLegacy, MemoryCacheDisableWithinResourceLoadDelegate)
         RetainPtr<MemoryCacheDisableTestResourceLoadDelegate> resourceLoadDelegate = adoptNS([[MemoryCacheDisableTestResourceLoadDelegate alloc] init]);
         webView.get().resourceLoadDelegate = resourceLoadDelegate.get();
 
-        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"MemoryCacheDisableWithinResourceLoadDelegate" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"MemoryCacheDisableWithinResourceLoadDelegate" withExtension:@"html"]]];
 
         Util::run(&didFinishLoad);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/MemoryCachePruneWithinResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MemoryCachePruneWithinResourceLoadDelegate.mm
@@ -88,7 +88,7 @@ TEST(WebKitLegacy, DISABLED_MemoryCachePruneWithinResourceLoadDelegate)
         resourceLoadDelegate.get()->_window = window.get();
         webView1.get().resourceLoadDelegate = resourceLoadDelegate.get();
 
-        [[webView1.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"MemoryCachePruneWithinResourceLoadDelegate" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView1.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"MemoryCachePruneWithinResourceLoadDelegate" withExtension:@"html"]]];
 
         Util::run(&didFinishLoad);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/NoPolicyDelegateResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/NoPolicyDelegateResponse.mm
@@ -80,7 +80,7 @@ TEST(WebKitLegacy, NoDecidePolicyForMIMETypeDecision)
 
     webView.get().frameLoadDelegate = delegate.get();
     webView.get().policyDelegate = delegate.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"verboseMarkup" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"verboseMarkup" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
 
@@ -94,7 +94,7 @@ TEST(WebKitLegacy, NoDecidePolicyForNavigationActionDecision)
 
     webView.get().frameLoadDelegate = delegate.get();
     webView.get().policyDelegate = delegate.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"verboseMarkup" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"verboseMarkup" withExtension:@"html"]]];
 
     Util::run(&didNavigationActionCheck);
 

--- a/Tools/TestWebKitAPI/Tests/mac/PageVisibilityStateWithWindowChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/PageVisibilityStateWithWindowChanges.mm
@@ -69,7 +69,7 @@ public:
     template <typename View> void runTest(View);
 
     // WebKitAgnosticTest
-    NSURL *url() const override { return [[NSBundle mainBundle] URLForResource:@"PageVisibilityStateWithWindowChanges" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]; }
+    NSURL *url() const override { return [NSBundle.test_resourcesBundle URLForResource:@"PageVisibilityStateWithWindowChanges" withExtension:@"html"]; }
     void didLoadURL(WebView *webView) override { runTest(webView); }
     void didLoadURL(WKWebView *wkView) override { runTest(wkView); }
 

--- a/Tools/TestWebKitAPI/Tests/mac/SetDocumentURI.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/SetDocumentURI.mm
@@ -52,7 +52,7 @@ TEST(WebKitLegacy, SetDocumentURITestFile)
     RetainPtr<WebView> webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
     RetainPtr<SetDocumentURITest> testController = adoptNS([SetDocumentURITest new]);
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"SetDocumentURI" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"SetDocumentURI" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     didFinishLoad = false;
     DOMDocument *document = webView.get().mainFrameDocument;
@@ -69,7 +69,7 @@ TEST(WebKitLegacy, SetDocumentURITestURL)
     RetainPtr<WebView> webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
     RetainPtr<SetDocumentURITest> testController = adoptNS([SetDocumentURITest new]);
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"SetDocumentURI" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"SetDocumentURI" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     didFinishLoad = false;
     DOMDocument *document = webView.get().mainFrameDocument;
@@ -89,7 +89,7 @@ TEST(WebKitLegacy, SetDocumentURITestString)
     RetainPtr<WebView> webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
     RetainPtr<SetDocumentURITest> testController = adoptNS([SetDocumentURITest new]);
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"SetDocumentURI" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"SetDocumentURI" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     didFinishLoad = false;
     DOMDocument *document = webView.get().mainFrameDocument;
@@ -105,7 +105,7 @@ TEST(WebKitLegacy, SetDocumentURITestNull)
     RetainPtr<WebView> webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
     RetainPtr<SetDocumentURITest> testController = adoptNS([SetDocumentURITest new]);
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"SetDocumentURI" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"SetDocumentURI" withExtension:@"html"]]];
     Util::run(&didFinishLoad);
     didFinishLoad = false;
     DOMDocument *document = webView.get().mainFrameDocument;

--- a/Tools/TestWebKitAPI/Tests/mac/SimplifyMarkup.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/SimplifyMarkup.mm
@@ -54,13 +54,13 @@ TEST(WebKitLegacy, SimplifyMarkupTest)
     RetainPtr<SimplifyMarkupTest> testController = adoptNS([SimplifyMarkupTest new]);
     
     webView1.get().frameLoadDelegate = testController.get();
-    [[webView1.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"verboseMarkup" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView1.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"verboseMarkup" withExtension:@"html"]]];
     
     Util::run(&didFinishLoad);
     didFinishLoad = false;
 
     webView2.get().frameLoadDelegate = testController.get();
-    [[webView2.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"verboseMarkup" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView2.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"verboseMarkup" withExtension:@"html"]]];
     
     Util::run(&didFinishLoad);
     didFinishLoad = false;

--- a/Tools/TestWebKitAPI/Tests/mac/StartLoadInDidFailProvisionalLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/StartLoadInDidFailProvisionalLoad.mm
@@ -41,7 +41,7 @@ static WebView *testView = nullptr;
     EXPECT_FALSE(didFailProvisionalLoad);
     didFailProvisionalLoad = true;
 
-    [[testView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple3" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[testView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"]]];
 }
 
 - (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
@@ -59,14 +59,14 @@ TEST(WebKitLegacy, StartLoadInDidFailProvisionalLoad)
     testView = webView.get();
     auto frameLoadDelegate = adoptNS([[StartLoadInDidFailProvisionalLoadDelegate alloc] init]);
     webView.get().frameLoadDelegate = frameLoadDelegate.get();
-    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
 
     // Start another load before the first one has a chance to complete. This should cancel the previous load and call didFailProvisionalLoadWithError.
-    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
     Util::run(&finished);
     EXPECT_TRUE(didFailProvisionalLoad);
 
-    EXPECT_WK_STREQ([[[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"] absoluteString], webView.get().mainFrameURL);
+    EXPECT_WK_STREQ([[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"] absoluteString], webView.get().mainFrameURL);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/mac/StopLoadingFromDidReceiveResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/StopLoadingFromDidReceiveResponse.mm
@@ -61,7 +61,7 @@ TEST(WebKitLegacy, StopLoadingFromDidReceiveResponse)
         RetainPtr<StopLoadingFromDidReceiveResponse> resourceLoadDelegate = adoptNS([[StopLoadingFromDidReceiveResponse alloc] init]);
         webView.get().resourceLoadDelegate = resourceLoadDelegate.get();
 
-        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"StopLoadingFromDidReceiveResponse" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"StopLoadingFromDidReceiveResponse" withExtension:@"html"]]];
 
         Util::run(&didFinishLoad);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/WebScriptObjectDescription.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebScriptObjectDescription.mm
@@ -65,8 +65,8 @@ TEST(WebKitLegacy, WebScriptObjectDescription)
     auto object = adoptNS([[NSObject alloc] init]);
 
     webView.get().frameLoadDelegate = testController.get();
-    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle]
-        URLForResource:@"WebScriptObjectDescription" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle
+        URLForResource:@"WebScriptObjectDescription" withExtension:@"html"]]];
 
     Util::run(&didFinishLoad);
     didFinishLoad = false;

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewCanPasteZeroPng.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewCanPasteZeroPng.mm
@@ -39,7 +39,7 @@ TEST(WebKitLegacy, WebViewCanPasteZeroPng)
     
     //pasting a 0x0 image as pdf board type. Referring to <rdar://problem/11141920>
     [[NSPasteboard generalPasteboard] declareTypes:@[NSPDFPboardType] owner:nil];
-    [[[NSBundle mainBundle] URLForResource:@"0" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"] writeToPasteboard:[NSPasteboard generalPasteboard]];
+    [[NSBundle.test_resourcesBundle URLForResource:@"0" withExtension:@"png"] writeToPasteboard:[NSPasteboard generalPasteboard]];
     [webView paste:nil];
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewDidCreateJavaScriptContext.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewDidCreateJavaScriptContext.mm
@@ -275,15 +275,11 @@ TEST(WebKitLegacy, DidCreateJavaScriptContextBackForwardCacheTest)
         webView.get().frameLoadDelegate = frameLoadDelegate.get();
         WebFrame *mainFrame = webView.get().mainFrame;
 
-        NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"JSContextBackForwardCache1" 
-                                              withExtension:@"html" 
-                                               subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"JSContextBackForwardCache1" withExtension:@"html"];
         [mainFrame loadRequest:[NSURLRequest requestWithURL:url1]];
         Util::run(&didInsertMyCustomProperty);
 
-        NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"JSContextBackForwardCache2" 
-                                              withExtension:@"html" 
-                                               subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"JSContextBackForwardCache2" withExtension:@"html"];
         [mainFrame loadRequest:[NSURLRequest requestWithURL:url2]];
         Util::run(&didCompleteTestSuccessfully);
 

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
@@ -49,13 +49,13 @@ static NSData *mainResourceData()
 
 static NSData *defaultFaviconData()
 {
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"];
     return [NSData dataWithContentsOfURL:url];
 }
 
 static NSData *customFaviconData()
 {
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"large-red-square" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square" withExtension:@"png"];
     return [NSData dataWithContentsOfURL:url];
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewScheduleInRunLoop.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewScheduleInRunLoop.mm
@@ -58,7 +58,7 @@ TEST(WebKitLegacy, ScheduleInRunLoop)
         [webView setFrameLoadDelegate:delegate.get()];
         [webView unscheduleFromRunLoop:[NSRunLoop currentRunLoop] forMode:(NSString *)kCFRunLoopCommonModes];
         [webView scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:@"TestRunLoopMode"];
-        [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
         webViews.append(WTFMove(webView));
     }
 

--- a/Tools/TestWebKitAPI/Tests/mac/WillPerformClientRedirectToURLCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WillPerformClientRedirectToURLCrash.mm
@@ -33,7 +33,7 @@ static bool testFinished;
 
 static NSURL *testURL()
 {
-    static RetainPtr<NSURL> url = [[NSBundle mainBundle] URLForResource:@"WillPerformClientRedirectToURLCrash" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    static RetainPtr<NSURL> url = [NSBundle.test_resourcesBundle URLForResource:@"WillPerformClientRedirectToURLCrash" withExtension:@"html"];
     return url.get();
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/WillSendSubmitEvent.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WillSendSubmitEvent.mm
@@ -65,7 +65,7 @@ TEST(WebKitLegacy, WillSendSubmitEvent)
         RetainPtr<FormDelegate> formDelegate = adoptNS([[FormDelegate alloc] init]);
         [webView _setFormDelegate:formDelegate.get()];
 
-        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"auto-submitting-form" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"auto-submitting-form" withExtension:@"html"]]];
 
         Util::run(&didFinishLoad);
     }

--- a/Tools/TestWebKitAPI/Tests/mac/WindowlessWebViewWithMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WindowlessWebViewWithMedia.mm
@@ -67,7 +67,7 @@ TEST(WebKitLegacy, WindowlessWebViewWithMedia)
         auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
         auto testController = adoptNS([WindowlessWebViewWithMediaFrameLoadDelegate new]);
         webView.get().frameLoadDelegate = testController.get();
-        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WindowlessWebViewWithMedia" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+        [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WindowlessWebViewWithMedia" withExtension:@"html"]]];
 
         EXPECT_EQ(nil, [webView.get() window]);
 

--- a/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "TestInspectorURLSchemeHandler.h"
 
+#import "PlatformUtilities.h"
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebKit/WKURLSchemeTask.h>
 #import <wtf/Assertions.h>
@@ -43,7 +44,7 @@
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
     if (!_cachedBundle)
-        _cachedBundle = [NSBundle mainBundle];
+        _cachedBundle = NSBundle.test_resourcesBundle;
 
     if (!_fileLoadOperations)
         _fileLoadOperations = adoptNS([[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory valueOptions:NSPointerFunctionsStrongMemory capacity:5]);
@@ -64,7 +65,7 @@
         });
 
         NSURL *requestURL = urlSchemeTask.request.URL;
-        NSURL *fileURLForRequest = [_cachedBundle URLForResource:requestURL.relativePath withExtension:@"" subdirectory:@"TestWebKitAPI.resources"];
+        NSURL *fileURLForRequest = [_cachedBundle URLForResource:requestURL.relativePath withExtension:@""];
         if (!fileURLForRequest) {
             [urlSchemeTask didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil]];
             return;

--- a/Tools/TestWebKitAPI/cocoa/TestProtocol.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestProtocol.mm
@@ -130,7 +130,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
         NSString *fileName = requestURL.lastPathComponent;
         NSString *fileExtension = fileName.pathExtension;
         contentType = contentTypeForFileExtension(fileExtension);
-        data = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:fileName.stringByDeletingPathExtension withExtension:fileExtension subdirectory:@"TestWebKitAPI.resources"]];
+        data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:fileName.stringByDeletingPathExtension withExtension:fileExtension]];
     } else {
         contentType = @"text/html";
         data = [@"PASS" dataUsingEncoding:NSASCIIStringEncoding];

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -78,7 +78,7 @@ static NSString *overrideBundleIdentifier(id, SEL)
 
 - (void)loadTestPageNamed:(NSString *)pageName
 {
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:pageName withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:pageName withExtension:@"html"]];
     [self loadRequest:request];
 }
 
@@ -120,12 +120,12 @@ static NSString *overrideBundleIdentifier(id, SEL)
 
 - (void)synchronouslyLoadHTMLString:(NSString *)html
 {
-    [self synchronouslyLoadHTMLString:html baseURL:[[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"TestWebKitAPI.resources"]];
+    [self synchronouslyLoadHTMLString:html baseURL:NSBundle.test_resourcesBundle.resourceURL];
 }
 
 - (void)synchronouslyLoadHTMLString:(NSString *)html preferences:(WKWebpagePreferences *)preferences
 {
-    [self loadHTMLString:html baseURL:[[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"TestWebKitAPI.resources"]];
+    [self loadHTMLString:html baseURL:NSBundle.test_resourcesBundle.resourceURL];
     [self _test_waitForDidFinishNavigationWithPreferences:preferences];
 }
 
@@ -137,7 +137,7 @@ static NSString *overrideBundleIdentifier(id, SEL)
 
 - (void)synchronouslyLoadTestPageNamed:(NSString *)pageName asStringWithBaseURL:(NSURL *)url
 {
-    [self synchronouslyLoadHTMLString:[NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:pageName withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"] encoding:NSUTF8StringEncoding error:nil] baseURL:url];
+    [self synchronouslyLoadHTMLString:[NSString stringWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:pageName withExtension:@"html"] encoding:NSUTF8StringEncoding error:nil] baseURL:url];
 }
 
 - (void)synchronouslyLoadTestPageNamed:(NSString *)pageName preferences:(WKWebpagePreferences *)preferences
@@ -947,7 +947,7 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 {
     bool didFireDOMLoadEvent = false;
     [self performAfterLoading:[&] { didFireDOMLoadEvent = true; }];
-    [self loadHTMLString:html baseURL:[NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"]];
+    [self loadHTMLString:html baseURL:NSBundle.test_resourcesBundle.resourceURL];
     TestWebKitAPI::Util::run(&didFireDOMLoadEvent);
     [self waitForNextPresentationUpdate];
 }

--- a/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
@@ -80,7 +80,7 @@ const double dragUpdateProgressIncrement = 0.05;
 
 static RetainPtr<NSImage> defaultExternalDragImage()
 {
-    return adoptNS([[NSImage alloc] initWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]]);
+    return adoptNS([[NSImage alloc] initWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]]);
 }
 
 @implementation DragAndDropSimulator {

--- a/Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm
@@ -44,7 +44,7 @@ WKStringRef createInjectedBundlePath()
 
 WKURLRef createURLForResource(const char* resource, const char* extension)
 {
-    NSURL *nsURL = [[NSBundle mainBundle] URLForResource:[NSString stringWithUTF8String:resource] withExtension:[NSString stringWithUTF8String:extension] subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *nsURL = [NSBundle.test_resourcesBundle URLForResource:[NSString stringWithUTF8String:resource] withExtension:[NSString stringWithUTF8String:extension]];
     return WKURLCreateWithCFURL((__bridge CFURLRef)nsURL);
 }
 


### PR DESCRIPTION
#### 914a60022d816b11cab8836e3f125670dd85a4d5
<pre>
Create a standalone bundle for TestWebKitAPI resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=279798">https://bugs.webkit.org/show_bug.cgi?id=279798</a>
<a href="https://rdar.apple.com/136114896">rdar://136114896</a>

Reviewed by Alex Christensen.

In preparation for introducing TestWebKitAPI.app on iOS, created a standalone bundle for storing
TestWebKitAPI resources. For the TestWebKitAPI command-line tool, this bundle is installed
alongside the binary in $BUILT_PRODUCTS_DIR (like TestWebKitAPI.resources was before this change).
For TestWebKitAPI.app, the resources bundle will be embedded in the app bundle. A category method
was added to NSBundle that returns the resources NSBundle (+test_resourcesBundle) and tests were
updated to use this new method.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPIResources.xcconfig: Added.
* Tools/TestWebKitAPI/PlatformUtilities.h:
* Tools/TestWebKitAPI/TestNSBundleExtras.h: Added.
* Tools/TestWebKitAPI/TestNSBundleExtras.m: Added.
(+[NSBundle test_resourcesBundle]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/LineBreaking.mm:
(testAFewStrings):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreNSURLSession.mm:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm:
(TestWebKitAPI::TEST_F(XMLParsing, WebCoreDoesNotBreakLibxml2)):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, VerifyDataURLFromNoisyWebGLAPI)):
* Tools/TestWebKitAPI/Tests/WebKit/FontRegistrySandboxCheck.mm:
(TEST(WebKit, UserInstalledFontsWork)):
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::(WebKit, InvalidDeviceIdHashSalts)):
* Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm:
(TestWebKitAPI::TEST(WebKit, NetworkProcessCrashWithPendingConnection)):
(TestWebKitAPI::TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)):
* Tools/TestWebKitAPI/Tests/WebKit/NoHistoryItemScrollToFragment.mm:
(TestWebKitAPI::TEST(WebKit, NoHistoryItemScrollToFragment)):
* Tools/TestWebKitAPI/Tests/WebKit/OrthogonalFlowAvailableSize.mm:
(TEST(WebKit, OrthogonalFlowAvailableSize)):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, WindowLocationAsyncPolicyDecision)):
(TEST(WKBackForwardList, InteractionStateRestoration)):
(TEST(WKBackForwardList, InteractionStateRestorationNil)):
(TEST(WKBackForwardList, InteractionStateRestorationInvalid)):
(TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)):
(TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)):
(runBackForwardNavigationSkipsItemsWithoutUserGestureTest):
(runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUserGesture)):
(TEST(WKBackForwardList, BackNavigationHijacking)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm:
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAsPictureElement)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAtLargerFontSize)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphMatchStyle)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertMultiple)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertTextAfterAdaptiveImageGlyph)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, CopyRTF)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, ContentsAsAttributedString)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, DragAdaptiveImageGlyphFromContentEditable)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsText)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsSticker)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm:
(TEST(WebKit, NSAttributedStringWithReadOnlyPaths)):
(TEST(WebKit, NSAttributedStringWithAndWithoutReadOnlyPaths)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalSupportedImageTypes.mm:
(runTest):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST(AnimatedResize, DISABLED_ResizeWithHiddenContentDoesNotHang)):
(TEST(AnimatedResize, AnimatedResizeDoesNotHang)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm:
(TEST(AppPrivacyReport, AppInitiatedRequestWithSubFrame)):
(TEST(AppPrivacyReport, NonAppInitiatedRequestWithSubFrame)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST(ApplicationManifest, DisplayMode)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AsyncPolicyForNavigationResponse.mm:
(TestWebKitAPI::TEST(WebKit, RespondToPolicyForNavigationResponseAsynchronously)):
(TestWebKitAPI::TEST(WebKit, PolicyForNavigationResponseCancelAsynchronously)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AttrStyle.mm:
(TEST(WebKit, AttrStyle)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm:
(TEST(CSSViewportUnits, SVGDocument)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CancelFontSubresource.mm:
(TEST(CancelLoading, CancelFontSubresource)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm:
(TEST(ClipboardTests, ConvertTIFFToPNGWhenPasting)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CommandBackForward.mm:
(WebKit2_CommandBackForwardTestWKWebView::loadFiles):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm:
(TEST(ContentFiltering, LazilyLoadPlatformFrameworks)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm:
(TEST(WKWebView, DISABLED_SetOverrideContentSecurityPolicyWithEmptyStringForPageWithCSP)):
(TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithCSP)):
(TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithoutCSP)):
(TEST(WKWebView, CheckViolationReportDocumentURIForFileProtocol)):
(TEST(WKWebView, CheckViolationReportDocumentURIForDataProtocol)):
(TEST(WKWebView, CheckViolationReportDocumentURIForAboutProtocol)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm:
(TEST(WebKit, CookieAcceptPolicy)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:
(TestWebKitAPI::(WebArchive, SaveResourcesBasic)):
(TestWebKitAPI::(WebArchive, SaveResourcesIframe)):
(TestWebKitAPI::(WebArchive, SaveResourcesFrame)):
(TestWebKitAPI::(WebArchive, SaveResourcesValidFileName)):
(TestWebKitAPI::(WebArchive, SaveResourcesBlobURL)):
(TestWebKitAPI::(WebArchive, SaveResourcesResponsiveImages)):
(TestWebKitAPI::(WebArchive, SaveResourcesDataURL)):
(TestWebKitAPI::(WebArchive, SaveResourcesStyle)):
(TestWebKitAPI::(WebArchive, SaveResourcesInlineStyle)):
(TestWebKitAPI::(WebArchive, SaveResourcesLink)):
(TestWebKitAPI::(WebArchive, SaveResourcesCSSImportRule)):
(TestWebKitAPI::(WebArchive, SaveResourcesCSSSupportsRule)):
(TestWebKitAPI::(WebArchive, SaveResourcesCSSMediaRule)):
(TestWebKitAPI::(WebArchive, SaveResourcesExcludeBaseElement)):
(TestWebKitAPI::(WebArchive, SaveResourcesStyleWithUnloadedResources)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, DelayDecidePolicyForNavigationAction)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceManagementRestrictions.mm:
(TEST(WebKit, DeviceManagementRestrictions)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm:
(runDeviceOrientationTest):
(TEST(DeviceOrientation, RememberPermissionForSession)):
(TEST(DeviceOrientation, FireOrientationEventsRightAwayIfPermissionAlreadyGranted)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TEST(_WKDownload, DownloadRequestOriginalURL)):
(TEST(_WKDownload, DownloadRequestOriginalURLFrame)):
(TEST(_WKDownload, DownloadRequestOriginalURLDirectDownloadWithLoadedContent)):
(TEST(_WKDownload, DownloadRequestBlobURL)):
(TEST(_WKDownload, SystemPreviewUSDZBlobNaming)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm:
(TEST(DragAndDropTests, DragAndDropOnEmptyView)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DuplicateCompletionHandlerCalls.mm:
(TEST(WebKit, DuplicateCompletionHandlerCalls)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FileSystemAccess.mm:
(MigrateToNewStorageDirectory)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST(WebKit, FindInPage)):
(TEST(WebKit, FindInPageSelectMatch)):
(TEST(WebKit, FindInPageWithPlatformPresentation)):
(TEST(WebKit, FindInPageCaseInsensitive)):
(TEST(WebKit, FindInPageStartsWith)):
(TEST(WebKit, FindInPageFullWord)):
(TEST(WebKit, FindInPageDoNotCrashWhenUsingMutableString)):
(TEST(WebKit, CannotHaveMultipleFindOverlays)):
(TEST(WebKit, FindOverlayCloseWebViewCrash)):
(TEST(WebKit, FindOverlaySPI)):
(TEST(WebKit, FindInPDF)):
(TEST(WebKit, FindInPDFAfterReload)):
(TEST(WebKit, FindInPDFAfterFindInPage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FirstVisuallyNonEmptyMilestone.mm:
(TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithDeferredScript)):
(-[NeverFinishLoadingSchemeHandler webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FixedLayoutSize.mm:
(TEST(WebKit, FixedLayoutSize)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm:
(TestWebKitAPI::TEST(Fullscreen, Delegate)):
(TestWebKitAPI::TEST(Fullscreen, VisibilityChangeNotDispatched)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLayoutConstraints.mm:
(TestWebKitAPI::TEST(Fullscreen, LayoutConstraints)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetResourceData.mm:
(TEST(WebKit, GetPDFResourceData)):
(TEST(WebKit, GetPDFResourceDataInUnparentedWebView)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm:
(TEST(IndexedDB, CheckpointsWALAutomatically)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBDeleteRecovery.mm:
(TEST(IndexedDB, DeleteRecovery)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm:
(TEST(IndexedDB, IndexUpgradeToV2)):
(runMultipleIndicesTestWithDatabase):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm:
(TEST(IndexedDB, IDBObjectStoreInfoUpgradeToV2)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm:
(TEST(IconLoading, AlreadyCachedIcon)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm:
(TestWebKitAPI::iconImage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/InAppBrowserPrivacy.mm:
(TEST(InAppBrowserPrivacy, LocalFilesAreAppBound)):
(TEST(InAppBrowserPrivacy, AppBoundDomainCanAccessMessageHandlers)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBDatabaseProcessKill.mm:
(TEST(IndexedDB, DatabaseProcessKill)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm:
(runTest):
(createDirectories):
(TEST(IndexedDB, IndexedDBFileHashCollision)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm:
(TEST(IndexedDB, IndexedDBInPageCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm:
(TEST(IndexedDB, IndexedDBMultiProcess)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
(TEST(IndexedDB, IndexedDBPersistence)):
(TEST(IndexedDB, IndexedDBPersistencePrivate)):
(TEST(IndexedDB, IndexedDBDataRemoval)):
(MigrateThirdPartyDataToGeneralStorageDirectory)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBStructuredCloneBackwardCompatibility.mm:
(TEST(IndexedDB, StructuredCloneBackwardCompatibility)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm:
(TEST(IndexedDB, IndexedDBSuspendImminently)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm:
(TEST(IndexedDB, IndexedDBTempFileSize)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm:
(TEST(IndexedDB, IndexedDBUserDelete)):
(TEST(IndexedDB, IndexedDBUserDeleteBeforeLoading)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JavaScriptDuringNavigation.mm:
(TEST(WebKit, JavaScriptDuringNavigation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm:
(TestWebKitAPI::TEST(WebKit, LoadAndDecodeImage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadFileThenReload.mm:
(TEST(WKWebView, LoadFileThenReload)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadFileURL.mm:
(TEST(WKWebView, LoadFileWithLoadRequest)):
(TEST(WKWebView, LoadTwoFiles)):
(TEST(WKWebView, LoadRelativeFileURL)):
(TEST(WKWebView, RepeatLoadFileURL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm:
(TestWebKitAPI::TEST(WebKit, LoadNSURLRequestWithMutablePropertiesAndKeys)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageClear.mm:
(TEST(WKWebView, LocalStorageClear)):
(TEST(WKWebView, ClearStaleAppCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageNullEntries.mm:
(TEST(WKWebView, LocalStorageNullEntries)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm:
(TEST(WKWebView, LocalStorageProcessCrashes)):
(TEST(WKWebView, LocalStorageProcessSuspends)):
(TEST(WKWebView, LocalStorageEmptyString)):
(TEST(WKWebView, LocalStorageOpenWindowPrivate)):
(TEST(WKWebView, PrivateBrowsingAffectsLocalStorage)):
(TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)):
(TEST(WebKit, LocalStorageCorruptedDatabase)):
(TEST(WKWebView, LocalStorageDirectoryExcludedFromBackup)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageQuirkTest.mm:
(TEST(WKWebView, LocalStorageQuirkEnabled)):
(TEST(WKWebView, LocalStorageQuirkDisabledAccessPermitted)):
(TEST(WKWebView, LocalStorageQuirkDisabledAccessDenied)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm:
(TestWebKitAPI::TEST(LockdownMode, SVGFonts)):
(TestWebKitAPI::TEST(LockdownMode, NotAllowedFontLoadingAPI)):
(TestWebKitAPI::TEST(LockdownMode, AllowedFontLoadingAPI)):
(TestWebKitAPI::TEST(LockdownMode, AllowedFont)):
(TestWebKitAPI::TEST(LockdownMode, NotAllowedFont)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaDocument.mm:
(TestWebKitAPI::TEST(MediaDocument, WirelessPlaybackEnabled)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm:
(TestWebKitAPI::testVideoBytes):
(TestWebKitAPI::TEST(MediaLoading, LockdownModeHLS)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm:
(TEST(WebKit, ModalAlerts)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm:
(TEST(NSAttributedStringWebKitAdditions, FontDataURL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, LoadRequest)):
(-[BackForwardDelegate _webView:willGoToBackForwardListItem:inPageCache:]):
(TEST(WKNavigation, WillGoToBackForwardListItem)):
(-[ListItemDelegate _webView:backForwardListItemAdded:removed:]):
(TEST(WKNavigation, ListItemAddedRemoved)):
(TEST(WKNavigation, SimultaneousNavigationWithFontsFinishes)):
(TEST(WKNavigation, GeneratePageLoadTiming)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcessCrashNonPersistentDataStore.mm:
(checkRecoveryAfterCrash):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm:
(TEST(WebKit, OpenAndCloseWindow)):
(TEST(WebKit, OpenAndCloseWindowAsync)):
(TEST(WebKit, OpenAsyncWithNil)):
(TEST(WebKit, OpenWindowThenDocumentOpen)):
(TEST(WebKit, OpenFileURLWithHost)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PageZoom.mm:
(TestWebKitAPI::TEST(WKWebView, PageZoomAfterPDF)):
(TestWebKitAPI::TEST(WKWebView, MinimumMagnificationPDF)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ParserYieldTokenTests.mm:
(TEST(ParserYieldTokenTests, AsyncScriptRunsWhenFetched)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:
(TEST(PasteHTML, PreservesMSOList)):
(TEST(PasteHTML, PreservesMSOListInCompatibilityMode)):
(TEST(PasteHTML, PreservesMSOListOnH4)):
(TEST(PasteHTML, StripsMSOListWhenMissingMSOHTMLElement)):
(TEST(PasteHTML, StripsSystemFontNames)):
(TEST(PasteHTML, DoesNotAddStandardFontFamily)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteImage.mm:
(TEST(PasteImage, PasteGIFImage)):
(TEST(PasteImage, PasteJPEGImage)):
(TEST(PasteImage, PastePNGImage)):
(TEST(PasteImage, PasteImageWithMultipleRepresentations)):
(TEST(PasteImage, RevealSelectionAfterPastingImage)):
(TEST(PasteImage, PasteGIFFile)):
(TEST(PasteImage, PasteJPEGFile)):
(TEST(PasteImage, PastePNGFile)):
(TEST(PasteImage, PasteTIFFFile)):
(TEST(PasteImage, PasteLegacyTIFFImage)):
(TEST(PasteImage, PasteTIFFImage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteMixedContent.mm:
(TestWebKitAPI::imagePath):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteRTFD.mm:
(TEST(PasteRTFD, ImageElementUsesBlobURL)):
(TEST(PasteRTFD, ImageElementUsesBlobURLInHTML)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm:
(TEST(PasteWebArchive, PreservesMSOList)):
(TEST(PasteWebArchive, PreservesMSOListInCompatibilityMode)):
(msoListMarkupWithoutProperHTMLElement):
(TEST(PasteWebArchive, PreservesPictureInsideSpan)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm:
(TestWebKitAPI::TEST(PictureInPicture, WKUIDelegate)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm:
(TEST(WKWebView, PrepareForMoveToWindow)):
(TEST(WKWebView, PrepareForMoveToWindowThenClose)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSuspension.mm:
(TEST(ProcessSuspension, DeallocateSuspendedView)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, NoProcessSwappingWithinSameNonHTTPFamilyProtocol)):
((ProcessSwap, CrossSiteClientSideRedirectFromFileURL)):
((ProcessSwap, ClosePageAfterCrossSiteProvisionalLoad)):
((ProcessSwap, UsePrewarmedProcessAfterTerminatingNetworkProcess)):
((ProcessSwap, UseSessionCookiesAfterProcessSwapInPrivateBrowsing)):
((ProcessSwap, UseSessionCookiesAfterProcessSwapInNonDefaultPersistentSession)):
((ProcessSwap, QuickLookRequestsPasswordAfterSwap)):
((ProcessSwap, PassSandboxExtension)):
((ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)):
((ProcessSwap, NavigatingToLockdownMode)):
((ProcessSwap, LockdownModeSystemSettingChange)):
((ProcessSwap, CannotDisableLockdownModeWithoutBrowserEntitlement)):
((ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)):
((ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSetExplicitly1)):
((ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSetExplicitly2)):
((ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSetExplicitly3)):
((ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSetExplicitly4)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm:
(pagesDocumentURL):
(TEST(QuickLook, RequestPasswordBeforeLoadingPreview)):
(TEST(QuickLook, RequestPasswordAfterLoadingPreview)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RenderedImageWithOptions.mm:
(runTestWithWidth):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RequestTextInputContext.mm:
(TestWebKitAPI::webViewLoadHTMLStringAndWaitForAllFramesToPaint):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RequiresUserActionForPlayback.mm:
(RequiresUserActionForPlaybackTest::testVideoWithAudio):
(RequiresUserActionForPlaybackTest::testVideoWithoutAudio):
(RequiresUserActionForPlaybackTest::testAudioOnly):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm:
(TEST(ResourceLoadDelegate, Basic)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)):
(TEST(ResourceLoadStatistics, MigrateDataFromIncorrectCreateTableSchema)):
(TEST(ResourceLoadStatistics, MigrateDataFromMissingTopFrameUniqueRedirectSameSiteStrictTableSchema)):
(TEST(ResourceLoadStatistics, CanAccessDataSummaryWithNoProcessPool)):
(TEST(ResourceLoadStatistics, MigrateDistinctDataFromTableWithMissingIndexes)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimer.mm:
(TestWebKitAPI::TEST(WebKit, ResponsivenessTimerShouldNotFireAfterTearDown)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResponsivenessTimerDoesntFireEarly.mm:
(TestWebKitAPI::TEST(WebKit, ResponsivenessTimerDoesntFireEarly)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStateWithoutNavigation.mm:
(TestWebKitAPI::createSessionStateData):
(TestWebKitAPI::TEST(WebKit, RestoreSessionStateWithoutNavigation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, NoInterceptions)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DisableSSO)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed1)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed2)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed3)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed4)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionErrorWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, ShowUITwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, NSNotificationCenter)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturization)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringHiding)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturizationThenAnother)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringHidingThenAnother)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, NoInterceptions)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, NoInterceptions)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm:
(resourceURL):
(TEST(SafeBrowsing, GoBackAfterRestoreFromSessionState)):
(TEST(SafeBrowsing, NavigationClearsWarning)):
(TEST(SafeBrowsing, URLObservation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((WebKit, ServiceWorkerDatabaseWithRecordsTableButUnexpectedSchema)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldGoToBackForwardListItem.mm:
(TestWebKitAPI::TEST(WebKit, ShouldGoToBackForwardListItem)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm:
(TEST(WebKit, RestoreShouldOpenExternalURLsPolicyAfterCrash)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ShrinkToFit.mm:
(TEST(WebKit, ShrinkToFit)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, PasteGIF)):
(TestWebKitAPI::TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm:
(TEST(IndexedDB, StoreBlobThenRemoveData)):
(TEST(IndexedDB, StoreBlobThenDeleteDatabase)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::TEST(WebKit, SystemPreviewBlobRevokedImmediately)):
(TestWebKitAPI::TEST(WebKit, SystemPreviewUnknownMIMEType)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm:
(TestWebKitAPI::TEST(TLSVersion, NegotiatedLegacyTLS)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TestWebKitAPI::TEST(TextManipulation, StartTextManipulationExtractsUserInfo)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm:
(TEST(WebKit, TextWidth)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TopContentInset.mm:
(TestWebKitAPI::TEST(TopContentInset, Fullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[NoUIDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(TEST(WebKit, WindowOpenWithoutUIDelegate)):
(-[SaveDataToFileDelegate _webView:saveDataToFile:suggestedFilename:mimeType:originatingURL:]):
((WebKit, SaveDataToFile)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, ScriptMessageHandlerBasicPost)):
(TEST(WKUserContentController, ScriptMessageHandlerBasicPostIsolatedWorld)):
(TEST(WKUserContentController, ScriptMessageHandlerBasicRemove)):
(TEST(WKUserContentController, ScriptMessageHandlerCallRemovedHandler)):
(webViewForScriptMessageHandlerMultipleHandlerRemovalTest):
(TEST(WKUserContentController, ScriptMessageHandlerWithNavigation)):
(TEST(WKUserContentController, ScriptMessageHandlerReplaceWithSameName)):
(TEST(WKUserContentController, InjectUserScriptImmediately)):
(TEST(WKUserContentController, AddUserScriptInWorldWithGlobalObjectAvailableInIframe)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserInitiatedActionInNavigationAction.mm:
(UserInitiatedActionTest::SetUp):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm:
(TestWebKitAPI::TEST(VideoControlsManager, VideoControlsManagerTearsDownMediaControlsOnDealloc)):
(TestWebKitAPI::TEST(VideoControlsManager, VideoControlsManagerSmallVideoInMediaDocument)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(testiWorkAttachmentFileURL):
(testZIPData):
(testImageFileURL):
(testGIFFileURL):
(testPDFFileURL):
(testJPEGFileURL):
(TestWebKitAPI::TEST(WKAttachmentTestsIOS, TargetedPreviewIsClippedWhenDroppingTallImage)):
(TestWebKitAPI::calendarInviteForTesting):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, AddRemove)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKInspectorExtension.mm:
(TEST(WKInspectorExtension, EvaluateScriptOnPage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm:
(TEST(WebKit, SkipDecidePolicyForResponse)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm:
(pdfData):
(TEST(WebKit, WKPDFViewResizeCrash)):
(TEST(WebKit, WKPDFViewStablePresentationUpdateCallback)):
(TEST(WebKit, WKPDFViewFindActions)):
(TEST(WKPDFView, BackgroundColor)):
(TEST(PDF, PrintSize)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm:
(TEST(Printing, PrintWithDelayedCompletion)):
(TEST(Printing, PrintPageBorders)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm:
(TestWebKitAPI::TEST(_WKActivatedElementInfo, InfoForImage)):
(TestWebKitAPI::TEST(_WKActivatedElementInfo, InfoForMediaDocument)):
(TestWebKitAPI::TEST(_WKActivatedElementInfo, InfoForLinkAroundImage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
((URLSchemeHandler, DisableCORSCanvas)):
((URLSchemeHandler, Ranges)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptBlockCrash)):
(TEST(WKWebView, EvaluateJavaScriptErrorCases)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TEST(WKWebView, AttributedStringAccessibilityLabel)):
(TEST(WKWebView, TextWithWebFontAsAttributedString)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewLoadAPIs.mm:
(TEST(WKWebView, LoadFileRequest)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(TestWebKitAPI::TEST(WKWebView, SnapshotImageLargeAsyncDecoding)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm:
(TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)):
(TEST(WKNavigation, AutomaticHiddenViewDelayedReloadAfterWebProcessCrash)):
(TEST(WKNavigation, ProcessCrashDuringCallback)):
(TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm:
(TestWebKitAPI::TEST(WebKit, WebCryptoNilMasterKey)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm:
(TEST(IndexedDB, WebProcessKillIDBCleanup)):
(TEST(IndexedDB, KillWebProcessWithOpenConnection)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSQLBasics.mm:
(TEST(WebSQL, OpenDatabaseAlwaysExists)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(runWebsiteDataStoreCustomPaths):
(TEST(WebKit, WebsiteDataStoreEphemeral)):
(TEST(WebKit, WebsiteDataStoreEphemeralViaConfiguration)):
(TEST(WebKit, DoLoadWithNonDefaultDataStoreAfterTerminatingNetworkProcess)):
(TEST(WebKit, MediaCache)):
(TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)):
(TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)):
(TEST(WebKit, FetchDataAfterEnablingGeneralStorageDirectory)):
(TEST(WebKit, DeleteDataAfterEnablingGeneralStorageDirectory)):
(TEST(WebKit, CreateOriginFileWhenNeeded)):
(TEST(WKWebsiteDataStoreConfiguration, SameCustomPathForDifferentTypes)):
(TEST(WebKit, DeleteEmptyOriginDirectoryWhenFetchData)):
(TEST(WebKit, DeleteEmptyOriginDirectoryWhenOriginIsGone)):
(TEST(WebKit, OriginDirectoryExcludedFromBackup)):
(TEST(WebKit, RemoveStaleWebSQLData)):
(TEST(WKWebsiteDataStore, MigrateCacheStorageDataToGeneralStorageDirectory)):
((WKWebsiteDataStore, FetchAndDeleteMediaKeysData)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)):
(TEST(WebpagePreferences, WebsitePoliciesAutoplayEnabled)):
(TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)):
(TEST(WebpagePreferences, WebsitePoliciesPlayingWithUserGesture)):
(TEST(WebpagePreferences, WebsitePoliciesPlayingWithoutInterference)):
(TEST(WebpagePreferences, WebsitePoliciesUserInterferenceWithPlaying)):
(-[TestSchemeHandler webView:startURLSchemeTask:]):
(TEST(WebpagePreferences, WebsitePoliciesDuringRedirect)):
(TEST(WebpagePreferences, WebsitePoliciesUpdates)):
(TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)):
(TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)):
(TEST(WebpagePreferences, DISABLED_WebsitePoliciesAutoplayQuirksAsyncPolicyDelegate)):
((WebpagePreferences, WebsitePoliciesPopUp)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, CompositionWithTextAttachment)):
(TEST(WritingTools, CompositionWithImageAttachmentRoundTrip)):
(TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, NoPanelNfcSucceed)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NoPanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccess1)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccess2)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelRacy1)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelRacy2)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelTwice)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, ReloadHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LocationChangeHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NewLoadHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, CloseHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, FakePanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NullPanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NullPanelHidCtapNoCredentialsFound)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelMultipleNFCTagsPresent)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinGetRetriesError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinGetKeyAgreementError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinRequestPinErrorNoDelegate)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinRequestPinErrorNullDelegate)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinRequestPinError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinGetPinTokenPinBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinGetPinTokenPinInvalidErrorAndRetry)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthInvalidErrorAndRetry)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialInternalUV)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialPin)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPin)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionInternalUV)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NfcPinCachedDisconnect)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MultipleAccounts)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LADuplicateCredential)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LADuplicateCredentialWithConsent)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LANoCredential)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertion)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm:
(TestWebKitAPI::TEST(WebKitLegacy, AudioSessionCategoryIOS)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/PreemptVideoFullscreen.mm:
(TestWebKitAPI::TEST(WebKitLegacy, PreemptVideoFullscreen)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollingDoesNotPauseMedia.mm:
(TestWebKitAPI::TEST(WebKitLegacy, ScrollingDoesNotPauseMedia)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm:
(TestWebKitAPI::TEST(WebKitLegacy, RenderInContextSnapshot)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLPrepareDisplayOnWebThread.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WebGLPrepareDisplayOnWebThread)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/AccessingPastedImage.mm:
(TestWebKitAPI::TEST(WebKitLegacy, AccessingImageInPastedRTFD)):
(TestWebKitAPI::TEST(WebKitLegacy, AccessingImageInPastedWebArchive)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DownloadThread.mm:
(TestWebKitAPI::TEST(WebKitLegacy, DownloadThread)):
* Tools/TestWebKitAPI/Tests/WebKitObjC/WKBrowsingContextLoadDelegateTest.mm:
(TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoad)):
* Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm:
(TestWebKitAPI::TEST(ApplicationStateTracking, NavigatingFromPDFDoesNotLeaveWebViewInactive)):
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(testIconImage):
(testZIPArchive):
(testIconImageData):
(TestWebKitAPI::testIconImageData):
(TestWebKitAPI::TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageWithFileURL)):
(TestWebKitAPI::TEST(DragAndDropTests, CanStartDragOnModel)):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(+[InputAssistantItemTestingWebView barButtonIcon]):
(TestWebKitAPI::TEST(KeyboardInputTests, InsertTextSimulatingKeyboardInput)):
(TestWebKitAPI::TEST(KeyboardInputTests, InsertDictationAlternativesSimulatingKeyboardInput)):
* Tools/TestWebKitAPI/Tests/ios/OverflowScrollViewTests.mm:
(TestWebKitAPI::TEST(OverflowScrollViewTests, ContentChangeMaintainsScrollbars)):
(TestWebKitAPI::TEST(OverflowScrollViewTests, CompositingChangeMaintainsCustomView)):
* Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm:
(TestWebKitAPI::TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrashWithAsyncPolicyDelegates)):
(TestWebKitAPI::TEST(ScrollViewInsetTests, RestoreContentOffsetAfterBackWithInsetChange)):
* Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm:
(TestWebKitAPI::TEST(ScrollViewScrollabilityTests, ScrollableAfterNavigateToPDF)):
* Tools/TestWebKitAPI/Tests/ios/SetTimeoutFunction.mm:
(TestWebKitAPI::TEST(WebKitLegacy, SetTimeoutFunction)):
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:
(TestWebKitAPI::TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)):
* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:
(TestWebKitAPI::TEST(UIPasteboardTests, DataTransferGetDataWhenPastingImageAndText)):
(TestWebKitAPI::TEST(UIPasteboardTests, ValidPreferredPresentationSizeForImage)):
(TestWebKitAPI::TEST(UIPasteboardTests, InvalidPreferredPresentationSizeForImage)):
(TestWebKitAPI::TEST(UIPasteboardTests, MissingPreferredPresentationSizeForImage)):
* Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm:
(TestWebKitAPI::AcceptsFirstMouse::url const):
* Tools/TestWebKitAPI/Tests/mac/AdditionalSupportedImageTypes.mm:
(TestWebKitAPI::runTest):
* Tools/TestWebKitAPI/Tests/mac/AttributedString.mm:
(TestWebKitAPI::AttributedStringTest_CustomFont::url const):
(TestWebKitAPI::AttributedStringTest_Strikethrough::url const):
(TestWebKitAPI::AttributedStringTest_NewlineAtEndOfDocument::url const):
* Tools/TestWebKitAPI/Tests/mac/CancelLoadFromResourceLoadDelegate.mm:
(TestWebKitAPI::TEST(WebKitLegacy, CancelLoadFromResourceLoadDelegate)):
* Tools/TestWebKitAPI/Tests/mac/CandidateTests.mm:
(TestWebKitAPI::TEST(CandidateTests, DISABLED_DoNotLeakViewThatLoadsEditableArea)):
(TestWebKitAPI::TEST(CandidateTests, DISABLED_RequestCandidatesForTextInput)):
(TestWebKitAPI::TEST(CandidateTests, DoNotRequestCandidatesForPasswordInput)):
* Tools/TestWebKitAPI/Tests/mac/CloseNewWindowInNavigationPolicyDelegate.mm:
(TestWebKitAPI::TEST(WebKitLegacy, CloseNewWindowInNavigationPolicyDelegate)):
* Tools/TestWebKitAPI/Tests/mac/CloseWhileCommittingLoad.mm:
(TestWebKitAPI::TEST(WebKitLegacy, CloseWhileCommittingLoad)):
* Tools/TestWebKitAPI/Tests/mac/ContextMenuCanCopyURL.mm:
(TestWebKitAPI::TEST(WebKitLegacy, ContextMenuCanCopyURL)):
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, NavigationTypeWhenOpeningLink)):
* Tools/TestWebKitAPI/Tests/mac/CrossPartitionFileSchemeAccess.mm:
(TestWebKitAPI::TEST(WebKitLegacy, CrossPartitionFileSchemeAccess)):
* Tools/TestWebKitAPI/Tests/mac/DOMHTMLTableCellCellAbove.mm:
(TestWebKitAPI::TEST(WebKitLegacy, HTMLTableCellElementCellAbove)):
* Tools/TestWebKitAPI/Tests/mac/DOMRangeOfString.mm:
(TestWebKitAPI::TEST(WebKitLegacy, DOMRangeOfString)):
* Tools/TestWebKitAPI/Tests/mac/DeviceScaleFactorOnBack.mm:
(TestWebKitAPI::DeviceScaleFactorOnBack::url const):
* Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)):
(TEST(DragAndDropTests, DragImageFileIntoFileUpload)):
* Tools/TestWebKitAPI/Tests/mac/DynamicDeviceScaleFactor.mm:
(TestWebKitAPI::DynamicDeviceScaleFactor::url const):
* Tools/TestWebKitAPI/Tests/mac/FragmentNavigation.mm:
(TestWebKitAPI::TEST(WebKitLegacy, FragmentNavigation)):
* Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm:
* Tools/TestWebKitAPI/Tests/mac/HTMLCollectionNamedItem.mm:
(TestWebKitAPI::TEST(WebKitLegacy, HTMLCollectionNamedItemTest)):
* Tools/TestWebKitAPI/Tests/mac/HTMLFormCollectionNamedItem.mm:
(TestWebKitAPI::TEST(WebKitLegacy, HTMLFormCollectionNamedItemTest)):
* Tools/TestWebKitAPI/Tests/mac/IsNavigationActionTrusted.mm:
(TestWebKitAPI::TEST(WebKit, IsNavigationActionTrusted)):
(TestWebKitAPI::TEST(WebKitLegacy, IsNavigationActionTrusted)):
* Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm:
(TestWebKitAPI::getTestImage):
(TestWebKitAPI::webViewAfterPerformingDragOperation):
* Tools/TestWebKitAPI/Tests/mac/LimitTitleSize.mm:
(TEST(WebKitLegacy, LimitTitleSize)):
(TEST(WebKit, LimitTitleSize)):
* Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm:
(TestWebKitAPI::TEST(WebKitLegacy, LoadInvalidURLRequest)):
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::TEST(LoadWebArchive, FailNavigation1)):
(TestWebKitAPI::TEST(LoadWebArchive, FailNavigation2)):
(TestWebKitAPI::TEST(LoadWebArchive, ClientNavigationSucceed)):
(TestWebKitAPI::TEST(LoadWebArchive, ClientNavigationReload)):
(TestWebKitAPI::TEST(LoadWebArchive, ClientNavigationWithStorageReload)):
(TestWebKitAPI::TEST(LoadWebArchive, DragNavigationSucceed)):
(TestWebKitAPI::TEST(LoadWebArchive, DragNavigationReload)):
(TestWebKitAPI::TEST(LoadWebArchive, SiteToWebArchiveAndBack)):
(TestWebKitAPI::TEST(LoadWebArchive, WebArchiveToSiteAndBack)):
(TestWebKitAPI::TEST(LoadWebArchive, FileWebArchiveToDataWebArchiveAndBack)):
* Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.mm:
(TestWebKitAPI::TEST(WebKitLegacy, MediaPlaybackSleepAssertion)):
* Tools/TestWebKitAPI/Tests/mac/MemoryCacheDisableWithinResourceLoadDelegate.mm:
(TestWebKitAPI::TEST(WebKitLegacy, MemoryCacheDisableWithinResourceLoadDelegate)):
* Tools/TestWebKitAPI/Tests/mac/MemoryCachePruneWithinResourceLoadDelegate.mm:
(TestWebKitAPI::TEST(WebKitLegacy, DISABLED_MemoryCachePruneWithinResourceLoadDelegate)):
* Tools/TestWebKitAPI/Tests/mac/NoPolicyDelegateResponse.mm:
(TestWebKitAPI::TEST(WebKitLegacy, NoDecidePolicyForMIMETypeDecision)):
(TestWebKitAPI::TEST(WebKitLegacy, NoDecidePolicyForNavigationActionDecision)):
* Tools/TestWebKitAPI/Tests/mac/PageVisibilityStateWithWindowChanges.mm:
* Tools/TestWebKitAPI/Tests/mac/SetDocumentURI.mm:
(TestWebKitAPI::TEST(WebKitLegacy, SetDocumentURITestFile)):
(TestWebKitAPI::TEST(WebKitLegacy, SetDocumentURITestURL)):
(TestWebKitAPI::TEST(WebKitLegacy, SetDocumentURITestString)):
(TestWebKitAPI::TEST(WebKitLegacy, SetDocumentURITestNull)):
* Tools/TestWebKitAPI/Tests/mac/SimplifyMarkup.mm:
(TestWebKitAPI::TEST(WebKitLegacy, SimplifyMarkupTest)):
* Tools/TestWebKitAPI/Tests/mac/StartLoadInDidFailProvisionalLoad.mm:
(-[StartLoadInDidFailProvisionalLoadDelegate webView:didFailProvisionalLoadWithError:forFrame:]):
(TestWebKitAPI::TEST(WebKitLegacy, StartLoadInDidFailProvisionalLoad)):
* Tools/TestWebKitAPI/Tests/mac/StopLoadingFromDidReceiveResponse.mm:
(TestWebKitAPI::TEST(WebKitLegacy, StopLoadingFromDidReceiveResponse)):
* Tools/TestWebKitAPI/Tests/mac/WebScriptObjectDescription.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WebScriptObjectDescription)):
* Tools/TestWebKitAPI/Tests/mac/WebViewCanPasteZeroPng.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WebViewCanPasteZeroPng)):
* Tools/TestWebKitAPI/Tests/mac/WebViewDidCreateJavaScriptContext.mm:
(TestWebKitAPI::(WebKitLegacy, DidCreateJavaScriptContextBackForwardCacheTest)):
* Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm:
(defaultFaviconData):
(customFaviconData):
* Tools/TestWebKitAPI/Tests/mac/WebViewScheduleInRunLoop.mm:
(TestWebKitAPI::TEST(WebKitLegacy, ScheduleInRunLoop)):
* Tools/TestWebKitAPI/Tests/mac/WillPerformClientRedirectToURLCrash.mm:
(testURL):
* Tools/TestWebKitAPI/Tests/mac/WillSendSubmitEvent.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WillSendSubmitEvent)):
* Tools/TestWebKitAPI/Tests/mac/WindowlessWebViewWithMedia.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WindowlessWebViewWithMedia)):
* Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm:
(-[TestInspectorURLSchemeHandler webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/cocoa/TestProtocol.mm:
(-[TestProtocol startLoading]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView loadTestPageNamed:]):
(-[WKWebView synchronouslyLoadHTMLString:]):
(-[WKWebView synchronouslyLoadHTMLString:preferences:]):
(-[WKWebView synchronouslyLoadTestPageNamed:asStringWithBaseURL:]):
(-[TestWKWebView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:]):
* Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm:
(defaultExternalDragImage):
* Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm:
(TestWebKitAPI::Util::createURLForResource):

Canonical link: <a href="https://commits.webkit.org/283810@main">https://commits.webkit.org/283810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b09fb876e6ad9c071609f3befca217fb8018a775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/67464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/46843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/20096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/69582 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/54641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/18392 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/70531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/54641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/20096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/54641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/20096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/54641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/20096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/11423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/18392 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/73211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/11458 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/20096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/20096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10247 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/43466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->