### PR TITLE
Cloudflare Captcha does not render under site isolation.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/remote-frame-loaded-while-hidden-expected.html
+++ b/LayoutTests/http/tests/site-isolation/remote-frame-loaded-while-hidden-expected.html
@@ -1,0 +1,3 @@
+<body bgcolor=blue>
+<div style="width:300px;height:150px;background-color:green;">
+</body>

--- a/LayoutTests/http/tests/site-isolation/remote-frame-loaded-while-hidden.html
+++ b/LayoutTests/http/tests/site-isolation/remote-frame-loaded-while-hidden.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script>
+if (window.testRunner) { testRunner.waitUntilDone() }
+onload = ()=>{
+    let i = document.getElementById('testiframe');
+    i.src = 'http://localhost:8000/site-isolation/resources/green-background.html';
+    i.addEventListener('load', () => {
+        i.style.display = "inline";
+        if (window.testRunner) {
+            testRunner.notifyDone();
+        }
+    });
+}
+</script>
+</head>
+<body bgcolor=blue>
+<iframe id='testiframe' frameborder=0 style="display:none"></iframe>
+</body>

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -175,6 +175,9 @@ void RenderWidget::setWidget(RefPtr<Widget>&& widget)
     if (widget == m_widget)
         return;
 
+    if (is<RemoteFrameView>(m_widget) != is<RemoteFrameView>(widget))
+        frameOwnerElement().scheduleInvalidateStyleAndLayerComposition();
+
     if (m_widget) {
         moveWidgetToParentSoon(*m_widget, nullptr);
         view().frameView().willRemoveWidgetFromRenderTree(*m_widget);
@@ -206,7 +209,7 @@ void RenderWidget::setWidget(RefPtr<Widget>&& widget)
         }
         moveWidgetToParentSoon(*m_widget, &view().frameView());
     }
-    
+
     if (CheckedPtr cache = document().existingAXObjectCache())
         cache->childrenChanged(this);
 }


### PR DESCRIPTION
#### cf950ff77fd741c2320824ed6f8720ff54cf9edb
<pre>
Cloudflare Captcha does not render under site isolation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279803">https://bugs.webkit.org/show_bug.cgi?id=279803</a>
&lt;<a href="https://rdar.apple.com/136116291">rdar://136116291</a>&gt;

Reviewed by Alex Christensen.

<a href="https://app.dashlane.com">https://app.dashlane.com</a> never displays the captcha with site-isolation enabled.

The issue is that RenderWidget::setWidget doesn&apos;t get called until after
::requiresLayers has been evaluated.

Setting a new widget can affect the result of requiresLayer, so we need to
invalidate style so that it gets checked again.

* LayoutTests/http/tests/site-isolation/remote-frame-loaded-while-hidden-expected.html: Added.
* LayoutTests/http/tests/site-isolation/remote-frame-loaded-while-hidden.html: Added.
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::setWidget):

Canonical link: <a href="https://commits.webkit.org/283881@main">https://commits.webkit.org/283881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/842060753d17be0f4ac91115ca8bcc84dabce97d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54077 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12468 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16995 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73247 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11459 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15435 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-activesourcebuffers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61521 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58448 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61586 "Found 2 new API test failures: /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15030 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9364 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2977 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->