### PR TITLE
Add check in AudioBufferSourceNode::renderFromBuffer() when pitchRate == -1 && !needsInterpolation

### DIFF
--- a/LayoutTests/fast/forms/datalist/suggestions-list-outside-of-visual-viewport-expected.txt
+++ b/LayoutTests/fast/forms/datalist/suggestions-list-outside-of-visual-viewport-expected.txt
@@ -1,0 +1,4 @@
+
+Is showing suggestions? false
+
+This test verifies that datalist suggestions UI is not shown when the input is outside of the visual viewport.

--- a/LayoutTests/fast/forms/datalist/suggestions-list-outside-of-visual-viewport.html
+++ b/LayoutTests/fast/forms/datalist/suggestions-list-outside-of-visual-viewport.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html style="margin-top: -11;">
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    margin-top: -60px;
+    width: 500px;
+}
+</style>
+</head>
+<body onload="runTest()">
+<input id="input" list="fruits"/>
+<datalist id="fruits">
+    <option>Apple</option>
+</datalist>
+<pre>Is showing suggestions? <span id="before"></span></pre>
+<br>
+<div>This test verifies that datalist suggestions UI is not shown when the input is outside of the visual viewport.</div>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+async function runTest() {
+    document.getElementById("input").focus();
+
+    before.textContent = await UIHelper.isShowingDataListSuggestions();
+
+    testRunner.notifyDone();
+}
+</script>
+</html>

--- a/LayoutTests/security/decode-buffer-size-expected.txt
+++ b/LayoutTests/security/decode-buffer-size-expected.txt
@@ -1,0 +1,3 @@
+ALERT: successfully caught exception RangeError: Bad value
+ALERT: successfully caught exception RangeError: Bad value
+

--- a/LayoutTests/security/decode-buffer-size.html
+++ b/LayoutTests/security/decode-buffer-size.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<script>
+if (window.testRunner) { testRunner.dumpAsText() }
+const decoder = new TextDecoder('utf-8', { fatal: true });
+decoder.decode(new Uint8Array([0xf0]), {stream: true});
+try { decoder.decode(new Uint8Array(0xffffffff)) } catch (e) { alert('successfully caught exception ' + e); }
+try { decoder.decode(new Uint8Array(0x7fffffff)) } catch (e) { alert('successfully caught exception ' + e); }
+</script>
+</body>
+</html>

--- a/LayoutTests/security/text-decode-long-strings-expected.txt
+++ b/LayoutTests/security/text-decode-long-strings-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: error RangeError: Bad value
+CONSOLE MESSAGE: error RangeError: Bad value
+

