### PR TITLE
[scroll-animations] Implement basic view timeline progress calculation

### DIFF
--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -45,7 +45,7 @@ public:
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
     static Ref<ScrollTimeline> createFromCSSValue(const CSSScrollValue&);
 
-    Element* source() const { return m_source.get(); }
+    virtual Element* source() const { return m_source.get(); }
 
     ScrollAxis axis() const { return m_axis; }
     void setAxis(ScrollAxis axis) { m_axis = axis; }

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -59,7 +59,18 @@ public:
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
     AnimationTimelinesController* controller() const override;
 
+    RenderBox* sourceRenderer() const;
+    Element* source() const override;
+
 private:
+    struct Data {
+        float scrollContainerSize { 0 };
+        float subjectOffset { 0 };
+        float currentScrollOffset { 0 };
+        float coverRangeEnd { 0 };
+    };
+    Data computeViewTimelineData() const;
+
     explicit ViewTimeline(ViewTimelineOptions&& = { });
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -100,10 +100,10 @@ static IntRect boundingRectForScrollableArea(ScrollableArea& scrollableArea)
     return IntRect(downcast<LocalFrameView>(downcast<ScrollView>(scrollableArea)).layoutViewportRect());
 }
 
-FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObject& candidate)
+FloatPoint ScrollAnchoringController::computeOffsetFromScrollableArea(RenderObject& candidate, ScrollableArea& area, ShouldIncludeFrameViewLocation shouldIncludeFrameViewLocation)
 {
     // TODO: investigate this for zoom/rtl
-    return FloatPoint(candidate.absoluteBoundingBoxRect().location() - boundingRectForScrollableArea(m_owningScrollableArea).location());
+    return FloatPoint(candidate.absoluteBoundingBoxRect().location() - ((shouldIncludeFrameViewLocation == ShouldIncludeFrameViewLocation::No && is<ScrollView>(area)) ? FloatPoint() : boundingRectForScrollableArea(area).location()));
 }
 
 void ScrollAnchoringController::notifyChildHadSuppressingStyleChange()
@@ -188,7 +188,7 @@ bool ScrollAnchoringController::didFindPriorityCandidate(Document& document)
     // TODO: need to figure out how to get element that is the current find-in-page element (look into FindController)
     if (RefPtr priorityCandidate = viablePriorityCandidateForElement(document.focusedElement())) {
         m_anchorElement = priorityCandidate;
-        m_lastOffsetForAnchorElement = computeOffsetFromOwningScroller(*m_anchorElement->renderer());
+        m_lastOffsetForAnchorElement = computeOffsetFromScrollableArea(*m_anchorElement->renderer(), m_owningScrollableArea);
         LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::viablePriorityCandidateForElement() found priority candidate: " << *priorityCandidate << " for element: " << ValueOrNull(elementForScrollableArea(m_owningScrollableArea)));
         return true;
     }
@@ -320,8 +320,8 @@ void ScrollAnchoringController::chooseAnchorElement(Document& document)
     }
 
     m_anchorElement = anchorElement;
-    m_lastOffsetForAnchorElement = computeOffsetFromOwningScroller(*m_anchorElement->renderer());
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() found anchor node: " << *anchorElement << " offset: " << computeOffsetFromOwningScroller(*m_anchorElement->renderer()));
+    m_lastOffsetForAnchorElement = computeOffsetFromScrollableArea(*m_anchorElement->renderer(), m_owningScrollableArea);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() found anchor node: " << *anchorElement << " offset: " << computeOffsetFromScrollableArea(*m_anchorElement->renderer(), m_owningScrollableArea));
 }
 
 void ScrollAnchoringController::updateAnchorElement()
@@ -361,7 +361,7 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     }
     SetForScope midUpdatingScrollPositionForAnchorElement(m_midUpdatingScrollPositionForAnchorElement, true);
 
