### PR TITLE
[JSC] Remove useWasmJITLessJSEntrypoint option

### DIFF
--- a/JSTests/microbenchmarks/wasm-cc-int-to-int.js
+++ b/JSTests/microbenchmarks/wasm-cc-int-to-int.js
@@ -1,5 +1,5 @@
 //@ skip unless $isWasmPlatform
-//@ runDefaultWasm("--useWasm=1", "--useWasmJITLessJSEntrypoint=1")
+//@ runDefaultWasm("--useWasm=1")
 
 var wasm_code;
 try {

--- a/JSTests/wasm/stress/cc-double-to-double.js
+++ b/JSTests/wasm/stress/cc-double-to-double.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-f32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-f32-kitchen-sink.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-float-to-float.js
+++ b/JSTests/wasm/stress/cc-float-to-float.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-funcref.js
+++ b/JSTests/wasm/stress/cc-funcref.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i32-kitchen-sink-neg.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink-neg.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i64-kitchen-sink-neg.js
+++ b/JSTests/wasm/stress/cc-i64-kitchen-sink-neg.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i64-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i64-kitchen-sink.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-infinite-int-glitch.js
+++ b/JSTests/wasm/stress/cc-infinite-int-glitch.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,5 +1,5 @@
 //@ skip unless $isWasmPlatform
-//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useWasmJITLessJSEntrypoint=1")
+//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0")
 
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-memory.js
+++ b/JSTests/wasm/stress/cc-int-to-int-memory.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-no-jit.js
+++ b/JSTests/wasm/stress/cc-int-to-int-no-jit.js
@@ -1,4 +1,4 @@
-//@ runDefaultWasm("-m", "--useJIT=0", "--useWasm=1", "--useWasmJITLessJSEntrypoint=1")
+//@ runDefaultWasm("-m", "--useJIT=0", "--useWasm=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-to-js.js
+++ b/JSTests/wasm/stress/cc-int-to-int-to-js.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int.js
+++ b/JSTests/wasm/stress/cc-int-to-int.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-lotsofints-to-int.js
+++ b/JSTests/wasm/stress/cc-lotsofints-to-int.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-lotsofints-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-lotsofints-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-so-i-heard-you-like-parameters.js
+++ b/JSTests/wasm/stress/cc-so-i-heard-you-like-parameters.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -660,7 +660,7 @@ end
 
 if ASSERT_ENABLED
     # Check to confirm we have the right kind of callee
-    loadi Wasm::JSEntrypointCallee::ident[ws1], wa0
+    loadi Wasm::JSEntrypointCallee::m_ident[ws1], wa0
     move 0xBF, wa1
     bpeq wa0, wa1, .ident_ok
     break
@@ -691,7 +691,7 @@ end
     end
 
     # Allocate stack space
-    loadi Wasm::JSEntrypointCallee::frameSize[ws1], wa0
+    loadi Wasm::JSEntrypointCallee::m_frameSize[ws1], wa0
     subp sp, wa0, wa0
 
     bpa wa0, cfr, .stackOverflow
@@ -756,16 +756,16 @@ end
 
     # Store Callee's wasm callee
 if JSVALUE64
-    loadp Wasm::JSEntrypointCallee::wasmCallee[ws0], ws1
+    loadp Wasm::JSEntrypointCallee::m_wasmCallee[ws0], ws1
     storep ws1, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8[sp]
 else
-    loadp Wasm::JSEntrypointCallee::wasmCallee + PayloadOffset[ws0], ws1
+    loadp Wasm::JSEntrypointCallee::m_wasmCallee + PayloadOffset[ws0], ws1
     storep ws1, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8 + PayloadOffset[sp]
-    loadp Wasm::JSEntrypointCallee::wasmCallee + TagOffset[ws0], ws1
+    loadp Wasm::JSEntrypointCallee::m_wasmCallee + TagOffset[ws0], ws1
     storep ws1, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8 + TagOffset[sp]
 end
 
-    call Wasm::JSEntrypointCallee::wasmFunctionPrologue[ws0], WasmEntryPtrTag
+    call Wasm::JSEntrypointCallee::m_wasmFunctionPrologue[ws0], WasmEntryPtrTag
 
 if ASSERT_ENABLED
     clobberVolatileRegisters()
@@ -779,7 +779,7 @@ end
     leap WTFConfig + constexpr WTF::offsetOfWTFConfigLowestAccessibleAddress, ws1
     loadp [ws1], ws1
     addp ws1, ws0
-    loadi Wasm::JSEntrypointCallee::frameSize[ws0], ws1
+    loadi Wasm::JSEntrypointCallee::m_frameSize[ws0], ws1
     subp cfr, ws1, ws1
     move ws1, sp
     subp constexpr Wasm::JSEntrypointCallee::SpillStackSpaceAligned, sp

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -667,9 +667,6 @@ static inline void disableAllJITOptions()
     Options::useJITCage() = false;
     Options::useConcurrentJIT() = false;
 
-    if (!Options::useWasmJITLessJSEntrypoint() && Options::useWasm())
-        disableAllWasmOptions();
-
     Options::useWasmSIMD() = false;
 
     Options::usePollingTraps() = true;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -578,7 +578,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
     v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
     v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
-    v(Bool, useWasmJITLessJSEntrypoint, true, Normal, "Allow JS->wasm wrappers to be replaced by jit-less versions."_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     \
     /* Feature Flags */\

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -246,17 +246,7 @@ void BBQPlan::compileFunction(uint32_t functionIndex)
     m_callees[functionIndex] = WTFMove(bbqCallee);
 
     if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
-        TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-        CallInformation wasmFrameConvention = wasmCallingConvention().callInformationFor(signature, CallRole::Caller);
-
-        RegisterAtOffsetList savedResultRegisters = wasmFrameConvention.computeResultsOffsetList();
-        size_t totalFrameSize = wasmFrameConvention.headerAndArgumentStackSizeInBytes;
-        totalFrameSize += savedResultRegisters.sizeOfAreaInBytes();
-        totalFrameSize += JSEntrypointCallee::RegisterStackSpaceAligned;
-        totalFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(totalFrameSize);
-
-        auto callee = JSEntrypointCallee::create(totalFrameSize, typeIndex, m_moduleInformation->usesSIMD(functionIndex));
+        auto callee = JSEntrypointCallee::create(m_moduleInformation->internalFunctionTypeIndices[functionIndex], m_moduleInformation->usesSIMD(functionIndex));
 
         Locker locker { m_lock };
         auto result = m_jsToWasmInternalFunctions.add(functionIndex, WTFMove(callee));

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -167,20 +167,7 @@ bool LLIntPlan::ensureEntrypoint(LLIntCallee&, unsigned functionIndex)
     if (m_entrypoints[functionIndex])
         return true;
 
-    if (!Options::useWasmJITLessJSEntrypoint())
-        return false;
-
-    TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-    const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-    CallInformation wasmFrameConvention = wasmCallingConvention().callInformationFor(signature, CallRole::Caller);
-
-    RegisterAtOffsetList savedResultRegisters = wasmFrameConvention.computeResultsOffsetList();
-    size_t totalFrameSize = wasmFrameConvention.headerAndArgumentStackSizeInBytes;
-    totalFrameSize += savedResultRegisters.sizeOfAreaInBytes();
-    totalFrameSize += JSEntrypointCallee::RegisterStackSpaceAligned;
-    totalFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(totalFrameSize);
-
-    m_entrypoints[functionIndex] = JSEntrypointCallee::create(totalFrameSize, typeIndex, m_moduleInformation->usesSIMD(functionIndex));
+    m_entrypoints[functionIndex] = JSEntrypointCallee::create(m_moduleInformation->internalFunctionTypeIndices[functionIndex], m_moduleInformation->usesSIMD(functionIndex));
     return true;
 }
 
@@ -210,7 +197,7 @@ void LLIntPlan::didCompleteCompilation()
         }
         if (auto& callee = m_entrypoints[functionIndex]) {
             if (callee->compilationMode() == CompilationMode::JSToWasmEntrypointMode)
-                static_cast<JSEntrypointCallee*>(callee.get())->wasmCallee = CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get());
+                static_cast<JSEntrypointCallee*>(callee.get())->setWasmCallee(CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get()));
             m_jsEntrypointCallees.add(functionIndex, callee);
         }
     }


### PR DESCRIPTION
#### f06b058c97b0569042d34a415df9dbf370dcd303
<pre>
[JSC] Remove useWasmJITLessJSEntrypoint option
<a href="https://bugs.webkit.org/show_bug.cgi?id=279802">https://bugs.webkit.org/show_bug.cgi?id=279802</a>
<a href="https://rdar.apple.com/136116308">rdar://136116308</a>

Reviewed by Ross Kirsling and Mark Lam.

283638@main removed JSEntrypointJITCallee. This means useWasmJITLessJSEntrypoint must be always true
for wasm enablement. So putting it to false breaks wasm execution. This patch removes this broken option.

* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::disableAllJITOptions):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::JSEntrypointCallee::JSEntrypointCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::ensureEntrypoint):
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/283756@main">https://commits.webkit.org/283756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d9b9e65c1459b60a35a0f53526ba02007180766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71320 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12358 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39537 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15604 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 23 flakes 3 failures; Uploaded test results; 21 flakes 3 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16770 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60392 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61505 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73022 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15279 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61463 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2814 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88291 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10213 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15551 "Found 1055 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-bbq, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-collect-continuously, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-eager-jettison, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-no-cjit, wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.wasm-bbq ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->