--- a/LayoutTests/security/text-decode-long-strings.html
+++ b/LayoutTests/security/text-decode-long-strings.html
@@ -1,0 +1,10 @@
+<script>
+ if (window.testRunner) { testRunner.dumpAsText() }
+
+ var decoder = new TextDecoder('utf-8');
+ decoder.decode(new Uint8Array(0x7fffffff), { stream: true });
+ try { decoder.decode(new Uint8Array(1), { stream: true }) } catch (e) { console.log('error ' + e) }
+
+ var decoder = new TextDecoder('utf-8');
+ try { decoder.decode(new Uint8Array(0x80000000)) } catch (e) { console.log('error ' + e) }
+ </script>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -327,6 +327,12 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
         // 8.7. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 8.8. Use the cdm to execute the following steps:
         m_instanceSession->loadSession(m_sessionType, *sanitizedSessionId, origin, [this, weakThis, promise = WTFMove(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTFMove(identifier)] (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+            auto protectedThis = RefPtr { weakThis.get() };
+            if (!protectedThis) {
+                promise->reject(ExceptionCode::InvalidStateError);
+                return;
+            }
+
             // 8.8.1. If there is no data stored for the sanitized session ID in the origin, resolve promise with false and abort these steps.
             // 8.8.2. If the stored session's session type is not the same as the current MediaKeySession session type, reject promise with a newly created TypeError.
             // 8.8.3. Let session data be the data stored for the sanitized session ID in the origin. This must not include data from other origin(s) or that is not associated with an origin.

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -299,6 +299,10 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
     } else if (pitchRate == -1 && !needsInterpolation) {
         int readIndex = static_cast<int>(virtualReadIndex);
         int deltaFrames = static_cast<int>(virtualDeltaFrames);
+        int maxFrame = static_cast<int>(virtualMaxFrame);
+        if (readIndex > maxFrame)
+            readIndex = maxFrame;
+
         int minFrame = static_cast<int>(virtualMinFrame) - 1;
         while (framesToProcess > 0) {
             int framesToEnd = readIndex - minFrame;

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -66,6 +66,10 @@ ExceptionOr<String> TextDecoder::decode(std::optional<BufferSource::VariantType>
             m_codec->stripByteOrderMark();
     }
 
+    m_decodedBytes += data.size();
+    if (m_decodedBytes > String::MaxLength)
+        return Exception { ExceptionCode::RangeError };
+
     bool sawError = false;
     String result = m_codec->decode(data, !options.stream, m_options.fatal, sawError);
 

--- a/Source/WebCore/dom/TextDecoder.h
+++ b/Source/WebCore/dom/TextDecoder.h
@@ -60,6 +60,7 @@ private:
     const PAL::TextEncoding m_textEncoding;
     const Options m_options;
     std::unique_ptr<PAL::TextCodec> m_codec;
+    size_t m_decodedBytes { 0 };
 };
 
 }

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -541,21 +541,33 @@ void GPUProcess::addSession(PAL::SessionID sessionID, GPUProcessSessionParameter
 
 void GPUProcess::removeSession(PAL::SessionID sessionID)
 {
-    ASSERT(m_sessions.contains(sessionID));
-    m_sessions.remove(sessionID);
+    auto findResult = m_sessions.find(sessionID);
+    if (findResult == m_sessions.end()) {
+        ASSERT_NOT_REACHED("Invalid SessionID");
+        return;
+    }
+    m_sessions.remove(findResult);
 }
 
 const String& GPUProcess::mediaCacheDirectory(PAL::SessionID sessionID) const
 {
-    ASSERT(m_sessions.contains(sessionID));
-    return m_sessions.find(sessionID)->value.mediaCacheDirectory;
+    auto findResult = m_sessions.find(sessionID);
+    if (findResult == m_sessions.end()) {
+        ASSERT_NOT_REACHED("Invalid SessionID");
+        return nullString();
+    }
+    return findResult->value.mediaCacheDirectory;
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
 const String& GPUProcess::mediaKeysStorageDirectory(PAL::SessionID sessionID) const
 {
-    ASSERT(m_sessions.contains(sessionID));
-    return m_sessions.find(sessionID)->value.mediaKeysStorageDirectory;
+    auto findResult = m_sessions.find(sessionID);
+    if (findResult == m_sessions.end()) {
+        ASSERT_NOT_REACHED("Invalid SessionID");
+        return nullString();
+    }
+    return findResult->value.mediaKeysStorageDirectory;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
@@ -71,9 +71,17 @@ void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSug
     }
 
     Ref page { m_page.get() };
+
+    auto elementRectInRootViewCoordinates = m_client.elementRectInRootViewCoordinates();
+    if (RefPtr view = page->localMainFrameView()) {
+        auto unobscuredRootViewRect = view->contentsToRootView(view->unobscuredContentRect());
+        if (!unobscuredRootViewRect.intersects(elementRectInRootViewCoordinates))
+            return close();
+    }
+
     page->setActiveDataListSuggestionPicker(*this);
 
-    WebCore::DataListSuggestionInformation info { type, WTFMove(suggestions), m_client.elementRectInRootViewCoordinates() };
+    WebCore::DataListSuggestionInformation info { type, WTFMove(suggestions), WTFMove(elementRectInRootViewCoordinates) };
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowDataListSuggestions(info), page->identifier());
 }
 


### PR DESCRIPTION
#### 290b276c74a8e542b178a35d4d99ef28a5a9a809
<pre>
Add check in AudioBufferSourceNode::renderFromBuffer() when pitchRate == -1 &amp;&amp; !needsInterpolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=276645">https://bugs.webkit.org/show_bug.cgi?id=276645</a>
<a href="https://rdar.apple.com/130939143">rdar://130939143</a>

Reviewed by Andy Estes.

Add a boundary check to renderFromBuffer() to ensure we don&apos;t read off the end of the buffer.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):

Originally-landed-as: 280938.8@safari-7619-branch (252fb2fc9cfd). <a href="https://rdar.apple.com/136112007">rdar://136112007</a>
Canonical link: <a href="https://commits.webkit.org/283767@main">https://commits.webkit.org/283767@main</a>
</pre>
----------------------------------------------------------------------
#### d1154cafe84288cf4492b7b9faed46208a62cd18
<pre>
UAF in MediaKeySession::load()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276633">https://bugs.webkit.org/show_bug.cgi?id=276633</a>
<a href="https://rdar.apple.com/129490880">rdar://129490880</a>

Reviewed by Andy Estes.

Check nullity of weakThis inside the lamda passed into loadSession() before continuing.

* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::load):

