### PR TITLE
Fix miscellaneous unexpected smart pointer warnings

### DIFF
--- a/Source/WebCore/SmartPointerExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SmartPointerExpectations/NoUncountedMemberCheckerExpectations
@@ -111,6 +111,7 @@ page/WheelEventTestMonitor.h
 page/scrolling/ScrollLatchingController.h
 page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingTreeGestureState.h
+page/scrolling/ScrollingTreeNode.h
 page/scrolling/ScrollingTreeScrollingNodeDelegate.h
 page/scrolling/mac/ScrollerMac.h
 platform/DragImage.cpp

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -57,7 +57,7 @@ CSSNumberishTime::CSSNumberishTime(CSSNumberish value)
 
     ASSERT(std::holds_alternative<RefPtr<CSSNumericValue>>(value));
     auto numericValue = std::get<RefPtr<CSSNumericValue>>(value);
-    if (auto* unitValue = dynamicDowncast<CSSUnitValue>(numericValue.get())) {
+    if (RefPtr unitValue = dynamicDowncast<CSSUnitValue>(numericValue.get())) {
         if (unitValue->unitEnum() == CSSUnitType::CSS_NUMBER) {
             m_type = Type::Time;
             m_source = Source::Number;

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -31,6 +31,7 @@
 #include "CSSScrollValue.h"
 #include "CSSValuePool.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 
 namespace WebCore {
@@ -128,7 +129,7 @@ Ref<CSSValue> ScrollTimeline::toCSSValue(const RenderStyle&) const
 AnimationTimelinesController* ScrollTimeline::controller() const
 {
     if (m_source)
-        return &m_source->document().ensureTimelinesController();
+        return &m_source->protectedDocument()->ensureTimelinesController();
     return nullptr;
 }
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -34,6 +34,7 @@
 #include "CSSValuePool.h"
 #include "CSSViewValue.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "StyleBuilderConverter.h"
 
@@ -128,7 +129,7 @@ Ref<CSSValue> ViewTimeline::toCSSValue(const RenderStyle& style) const
 AnimationTimelinesController* ViewTimeline::controller() const
 {
     if (m_subject)
-        return &m_subject->document().ensureTimelinesController();
+        return &m_subject->protectedDocument()->ensureTimelinesController();
     return nullptr;
 }
 

--- a/Source/WebCore/css/CSSFontVariationValue.cpp
+++ b/Source/WebCore/css/CSSFontVariationValue.cpp
@@ -39,9 +39,14 @@ CSSFontVariationValue::CSSFontVariationValue(FontTag tag, Ref<CSSPrimitiveValue>
 {
 }
 
+Ref<CSSPrimitiveValue> CSSFontVariationValue::protectedValue() const
+{
+    return m_value;
+}
+
 String CSSFontVariationValue::customCSSText() const
 {
-    return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, m_value->customCSSText());
+    return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, protectedValue()->customCSSText());
 }
 
 bool CSSFontVariationValue::equals(const CSSFontVariationValue& other) const

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -54,6 +54,8 @@ public:
 private:
     CSSFontVariationValue(FontTag, Ref<CSSPrimitiveValue>&&);
 
+    Ref<CSSPrimitiveValue> protectedValue() const;
+
     FontTag m_tag;
     Ref<CSSPrimitiveValue> m_value;
 };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
@@ -50,6 +50,8 @@ template<typename T> struct UnevaluatedCalc {
     using RawType = T;
     Ref<CSSCalcValue> calc;
 
+    Ref<CSSCalcValue> protectedCalc() const { return calc; }
+
     bool operator==(const UnevaluatedCalc<T>& other) const
     {
         return unevaluatedCalcEqual(calc, other.calc);

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -109,8 +109,8 @@ WindowProxy* HTMLFrameOwnerElement::contentWindow() const
 void HTMLFrameOwnerElement::setSandboxFlags(SandboxFlags flags)
 {
     m_sandboxFlags = flags;
-    if (m_contentFrame)
-        m_contentFrame->updateSandboxFlags(flags, Frame::NotifyUIProcess::Yes);
+    if (RefPtr contentFrame = m_contentFrame.get())
+        contentFrame->updateSandboxFlags(flags, Frame::NotifyUIProcess::Yes);
 }
 
 bool HTMLFrameOwnerElement::isKeyboardFocusable(KeyboardEvent* event) const

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -44,21 +44,21 @@ FECompositeSoftwareApplier::FECompositeSoftwareApplier(const FEComposite& effect
 
 bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input = inputs[0];
+    Ref input2 = inputs[1];
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
-    RefPtr inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
+    RefPtr inputImage2 = input2->imageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 
     auto& filterContext = resultImage->context();
-    auto inputImageRect = input.absoluteImageRectRelativeTo(result);
-    auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
+    auto inputImageRect = input->absoluteImageRectRelativeTo(result);
+    auto inputImageRect2 = input2->absoluteImageRectRelativeTo(result);
 
     switch (m_effect.operation()) {
     case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
@@ -71,14 +71,14 @@ bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& i
 
     case CompositeOperationType::FECOMPOSITE_OPERATOR_IN: {
         // Applies only to the intersected region.
-        IntRect destinationRect = input.absoluteImageRect();
-        destinationRect.intersect(input2.absoluteImageRect());
+        IntRect destinationRect = input->absoluteImageRect();
+        destinationRect.intersect(input2->absoluteImageRect());
         destinationRect.intersect(result.absoluteImageRect());
         if (destinationRect.isEmpty())
             break;
         IntRect adjustedDestinationRect = destinationRect - result.absoluteImageRect().location();
-        IntRect sourceRect = destinationRect - input.absoluteImageRect().location();
-        IntRect source2Rect = destinationRect - input2.absoluteImageRect().location();
+        IntRect sourceRect = destinationRect - input->absoluteImageRect().location();
+        IntRect source2Rect = destinationRect - input2->absoluteImageRect().location();
         filterContext.drawImageBuffer(*inputImage2, FloatRect(adjustedDestinationRect), FloatRect(source2Rect));
         filterContext.drawImageBuffer(*inputImage, FloatRect(adjustedDestinationRect), FloatRect(sourceRect), { CompositeOperator::SourceIn });
         break;

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -173,14 +173,14 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
 
 bool FELightingSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
-    input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
+    input->copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
 
     // FIXME: support kernelUnitLengths other than (1,1). The issue here is that the W3
     // standard has no test case for them, and other browsers (like Firefox) has strange
@@ -206,7 +206,7 @@ bool FELightingSoftwareApplier::apply(const Filter& filter, const FilterImageVec
     data.lightSource = m_effect.lightSource().ptr();
     data.operatingColorSpace = &m_effect.operatingColorSpace();
 
-    data.pixels = destinationPixelBuffer;
+    data.pixels = destinationPixelBuffer.get();
     data.widthMultipliedByPixelSize = size.width() * cPixelSize;
     data.width = size.width();
     data.height = size.height();

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
@@ -32,10 +32,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceGraphicSoftwareApplier);
 
 bool SourceGraphicSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input->imageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/style/StyleResolveForFontRaw.cpp
+++ b/Source/WebCore/style/StyleResolveForFontRaw.cpp
@@ -250,7 +250,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
             if (requiresConversionData(calc))
                 return 0.0f;
 
-            auto length = calc.calc->lengthPercentageValueNoConversionDataRequired({ });
+            auto length = calc.protectedCalc()->lengthPercentageValueNoConversionDataRequired({ });
             return floatValueForLength(length, parentSize);
         }
     );

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.h
@@ -43,6 +43,8 @@ private:
 
     Type type() const final { return Type::RemoteModel; }
 
+    Ref<WebCore::Model> protectedModel() const { return m_model; }
+
     Ref<WebCore::PlatformCALayer> clone(WebCore::PlatformCALayerClient* owner) const override;
     
     void populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties&, const RemoteLayerTreeContext&, WebCore::PlatformCALayer::LayerType) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
@@ -72,7 +72,7 @@ void PlatformCALayerRemoteModelHosting::populateCreationProperties(RemoteLayerTr
 void PlatformCALayerRemoteModelHosting::dumpAdditionalProperties(TextStream& ts, OptionSet<WebCore::PlatformLayerTreeAsTextFlags> flags)
 {
     if (flags.contains(WebCore::PlatformLayerTreeAsTextFlags::IncludeModels))
-        ts << indent << "(model data size " << m_model->data()->size() << ")\n";
+        ts << indent << "(model data size " << protectedModel()->data()->size() << ")\n";
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### b062fe25ac4a0fcf68d46210c9812dd862f1e35c
<pre>
Fix miscellaneous unexpected smart pointer warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=279795">https://bugs.webkit.org/show_bug.cgi?id=279795</a>

Reviewed by Chris Dumez and Basuke Suzuki.

Address most of unexpected smart pointer warnings, and suppress one of the warnings
since making ScrollingTree support ThreadSafeWeakPtr will be a bigger change.

* Source/WebCore/SmartPointerExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::CSSNumberishTime):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::controller const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::controller const):
* Source/WebCore/css/CSSFontVariationValue.cpp:
(WebCore::CSSFontVariationValue::protectedValue const):
(WebCore::CSSFontVariationValue::customCSSText const):
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h:
(WebCore::UnevaluatedCalc::protectedCalc const):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::setSandboxFlags):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp:
(WebCore::FELightingSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp:
(WebCore::SourceGraphicSoftwareApplier::apply const):
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForUnresolvedFont):
* Source/WebKit/Shared/graphics/ImageBufferSet.cpp:
(WebKit::ImageBufferSet::swapBuffersForDisplay):
(WebKit::ImageBufferSet::prepareBufferForDisplay):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm:
(WebKit::PlatformCALayerRemoteModelHosting::dumpAdditionalProperties):

Canonical link: <a href="https://commits.webkit.org/283749@main">https://commits.webkit.org/283749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd170656678e94ec69efa8133ab48116b6427d3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71314 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18199 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12353 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42862 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16764 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61460 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9206 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10210 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->