-    FloatSize adjustment = computeOffsetFromOwningScroller(*renderer) - m_lastOffsetForAnchorElement;
+    FloatSize adjustment = computeOffsetFromScrollableArea(*renderer, m_owningScrollableArea) - m_lastOffsetForAnchorElement;
     if (!adjustment.isZero()) {
         if (m_owningScrollableArea.isUserScrollInProgress()) {
             invalidateAnchorElement();

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -65,10 +65,13 @@ public:
     bool isInScrollAnchoringAncestorChain(const RenderObject&);
 
     Element* anchorElement() const { return m_anchorElement.get(); }
+
+    enum class ShouldIncludeFrameViewLocation { Yes, No };
+    static FloatPoint computeOffsetFromScrollableArea(RenderObject&, ScrollableArea&, ShouldIncludeFrameViewLocation = ShouldIncludeFrameViewLocation::Yes);
+
 private:
     Element* findAnchorElementRecursive(Element*);
     bool didFindPriorityCandidate(Document&);
-    FloatPoint computeOffsetFromOwningScroller(RenderObject& candidate);
     LocalFrameView& frameView();
 
     ScrollableArea& m_owningScrollableArea;

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -346,7 +346,7 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
     auto scrollSnapPort = computeScrollSnapPortOrAreaRect(viewportRectInBorderBoxCoordinates, scrollingElementStyle.scrollPadding(), InsetOrOutset::Inset);
     LOG_WITH_STREAM(ScrollSnap, stream << "Computing scroll snap offsets for " << scrollableArea << " in snap port " << scrollSnapPort);
     for (auto& child : boxesWithScrollSnapPositions) {
-        if (child.enclosingScrollableContainerForSnapping() != &scrollingElementBox || !child.element())
+        if (child.enclosingScrollableContainer() != &scrollingElementBox || !child.element())
             continue;
 
         // The bounds of the child element's snap area, where the top left of the scrolling container's border box is the origin.

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -211,7 +211,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
     bool scrollAlignChanged = oldStyle && oldStyle->scrollSnapAlign() != newStyle.scrollSnapAlign();
     bool scrollSnapStopChanged = oldStyle && oldStyle->scrollSnapStop() != newStyle.scrollSnapStop();
     if (scrollMarginChanged || scrollAlignChanged || scrollSnapStopChanged) {
-        if (auto* scrollSnapBox = enclosingScrollableContainerForSnapping())
+        if (auto* scrollSnapBox = enclosingScrollableContainer())
             scrollSnapBox->setNeedsLayout();
     }
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -513,7 +513,7 @@ RenderBoxModelObject& RenderObject::enclosingBoxModelObject() const
     return *lineageOfType<RenderBoxModelObject>(const_cast<RenderObject&>(*this)).first();
 }
 
-RenderBox* RenderObject::enclosingScrollableContainerForSnapping() const
+RenderBox* RenderObject::enclosingScrollableContainer() const
 {
     // Walk up the container chain to find the scrollable container that contains
     // this RenderObject. The important thing here is that `container()` respects

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -388,7 +388,7 @@ public:
 
     WEBCORE_EXPORT RenderBox& enclosingBox() const;
     RenderBoxModelObject& enclosingBoxModelObject() const;
-    RenderBox* enclosingScrollableContainerForSnapping() const;
+    RenderBox* enclosingScrollableContainer() const;
 
     // Return our enclosing flow thread if we are contained inside one. Follows the containing block chain.
     RenderFragmentedFlow* enclosingFragmentedFlow() const;


### PR DESCRIPTION
#### 1e0887d7f58e38cfb3f720ecb18dfca4ba43cc9f
<pre>
[scroll-animations] Implement basic view timeline progress calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=279799">https://bugs.webkit.org/show_bug.cgi?id=279799</a>
<a href="https://rdar.apple.com/136115845">rdar://136115845</a>

Reviewed by Simon Fraser.

Implement basic view timeline progress calculation based on the spec:
<a href="https://drafts.csswg.org/scroll-animations-1/#view-timeline-progress.">https://drafts.csswg.org/scroll-animations-1/#view-timeline-progress.</a> Also add a way
to find the source element for the ViewTimeline, based on the spec:
<a href="https://drafts.csswg.org/scroll-animations-1/#dom-scrolltimeline-source.">https://drafts.csswg.org/scroll-animations-1/#dom-scrolltimeline-source.</a>

* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::source const):
(WebCore::ViewTimeline::sourceRenderer const):
(WebCore::ViewTimeline::computeViewTimelineData const):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/284126@main">https://commits.webkit.org/284126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3f5f568a55f9ddeeed29cd2a49a94688dac5702

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21165 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19467 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13082 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43792 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74269 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16188 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62156 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10085 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44773 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->