Originally-landed-as: 280938.7@safari-7619-branch (b89347ebdcc1). <a href="https://rdar.apple.com/136112074">rdar://136112074</a>
Canonical link: <a href="https://commits.webkit.org/283766@main">https://commits.webkit.org/283766@main</a>
</pre>
----------------------------------------------------------------------
#### ca74f3149f0f8e5cb4b8b77ffd571e9b0f2384b3
<pre>
CRASH in GPUProcess::mediaCacheDirectory()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276340">https://bugs.webkit.org/show_bug.cgi?id=276340</a>
<a href="https://rdar.apple.com/125544057">rdar://125544057</a>

Reviewed by Eric Carlson.

Verify that the given sessionID is present in m_sessions before dereferencing.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::removeSession):
(WebKit::GPUProcess::mediaCacheDirectory const):
(WebKit::GPUProcess::mediaKeysStorageDirectory const):

Originally-landed-as: 280938.6@safari-7619-branch (6091303acb69). <a href="https://rdar.apple.com/136112238">rdar://136112238</a>
Canonical link: <a href="https://commits.webkit.org/283765@main">https://commits.webkit.org/283765@main</a>
</pre>
----------------------------------------------------------------------
#### 73a87ea505fa3554ebedc55b34ef74871323d5ab
<pre>
Websites can spoof the contents of the address bar using &lt;datalist&gt;
<a href="https://rdar.apple.com/115912814">rdar://115912814</a>

Reviewed by Wenson Hsieh.

&lt;input&gt; elements positioned outside of the visual viewport are never
visible, since they are rendered in the page. On the contrary, it is
possible for a &lt;datalist&gt; suggestions list to seemingly hover freely in
space while its associated &lt;input&gt; is not visible in the page content.
This is because our datalist presentation logic anchors said lists (in
their own NSWindow) to the inputs.

This style of presentation makes us susceptible to free-floating
&lt;datalist&gt; elements, which, if positioned with the right margins and
contents, may resemble a UA&apos;s address bar!

To fix this vulnerability, we harden our datalist presentation logic by
asking the UI process to _not_ `ShowDataListSuggestions` if the associated
input element is (completely) absent from the visual viewport.

* LayoutTests/fast/forms/datalist/suggestions-list-outside-of-visual-viewport-expected.txt: Added.
* LayoutTests/fast/forms/datalist/suggestions-list-outside-of-visual-viewport.html: Added.
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp:
(WebKit::WebDataListSuggestionPicker::displayWithActivationType):

Originally-landed-as: 280938.5@safari-7619-branch (46af4f50bd12). <a href="https://rdar.apple.com/136112387">rdar://136112387</a>
Canonical link: <a href="https://commits.webkit.org/283764@main">https://commits.webkit.org/283764@main</a>
</pre>
----------------------------------------------------------------------
#### 940dcc945a56e9f15ea23665fe77a72c181f1abc
<pre>
Limit TextDecoder input to 2GB
<a href="https://rdar.apple.com/130960796">rdar://130960796</a>

Reviewed by John Wilander.

Rebasing Alex Christensen&apos;s change in
<a href="https://github.com/apple/WebKit/pull/1360">https://github.com/apple/WebKit/pull/1360</a> on the new security branch.

This basically matches the behavior of other browsers and prevents us from creating a string
longer than String::MaxLength.

* LayoutTests/security/decode-buffer-size-expected.txt: Added.
* LayoutTests/security/decode-buffer-size.html: Added.
* LayoutTests/security/text-decode-long-strings-expected.txt: Added.
* LayoutTests/security/text-decode-long-strings.html: Added.
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::decode):
* Source/WebCore/dom/TextDecoder.h:

Co-authored-by: Alex Christensen &lt;achristensen@apple.com&gt;

Originally-landed-as: 280938.4@safari-7619-branch (96ca9f96746c). <a href="https://rdar.apple.com/136112461">rdar://136112461</a>
Canonical link: <a href="https://commits.webkit.org/283763@main">https://commits.webkit.org/283763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc14f7c46cd0a075816919ab4e62177760a55e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53896 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61377 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14914 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2801 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42456 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44719 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->